### PR TITLE
Make MicroBenchmarks.sln work for VS 2017

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.sln
+++ b/src/benchmarks/micro/MicroBenchmarks.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MicroBenchmarks", "MicroBenchmarks.csproj", "{D99F63AE-3154-4F13-9424-FA5F9D032D1D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{A40E51E2-99EB-4F64-ADCC-94FEA3FF1399}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D99F63AE-3154-4F13-9424-FA5F9D032D1D} = {D99F63AE-3154-4F13-9424-FA5F9D032D1D}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/benchmarks/micro/Tests/Tests.csproj
+++ b/src/benchmarks/micro/Tests/Tests.csproj
@@ -1,20 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="$(MSBuildThisFileDirectory)\..\common.props" />
-
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\MicroBenchmarks.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/benchmarks/micro/common.props
+++ b/src/benchmarks/micro/common.props
@@ -4,7 +4,6 @@
     <UseSharedCompilation>false</UseSharedCompilation>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
-    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.2'">2.2.0-*</RuntimeFrameworkVersion>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Today I was preparing for my tomorrow's demo and when I opened MicroBenchmarks.sln with most recent VS 2017 I run into following problems:

* VS offered me to update Unit Test project to "newer project system". It kept doing that... Adding `<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">` instead of `<Project Sdk="Microsoft.NET.Sdk">` made it happy
* VS did not recognize the dependency between `MicroBenchmarks.csproj` and `Tests.csproj` so I had to define it in explicit way in the solution file to get it working with pressing "Build" just once
* The old `<RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.2'">2.2.0-*</RuntimeFrameworkVersion>` was a workaround (https://github.com/dotnet/cli/issues/10074), which is not needed anymore since 2.2 was shipped

btw if you want to use preview of .NET Core 3.0 in VS 2017 you need to enable following setting in VS:
![image](https://user-images.githubusercontent.com/6011991/49593755-99ffc980-f974-11e8-9a77-8184a7fa8837.png)
