### PR TITLE
Minor fixes

### DIFF
--- a/src/benchmarks/micro/Harness/TooManyTestCasesValidator.cs
+++ b/src/benchmarks/micro/Harness/TooManyTestCasesValidator.cs
@@ -9,7 +9,7 @@ using BenchmarkDotNet.Validators;
 namespace MicroBenchmarks
 {
     /// <summary>
-    /// we need to tell our users that having more than 20 test cases per benchmark is a VERY BAD idea
+    /// we need to tell our users that having more than 16 test cases per benchmark is a VERY BAD idea
     /// </summary>
     public class TooManyTestCasesValidator : IValidator
     {

--- a/src/benchmarks/micro/coreclr/System.Reflection/Attributes.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Attributes.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
 namespace System.Reflection

--- a/src/benchmarks/micro/corefx/System.Collections/CopyTo.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/CopyTo.cs
@@ -31,7 +31,7 @@ namespace System.Collections
             _destination = new T[Size];
         }
 
-        [Benchmark(Baseline = true)]
+        [Benchmark]
         public void Array() => System.Array.Copy(_array, _destination, Size);
 
         [BenchmarkCategory(Categories.Span)]

--- a/src/benchmarks/micro/corefx/System.Memory/Constructors.cs
+++ b/src/benchmarks/micro/corefx/System.Memory/Constructors.cs
@@ -31,7 +31,7 @@ namespace System.Memory
             _readOnlyMemory = new System.ReadOnlyMemory<T>(_nonEmptyArray);
         }
 
-        [Benchmark(Baseline = true)]
+        [Benchmark]
         public System.Span<T> SpanFromArray() => new System.Span<T>(_nonEmptyArray);
 
         [Benchmark]


### PR DESCRIPTION
I did remove `[Benchmark(Baseline = true)]` from the code because it's confusing when running the benchmarks for more than 1 runtime.

Explanation:

When we have:

```cs
[Benchmark(Baseline = true)]
public void A() {} 

[Benchmark]
public void B() {}
```

and run it for 1 runtime, the baseline is A and the ratio for B is scaled to A.

However, when we run it for few runtimes, let's say `--runtimes netcoreapp2.1 netcoreapp3.0`

the Baseline is `A` for .NET Core 2.1 and all the ratios as scaled to it. This is very confusing when reading the results. I think we should remove it. I am also the person who added it so nobody will be missing it ;)
