### PR TITLE
add ARM support for the Python scripts

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -316,6 +316,8 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     SUPPORTED_ARCHITECTURES = [
         'x64',  # Default architecture
         'x86',
+        'arm32',
+        'arm64',
     ]
     parser.add_argument(
         '--architecture',


### PR DESCRIPTION
@jorive wrote an awesome script that downloads the dotnet cli, adds it to PATH and runs the benchmarks for us with a single command line argument on a clean box.

The script supported x64 and x86. I just added `arm32` and `arm64` to it.

Thanks to the machine access I got from @AndyAyersMS I was able to test it.

```cmd
python3 ./scripts/benchmarks_ci.py -f netcoreapp3.0 --filter *BinaryTrees* --architecture arm64
```

```log
----------------------------------------------
Initializing logger 2018-12-10 11:59:58.736331
----------------------------------------------
Installing tools.
----------------------
Downloading DotNet Cli
----------------------
DotNet Install Path: '/home/robox/adsitnik/performance/tools/dotnet/arm64'
Downloading https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh
$ pushd "/home/robox/adsitnik/performance"
$ /home/robox/adsitnik/performance/tools/dotnet/arm64/dotnet-install.sh -InstallDir /home/robox/adsitnik/performance/tools/dotnet/arm64 -Architecture arm64 -Channel master
dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview-009820/dotnet-sdk-3.0.100-preview-009820-linux-arm64.tar.gz
dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview-009820/dotnet-sdk-3.0.100-preview-009820-linux-arm64.tar.gz
dotnet-install: Adding to current process PATH: `/home/robox/adsitnik/performance/tools/dotnet/arm64`. Note: This change will be visible only when sourcing script.
dotnet-install: Installation finished successfully.
$ popd
-----------------------------
Downloading BenchView scripts
-----------------------------
http://benchviewtestfeed.azurewebsites.net/api/v2/package/microsoft.benchview.jsonformat/0.1.0-pre029 -> /home/robox/adsitnik/performance/tools/Microsoft.BenchView.JSONFormat
$ dotnet --info
.NET Core SDK (reflecting any global.json):
 Version:   3.0.100-preview-009820
 Commit:    799a33c6ba

Runtime Environment:
 OS Name:     ubuntu
 OS Version:  16.04
 OS Platform: Linux
 RID:         ubuntu.16.04-arm64
 Base Path:   /home/robox/adsitnik/performance/tools/dotnet/arm64/sdk/3.0.100-preview-009820/

Host (useful for support):
  Version: 3.0.0-preview-27205-02
  Commit:  04035b3a4c

.NET Core SDKs installed:
  3.0.100-preview-009820 [/home/robox/adsitnik/performance/tools/dotnet/arm64/sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.App 3.0.0-preview-18579-0056 [/home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 3.0.0-preview-27205-02 [/home/robox/adsitnik/performance/tools/dotnet/arm64/shared/Microsoft.NETCore.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download
-------------------------------
Restoring .NET micro benchmarks
-------------------------------
$ pushd "/home/robox/adsitnik/performance/src/benchmarks/micro"
$ dotnet restore MicroBenchmarks.csproj --packages /home/robox/adsitnik/performance/packages

Welcome to .NET Core!
```

Sample results:

``` ini

BenchmarkDotNet=v0.11.3.886-nightly, OS=ubuntu 16.04
Unknown processor
.NET Core SDK=3.0.100-preview-009820
  [Host]     : .NET Core 3.0.0-preview-27205-02 (CoreCLR 4.6.27204.02, CoreFX 4.7.18.60501), 64bit RyuJIT
  Job-LKKOCU : .NET Core 3.0.0-preview-27205-02 (CoreCLR 4.6.27204.02, CoreFX 4.7.18.60501), 64bit RyuJIT

IterationTime=250.0000 ms  MaxIterationCount=40  MinIterationCount=15
WarmupCount=1

```
|        Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------- |---------:|---------:|---------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
| BinaryTrees_5 | 480.6 ms | 12.39 ms | 19.29 ms | 483.6 ms | 437.2 ms | 519.2 ms |  38000.0000 |   6000.0000 |   2000.0000 |              1.7 KB |

also, I was able to verify that the fix provided by @janvorli in https://github.com/dotnet/corefx/pull/33825 works and BDN does not print invalid CPU affinity anymore 