### PR TITLE
Generated string should contain only 0-9, a-Z characters

### DIFF
--- a/src/benchmarks/Tests/UniqueValuesGeneratorTests.cs
+++ b/src/benchmarks/Tests/UniqueValuesGeneratorTests.cs
@@ -45,5 +45,20 @@ namespace Tests
                 Assert.Equal(generatedArray, anotherGeneratedArray);
             }
         }
+
+        [Fact]
+        public void GeneratedStringsContainOnlySimpleLettersAndDigits()
+        {
+            var strings = ValuesGenerator.ArrayOfUniqueValues<string>(1024);
+
+            foreach (var text in strings)
+            {
+                Assert.All(text, character => 
+                    Assert.True(
+                        char.IsDigit(character) 
+                        || (character >= 'a' && character <= 'z') 
+                        || (character >= 'A' && character <= 'Z')));
+            }
+        }
     }
 }

--- a/src/benchmarks/ValuesGenerator.cs
+++ b/src/benchmarks/ValuesGenerator.cs
@@ -86,7 +86,16 @@ namespace Benchmarks
 
             var builder = new StringBuilder(length);
             for (int i = 0; i < length; i++)
-                builder.Append((char) random.Next(char.MinValue, char.MaxValue));
+            {
+                var rangeSelector = random.Next(0, 3);
+
+                if (rangeSelector == 0)
+                    builder.Append((char) random.Next('a', 'z'));
+                else if (rangeSelector == 1)
+                    builder.Append((char) random.Next('A', 'Z'));
+                else
+                    builder.Append((char) random.Next('0', '9'));
+            }
 
             return builder.ToString();
         }


### PR DESCRIPTION
Today I was running all of the benchmarks after the merge of #94 to make sure that they work and 3 benchmarks have failed due to the content of random-generated strings.

using char.min - char.max was bad idea because most of the strings were containing some weird chars, now I have changed it to contain only 0-9, a-Z characters