### PR TITLE
update BDN for EtwProfiler improvements

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -22,8 +22,8 @@
     <None Remove="Tests\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.1.808" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.1.808" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1.812" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.1.812" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.26" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />


### PR DESCRIPTION
update BDN to version which does wait for delayed events and does not parse the trace file if no counters were defined

I was getting some errors that one event for iteration stop was missing, it turned out that the events are delayed and I added simple `Sleep(500ms)` to solve the problem (the same thing is done in PerfView)

the other improvement was: if user did not specify any hardware counters, don't parse the trace file. Sample improvement: from 20 to 12 seconds

related BDN changes https://github.com/dotnet/BenchmarkDotNet/commit/d917e63b23408a3d56842488f51a47d288573f50

@jorive  I need it for a demo in 2 hours so I am going to ask some folks from my time zone for the approval
