### PR TITLE
Net.Primitives

### DIFF
--- a/src/benchmarks/corefx/System.Net.Primitives/CredentialCacheTests.cs
+++ b/src/benchmarks/corefx/System.Net.Primitives/CredentialCacheTests.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Xunit.Performance;
-using Xunit;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 
 namespace System.Net.Primitives.Tests
 {
-    public static class CredentialCacheTests
+    public class CredentialCacheTests
     {
         private const string UriPrefix = "http://name";
         private const string HostPrefix = "name";
@@ -15,63 +16,52 @@ namespace System.Net.Primitives.Tests
         private const string AuthenticationType = "authType";
 
         private static readonly NetworkCredential s_credential = new NetworkCredential();
+        private Consumer _consumer = new Consumer();
+
+        private readonly Dictionary<(int uriCount, int hostPortCount), CredentialCache> _caches =
+            new Dictionary<(int uriCount, int hostPortCount), CredentialCache>
+            {
+                { (0, 0), CreateCredentialCache(0, 0) },
+                { (0, 10), CreateCredentialCache(0, 10) },
+                { (10, 0), CreateCredentialCache(10, 0) },
+                { (10, 10), CreateCredentialCache(10, 10) }
+        };
 
         [Benchmark]
-        [MeasureGCCounts]
-        [InlineData("http://notfound", 0)]
-        [InlineData("http://notfound", 10)]
-        [InlineData("http://name5", 10)]
-        public static void GetCredential_Uri(string uriString, int uriCount)
+        [Arguments("http://notfound", 0)]
+        [Arguments("http://notfound", 10)]
+        [Arguments("http://name5", 10)]
+        public NetworkCredential GetCredential_Uri(string uriString, int uriCount)
         {
-            var uri = new Uri(uriString);
-            CredentialCache cc = CreateCredentialCache(uriCount, hostPortCount: 0);
+            CredentialCache cc = _caches[(uriCount: uriCount, hostPortCount: 0)];
 
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    cc.GetCredential(uri, AuthenticationType);
-                }
-            }
+            return cc.GetCredential(new Uri(uriString), AuthenticationType);
         }
 
         [Benchmark]
-        [MeasureGCCounts]
-        [InlineData("notfound", 0)]
-        [InlineData("notfound", 10)]
-        [InlineData("name5", 10)]
-        public static void GetCredential_HostPort(string host, int hostPortCount)
+        [Arguments("notfound", 0)]
+        [Arguments("notfound", 10)]
+        [Arguments("name5", 10)]
+        public NetworkCredential GetCredential_HostPort(string host, int hostPortCount)
         {
-            CredentialCache cc = CreateCredentialCache(uriCount: 0, hostPortCount: 0);
+            CredentialCache cc = _caches[(uriCount: 0, hostPortCount: hostPortCount)];
 
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    cc.GetCredential(host, Port, AuthenticationType);
-                }
-            }
+            return cc.GetCredential(host, Port, AuthenticationType);
         }
 
         [Benchmark]
-        [MeasureGCCounts]
-        [InlineData(0, 0)]
-        [InlineData(10, 0)]
-        [InlineData(0, 10)]
-        [InlineData(10, 10)]
-        public static void ForEach(int uriCount, int hostPortCount)
+        [Arguments(0, 0)]
+        [Arguments(10, 0)]
+        [Arguments(0, 10)]
+        [Arguments(10, 10)]
+        public void ForEach(int uriCount, int hostPortCount)
         {
-            CredentialCache cc = CreateCredentialCache(uriCount, hostPortCount);
-
-            foreach (var iteration in Benchmark.Iterations)
+            CredentialCache cc = _caches[(uriCount: uriCount, hostPortCount: hostPortCount)];
+            Consumer consumer = _consumer;
+            
+            foreach (var c in cc)
             {
-                using (iteration.StartMeasurement())
-                {
-                    foreach (var c in cc)
-                    {
-                        // just iterate
-                    }
-                }
+                consumer.Consume(c);
             }
         }
 

