### PR TITLE
Switch to using InternalUtilities for job creation

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -11,14 +11,14 @@ def projectFolder = projectName + '/' + Utilities.getFolderName(branch)
     ['perf','illink','rwc','throughput'].each { jobType ->
         def jobName = "perf_monitoring_coreclr_${os}_${jobType}"
 
-        def newJob = job(Utilities.getFullJobName(project, jobName, false)) {
+        def newJob = job(InternalUtilities.getFullJobName(project, jobName, false)) {
             steps {
                 batchFile("py scripts\\getjenkinsstatus.py -repo coreclr -os ${os} -jobType ${jobType}")
             }
         }
 
         Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
-        Utilities.standardJobSetup(newJob, project, false, "*/${branch}")
+        InternalUtilities.standardJobSetup(newJob, project, false, "*/${branch}")
 
         Utilities.addPeriodicTrigger(newJob, "@hourly", true /*always run*/)
         newJob.with {
@@ -31,14 +31,14 @@ def projectFolder = projectName + '/' + Utilities.getFolderName(branch)
     }
 
     def jobName = "performance_monitoring_corefx_${os}"
-    def newJob = job(Utilities.getFullJobName(project, jobName, false)) {
+    def newJob = job(InternalUtilities.getFullJobName(project, jobName, false)) {
         steps {
             batchFile("py scripts\\getjenkinsstatus.py -repo corefx -os ${os}")
         }
     }
 
     Utilities.setMachineAffinity(newJob, "Windows_NT", '20170427-elevated')
-    Utilities.standardJobSetup(newJob, project, false, "*/${branch}")
+    InternalUtilities.standardJobSetup(newJob, project, false, "*/${branch}")
 
     Utilities.addPeriodicTrigger(newJob, "@hourly", true /*always run*/)
     newJob.with {


### PR DESCRIPTION
Private repos require credentials to pull down sources.