### PR TITLE
update to BDN with ARM support

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -21,8 +21,8 @@
     <None Remove="Tests\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.876" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.876" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.886" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.886" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />


### PR DESCRIPTION
This contains BDN fixes that were required to run on ARM 

https://github.com/dotnet/BenchmarkDotNet/pull/979

@AndyAyersMS could you please update to `0.11.3.886` and if everything works correctly merge this PR?

edit: was 0.11.3.8**7**6, should be 0.11.3.8**8**6