### PR TITLE
add CoreFX category to serializer benchmarks to REPLACE CoreFX json benchmarks

### DIFF
--- a/src/benchmarks/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/Serializers/Json_FromStream.cs
@@ -72,7 +72,7 @@ namespace Benchmarks.Serializers
                 return Jil.JSON.Deserialize<T>(reader);
         }
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "JSON.NET")]
         public T JsonNet_()
         {
@@ -89,7 +89,7 @@ namespace Benchmarks.Serializers
             return Utf8Json.JsonSerializer.Deserialize<T>(memoryStream);
         }
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "DataContractJsonSerializer")]
         public T DataContractJsonSerializer_()
         {

--- a/src/benchmarks/Serializers/Json_FromString.cs
+++ b/src/benchmarks/Serializers/Json_FromString.cs
@@ -21,7 +21,7 @@ namespace Benchmarks.Serializers
         [Benchmark(Description = "Jil")]
         public T Jil_() => Jil.JSON.Deserialize<T>(serialized);
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "JSON.NET")]
         public T JsonNet_() => Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serialized);
 

--- a/src/benchmarks/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/Serializers/Json_ToStream.cs
@@ -34,7 +34,7 @@ namespace Benchmarks.Serializers
             Jil.JSON.Serialize<T>(value, streamWriter);
         }
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "JSON.NET")]
         public void JsonNet_()
         {
@@ -49,7 +49,7 @@ namespace Benchmarks.Serializers
             Utf8Json.JsonSerializer.Serialize(memoryStream, value);
         }
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "DataContractJsonSerializer")]
         public void DataContractJsonSerializer_()
         {

--- a/src/benchmarks/Serializers/Json_ToString.cs
+++ b/src/benchmarks/Serializers/Json_ToString.cs
@@ -11,7 +11,7 @@ namespace Benchmarks.Serializers
         [Benchmark(Description = "Jil")]
         public string Jil_() => Jil.JSON.Serialize<T>(value);
 
-        [BenchmarkCategory(Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
         [Benchmark(Description = "JSON.NET")]
         public string JsonNet_() => Newtonsoft.Json.JsonConvert.SerializeObject(value);
 


### PR DESCRIPTION
This PR fixes #66

As part of my previous task I have designed a set of benchmarks for JSON serializers.

I believe that these benchmarks are better than what we have in CoreFX, so instead of porting the CoreFX benchmarks I just added `CoreFX` category to the new serializer benchmarks.

So now whenever we run `--categories CoreFX` these benchmarks are going to be executed

@jorive 