### PR TITLE
Port Console benchmarks

### DIFF
--- a/src/benchmarks/corefx/System.Console/Perf.Console.cs
+++ b/src/benchmarks/corefx/System.Console/Perf.Console.cs
@@ -13,6 +13,7 @@ namespace System.ConsoleTests
     /// - OpenStandardInput, OpenStandardOutput, OpenStandardError
     /// - ForegroundColor, BackgroundColor, ResetColor
     /// </summary>
+    [GcForce(true)] // forces full GC cleanup after every iteration, so streams allocated in OpenStandard* benchmarks are going to be finalized
     public class Perf_Console
     {
         const int StreamInnerIterations = 50;


### PR DESCRIPTION
Fixes #49

xunit

 System.Console.Performance.Tests.dll                | Metric   | Unit | Iterations | Average | STDEV.S |     Min |     Max
:--------------------------------------------------- |:-------- |:----:|:----------:| -------:| -------:| -------:| -------:
 System.ConsoleTests.Perf_Console.BackgroundColor    | Duration | msec |     26     | 387.373 |  10.858 | 379.085 | 434.927
 System.ConsoleTests.Perf_Console.ForegroundColor    | Duration | msec |     26     | 386.615 |   4.475 | 380.510 | 394.920
 System.ConsoleTests.Perf_Console.OpenStandardError  | Duration | msec |    1000    |   4.305 |   0.365 |   4.145 |  12.383
 System.ConsoleTests.Perf_Console.OpenStandardInput  | Duration | msec |    1000    |   0.143 |   0.411 |   0.106 |  13.012
 System.ConsoleTests.Perf_Console.OpenStandardOutput | Duration | msec |    1000    |   4.315 |   0.411 |   4.147 |  12.085
 System.ConsoleTests.Perf_Console.ResetColor         | Duration | msec |     21     | 477.709 |   7.391 | 470.593 | 498.833

BDN

|             Method |        Mean |        Error |       StdDev |      Median |         Min |         Max |  Gen 0 | Allocated |
|------------------- |------------:|-------------:|-------------:|------------:|------------:|------------:|-------:|----------:|
|  OpenStandardInput |    111.3 us |     5.773 us |     6.649 us |    108.1 us |    105.9 us |    127.2 us | 1.3112 |   11200 B |
| OpenStandardOutput |    252.7 us |     6.319 us |     7.024 us |    249.4 us |    245.7 us |    269.2 us | 0.9766 |   11200 B |
|  OpenStandardError |    249.8 us |     3.327 us |     2.778 us |    250.3 us |    246.3 us |    255.1 us | 0.9921 |   11200 B |
|    ForegroundColor | 38,930.5 us |   580.406 us |   453.143 us | 39,019.6 us | 37,984.6 us | 39,528.8 us |      - |       0 B |
|    BackgroundColor | 39,763.2 us | 1,244.018 us | 1,382.723 us | 38,979.3 us | 38,383.5 us | 43,101.5 us |      - |       0 B |
|         ResetColor | 58,425.0 us | 1,145.076 us | 1,124.618 us | 58,267.7 us | 56,817.4 us | 61,648.6 us |      - |       0 B |

Comment: BDN produced more stable results, mostly because it runs the benchmarks multiple times per operation. The fact that BDN is using System.Console was not an issue.