### PR TITLE
Fixing BenchmarkDotNet restore timeout in the lab

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -136,7 +136,7 @@ def projectFolder = projectName + '/' + Utilities.getFolderName(branch)
                     def python = "C:\\Python35\\python.exe"
 
                     steps {
-                        batchFile("${python} .\\scripts\\benchmarks_ci.py --incremental no --architecture ${arch} --category CoreClr -f netcoreapp3.0 --generate-benchview-data --upload-to-benchview-container coreclr --benchview-run-type ${runType}")
+                        batchFile("""${python} .\\scripts\\benchmarks_ci.py --incremental no --bdn-arguments="--buildTimeout 300" --architecture ${arch} --category CoreClr -f netcoreapp3.0 --generate-benchview-data --upload-to-benchview-container coreclr --benchview-run-type ${runType}""")
                     }
 
                     label("windows_server_2016_clr_perf")


### PR DESCRIPTION
In the lab we are seeing getting this `The configured timeout 00:01:00 was reached!` while restoring the benchmarks. This change attempts to alleviate these errors.