### PR TITLE
Updating tracked status.

### DIFF
--- a/docs/dotnet-performance-ci-status.md
+++ b/docs/dotnet-performance-ci-status.md
@@ -11,7 +11,7 @@
 | Branch        | arch=[x64]<br>OptLevel=[full]                      | arch=[x64]<br>OptLevel=[min]                     | arch=[x86]<br>OptLevel=[full]                      | arch=[x86]<br>OptLevel=[min]                     |
 | :------------ | :------------------------------------------------: | :----------------------------------------------: | :------------------------------------------------: | :----------------------------------------------: |
 | master        | [![master_x64_win_full_icon]][master_x64_win_full] | [![master_x64_win_min_icon]][master_x64_win_min] | [![master_x86_win_full_icon]][master_x86_win_full] | [![master_x86_win_min_icon]][master_x86_win_min] |
-| release/2.1   | [![rel2.1_x64_win_full_icon]][rel2.1_x64_win_full] | [![rel2.1_x64_win_min_icon]][rel2.1_x64_win_min] | [![rel2.1_x86_win_full_icon]][rel2.1_x86_win_full] | [![rel2.1_x86_win_min_icon]][rel2.1_x86_win_min] |
+| release/2.1   | [![rel2.1_x64_win_full_icon]][rel2.1_x64_win_full] | N/A                                              | [![rel2.1_x86_win_full_icon]][rel2.1_x86_win_full] | N/A                                              |
 | release/2.0.0 | [![rel2.0_x64_win_full_icon]][rel2.0_x64_win_full] | N/A                                              | [![rel2.0_x86_win_full_icon]][rel2.0_x86_win_full] | N/A                                              |
 | release/1.1.0 | [![rel1.1_x64_win_full_icon]][rel1.1_x64_win_full] | N/A                                              | [![rel1.1_x86_win_full_icon]][rel1.1_x86_win_full] | N/A                                              |
 
@@ -35,8 +35,6 @@
 [rel2.1_x64_nix_full_icon]:             https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_Ubuntu16.04/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_x64_win_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x64_full_opt_ryujit/lastCompletedBuild/
 [rel2.1_x64_win_full_icon]:             https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x64_full_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_x64_win_min]:                   https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x64_min_opt_ryujit/lastCompletedBuild/
-[rel2.1_x64_win_min_icon]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x64_min_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_x64_nix_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_Ubuntu16.04/lastCompletedBuild/
 [rel2.0_x64_nix_full_icon]:             https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_Ubuntu16.04/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_x64_win_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_perflab_Windows_NT_x64/lastCompletedBuild/
@@ -53,8 +51,6 @@
 [master_x86_win_min_icon]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_perflab_Windows_NT_x86_min_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_x86_win_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x86_full_opt_ryujit/lastCompletedBuild/
 [rel2.1_x86_win_full_icon]:             https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x86_full_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_x86_win_min]:                   https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x86_min_opt_ryujit/lastCompletedBuild/
-[rel2.1_x86_win_min_icon]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_perflab_Windows_NT_x86_min_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_x86_win_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_perflab_Windows_NT_x86/lastCompletedBuild/
 [rel2.0_x86_win_full_icon]:             https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_perflab_Windows_NT_x86/lastCompletedBuild/badge/icon (Run Status)
 [rel1.1_x86_win_full]:                  https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_1.1.0/job/perf_perflab_Windows_NT_x86/lastCompletedBuild/
@@ -67,7 +63,7 @@
 | Branch      | arch=[x64]<br>OptLevel=[full]                              | arch=[x64]<br>OptLevel=[min]                             | arch=[x64]<br>OptLevel=[tiered]                                | arch=[x86]<br>OptLevel=[full]                              | arch=[x86]<br>OptLevel=[min]                             | arch=[x86]<br>OptLevel=[tiered]                                |
 | :---------- | :--------------------------------------------------------: | :------------------------------------------------------: | :------------------------------------------------------------: | :--------------------------------------------------------: | :------------------------------------------------------: | :------------------------------------------------------------: |
 | master      | [![master_e2e_x64_win_full_icon]][master_e2e_x64_win_full] | [![master_e2e_x64_win_min_icon]][master_e2e_x64_win_min] | [![master_e2e_x64_win_tiered_icon]][master_e2e_x64_win_tiered] | [![master_e2e_x86_win_full_icon]][master_e2e_x86_win_full] | [![master_e2e_x86_win_min_icon]][master_e2e_x86_win_min] | [![master_e2e_x86_win_tiered_icon]][master_e2e_x86_win_tiered] |
