### PR TITLE
Sockets

### DIFF
--- a/src/benchmarks/Benchmarks.csproj
+++ b/src/benchmarks/Benchmarks.csproj
@@ -48,6 +48,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2.1' ">
     <Compile Remove="corefx\System.Security.Cryptography.Primitives\**" />
+    <Compile Remove="corefx\System.Net.Http\Perf.SocketsHttpHandler.cs" />
+    <Compile Remove="corefx\System.Net.Sockets\Perf.Socket.SendReceive.cs" />
+    <Compile Remove="corefx\System.Numerics.Vectors\GenericVectorFromSpanConstructorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(NuGetPackageRoot)\system.text.regularexpressions.testdata\1.0.2\content\regexredux\*.*">

--- a/src/benchmarks/corefx/System.Net.Http/Perf.SocketsHttpHandler.cs
+++ b/src/benchmarks/corefx/System.Net.Http/Perf.SocketsHttpHandler.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP2_1 // the benchmark uses .NET Core 2.1 APIs (which consume ReadOnlySpan)
+// following benchmarks consume .NET Core 2.1 APIs and are disabled for other frameworks in .csproj file
 
 using System.IO;
 using System.Net.Security;
@@ -119,4 +119,3 @@ namespace System.Net.Http.Tests
         }
     }
 }
-#endif

--- a/src/benchmarks/corefx/System.Net.Sockets/Perf.Socket.SendReceive.cs
+++ b/src/benchmarks/corefx/System.Net.Sockets/Perf.Socket.SendReceive.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP2_1
+// following benchmarks consume .NET Core 2.1 APIs and are disabled for other frameworks in .csproj file
 
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -175,5 +175,3 @@ namespace System.Net.Sockets.Tests
         }
     }
 }
-
-#endif

