### PR TITLE
update BDN to version with consistent file names across all OSes

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.886" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.886" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.889" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.889" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />


### PR DESCRIPTION
https://github.com/dotnet/BenchmarkDotNet/issues/981

So far BDN used `Path.GetInvalidFileNameChars()` to determine invalid path characters and `<` & `>` are valid on Unix, but not on Windows. The side effect was that when we tried to copy Unix results to Windows, we could not do it without changing the files names first.

This simple change replaces `>` and `<` with `_` for every OS.

/cc @AndyAyersMS 