-| release/2.1 | [![rel2.1_e2e_x64_win_full_icon]][rel2.1_e2e_x64_win_full] | [![rel2.1_e2e_x64_win_min_icon]][rel2.1_e2e_x64_win_min] | [![rel2.1_e2e_x64_win_tiered_icon]][rel2.1_e2e_x64_win_tiered] | [![rel2.1_e2e_x86_win_full_icon]][rel2.1_e2e_x86_win_full] | [![rel2.1_e2e_x86_win_min_icon]][rel2.1_e2e_x86_win_min] | [![rel2.1_e2e_x86_win_tiered_icon]][rel2.1_e2e_x86_win_tiered] |
+| release/2.1 | [![rel2.1_e2e_x64_win_full_icon]][rel2.1_e2e_x64_win_full] | N/A                                                      | N/A                                                            | [![rel2.1_e2e_x86_win_full_icon]][rel2.1_e2e_x86_win_full] | N/A                                                      | N/A                                                            |
 
 [//]: # (These are the x64 links)
 [master_e2e_x64_win_full]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_scenarios_Windows_NT_x64_full_opt_ryujit/lastCompletedBuild/
@@ -78,10 +74,6 @@
 [master_e2e_x64_win_tiered_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_scenarios_Windows_NT_x64_tiered_ryujit/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_e2e_x64_win_full]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_full_opt_ryujit/lastCompletedBuild/
 [rel2.1_e2e_x64_win_full_icon]:         https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_full_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_e2e_x64_win_min]:               https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_min_opt_ryujit/lastCompletedBuild/
