### PR TITLE
Make sure the benchmarks run on all OSes

### DIFF
--- a/src/benchmarks/micro/corefx/System.Console/Perf.Console.cs
+++ b/src/benchmarks/micro/corefx/System.Console/Perf.Console.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 
 namespace System.ConsoleTests
 {
@@ -13,17 +14,36 @@ namespace System.ConsoleTests
     /// - OpenStandardInput, OpenStandardOutput, OpenStandardError
     /// - ForegroundColor, BackgroundColor, ResetColor
     /// </summary>
-    [GcForce(true)] // forces full GC cleanup after every iteration, so streams allocated in OpenStandard* benchmarks are going to be finalized
     public class Perf_Console
     {
-        [Benchmark]
-        public Stream OpenStandardInput() => Console.OpenStandardInput();
+        private readonly Consumer consumer = new Consumer();
 
         [Benchmark]
-        public Stream OpenStandardOutput() => Console.OpenStandardOutput();
+        public void OpenStandardInput()
+        {
+            using (var input = Console.OpenStandardInput())
+            {
+                consumer.Consume(input);
+            };
+        }
 
         [Benchmark]
-        public Stream OpenStandardError() => Console.OpenStandardError();
+        public void OpenStandardOutput()
+        {
+            using (var output = Console.OpenStandardOutput())
+            {
+                consumer.Consume(output);
+            };
+        }
+
+        [Benchmark]
+        public void OpenStandardError()
+        {
+            using (var error = Console.OpenStandardError())
+            {
+                consumer.Consume(error);
+            };
+        }
 
         [Benchmark(OperationsPerInvoke = 8)]
         public void ForegroundColor()

--- a/src/benchmarks/micro/corefx/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/corefx/System.Net.Http/Configuration.Certificates.cs
@@ -4,7 +4,6 @@
 
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading;
 
 namespace System.Net.Test.Common
 {
@@ -13,7 +12,6 @@ namespace System.Net.Test.Common
         public static class Certificates
         {
             private const string CertificatePassword = "testcertificate";
-            private const string TestDataFolder = @"corefx\System.Net.Http";
 
             public static X509Certificate2 GetServerCertificate() => GetCertificate("testservereku.contoso.com.pfx");
 
@@ -21,7 +19,7 @@ namespace System.Net.Test.Common
 
             private static X509Certificate2 GetCertificate(string certificateFileName) 
                 => new X509Certificate2(
-                    File.ReadAllBytes(Path.Combine(TestDataFolder, certificateFileName)),
+                    File.ReadAllBytes(Path.Combine("corefx", "System.Net.Http", certificateFileName)),
                     CertificatePassword,
                     X509KeyStorageFlags.DefaultKeySet);
         }


### PR DESCRIPTION
I tried to run all the benchmarks we have on MacOS and Ubuntu for 2.1 vs 2.2.

On Ubuntu it failed with too many files opened exception for the Console tests. This is why I have changed the benchmark to also dispose the stream. Previously I was hoping that single iteration will create not so many finalizable streams  and GC.Collect x2 with WaitForPendingFinalizers that we do in BDN after every iteration will clean them up. I was wrong ;)

The other fix is trivial: don't hardcode Windows path separator in the code. use `Path.Combine`.

Fixes #102