--- a/src/benchmarks/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
+++ b/src/benchmarks/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
@@ -2,155 +2,57 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Xunit.Performance;
-using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
 
 namespace System.Net.Primitives.Tests
 {
-    public static class IPAddressPerformanceTests
+    public class IPAddressPerformanceTests
     {
-        public static readonly object[][] TestAddresses =
+        public static IEnumerable<object> ByteAddresses()
         {
-            new object[] { new byte[] { 0x8f, 0x18, 0x14, 0x24 } },
-            new object[] { new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 } },
-        };
+            yield return new byte[] { 0x8f, 0x18, 0x14, 0x24 };
+            yield return new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16 };
+        }
+        
+        public IEnumerable<object> Addresses() 
+            => ByteAddresses().OfType<byte[]>().Select(bytes => new IPAddress(bytes));
+
+        private byte[] _destination = new byte[ByteAddresses().OfType<byte[]>().Max(bytes => bytes.Length)];
+        private const int INET6_ADDRSTRLEN = 65;
+        private char[] _charBuffer = new char[INET6_ADDRSTRLEN];
 
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void TryWriteBytes(byte[] address)
-        {
-            var ip = new IPAddress(address);
-            var bytes = new byte[address.Length];
-            var bytesSpan = new Span<byte>(bytes);
-            int bytesWritten = 0;
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        ip.TryWriteBytes(bytesSpan, out bytesWritten); ip.TryWriteBytes(bytesSpan, out bytesWritten);
-                        ip.TryWriteBytes(bytesSpan, out bytesWritten); ip.TryWriteBytes(bytesSpan, out bytesWritten);
-                        ip.TryWriteBytes(bytesSpan, out bytesWritten); ip.TryWriteBytes(bytesSpan, out bytesWritten);
-                        ip.TryWriteBytes(bytesSpan, out bytesWritten); ip.TryWriteBytes(bytesSpan, out bytesWritten);
-                    }
-                }
-            }
-        }
+        [ArgumentsSource(nameof(Addresses))]
+        public byte[] GetAddressBytes(IPAddress address)
+            => address.GetAddressBytes();
 
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void GetAddressBytes(byte[] address)
-        {
-            var ip = new IPAddress(address);
-            byte[] bytes;
-
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        bytes = ip.GetAddressBytes(); bytes = ip.GetAddressBytes();
-                        bytes = ip.GetAddressBytes(); bytes = ip.GetAddressBytes();
-                        bytes = ip.GetAddressBytes(); bytes = ip.GetAddressBytes();
-                    }
-                }
-            }
-        }
+        [ArgumentsSource(nameof(ByteAddresses))]
+        public IPAddress Ctor_Bytes(byte[] address)
+            => new IPAddress(address);
 
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void Ctor_Bytes(byte[] address)
-        {
-            IPAddress ip;
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        ip = new IPAddress(address); ip = new IPAddress(address);
-                        ip = new IPAddress(address); ip = new IPAddress(address);
-                        ip = new IPAddress(address); ip = new IPAddress(address);
-                        ip = new IPAddress(address); ip = new IPAddress(address);
-                    }
-                }
-            }
-        }
- 
+        [ArgumentsSource(nameof(Addresses))]
+        public string ToString(IPAddress address)
+            => address.ToString();
+        
+#if NETCOREAPP2_1
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void Ctor_Span(byte[] address)
-        {
-            var span = new ReadOnlySpan<byte>(address);
-            IPAddress ip;
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        ip = new IPAddress(span); ip = new IPAddress(span);
-                        ip = new IPAddress(span); ip = new IPAddress(span);
-                        ip = new IPAddress(span); ip = new IPAddress(span);
-                        ip = new IPAddress(span); ip = new IPAddress(span);
-                    }
-                }
-            }
-        }
+        [ArgumentsSource(nameof(ByteAddresses))]
+        public IPAddress Ctor_Span(byte[] address)
+            => new IPAddress(new ReadOnlySpan<byte>(address));
 
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void TryFormat(byte[] address)
-        {
-            const int INET6_ADDRSTRLEN = 65;
-            var buffer = new char[INET6_ADDRSTRLEN];
-            var result = new Span<char>(buffer);
-            int charsWritten;
-
-            var ip = new IPAddress(address);
-
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        ip.TryFormat(result, out charsWritten);
-                    }
-                }
-            }
-        }
- 
+        [ArgumentsSource(nameof(Addresses))]
+        public bool TryFormat(IPAddress address)
+            => address.TryFormat(new Span<char>(_charBuffer), out _);
+        
         [Benchmark]
-        [MeasureGCCounts]
-        [MemberData(nameof(TestAddresses))]
-        public static void ToString(byte[] address)
-        {
-            var ip = new IPAddress(address);
-
-            string result;
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < 10000; ++i)
-                    {
-                        result = ip.ToString(); result = ip.ToString();
-                        result = ip.ToString(); result = ip.ToString();
-                        result = ip.ToString(); result = ip.ToString();
-                        result = ip.ToString(); result = ip.ToString();
-                        result = ip.ToString(); result = ip.ToString();
-                        result = ip.ToString(); result = ip.ToString();
-                    }
-                }
-            }
-        }
+        [ArgumentsSource(nameof(Addresses))]
+        public bool TryWriteBytes(IPAddress address)
+            => address.TryWriteBytes(new Span<byte>(_destination), out _);
+#endif
     }
 }


### PR DESCRIPTION
Fixes #60 

Bonus `GetCredential_HostPort` was not using the value of `hostPortCount` and was hardcoding it to  zero. I have fixed that.

```cs
public static void GetCredential_HostPort(string host, int hostPortCount)
{
      CredentialCache cc = CreateCredentialCache(uriCount: 0, hostPortCount: 0);
```