-[rel2.1_e2e_x64_win_min_icon]:          https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_min_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_e2e_x64_win_tiered]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_tiered_ryujit/lastCompletedBuild/
-[rel2.1_e2e_x64_win_tiered_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x64_tiered_ryujit/lastCompletedBuild/badge/icon (Run Status)
 
 [//]: # (These are the x86 links)
 [master_e2e_x86_win_full]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_scenarios_Windows_NT_x86_full_opt_ryujit/lastCompletedBuild/
@@ -92,10 +84,6 @@
 [master_e2e_x86_win_tiered_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_scenarios_Windows_NT_x86_tiered_ryujit/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_e2e_x86_win_full]:              https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_full_opt_ryujit/lastCompletedBuild/
 [rel2.1_e2e_x86_win_full_icon]:         https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_full_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_e2e_x86_win_min]:               https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_min_opt_ryujit/lastCompletedBuild/
-[rel2.1_e2e_x86_win_min_icon]:          https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_min_opt_ryujit/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_e2e_x86_win_tiered]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_tiered_ryujit/lastCompletedBuild/
-[rel2.1_e2e_x86_win_tiered_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_scenarios_Windows_NT_x86_tiered_ryujit/lastCompletedBuild/badge/icon (Run Status)
 
 ### Throughput
 
@@ -104,7 +92,7 @@
 | Branch        | OptLevel=[full]<br>PGO=[nopgo]                                       | OptLevel=[full]<br>PGO=[pgo]                                     | OptLevel=[min]<br>PGO=[nopgo]                                      | OptLevel=[min]<br>PGO=[pgo]                                    |
 | :------------ | :------------------------------------------------------------------: | :--------------------------------------------------------------: | :----------------------------------------------------------------: | :------------------------------------------------------------: |
 | master        | [![master_TP_x64_win_full_nopgo_icon]][master_TP_x64_win_full_nopgo] | [![master_TP_x64_win_full_pgo_icon]][master_TP_x64_win_full_pgo] | [![master_TP_x64_win_min_nopgo_icon]][master_TP_x64_win_min_nopgo] | [![master_TP_x64_win_min_pgo_icon]][master_TP_x64_win_min_pgo] |
-| release/2.1   | [![rel2.1_TP_x64_win_full_nopgo_icon]][rel2.1_TP_x64_win_full_nopgo] | [![rel2.1_TP_x64_win_full_pgo_icon]][rel2.1_TP_x64_win_full_pgo] | [![rel2.1_TP_x64_win_min_nopgo_icon]][rel2.1_TP_x64_win_min_nopgo] | [![rel2.1_TP_x64_win_min_pgo_icon]][rel2.1_TP_x64_win_min_pgo] |
+| release/2.1   | [![rel2.1_TP_x64_win_full_nopgo_icon]][rel2.1_TP_x64_win_full_nopgo] | [![rel2.1_TP_x64_win_full_pgo_icon]][rel2.1_TP_x64_win_full_pgo] | N/A                                                                | N/A                                                            |
 | release/2.0.0 | N/A                                                                  | [![rel2.0_TP_x64_win_full_pgo_icon]][rel2.0_TP_x64_win_full_pgo] | N/A                                                                | [![rel2.0_TP_x64_win_min_pgo_icon]][rel2.0_TP_x64_win_min_pgo] |
 
 #### Throughput / Ubuntu 16.04 / x64
@@ -112,7 +100,7 @@
 | Branch        | OptLevel=[full]<br>PGO=[pgo]                                     |  OptLevel=[min]<br>PGO=[pgo]                                    |
 | :------------ | :--------------------------------------------------------------: |  :------------------------------------------------------------: |
 | master        | [![master_TP_x64_nix_full_pgo_icon]][master_TP_x64_nix_full_pgo] |  [![master_TP_x64_nix_min_pgo_icon]][master_TP_x64_nix_min_pgo] |
-| release/2.1   | [![rel2.1_TP_x64_nix_full_pgo_icon]][rel2.1_TP_x64_nix_full_pgo] |  [![rel2.1_TP_x64_nix_min_pgo_icon]][rel2.1_TP_x64_nix_min_pgo] |
+| release/2.1   | [![rel2.1_TP_x64_nix_full_pgo_icon]][rel2.1_TP_x64_nix_full_pgo] |  N/A                                                            |
 | release/2.0.0 | [![rel2.0_TP_x64_nix_full_pgo_icon]][rel2.0_TP_x64_nix_full_pgo] |  [![rel2.0_TP_x64_nix_min_pgo_icon]][rel2.0_TP_x64_nix_min_pgo] |
 
 [//]: # (These are the x64 links)
@@ -130,16 +118,10 @@
 [master_TP_x64_win_min_pgo_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/master/job/perf_throughput_perflab_Windows_NT_x64_min_opt_ryujit_pgo/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_TP_x64_nix_full_pgo]:           https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_Ubuntu14.04_full_opt/lastCompletedBuild/
 [rel2.1_TP_x64_nix_full_pgo_icon]:      https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_Ubuntu14.04_full_opt/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_TP_x64_nix_min_pgo]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_Ubuntu14.04_min_opt/lastCompletedBuild/
-[rel2.1_TP_x64_nix_min_pgo_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_Ubuntu14.04_min_opt/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_TP_x64_win_full_nopgo]:         https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_full_opt_ryujit_nopgo/lastCompletedBuild/
 [rel2.1_TP_x64_win_full_nopgo_icon]:    https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_full_opt_ryujit_nopgo/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_TP_x64_win_full_pgo]:           https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_full_opt_ryujit_pgo/lastCompletedBuild/
 [rel2.1_TP_x64_win_full_pgo_icon]:      https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_full_opt_ryujit_pgo/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_TP_x64_win_min_nopgo]:          https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_min_opt_ryujit_nopgo/lastCompletedBuild/
-[rel2.1_TP_x64_win_min_nopgo_icon]:     https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_min_opt_ryujit_nopgo/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_TP_x64_win_min_pgo]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_min_opt_ryujit_pgo/lastCompletedBuild/
-[rel2.1_TP_x64_win_min_pgo_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x64_min_opt_ryujit_pgo/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_TP_x64_nix_full_pgo]:           https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_Ubuntu16.04_full_opt/lastCompletedBuild/
 [rel2.0_TP_x64_nix_full_pgo_icon]:      https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_Ubuntu16.04_full_opt/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_TP_x64_nix_min_pgo]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_Ubuntu16.04_min_opt/lastCompletedBuild/
