### PR TITLE
 Adding perf tests for the new System.Math/MathF APIs added in netcoreapp2.1/3.0

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -65,6 +65,14 @@
     <Compile Remove="corefx\System.Runtime\Perf.HashCode.cs" />
     <Compile Remove="corefx\System.Security.Cryptography.Primitives\**" />
     <Compile Remove="corefx\System.Security.Cryptography\Perf.Rfc2898DeriveBytes.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\Acosh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\Asinh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\Atanh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\Cbrt.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\Acosh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\Asinh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\Atanh.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\Cbrt.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -75,6 +75,17 @@
     <Compile Remove="coreclr\Math\Functions\Single\Cbrt.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0')">
+    <Compile Remove="coreclr\Math\Functions\Double\FusedMultiplyAdd.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\ILogB.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\Log2.cs" />
+    <Compile Remove="coreclr\Math\Functions\Double\ScaleB.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\FusedMultiplyAdd.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\ILogB.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\Log2.cs" />
+    <Compile Remove="coreclr\Math\Functions\Single\ScaleB.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <Compile Remove="corefx\System.Drawing\Perf_Graphics*.cs" />
   </ItemGroup>

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Acosh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Acosh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Acosh(double) over 5000 iterations for the domain +1, +3
+
+        private const double acoshDelta = 0.0004;
+        private const double acoshExpectedResult = 6148.648751739127;
+
+        [Benchmark]
+        public void Acosh() => AcoshTest();
+
+        public static void AcoshTest()
+        {
+            var result = 0.0; var value = 1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.Acosh(value);
+                value += acoshDelta;
+            }
+
+            var diff = Math.Abs(acoshExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {acoshExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Asinh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Asinh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Asinh(double) over 5000 iterations for the domain -1, +1
+
+        private const double asinhDelta = 0.0004;
+        private const double asinhExpectedResult = -0.88137358721605752;
+
+        [Benchmark]
+        public void Asinh() => AsinhTest();
+
+        public static void AsinhTest()
+        {
+            var result = 0.0; var value = -1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.Asinh(value);
+                value += asinhDelta;
+            }
+
+            var diff = Math.Abs(asinhExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {asinhExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atanh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atanh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Atanh(double) over 5000 iterations for the domain -1, +1
+
+        private const double atanhDelta = 0.0004;
+        private const double atanhExpectedResult = float.NegativeInfinity;
+
+        [Benchmark]
+        public void Atanh() => AtanhTest();
+
+        public static void AtanhTest()
+        {
+            var result = 0.0; var value = -1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.Atanh(value);
+                value += atanhDelta;
+            }
+
+            var diff = Math.Abs(atanhExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {atanhExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Cbrt.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Cbrt.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Cbrt(double) over 5000 iterations for the domain +0, +PI
+
+        private const double cbrtDelta = 0.0006283185307180;
+        private const double cbrtExpectedResult = 5491.4635361574383;
+
+        [Benchmark]
+        public void Cbrt() => CbrtTest();
+
+        public static void CbrtTest()
+        {
+            var result = 0.0; var value = 0.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.Cbrt(value);
+                value += cbrtDelta;
+            }
+
+            var diff = Math.Abs(cbrtExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {cbrtExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FusedMultiplyAdd.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FusedMultiplyAdd.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.FusedMultiplyAdd(double, double, double) over 5000 iterations for the domain x: +2, +1; y: -2, -1, z: +1, -1
+
+        private const double fusedMultiplyAddDeltaX = -0.0004;
+        private const double fusedMultiplyAddDeltaY = 0.0004;
+        private const double fusedMultiplyAddDeltaZ = -0.0004;
+        private const double fusedMultiplyAddExpectedResult = -6667.6668000005066;
+
+        [Benchmark]
+        public void FusedMultiplyAdd() => FusedMultiplyAddTest();
+
+        public static void FusedMultiplyAddTest()
+        {
+            var result = 0.0; var valueX = 2.0; var valueY = -2.0; var valueZ = 1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.FusedMultiplyAdd(valueX, valueY, valueZ);
+                valueX += fusedMultiplyAddDeltaX; valueY += fusedMultiplyAddDeltaY; valueZ += fusedMultiplyAddDeltaZ;
+            }
+
+            var diff = Math.Abs(fusedMultiplyAddExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {fusedMultiplyAddExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ILogB.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ILogB.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.ILogB(double) over 5000 iterations for the domain +1, +3
+
+        private const double iLogBDelta = 0.0004;
+        private const int iLogBExpectedResult = 2499;
+
+        [Benchmark]
+        public void ILogB() => ILogBTest();
+
+        public static void ILogBTest()
+        {
+            var result = 0; var value = 1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.ILogB(value);
+                value += iLogBDelta;
+            }
+
+            if (result != iLogBExpectedResult)
+            {
+                throw new Exception($"Expected Result {iLogBExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log2.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log2.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Log2(double) over 5000 iterations for the domain +1, +3
+
+        private const double log2Delta = 0.0004;
+        private const double log2ExpectedResult = 4672.9510376532398;
+
+        [Benchmark]
+        public void Log2() => Log2Test();
+
+        public static void Log2Test()
+        {
+            var result = 0.0; var value = 1.0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.Log2(value);
+                value += log2Delta;
+            }
+
+            var diff = Math.Abs(log2ExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {log2ExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ScaleB.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ScaleB.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.ScaleB(double, int) over 5000 iterations for the domain x: -1, +1; y: +0, +5000
+
+        private const double scaleBDeltaX = -0.0004;
+        private const int scaleBDeltaY = 1;
+        private const double scaleBExpectedResult = double.NegativeInfinity;
+
+        [Benchmark]
+        public void ScaleB() => ScaleBTest();
+
+        public static void ScaleBTest()
+        {
+            var result = 0.0; var valueX = -1.0; var valueY = 1;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += Math.ScaleB(valueX, valueY);
+                valueX += scaleBDeltaX; valueY += scaleBDeltaY;
+            }
+
+            var diff = Math.Abs(scaleBExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {scaleBExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Acosh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Acosh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.Acosh(float) over 5000 iterations for the domain +1, +3
+
+        private const float acoshDelta = 0.0004f;
+        private const float acoshExpectedResult = 6148.45459f;
+
+        [Benchmark]
+        public void Acosh() => AcoshTest();
+
+        public static void AcoshTest()
+        {
+            var result = 0.0f; var value = 1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.Acosh(value);
+                value += acoshDelta;
+            }
+
+            var diff = MathF.Abs(acoshExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {acoshExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Asinh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Asinh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.Asinh(float) over 5000 iterations for the domain -1, +1
+
+        private const float asinhDelta = 0.0004f;
+        private const float asinhExpectedResult = -0.814757347f;
+
+        [Benchmark]
+        public void Asinh() => AsinhTest();
+
+        public static void AsinhTest()
+        {
+            var result = 0.0f; var value = -1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.Asinh(value);
+                value += asinhDelta;
+            }
+
+            var diff = MathF.Abs(asinhExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {asinhExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atanh.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atanh.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.Atanh(float) over 5000 iterations for the domain -1, +1
+
+        private const float atanhDelta = 0.0004f;
+        private const float atanhExpectedResult = float.NegativeInfinity;
+
+        [Benchmark]
+        public void Atanh() => AtanhTest();
+
+        public static void AtanhTest()
+        {
+            var result = 0.0f; var value = -1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.Atanh(value);
+                value += atanhDelta;
+            }
+
+            var diff = MathF.Abs(atanhExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {atanhExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Cbrt.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Cbrt.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.Cbrt(float) over 5000 iterations for the domain +0, +PI
+
+        private const float cbrtDelta = 0.000628318531f;
+        private const float cbrtExpectedResult = 5491.4541f;
+
+        [Benchmark]
+        public void Cbrt() => CbrtTest();
+
+        public static void CbrtTest()
+        {
+            var result = 0.0f; var value = 0.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.Cbrt(value);
+                value += cbrtDelta;
+            }
+
+            var diff = MathF.Abs(cbrtExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {cbrtExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FusedMultiplyAdd.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FusedMultiplyAdd.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.FusedMultiplyAdd(float, float, float) over 5000 iterations for the domain x: +2, +1; y: -2, -1, z: +1, -1
+
+        private const float fusedMultiplyAddDeltaX = -0.0004f;
+        private const float fusedMultiplyAddDeltaY = 0.0004f;
+        private const float fusedMultiplyAddDeltaZ = -0.0004f;
+        private const float fusedMultiplyAddExpectedResult = -6668.49072f;
+
+        [Benchmark]
+        public void FusedMultiplyAdd() => FusedMultiplyAddTest();
+
+        public static void FusedMultiplyAddTest()
+        {
+            var result = 0.0f; var valueX = 2.0f; var valueY = -2.0f; var valueZ = 1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.FusedMultiplyAdd(valueX, valueY, valueZ);
+                valueX += fusedMultiplyAddDeltaX; valueY += fusedMultiplyAddDeltaY; valueZ += fusedMultiplyAddDeltaZ;
+            }
+
+            var diff = MathF.Abs(fusedMultiplyAddExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {fusedMultiplyAddExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ILogB.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ILogB.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.ILogB(float) over 5000 iterations for the domain +1, +3
+
+        private const float iLogBDelta = 0.0004f;
+        private const int iLogBExpectedResult = 2499;
+
+        [Benchmark]
+        public void ILogB() => ILogBTest();
+
+        public static void ILogBTest()
+        {
+            var result = 0; var value = 1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.ILogB(value);
+                value += iLogBDelta;
+            }
+
+            if (result != iLogBExpectedResult)
+            {
+                throw new Exception($"Expected Result {iLogBExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log2.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log2.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.Log2(float) over 5000 iterations for the domain +1, +3
+
+        private const float log2Delta = 0.0004f;
+        private const float log2ExpectedResult = 4672.73193f;
+
+        [Benchmark]
+        public void Log2() => Log2Test();
+
+        public static void Log2Test()
+        {
+            var result = 0.0f; var value = 1.0f;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.Log2(value);
+                value += log2Delta;
+            }
+
+            var diff = MathF.Abs(log2ExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {log2ExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ScaleB.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ScaleB.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests MathF.ScaleB(float, int) over 5000 iterations for the domain x: -1, +1; y: +0, +5000
+
+        private const float scaleBDeltaX = -0.0004f;
+        private const int scaleBDeltaY = 1;
+        private const float scaleBExpectedResult = float.NegativeInfinity;
+
+        [Benchmark]
+        public void ScaleB() => ScaleBTest();
+
+         public static void ScaleBTest()
+        {
+            var result = 0.0f; var valueX = -1.0f; var valueY = 0;
+
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathF.ScaleB(valueX, valueY);
+                valueX += scaleBDeltaX; valueY += scaleBDeltaY;
+            }
+
+            var diff = MathF.Abs(scaleBExpectedResult - result);
+
+            if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
+            {
+                throw new Exception($"Expected Result {scaleBExpectedResult,10:g9}; Actual Result {result,10:g9}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds perf tests for the `Acosh`, `Asinh`, `Atanh`, and `Cbrt` functions added to `System.Math` and `System.MathF` in netcoreapp2.1 and the `FusedMultiplyAdd`, `ILogB`, `Log2`, and `ScaleB` functions added to `System.Math` and `System.MathF` in netcoreapp3.0