### PR TITLE
Add a few Timer perf tests

### DIFF
--- a/src/benchmarks/micro/corefx/System.Threading.Timers/Perf.Timer.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Timers/Perf.Timer.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Threading.Tasks;
+
+namespace System.Threading.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class TimerPerfTest
+    {
+        private readonly Timer[] _timers = new Timer[1_000_000];
+        private readonly Task[] _tasks = new Task[Environment.ProcessorCount];
+
+        [Benchmark]
+        public void ShortScheduleAndDispose() => new Timer(_ => { }, null, 50, -1).Dispose();
+
+        [Benchmark]
+        public void LongScheduleAndDispose() => new Timer(_ => { }, null, int.MaxValue, -1).Dispose();
+
+        [Benchmark]
+        public void ScheduleManyThenDisposeMany()
+        {
+            Timer[] timers = _timers;
+
+            for (int i = 0; i < timers.Length; i++)
+            {
+                timers[i] = new Timer(_ => { }, null, int.MaxValue, -1);
+            }
+
+            foreach (Timer timer in timers)
+            {
+                timer.Dispose();
+            }
+        }
+
+        [Benchmark]
+        public void SynchronousContention()
+        {
+            Task[] tasks = _tasks;
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    for (int j = 0; j < 1_000_000; j++)
+                    {
+                        new Timer(delegate { }, null, int.MaxValue, -1).Dispose();
+                    }
+                });
+            }
+            Task.WaitAll(tasks);
+        }
+
+        [Benchmark]
+        public void AsynchronousContention()
+        {
+            Task[] tasks = _tasks;
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (int j = 0; j < 1_000_000; j++)
+                    {
+                        using (var t = new Timer(delegate { }, null, int.MaxValue, -1))
+                        {
+                            await Task.Yield();
+                        }
+                    }
+                });
+            }
+            Task.WaitAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
- Overhead of creating and disposing timers
- Multithreaded contention when the same threads create and then dispose timers.
- Multithreaded contention when likely different threads are creating and disposing the timers, or at least when there's queueing between those operations.

We don't currently have a way to benchmark / measure how much time is spent in a particular function, so this doesn't add any tests related to firing timers where we'd want to measure the CPU impact of FireNextTimers.

cc: @kouvel, @adamsitnik 