@@ -154,7 +136,7 @@
 | Branch        | OptLevel=[full]<br>PGO=[nopgo]                                       | OptLevel=[full]<br>PGO=[pgo]                                     | OptLevel=[min]<br>PGO=[nopgo]                                      | OptLevel=[min]<br>PGO=[pgo]                                    |
 | :------------ | :------------------------------------------------------------------: | :--------------------------------------------------------------: | :----------------------------------------------------------------: | :------------------------------------------------------------: |
 | master        | [![master_TP_x86_win_full_nopgo_icon]][master_TP_x86_win_full_nopgo] | [![master_TP_x86_win_full_pgo_icon]][master_TP_x86_win_full_pgo] | [![master_TP_x86_win_min_nopgo_icon]][master_TP_x86_win_min_nopgo] | [![master_TP_x86_win_min_pgo_icon]][master_TP_x86_win_min_pgo] |
-| release/2.1   | [![rel2.1_TP_x86_win_full_nopgo_icon]][rel2.1_TP_x86_win_full_nopgo] | [![rel2.1_TP_x86_win_full_pgo_icon]][rel2.1_TP_x86_win_full_pgo] | [![rel2.1_TP_x86_win_min_nopgo_icon]][rel2.1_TP_x86_win_min_nopgo] | [![rel2.1_TP_x86_win_min_pgo_icon]][rel2.1_TP_x86_win_min_pgo] |
+| release/2.1   | [![rel2.1_TP_x86_win_full_nopgo_icon]][rel2.1_TP_x86_win_full_nopgo] | [![rel2.1_TP_x86_win_full_pgo_icon]][rel2.1_TP_x86_win_full_pgo] | N/A                                                                | N/A                                                            |
 | release/2.0.0 | N/A                                                                  | [![rel2.0_TP_x86_win_full_pgo_icon]][rel2.0_TP_x86_win_full_pgo] | N/A                                                                | [![rel2.0_TP_x86_win_min_pgo_icon]][rel2.0_TP_x86_win_min_pgo] |
 
 [//]: # (These are the x86 links)
@@ -170,10 +152,6 @@
 [rel2.1_TP_x86_win_full_nopgo_icon]:    https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_full_opt_ryujit_nopgo/lastCompletedBuild/badge/icon (Run Status)
 [rel2.1_TP_x86_win_full_pgo]:           https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_full_opt_ryujit_pgo/lastCompletedBuild/
 [rel2.1_TP_x86_win_full_pgo_icon]:      https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_full_opt_ryujit_pgo/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_TP_x86_win_min_nopgo]:          https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_min_opt_ryujit_nopgo/lastCompletedBuild/
-[rel2.1_TP_x86_win_min_nopgo_icon]:     https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_min_opt_ryujit_nopgo/lastCompletedBuild/badge/icon (Run Status)
-[rel2.1_TP_x86_win_min_pgo]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_min_opt_ryujit_pgo/lastCompletedBuild/
-[rel2.1_TP_x86_win_min_pgo_icon]:       https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.1/job/perf_throughput_perflab_Windows_NT_x86_min_opt_ryujit_pgo/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_TP_x86_win_full_pgo]:           https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_perflab_Windows_NT_x86_full_opt/lastCompletedBuild/
 [rel2.0_TP_x86_win_full_pgo_icon]:      https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_perflab_Windows_NT_x86_full_opt/lastCompletedBuild/badge/icon (Run Status)
 [rel2.0_TP_x86_win_min_pgo]:            https://ci2.dot.net/job/dotnet_coreclr/job/perf/job/release_2.0.0/job/perf_throughput_perflab_Windows_NT_x86_min_opt/lastCompletedBuild/
@@ -194,7 +172,7 @@
 
 ### Size on disk / Windows
 
-| Branch      | arch=[x64]<br>                                   | arch=[x86]                                       |
+| Branch      | arch=[x64]                                       | arch=[x86]                                       |
 | :---------- | :----------------------------------------------: | :----------------------------------------------: |
 | master      | [![master_sod_x64_win_icon]][master_sod_x64_win] | [![master_sod_x86_win_icon]][master_sod_x86_win] |
 | release/2.1 | [![rel2.1_sod_x64_win_icon]][rel2.1_sod_x64_win] | [![rel2.1_sod_x86_win_icon]][rel2.1_sod_x86_win] |


### PR DESCRIPTION
- We stopped tracking min_opt/tiered permutations on CoreClr/release/2.1