### PR TITLE
Uploaded build commit data was set as this repo HEAD

### DIFF
--- a/scripts/coreclr_perf_ci.py
+++ b/scripts/coreclr_perf_ci.py
@@ -235,8 +235,9 @@ def main(args):
         runArgs = [
             python,
             os.path.join(benchviewPath, runScript), 'none',
-            '--number', dotnetVersion,
+            '--repository', 'https://github.com/dotnet/core-setup/',
             '--branch', args.branch,
+            '--number', dotnetVersion,
             '--source-timestamp', buildTimestamp,
             '--type', 'rolling'
         ]


### PR DESCRIPTION
With this change, I set the build type to none, so user must specify all repository data. Previously, it was pulling the commit sha for this repo.
