### PR TITLE
Add perf tests for .NET Core 2.0 perf blog post

### DIFF
--- a/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Functions
+{
+    public partial class MathTests
+    {
+        private static int _aInt32 = 99, _bInt32 = 10, _resultInt32;
+        private static long _aInt64 = 99, _bInt64 = 10, _resultInt64;
+
+        [Benchmark]
+        public int DivRemInt32() => Math.DivRem(_aInt32, _bInt32, out _resultInt32);
+
+        [Benchmark]
+        public long DivRemInt64() => Math.DivRem(_aInt64, _bInt64, out _resultInt64);
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/AddRemove/AddRemoveSteadyState.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/AddRemove/AddRemoveSteadyState.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Collections.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    [GenericTypeArguments(typeof(int))] // value type
+    [GenericTypeArguments(typeof(string))] // reference type
+    public class Add_Remove_SteadyState<T> // serialized producer/consumer throughput when the collection has reached a steady-state size
+    {
+        private ConcurrentBag<T> _concurrentBag;
+        private ConcurrentQueue<T> _concurrentQueue;
+        private ConcurrentStack<T> _concurrentStack;
+        private Queue<T> _queue;
+        private Stack<T> _stack;
+
+        [Params(Utils.DefaultCollectionSize)]
+        public int Count;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            T[] uniqueValues = ValuesGenerator.ArrayOfUniqueValues<T>(Count);
+            _concurrentBag = new ConcurrentBag<T>(uniqueValues);
+            _concurrentQueue = new ConcurrentQueue<T>(uniqueValues);
+            _concurrentStack = new ConcurrentStack<T>(uniqueValues);
+            _queue = new Queue<T>(uniqueValues);
+            _stack = new Stack<T>(uniqueValues);
+        }
+
+        [Benchmark]
+        public void ConcurrentBag()
+        {
+            _concurrentBag.TryTake(out T item);
+            _concurrentBag.Add(item);
+        }
+
+        [Benchmark]
+        public void ConcurrentQueue()
+        {
+            _concurrentQueue.TryDequeue(out T item);
+            _concurrentQueue.Enqueue(item);
+        }
+
+        [Benchmark]
+        public void ConcurrentStack()
+        {
+            _concurrentStack.TryPop(out T item);
+            _concurrentStack.Push(item);
+        }
+
+        [Benchmark]
+        public void Queue()
+        {
+            T item = _queue.Dequeue();
+            _queue.Enqueue(item);
+        }
+
+        [Benchmark]
+        public void Stack()
+        {
+            T item = _stack.Pop();
+            _stack.Push(item);
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/Concurrent/IsEmpty.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Concurrent/IsEmpty.cs
@@ -18,13 +18,13 @@ namespace System.Collections.Concurrent
         private ConcurrentStack<T> _stack;
         private ConcurrentBag<T> _bag;
 
-        [Params(Utils.DefaultCollectionSize)]
+        [Params(0, Utils.DefaultCollectionSize)] // IsEmpty perf can be significantly impacted by empty vs non-empty
         public int Size;
 
         [GlobalSetup]
         public void Setup()
         {
-            var values = ValuesGenerator.ArrayOfUniqueValues<T>(Size);
+            T[] values = ValuesGenerator.ArrayOfUniqueValues<T>(Size);
             
             _dictionary = new ConcurrentDictionary<T, T>(values.ToDictionary(v => v, v => v));
             _queue = new ConcurrentQueue<T>(values);

--- a/src/benchmarks/micro/corefx/System.Collections/SortedSet/Perf_SortedSet.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/SortedSet/Perf_SortedSet.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Collections.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    public class Perf_SortedSet
+    {
+        private SortedSet<int> _set;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _set = new SortedSet<int>();
+            for (int n = 0; n < 100_000; n++)
+            {
+                _set.Add(n);
+            }
+        }
+
+        [Benchmark]
+        public int Min() => _set.Min;
+
+        [Benchmark]
+        public int Max() => _set.Max;
+    }
+}

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileStream.cs
@@ -79,7 +79,16 @@ namespace System.IO.Tests
 
             return bytesRead;
         }
-        
+
+        [Benchmark]
+        public async Task CopyToAsync()
+        {
+            using (var reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
+            {
+                await reader.CopyToAsync(Stream.Null);
+            }
+        }
+
         [Benchmark]
         public void WriteByte()
         {

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -16,6 +16,8 @@ namespace System.Linq.Tests
         private const int DefaulIterationCount = 1000;
         
         private readonly Consumer _consumer = new Consumer();
+        private readonly IEnumerable<int> _range0to10 = Enumerable.Range(0, 10);
+        private readonly IEnumerable<int> _tenMillionToZero = Enumerable.Range(0, 10_000_000).Reverse();
 
         public static IEnumerable<object[]> IterationSizeWrapperData()
         {
@@ -141,11 +143,29 @@ namespace System.Linq.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
+        public int[] SelectToArray(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
+
+            return source.Select(i => i).ToArray();
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public List<int> ToList(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
         {
             IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
 
             return source.ToList();
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(IterationSizeWrapperData))]
+        public List<int> SelectToList(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
+
+            return source.Select(i => i).ToList();
         }
 
         [Benchmark]
@@ -173,6 +193,17 @@ namespace System.Linq.Tests
             IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
 
             return source.Contains(0);
+        }
+
+        [Benchmark]
+        public int Concat()
+        {
+            IEnumerable<int> result = _range0to10;
+            for (int i = 0; i < 1000; i++)
+            {
+                result = result.Concat(_range0to10);
+            }
+            return result.Sum();
         }
     }
 }

--- a/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.WebUtility.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.WebUtility.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Net;
+
+namespace System.Net.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_WebUtility
+    {
+        [Benchmark]
+        public string Decode_DecodingRequired() => WebUtility.UrlDecode("abcdefghijklmnopqrstuvwxy%22");
+
+        [Benchmark]
+        public string Decode_NoDecodingRequired() => WebUtility.UrlDecode("abcdefghijklmnopqrstuvwxyz");
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Runtime.Serialization.Formatters.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_BinaryFormatter
+    {
+        private readonly BinaryFormatter _formatter = new BinaryFormatter();
+        private Stream _largeListStream;
+
+        [GlobalSetup(Target = nameof(DeserializeLargeList))]
+        public void LargeListSetup()
+        {
+            List<Book> list = Enumerable.Range(0, 100_000).Select(i =>
+            {
+                string id = i.ToString();
+                return new Book { Name = id, Id = id };
+            }).ToList();
+
+            var mem = new MemoryStream();
+            _formatter.Serialize(mem, list);
+            _largeListStream = mem;
+        }
+
+        [Benchmark]
+        public List<Book> DeserializeLargeList()
+        {
+            _largeListStream.Position = 0;
+            return (List<Book>)_formatter.Deserialize(_largeListStream);
+        }
+
+        [Serializable]
+        public class Book
+        {
+            public string Name;
+            public string Id;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.DateTime.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.DateTime.cs
@@ -4,6 +4,7 @@
 
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using System.Collections.Generic;
 
 namespace System.Tests
 {
@@ -19,8 +20,18 @@ namespace System.Tests
         [Benchmark]
         public DateTime GetUtcNow() => DateTime.UtcNow;
 
-        [Benchmark(Description = "ToString")]
-        public string ToString_str() => date1.ToString("g");
+        public static IEnumerable<string> ToString_MemberData()
+        {
+            yield return null;
+            yield return "G";
+            yield return "s";
+            yield return "r";
+            yield return "o";
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(ToString_MemberData))]
+        public string ToString(string format) => date1.ToString(format);
 
         [Benchmark]
         public TimeSpan op_Subtraction() => date1 - date2;

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Enum.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Enum.cs
@@ -10,16 +10,23 @@ namespace System.Tests
     [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Enum
     {
-        private enum testEnum
+        [Flags]
+        public enum Colors
         {
-            Red = 1,
-            Blue = 2
+            Red = 0x1,
+            Orange = 0x2,
+            Yellow = 0x4,
+            Green = 0x8,
+            Blue = 0x10
         }
 
+        [Params("Red", "Red, Orange, Yellow, Green, Blue")] // test both a single value and multiple values
+        public string Text;
+
         [Benchmark]
-        public object Parse() => Enum.Parse(typeof(testEnum), "Red");
-        
+        public Colors Parse() => (Colors)Enum.Parse(typeof(Colors), Text);
+
         [Benchmark]
-        public bool TryParseGeneric() => Enum.TryParse<testEnum>("Red", out _);
+        public bool TryParseGeneric() => Enum.TryParse<Colors>(Text, out _);
     }
 }

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Lazy.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Lazy.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_Lazy
+    {
+        private Lazy<int> _lazy;
+
+        [GlobalSetup]
+        public void InitializeLazy()
+        {
+            _lazy = new Lazy<int>(() => 42);
+            int ignored = _lazy.Value;
+        }
+
+        [Benchmark]
+        public int ValueFromAlreadyInitialized() => _lazy.Value;
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Hashing.cs
+++ b/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Hashing.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace System.Security.Cryptography.Tests
+{
+    public class Perf_Hashing
+    {
+        private readonly byte[] _data = MicroBenchmarks.ValuesGenerator.Array<byte>(100 * 1024 * 1024);
+
+        private readonly SHA1 _sha1 = SHA1.Create();
+        private readonly SHA256 _sha256 = SHA256.Create();
+        private readonly SHA384 _sha384 = SHA384.Create();
+        private readonly SHA512 _sha512 = SHA512.Create();
+
+        [Benchmark]
+        public byte[] Sha1() => _sha1.ComputeHash(_data);
+
+        [Benchmark]
+        public byte[] Sha256() => _sha256.ComputeHash(_data);
+
+        [Benchmark]
+        public byte[] Sha384() => _sha384.ComputeHash(_data);
+
+        [Benchmark]
+        public byte[] Sha512() => _sha512.ComputeHash(_data);
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Text.RegularExpressions/Perf.Regex.cs
+++ b/src/benchmarks/micro/corefx/System.Text.RegularExpressions/Perf.Regex.cs
@@ -34,8 +34,19 @@ namespace System.Text.RegularExpressions.Tests
         {
             bool result = false;
             
-            foreach (var test in TestData)
+            foreach ((string pattern, string input, RegexOptions options) test in TestData)
                 result ^= Regex.Match(test.input, test.pattern, test.options).Success;
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool IsMatch()
+        {
+            bool result = false;
+
+            foreach ((string pattern, string input, RegexOptions options) test in TestData)
+                result ^= Regex.IsMatch(test.input, test.pattern, test.options);
 
             return result;
         }

--- a/src/benchmarks/micro/corefx/System.Threading.ThreadPool/Perf.ThreadPool.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.ThreadPool/Perf.ThreadPool.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Threading.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public partial class Perf_ThreadPool
+    {
+        [Params(20_000_000)]
+        public int WorkItemsPerCore;
+
+        [Benchmark]
+        public void QueueUserWorkItem_WaitCallback_Throughput()
+        {
+            int remaining = WorkItemsPerCore;
+            var mres = new ManualResetEventSlim();
+
+            WaitCallback wc = null;
+            wc = delegate
+            {
+                if (Interlocked.Decrement(ref remaining) <= 0)
+                {
+                    mres.Set();
+                }
+                else
+                {
+                    ThreadPool.QueueUserWorkItem(wc);
+                }
+            };
+
+            for (int i = 0; i < Environment.ProcessorCount; i++)
+                ThreadPool.QueueUserWorkItem(wc);
+            mres.Wait();
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Threading.Timers/Perf.Timer.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Timers/Perf.Timer.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace System.Threading.Tests
 {
     [BenchmarkCategory(Categories.CoreFX)]
-    public class TimerPerfTest
+    public class Perf_Timer
     {
         private readonly Timer[] _timers = new Timer[1_000_000];
         private readonly Task[] _tasks = new Task[Environment.ProcessorCount];

--- a/src/benchmarks/micro/corefx/System.Threading/Perf.SpinLock.cs
+++ b/src/benchmarks/micro/corefx/System.Threading/Perf.SpinLock.cs
@@ -10,7 +10,16 @@ namespace System.Threading.Tests
     [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_SpinLock
     {
-        SpinLock _spinLock = new SpinLock();
+        private SpinLock _spinLock = new SpinLock(enableThreadOwnerTracking: false);
+        private SpinLock _acquiredSpinLock;
+
+        [GlobalSetup(Target = nameof(TryEnter_Fail))]
+        public void AcquireAcquiredSpinLock()
+        {
+            _acquiredSpinLock = new SpinLock(enableThreadOwnerTracking: false);
+            bool lockTaken = false;
+            _acquiredSpinLock.Enter(ref lockTaken);
+        }
 
         [Benchmark]
         public bool EnterExit()
@@ -35,6 +44,14 @@ namespace System.Threading.Tests
             spinLock.TryEnter(0, ref lockTaken);
             spinLock.Exit();
 
+            return lockTaken;
+        }
+
+        [Benchmark]
+        public bool TryEnter_Fail()
+        {
+            bool lockTaken = false;
+            _acquiredSpinLock.TryEnter(0, ref lockTaken);
             return lockTaken;
         }
     }


### PR DESCRIPTION
Some of the benchmarks from https://blogs.msdn.microsoft.com/dotnet/2017/06/07/performance-improvements-in-net-core/ are already covered, but a bunch aren't.  This adds the missing ones.