### PR TITLE
Addition:  Initial Benchmarks for System.Reflection: Attributes

### DIFF
--- a/src/benchmarks/micro/Categories.cs
+++ b/src/benchmarks/micro/Categories.cs
@@ -19,6 +19,7 @@ namespace MicroBenchmarks
         public const string CoreFX = "CoreFX";
 
         public const string LINQ = "LINQ";
+        public const string Reflection = "Reflection";
         public const string SIMD = "SIMD";
         public const string Span = "Span";
         public const string Collections = "Collections";

--- a/src/benchmarks/micro/coreclr/System.Reflection/Attributes/AttributeTests.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Attributes/AttributeTests.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System;
+using System.Reflection;
+
+namespace Attributes
+{
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Reflection)]
+    public partial class AttributeTests
+    {
+        private static readonly MethodInfo AttributedOverride = typeof(AttributedClass).GetMethod(nameof(AttributedClass.FooAttributed));
+        private static readonly MethodInfo NonAttributedOverride = typeof(NonAttributedClass).GetMethod(nameof(NonAttributedClass.FooAttributed));
+        private static readonly MethodInfo AttributedBase = typeof(BaseClass).GetMethod(nameof(BaseClass.FooAttributed));
+        private static readonly MethodInfo NonAttributedBase = typeof(BaseClass).GetMethod(nameof(BaseClass.FooUnattributed));
+
+        [My("Test")]
+        [Serializable]
+        public class AttributedClass : BaseClass
+        {
+            [My("FooAttributed")]
+            public override string FooAttributed() => null;
+        }
+
+        public class NonAttributedClass : BaseClass
+        {
+            public override string FooUnattributed() => null;
+        }
+
+        public class BaseClass
+        {
+            [My("Foo")]
+            public virtual string FooAttributed() => null;
+            public virtual string FooUnattributed() => null;
+        }
+
+        [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+        public class MyAttribute : Attribute
+        {
+            private readonly string _name;
+            public MyAttribute(string name) => _name = name;
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/System.Reflection/Attributes/GetCustomAttributes.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Attributes/GetCustomAttributes.cs
@@ -1,0 +1,37 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Attributes
+{
+    public partial class AttributeTests
+    {
+        [Benchmark(Description = "GetCustomAttributes - Class: Hit (inherit)")]
+        public object[] GetCustomAttributesClassHitInherit() => typeof(AttributedClass).GetCustomAttributes(typeof(MyAttribute), true);
+        [Benchmark(Description = "GetCustomAttributes - Class: Miss (inherit)")]
+        public object[] GetCustomAttributesClassMissInherit() => typeof(NonAttributedClass).GetCustomAttributes(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "GetCustomAttributes - Class: Hit (no inherit)")]
+        public object[] GetCustomAttributesClassHit() => typeof(AttributedClass).GetCustomAttributes(typeof(MyAttribute), false);
+        [Benchmark(Description = "GetCustomAttributes - Class: Miss (no inherit)")]
+        public object[] GetCustomAttributesClassMiss() => typeof(NonAttributedClass).GetCustomAttributes(typeof(MyAttribute), false);
+
+        [Benchmark(Description = "GetCustomAttributes - Method Override: Hit (inherit)")]
+        public object[] GetCustomAttributesMethodOverrideHitInherit() => AttributedOverride.GetCustomAttributes(typeof(MyAttribute), true);
+        [Benchmark(Description = "GetCustomAttributes - Method Override: Miss (inherit)")]
+        public object[] GetCustomAttributesMethodOverrideMissInherit() => NonAttributedOverride.GetCustomAttributes(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "GetCustomAttributes - Method Override: Hit (no inherit)")]
+        public object[] GetCustomAttributesMethodOverrideHit() => AttributedOverride.GetCustomAttributes(typeof(MyAttribute), false);
+        [Benchmark(Description = "GetCustomAttributes - Method Override: Miss (no inherit)")]
+        public object[] GetCustomAttributesMethodOverrideMiss() => NonAttributedOverride.GetCustomAttributes(typeof(MyAttribute), false);
+
+        [Benchmark(Description = "GetCustomAttributes - Method Base: Hit (inherit)")]
+        public object[] GetCustomAttributesMethodBaseHitInherit() => AttributedBase.GetCustomAttributes(typeof(MyAttribute), true);
+        [Benchmark(Description = "GetCustomAttributes - Method Base: Miss (inherit)")]
+        public object[] GetCustomAttributesMethodBaseMissInherit() => NonAttributedBase.GetCustomAttributes(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "GetCustomAttributes - Method Base: Hit (no inherit)")]
+        public object[] GetCustomAttributesMethodBaseHit() => AttributedBase.GetCustomAttributes(typeof(MyAttribute), false);
+        [Benchmark(Description = "GetCustomAttributes - Method Base: Miss (no inherit)")]
+        public object[] GetCustomAttributesMethodBaseMiss() => NonAttributedBase.GetCustomAttributes(typeof(MyAttribute), false);
+    }
+}

