### PR TITLE
we need to tell BenchmarkDotNet where to restore the packages

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -497,6 +497,11 @@ def __main(args: list) -> int:
         if args.bdn_arguments:
             run_args += args.bdn_arguments
 
+        # we need to tell BenchmarkDotNet where to restore the packages
+        # if we don't it's gonna restore to default global folder
+        run_args += ['--packages', micro_benchmarks.get_packages_directory()]
+        run_args += ['--runtimes', framework] # the --packages requires this argument to work (BDN limitaiton)
+
         micro_benchmarks.run(args.configuration, framework, verbose, *run_args)
 
     __run_benchview_scripts(args, verbose)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -86,6 +86,11 @@ def get_supported_configurations() -> list:
     '''
     return ['Release', 'Debug']
 
+def get_packages_directory() -> str:
+    '''
+    The path to directory where packages should get restored
+    '''
+    return path.join(get_artifacts_directory(), 'packages')
 
 def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     '''
@@ -222,7 +227,7 @@ def build(
         verbose: bool) -> None:
     '''Restores and builds the benchmarks'''
 
-    packages = path.join(get_artifacts_directory(), 'packages')
+    packages = get_packages_directory()
 
     if incremental == 'no':
         __log_script_header("Removing packages, bin and obj folders.")


### PR DESCRIPTION
To support all the magic BDN offers it generates a new project with boilerplate code.
To build the auto-generated project BDN performs dotnet restore and dotnet build.

When we don't tell it where to restore, it's using default global location.

So far the scripts were restoring to `root\packages` but BDN was anyway restoring to global location. Because of that @adiaaida and @jorive were getting timeouts from BDN...