### PR TITLE
Port Port System.Xml.XmlDocument.Performance.Tests 

### DIFF
--- a/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlDocument.cs
+++ b/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlDocument.cs
@@ -4,9 +4,11 @@
 
 using System.Xml;
 using BenchmarkDotNet.Attributes;
+using Benchmarks;
 
 namespace XmlDocumentTests.XmlDocumentTests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_XmlDocument
     {
         private const int innerIterations = 10000;

--- a/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlNode.cs
+++ b/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlNode.cs
@@ -4,9 +4,11 @@
 
 using System.Xml;
 using BenchmarkDotNet.Attributes;
+using Benchmarks;
 
 namespace XmlDocumentTests.XmlNodeTests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_XmlNode
     {
         private const int innerIterations = 10000;

--- a/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlNodeList.cs
+++ b/src/benchmarks/corefx/System.Xml.XmlDocument/Perf.XmlNodeList.cs
@@ -4,9 +4,11 @@
 
 using System.Xml;
 using BenchmarkDotNet.Attributes;
+using Benchmarks;
 
 namespace XmlDocumentTests.XmlNodeListTests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_XmlNodeList
     {
         private const int innerIterations = 10000;


### PR DESCRIPTION
Fixes #63

 System.Xml.XmlDocument.Performance.Tests.dll                          | Metric   | Unit | Iterations | Average | STDEV.S |    Min |     Max
:--------------------------------------------------------------------- |:-------- |:----:|:----------:| -------:| -------:| ------:| -------:
 XmlDocumentTests.XmlDocumentTests.Perf_XmlDocument.Create             | Duration | msec |    120     |  83.747 |   5.654 | 79.314 | 113.515
 XmlDocumentTests.XmlDocumentTests.Perf_XmlDocument.GetDocumentElement | Duration | msec |    1000    |   0.749 |   0.157 |  0.714 |   5.605
 XmlDocumentTests.XmlDocumentTests.Perf_XmlDocument.LoadXml            | Duration | msec |    273     |  36.651 |   2.421 | 35.055 |  60.686
 XmlDocumentTests.XmlNodeListTests.Perf_XmlNodeList.Enumerator         | Duration | msec |    1000    |   1.978 |   0.377 |  1.849 |   6.334
 XmlDocumentTests.XmlNodeListTests.Perf_XmlNodeList.GetCount           | Duration | msec |    1000    |   1.400 |   0.126 |  1.349 |   3.216
 XmlDocumentTests.XmlNodeTests.Perf_XmlNode.GetAttributes              | Duration | msec |    1000    |   0.221 |   0.293 |  0.157 |   2.035
 XmlDocumentTests.XmlNodeTests.Perf_XmlNode.GetValue                   | Duration | msec |    1000    |   0.120 |   0.026 |  0.115 |   0.438

|                         Namespace |             Type |             Method |        Mean |         Error |        StdDev |      Median |         Min |         Max |      Gen 0 |    Gen 1 |   Allocated |
|---------------------------------- |----------------- |------------------- |------------:|--------------:|--------------:|------------:|------------:|------------:|-----------:|---------:|------------:|
| XmlDocumentTests.XmlDocumentTests | Perf_XmlDocument |             Create | 79,874.6 us | 1,953.0212 us | 1,630.8610 us | 79,365.4 us | 78,774.2 us | 84,755.9 us | 26250.0000 |        - | 166320000 B |
|     XmlDocumentTests.XmlNodeTests |     Perf_XmlNode |      GetAttributes |    164.1 us |     5.7572 us |     6.3991 us |    161.0 us |    158.9 us |    180.3 us |          - |        - |         0 B |
| XmlDocumentTests.XmlNodeListTests | Perf_XmlNodeList |         Enumerator |  1,960.8 us |    74.9655 us |    76.9840 us |  1,945.9 us |  1,893.7 us |  2,192.7 us |    54.6875 |        - |    400000 B |
| XmlDocumentTests.XmlDocumentTests | Perf_XmlDocument |            LoadXml | 37,199.1 us | 3,172.0916 us | 3,652.9851 us | 35,153.4 us | 34,266.0 us | 45,672.0 us | 17857.1429 | 571.4286 | 113360000 B |
|     XmlDocumentTests.XmlNodeTests |     Perf_XmlNode |           GetValue |    108.9 us |     0.2136 us |     0.1668 us |    108.9 us |    108.7 us |    109.2 us |          - |        - |         0 B |
| XmlDocumentTests.XmlNodeListTests | Perf_XmlNodeList |           GetCount |  1,443.1 us |    21.3549 us |    18.9305 us |  1,435.0 us |  1,428.2 us |  1,484.4 us |          - |        - |         0 B |
| XmlDocumentTests.XmlDocumentTests | Perf_XmlDocument | GetDocumentElement |    698.0 us |     1.9204 us |     1.4993 us |    697.9 us |    696.4 us |    701.8 us |          - |        - |         0 B |


Comment: BDN produced much better results, however it needed two times more time do that (25 vs 52 seconds)