### PR TITLE
System.Diagnostics.Process

### DIFF
--- a/src/benchmarks/corefx/System.Diagnostics/Perf_Process.cs
+++ b/src/benchmarks/corefx/System.Diagnostics/Perf_Process.cs
@@ -42,20 +42,33 @@ namespace System.Diagnostics
         }
         
         [Benchmark]
-        public void StartAndKillDotnetInfo()
+        public void StartAndWaitForExitDotNetVersion()
         {
-            using (var dotnetInfo = Process.Start(CreateStartInfo()))
+            using (var dotnet = Process.Start(CreateStartInfo()))
             {
-                dotnetInfo.Kill();
+                dotnet.WaitForExit();
+            }
+        }
+        
+        [Benchmark]
+        public void StartAndKillDotNetVersion()
+        {
+            using (var dotnet = Process.Start(CreateStartInfo()))
+            {
+                dotnet.Kill();
             }
         }
 
-        private ProcessStartInfo CreateStartInfo()
+        private static ProcessStartInfo CreateStartInfo()
         {
-            var processStartInfo = new ProcessStartInfo()
+            var processStartInfo = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = "--info"
+                Arguments = "--version",
+                RedirectStandardOutput = false,
+                RedirectStandardError = false,
+                RedirectStandardInput = false,
+                CreateNoWindow = true
             };
 
             // this benchmark will run on CI machines where there is no dotnet in PATH


### PR DESCRIPTION
The original benchmarks of Process class can be found [here ](https://github.com/dotnet/corefx/blob/e98c186f4f06856bdbfec317e0105158b805192a/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs)

These benchmarks were disabled by @DrewScoggins more than a [year ago ](https://github.com/dotnet/corefx/commit/4316a949967a4051108b94109e87eda60b7d598e#diff-03efa473c3c975eb6f8428726bcdd531)

I took a short look at those benchmarks and decided to rewrite them (some of these benchmarks were creating few hundreds of processes, I don't think it's a good idea).

CoreFX was using some simple executable for the tests, a program that was just sleeping. I could not find it and I decided to use "dotnet --version" as our test case. It's the simplest thing (it prints one number and exits) that we  will always have available on any box that we run the benchmarks (we need dotnet to build the benchmarks project).

Possible issues: `GetProcesses` might take more time there are more processes running on given box in given moment of time.

I run it on Windows and MacOS, no crashes ;)

These benchmarks are not perfect, but this was the best thing I could come up with. At least for now ;)

I am very open to any ideas or suggestions.