### PR TITLE
Marvin 

### DIFF
--- a/src/benchmarks/corefx/System/Hashing.cs
+++ b/src/benchmarks/corefx/System/Hashing.cs
@@ -18,6 +18,6 @@ namespace System
         public void Setup() => _string = new string(Enumerable.Repeat('a', BytesCount / (sizeof(char)/ sizeof(byte))).ToArray());
 
         [Benchmark]
-        public int ComputeHash() => _string.GetHashCode();
+        public int GetStringHashCode() => _string.GetHashCode();
     }
 }


### PR DESCRIPTION
Fixes #44

The original CoreFX benchmarks have it's own [copy](https://github.com/dotnet/performance/blob/master/src/CoreFx/Common/Marvin.cs) of Marvin and benchmark the copy. Which needs to be kept in sync manually. I think that we should avoid that.

As @ViktorHofer explained this was because the Marvin class is internal and to make it public we would need to go through API review.

IMHO the best we can do right now is to benchmark `string.GetHashCode` which is just a [call](https://github.com/dotnet/corefx/blob/8252ecc2eb0da08cd474a303b646e111d74d2a71/src/Common/src/CoreLib/System/String.Comparison.cs#L749) to `Marvin.ComputeHash`.

It also allows us to compare `string.GetHashCode` for .NET and .NET Core, where due to security reasons we have regressed the performance https://github.com/dotnet/corefx/issues/30994

@jorive @ViktorHofer what do you think?

`dotnet run -c Release -f netcoreapp2.1 -- -f *Hashing* --clr --core21 --join`

|      Method | Runtime | BytesCount |         Mean |
|------------ |-------- |----------- |-------------:|
| ComputeHash |     Clr |         10 |     5.785 ns |
| ComputeHash |    Core |         10 |     5.541 ns |
| ComputeHash |     Clr |        100 |    28.601 ns |
| ComputeHash |    Core |        100 |    39.793 ns |
| ComputeHash |     Clr |       1000 |   273.594 ns |
| ComputeHash |    Core |       1000 |   381.198 ns |
| ComputeHash |     Clr |      10000 | 2,713.600 ns |
| ComputeHash |    Core |      10000 | 3,804.547 ns |

