### PR TITLE
Using Mann–Whitney U Test to detect regressions

### DIFF
--- a/docs/benchmarking-workflow.md
+++ b/docs/benchmarking-workflow.md
@@ -268,7 +268,7 @@ Example: run Mann–Whitney U test with an absolute ratio of 3 milliseconds and 
 
 The following commands are represented in a few lines to make it easier to read on GitHub. Please remove the new lines when copy-pasting to console.
 
-```log
+```cmd
 dotnet run -c Release -f netcoreapp3.0
     --allCategories BenchmarksGame 
     --statisticalTest 3ms
@@ -279,7 +279,7 @@ dotnet run -c Release -f netcoreapp3.0
 
 Example: run all benchmarks for .NET Core 2.1 vs 2.2 and use Mann–Whitney U test with a relative ratio of 5%.
 
-```log
+```cmd
 dotnet run -c Release -f netcoreapp2.1 -- 
     --filter *
     --statisticalTest 5%

--- a/docs/benchmarking-workflow.md
+++ b/docs/benchmarking-workflow.md
@@ -258,17 +258,35 @@ dotnet run -c Release -f netcoreapp3.0 -- --filter *Span* --coreRun "C:\Projects
 8. Compare the results.
 9. Repeat steps 3-8 until you get the desired speedup.
 
-### Checking for regressions
+### Checking for regressions using Statistical Test
 
-1. Run the benchmarks with and without your changes.
-2. Compare the results.
+To perform a Mann–Whitney U Test and display the results in a dedicated column you need to provide the Threshold:
 
-Example: compare the CoreFX located in `C:\Projects\corefx_upstream\` vs `C:\Projects\corefx_fork\` for BenchmarksGame benchmarks.
+* `--statisticalTest` - Threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s
+
+Example: run Mann–Whitney U test with an absolute ratio of 3 milliseconds and compare the CoreFX located in `C:\Projects\corefx_upstream\` vs `C:\Projects\corefx_fork\` for BenchmarksGame benchmarks.
+
+The following commands are represented in a few lines to make it easier to read on GitHub. Please remove the new lines when copy-pasting to console.
 
 ```log
-dotnet run -c Release -f netcoreapp3.0 -- --allCategories BenchmarksGame --coreRun "C:\Projects\corefx_upstream\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe" --artifacts "upstream"
-dotnet run -c Release -f netcoreapp3.0 -- --allCategories BenchmarksGame --coreRun "C:\Projects\corefx_fork\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe" --artifacts "fork"
+dotnet run -c Release -f netcoreapp3.0
+    --allCategories BenchmarksGame 
+    --statisticalTest 3ms
+    --coreRun 
+        "C:\Projects\corefx_upstream\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
+        "C:\Projects\corefx_fork\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
 ```
+
+Example: run all benchmarks for .NET Core 2.1 vs 2.2 and use Mann–Whitney U test with a relative ratio of 5%.
+
+```log
+dotnet run -c Release -f netcoreapp2.1 -- 
+    --filter *
+    --statisticalTest 5%
+    --runtimes netcoreapp2.1 netcoreapp2.2
+```
+
+**Note:** some of our benchmarks are dependent on the alignment. You can use `--launchCount` option to specify how many processes BenchmarkDotNet should start to run given benchmarks. BDN does it sequentially. It's recommended to use this feature when releasing a new version of .NET Framework.
 
 **Note:** you don't need two copies of CoreCLR/FX to compare the performance. But in that case you have to run the benchmarks at least once before applying any changes.
 

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -12,7 +12,6 @@
     <UseSharedCompilation>false</UseSharedCompilation>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="img\**" />
@@ -22,9 +21,8 @@
     <None Remove="Tests\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.1.812" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.1.812" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.26" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.876" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.876" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -252,7 +252,7 @@ To perform a Mann–Whitney U Test and display the results in a dedicated column
 
 Example: run Mann–Whitney U test with relative ratio of 5% for `BinaryTrees_2` for .NET Core 2.1 (base) vs .NET Core 2.2 (diff). .NET Core 2.1 will be baseline because it was first.
 
-```log
+```cmd
 dotnet run -c Release -- --filter *BinaryTrees_2* --runtimes netcoreapp2.1 netcoreapp2.2 --statisticalTest 5%
 ```
 

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -244,6 +244,23 @@ To run benchmarks with private CoreRT build you need to provide the `IlcPath`.
 
 Sample arguments: `dotnet run -c Release -f netcoreapp2.1 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release`
 
+## Statistical Test
+
+To perform a Mann–Whitney U Test and display the results in a dedicated column you need to provide the Threshold:
+
+* `--statisticalTest` - Threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s
+
+Example: run Mann–Whitney U test with relative ratio of 5% for `BinaryTrees_2` for .NET Core 2.1 (base) vs .NET Core 2.2 (diff). .NET Core 2.1 will be baseline because it was first.
+
+```log
+dotnet run -c Release -- --filter *BinaryTrees_2* --runtimes netcoreapp2.1 netcoreapp2.2 --statisticalTest 5%
+```
+
+|        Method |     Toolchain |     Mean | MannWhitney(5%) |
+|-------------- |-------------- |---------:|---------------- |
+| BinaryTrees_2 | netcoreapp2.1 | 124.4 ms |            Base |
+| BinaryTrees_2 | netcoreapp2.2 | 153.7 ms |          Slower |
+
 ## Enabling given benchmark(s) for selected Operating System(s)
 
 This is possible with the `AllowedOperatingSystemsAttribute`. You need to provide a mandatory comment and OS(es) which benchmark(s) can run on.


### PR DESCRIPTION
Most of the Statistical Tests require normal distribution, which is rare for performance test results. [Mann–Whitney U Test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) is a Statistical Test that allows for comparing even multi-modal distributions. It's implemented in BenchmarkDotNet and we can take advantage of it by using it for detecting regressions

### Checking for regressions using Statistical Test

To perform the statistical test and display the results in a dedicated column you need to provide the Threshold:

* `--statisticalTest` - Threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s

Example: run Mann–Whitney U test with an absolute ratio of 3 milliseconds and compare the CoreFX located in `C:\Projects\corefx_upstream\` vs `C:\Projects\corefx_fork\` for BenchmarksGame benchmarks.

The following commands are represented in a few lines to make it easier to read on GitHub. Please remove the new lines when copy-pasting to console.

```log
dotnet run -c Release -f netcoreapp3.0
    --allCategories BenchmarksGame 
    --statisticalTest 3ms
    --coreRun 
        "C:\Projects\corefx_upstream\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
        "C:\Projects\corefx_fork\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
```

Example: run all benchmarks for .NET Core 2.1 vs 2.2 and use Mann–Whitney U test with a relative ratio of 5%.

```log
dotnet run -c Release -f netcoreapp2.1 -- 
    --filter *
    --statisticalTest 5%
    --runtimes netcoreapp2.1 netcoreapp2.2
```

Sample results (see the new column)

|        Method |     Toolchain |     Mean | Ratio | MannWhitney(5%) | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------- |-------------- |---------:|------:|---------------- |------------:|------------:|------------:|--------------------:|
| BinaryTrees_2 | netcoreapp2.1 | 124.4 ms |  1.00 |            Base |  37500.0000 |   1000.0000 |    500.0000 |           227.33 MB |
| BinaryTrees_2 | netcoreapp2.2 | 153.7 ms |  1.24 |          Slower |  37000.0000 |   3000.0000 |   1000.0000 |           227.33 MB |