--- a/src/benchmarks/micro/coreclr/System.Reflection/Attributes/IsDefined.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Attributes/IsDefined.cs
@@ -1,0 +1,37 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Attributes
+{
+    public partial class AttributeTests
+    {
+        [Benchmark(Description = "IsDefined - Class: Hit (inherit)")]
+        public bool IsDefinedClassHitInherit() => typeof(AttributedClass).IsDefined(typeof(MyAttribute), true);
+        [Benchmark(Description = "IsDefined - Class: Miss (inherit)")]
+        public bool IsDefinedClassMissInherit() => typeof(NonAttributedClass).IsDefined(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "IsDefined - Class: Hit (no inherit)")]
+        public bool IsDefinedClassHit() => typeof(AttributedClass).IsDefined(typeof(MyAttribute), false);
+        [Benchmark(Description = "IsDefined - Class: Miss (no inherit)")]
+        public bool IsDefinedClassMiss() => typeof(NonAttributedClass).IsDefined(typeof(MyAttribute), false);
+
+        [Benchmark(Description = "IsDefined - Method Override: Hit (inherit)")]
+        public bool IsDefinedMethodOverrideHitInherit() => AttributedOverride.IsDefined(typeof(MyAttribute), true);
+        [Benchmark(Description = "IsDefined - Method Override: Miss (inherit)")]
+        public bool IsDefinedMethodOverrideMissInherit() => NonAttributedOverride.IsDefined(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "IsDefined - Method Override: Hit (no inherit)")]
+        public bool IsDefinedMethodOverrideHit() => AttributedOverride.IsDefined(typeof(MyAttribute), false);
+        [Benchmark(Description = "IsDefined - Method Override: Miss (no inherit)")]
+        public bool IsDefinedMethodOverrideMiss() => NonAttributedOverride.IsDefined(typeof(MyAttribute), false);
+
+        [Benchmark(Description = "IsDefined - Method Base: Hit (inherit)")]
+        public bool IsDefinedMethodBaseHitInherit() => AttributedBase.IsDefined(typeof(MyAttribute), true);
+        [Benchmark(Description = "IsDefined - Method Base: Miss (inherit)")]
+        public bool IsDefinedMethodBaseMissInherit() => NonAttributedBase.IsDefined(typeof(MyAttribute), true);
+
+        [Benchmark(Description = "IsDefined - Method Base: Hit (no inherit)")]
+        public bool IsDefinedMethodBaseHit() => AttributedBase.IsDefined(typeof(MyAttribute), false);
+        [Benchmark(Description = "IsDefined - Method Base: Miss (no inherit)")]
+        public bool IsDefinedMethodBaseMiss() => NonAttributedBase.IsDefined(typeof(MyAttribute), false);
+    }
+}


### PR DESCRIPTION
This benchmarks specifically `GetCustomAttributes()` and `IsDefined()` paths (used in https://github.com/dotnet/coreclr/pull/20779 and https://github.com/dotnet/coreclr/pull/20795)

Note: there are many code paths through the attribute pipeline which vary drastically in terms of performance and allocations - so there's what seems to be an excessive number of benchmarks here, but they are all pretty unique.

Here's a sample run of the whole category on `netcoreapp2.1`:
![image](https://user-images.githubusercontent.com/454813/49697248-00f2cd80-fb83-11e8-993b-dfd28a6715e9.png)

The issue I can see here is naming. I tried to match conventions, but the descriptions are long because of the differentiation needed - is this okay? Suggestions for shortening them?
