### PR TITLE
allow the Python script to overwrite TFMs to avoid "error NETSDK1045"

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -460,6 +460,11 @@ def __main(args: list) -> int:
     elif args.optimization_level == 'full_opt':
         os.environ['COMPlus_TieredCompilation'] = '0'
 
+    # The MicroBenchmarks.csproj targets .NET Core 2.0, 2.1, 2.2 and 3.0
+    # to avoid a build failure when using older frameworks (error NETSDK1045: The current .NET SDK does not support targeting .NET Core $XYZ)
+    # we set the TFM to what the user has provided
+    os.environ['PYTHON_SCRIPT_TARGET_FRAMEWORKS'] = ';'.join(args.frameworks)
+
     # dotnet --info
     dotnet.info(verbose=verbose)
 

--- a/src/benchmarks/micro/common.props
+++ b/src/benchmarks/micro/common.props
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <UseSharedCompilation>false</UseSharedCompilation>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <!-- The Python script can narrow down the TFMs to what the user has asked for -->
+    <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>


### PR DESCRIPTION
When I use our scripts to run only for old TFMs like "netcoreapp2.1" the script downloads the right dotnet cli, but it fails to build the project because it has no idea what .NET Core 2.2 or 3.0 are.

```cmd
py.exe .\scripts\benchmarks_ci.py -f netcoreapp2.1 --filter *Adams*
```

I get:

```log
 ----------------------------------------------
 Initializing logger 2018-12-10 18:56:12.682540
 ----------------------------------------------
 Installing tools.
 ----------------------
 Downloading DotNet Cli
 ----------------------
 DotNet Install Path: 'C:\Projects\performance\tools\dotnet\x64'
 Downloading https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1
 $ pushd "C:\Projects\performance"
 $ powershell.exe -NoProfile -ExecutionPolicy Bypass C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 -InstallDir C:\Projects\performance\tools\dotnet\x64 -Architecture x64 -Channel 2.1
 dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.500/dotnet-sdk-2.1.500-win-x64.zip
 dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.500/dotnet-sdk-2.1.500-win-x64.zip
 dotnet-install: Adding to current process PATH: "C:\Projects\performance\tools\dotnet\x64\". Note: This change will not be visible if PowerShell was run as a child process.
 dotnet-install: Installation finished
 $ popd
 -----------------------------
 Downloading BenchView scripts
 -----------------------------
 http://benchviewtestfeed.azurewebsites.net/api/v2/package/microsoft.benchview.jsonformat/0.1.0-pre029 -> C:\Projects\performance\tools\Microsoft.BenchView.JSONFormat
 $ dotnet --info
 .NET Core SDK (reflecting any global.json):
  Version:   2.1.500
  Commit:    b68b931422

 Runtime Environment:
  OS Name:     Windows
  OS Version:  10.0.17763
  OS Platform: Windows
  RID:         win10-x64
  Base Path:   C:\Projects\performance\tools\dotnet\x64\sdk\2.1.500\

 Host (useful for support):
   Version: 2.1.6
   Commit:  3f4f8eebd8

 .NET Core SDKs installed:
   2.1.500 [C:\Projects\performance\tools\dotnet\x64\sdk]

 .NET Core runtimes installed:
   Microsoft.AspNetCore.All 2.1.6 [C:\Projects\performance\tools\dotnet\x64\shared\Microsoft.AspNetCore.All]
   Microsoft.AspNetCore.App 2.1.6 [C:\Projects\performance\tools\dotnet\x64\shared\Microsoft.AspNetCore.App]
   Microsoft.NETCore.App 2.1.6 [C:\Projects\performance\tools\dotnet\x64\shared\Microsoft.NETCore.App]

 To install additional .NET Core runtimes or SDKs:
   https://aka.ms/dotnet-download
 -------------------------------
 Restoring .NET micro benchmarks
 -------------------------------
 $ pushd "C:\Projects\performance\src\benchmarks\micro"
 $ dotnet restore MicroBenchmarks.csproj --packages C:\Projects\performance\packages

 Configuring...
 --------------
 A command is running to populate your local package cache to improve restore speed and enable offline access. This command takes up to one minute to complete and only runs once.
 Decompressing .......... 6481 ms
 Expanding .......... 10845 ms
 C:\Projects\performance\tools\dotnet\x64\sdk\2.1.500\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(137,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 2.2.  Either target .NET Core 2.1 or lower, or use a version of the .NET SDK that supports .NET Core 2.2. [C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
 Process exited with status 1
```

The important part:

```log
error NETSDK1045: The current .NET SDK does not support targeting .NET Core 2.2.  Either target .NET Core 2.1 or lower, or use a version of the .NET SDK that supports .NET Core 2.2. 
```

My proposal: set env var when running from script and set the TFM only to what the user has asked for.

I have tested it for the scripts, running from console, VS and Rider ;)

I know that the solution is not very clean, however it was the best idea I had.