--- a/src/benchmarks/corefx/System.Numerics.Vectors/GenericVectorConstructorTests.cs
+++ b/src/benchmarks/corefx/System.Numerics.Vectors/GenericVectorConstructorTests.cs
@@ -9,7 +9,7 @@ using Benchmarks;
 namespace System.Numerics.Tests
 {
     [BenchmarkCategory(Categories.CoreFX, Categories.SIMD)]
-    public class Constructor
+    public partial class Constructor
     {
         public const int DefaultInnerIterationsCount = 100000000;
 
@@ -23,46 +23,6 @@ namespace System.Numerics.Tests
         Int64[] _arrValues_Int64 = GenerateRandomValuesForVector<Int64>(Int32.MinValue, Int32.MaxValue);
         Single[] _arrValues_Single = GenerateRandomValuesForVector<Single>(Int32.MinValue, Int32.MaxValue);
         Double[] _arrValues_Double = GenerateRandomValuesForVector<Double>(Int32.MinValue, Int32.MaxValue);
-
-#if NETCOREAPP2_1 // Vector(Span) available in .NET Core 2.1+
-        [Benchmark]
-        public void ConstructorBenchmark_Byte() => Construct(new Span<Byte>(_arrValues_Byte));
-
-        [Benchmark]
-        public void ConstructorBenchmark_SByte() => Construct(new Span<SByte>(_arrValues_SByte));
-
-        [Benchmark]
-        public void ConstructorBenchmark_UInt16() => Construct(new Span<UInt16>(_arrValues_UInt16));
-
-        [Benchmark]
-        public void ConstructorBenchmark_Int16() => Construct(new Span<Int16>(_arrValues_Int16));
-
-        [Benchmark]
-        public void ConstructorBenchmark_UInt32() => Construct(new Span<UInt32>(_arrValues_UInt32));
-
-        [Benchmark]
-        public void ConstructorBenchmark_Int32() => Construct(new Span<Int32>(_arrValues_Int32));
-
-        [Benchmark]
-        public void ConstructorBenchmark_UInt64() => Construct(new Span<UInt64>(_arrValues_UInt64));
-
-        [Benchmark]
-        public void ConstructorBenchmark_Int64() => Construct(new Span<Int64>(_arrValues_Int64));
-
-        [Benchmark]
-        public void ConstructorBenchmark_Single() => Construct(new Span<Single>(_arrValues_Single));
-
-        [Benchmark]
-        public void ConstructorBenchmark_Double() => Construct(new Span<Double>(_arrValues_Double));
-
-        public static void Construct<T>(Span<T> values) where T : struct
-        {
-            for (var iteration = 0; iteration < DefaultInnerIterationsCount; iteration++)
-            {
-                Vector<T> vect = new Vector<T>(values);
-            }
-        }
-#endif // NETCOREAPP2_1
 
         [Benchmark]
         public void SpanCastBenchmark_Byte() => SpanCast(new ReadOnlySpan<Byte>(_arrValues_Byte));

--- a/src/benchmarks/corefx/System.Numerics.Vectors/GenericVectorFromSpanConstructorTests.cs
+++ b/src/benchmarks/corefx/System.Numerics.Vectors/GenericVectorFromSpanConstructorTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// following benchmarks consume .NET Core 2.1 APIs and are disabled for other frameworks in .csproj file
+
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Benchmarks;
+
+namespace System.Numerics.Tests
+{
+    public partial class Constructor
+    {
+        [Benchmark]
+        public void ConstructorBenchmark_Byte() => Construct(new Span<Byte>(_arrValues_Byte));
+
+        [Benchmark]
+        public void ConstructorBenchmark_SByte() => Construct(new Span<SByte>(_arrValues_SByte));
+
+        [Benchmark]
+        public void ConstructorBenchmark_UInt16() => Construct(new Span<UInt16>(_arrValues_UInt16));
+
+        [Benchmark]
+        public void ConstructorBenchmark_Int16() => Construct(new Span<Int16>(_arrValues_Int16));
+
+        [Benchmark]
+        public void ConstructorBenchmark_UInt32() => Construct(new Span<UInt32>(_arrValues_UInt32));
+
+        [Benchmark]
+        public void ConstructorBenchmark_Int32() => Construct(new Span<Int32>(_arrValues_Int32));
+
+        [Benchmark]
+        public void ConstructorBenchmark_UInt64() => Construct(new Span<UInt64>(_arrValues_UInt64));
+
+        [Benchmark]
+        public void ConstructorBenchmark_Int64() => Construct(new Span<Int64>(_arrValues_Int64));
+
+        [Benchmark]
+        public void ConstructorBenchmark_Single() => Construct(new Span<Single>(_arrValues_Single));
+
+        [Benchmark]
+        public void ConstructorBenchmark_Double() => Construct(new Span<Double>(_arrValues_Double));
+
+        public static void Construct<T>(Span<T> values) where T : struct
+        {
+            for (var iteration = 0; iteration < DefaultInnerIterationsCount; iteration++)
+            {
+                Vector<T> vect = new Vector<T>(values);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #61

Again, I was unable to run this benchmark with xunit-performance so only BDN results below.

|                                         Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Allocated |
|----------------------------------------------- |----------:|----------:|----------:|----------:|----------:|----------:|----------:|
|                 SendAsyncThenReceiveAsync_Task |  73.15 ms |  4.205 ms |  4.843 ms |  72.50 ms |  68.03 ms |  85.27 ms |      64 B |
|                 ReceiveAsyncThenSendAsync_Task | 340.26 ms | 32.494 ms | 37.421 ms | 332.94 ms | 281.82 ms | 397.22 ms |     320 B |
| SendAsyncThenReceiveAsync_SocketAsyncEventArgs |  70.44 ms |  3.795 ms |  4.371 ms |  68.23 ms |  66.51 ms |  80.41 ms |    1136 B |
| ReceiveAsyncThenSendAsync_SocketAsyncEventArgs | 234.60 ms |  3.754 ms |  3.511 ms | 235.09 ms | 227.51 ms | 238.87 ms |    1424 B |