### PR TITLE
Add template azure-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,30 @@
+variables:
+  Build.Repository.Clean: true
+  _HelixSource: pr/dotnet/performance/$(Build.SourceBranch)
+  _BuildConfig: Release
+  _HelixType: build/product
+  
+trigger:
+- master
+
+pr:
+- master
+
+# Full stack SDK Performance Testing
+jobs:
+- template: /eng/common/templates/jobs/jobs.yml
+  parameters:
+    enableTelemetry: true
+    enablePublishBuildArtifacts: true
+    helixRepo: dotnet/performance
+    jobs:
+    - job: sdk_performance
+      pool:
+        name: Hosted VS2017
+      steps:
+      - checkout: self
+        clean: true
+      - script: echo "Hello World"
+        name: echo
+        displayName: Echo
+        condition: succeeded()


### PR DESCRIPTION
This change adds a basic, boring, empty pipeline job, specifically to turn on pr trigger support so I can start testing my changes.