### PR TITLE
Add perf tests for .NET Core 2.1 perf blog post

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -56,12 +56,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netcoreapp2.0'">
-    <Compile Remove="corefx\System.Security.Cryptography.Primitives\**" />
+    <Compile Remove="corefx\System.IO.Compression\Brotli.cs" />
     <Compile Remove="corefx\System.Net.Http\Perf.SocketsHttpHandler.cs" />
     <Compile Remove="corefx\System.Net.Sockets\Perf.Socket.SendReceive.cs" />
     <Compile Remove="corefx\System.Numerics.Vectors\GenericVectorFromSpanConstructorTests.cs" />
-    <Compile Remove="corefx\System.IO.Compression\Brotli.cs" />
     <Compile Remove="corefx\System.Runtime\Perf.HashCode.cs" />
+    <Compile Remove="corefx\System.Security.Cryptography.Primitives\**" />
+    <Compile Remove="corefx\System.Security.Cryptography\Perf.Rfc2898DeriveBytes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/coreclr/Devirtualization/Boxing.cs
+++ b/src/benchmarks/micro/coreclr/Devirtualization/Boxing.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+// Performance tests for optimizations related to EqualityComparer<T>.Default
+
+namespace Devirtualization
+{
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+    public class Boxing
+    {
+        [Benchmark]
+        public void InterfaceTypeCheckAndCall() => TypeCheckAndCallMethodOnValueTypeInterface(default(Dog));
+
+        private void TypeCheckAndCallMethodOnValueTypeInterface<T>(T thing)
+        {
+            if (thing is IAnimal)
+            {
+                ((IAnimal)thing).MakeSound();
+            }
+        }
+
+        private struct Dog : IAnimal
+        {
+            public void Bark() { }
+            void IAnimal.MakeSound() => Bark();
+        }
+
+        private interface IAnimal
+        {
+            void MakeSound();
+        }
+    }
+}

--- a/src/benchmarks/micro/coreclr/Lowering/InstructionReplacement.cs
+++ b/src/benchmarks/micro/coreclr/Lowering/InstructionReplacement.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Lowering
+{
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public unsafe class InstructionReplacement
+    {
+        [Benchmark(OperationsPerInvoke = 10_000_000)]
+        public int TESTtoBT()
+        {
+            int y = 0, x = 0;
+
+            while (x++ < 10_000_000)
+            {
+                if ((x & (1 << y)) == 0)
+                {
+                    y++;
+                }
+            }
+
+            return y;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/Dictionary/Perf_Dictionary.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Dictionary/Perf_Dictionary.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Collections.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    public class Perf_Dictionary
+    {
+        [Params(3_000)]
+        public int Items;
+
+        private Dictionary<int, int> _dict;
+
+        [GlobalSetup(Target = nameof(ContainsValue))]
+        public void InitializeContainsValue()
+        {
+            _dict = Enumerable.Range(0, 3_000).ToDictionary(i => i);
+        }
+
+        [Benchmark]
+        public int ContainsValue()
+        {
+            Dictionary<int, int> d = _dict;
+            int count = 0;
+
+            for (int i = 0; i < Items; i++)
+            {
+                if (d.ContainsValue(i))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.Directory.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.Directory.cs
@@ -93,5 +93,21 @@ namespace System.IO.Tests
 
             return sb.ToString();
         }
+
+        [GlobalSetup(Target = nameof(EnumerateFiles))]
+        public void SetupEnumerateFiles()
+        {
+            Directory.CreateDirectory(_testFile);
+            for (int i = 0; i < 10_000; i++)
+            {
+                File.Create(Path.Combine(_testFile, $"File{i}.txt")).Dispose();
+            }
+        }
+
+        [Benchmark]
+        public int EnumerateFiles() => Directory.EnumerateFiles(_testFile, "*", SearchOption.AllDirectories).Count();
+
+        [GlobalCleanup(Target = nameof(EnumerateFiles))]
+        public void CleanupEnumerateFiles() => Directory.Delete(_testFile, recursive: true);
     }
 }

--- a/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 
+#pragma warning disable CS0618 // obsolete
+
 namespace System.Net.Primitives.Tests
 {
     public class IPAddressPerformanceTests
@@ -37,7 +39,12 @@ namespace System.Net.Primitives.Tests
         [ArgumentsSource(nameof(Addresses))]
         public string ToString(IPAddress address)
             => address.ToString();
-        
+
+        private static readonly long s_addr = IPAddress.Loopback.Address;
+
+        [Benchmark]
+        public long NetworkToHostOrder() => IPAddress.NetworkToHostOrder(s_addr);
+
 #if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(ByteAddresses))]

--- a/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.Convert.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.Convert.cs
@@ -4,6 +4,7 @@
 
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using System.Text;
 
 namespace System
 {
@@ -60,5 +61,14 @@ namespace System
         [Arguments("12/12/1999")]
         public DateTime ToDateTime_String(string value) 
             => Convert.ToDateTime(value);
+
+        private static readonly string s_base64String = Convert.ToBase64String(Encoding.ASCII.GetBytes("This is a test of Convert."));
+        private static readonly char[] s_base64Chars = s_base64String.ToCharArray();
+
+        [Benchmark]
+        public byte[] FromBase64String() => Convert.FromBase64String(s_base64String);
+
+        [Benchmark]
+        public byte[] FromBase64Chars() => Convert.FromBase64CharArray(s_base64Chars, 0, s_base64Chars.Length);
     }
 }

--- a/src/benchmarks/micro/corefx/System.Runtime.Numerics/Perf.BigInteger.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime.Numerics/Perf.BigInteger.cs
@@ -33,7 +33,17 @@ namespace System.Numerics.Tests
         [ArgumentsSource(nameof(NumberStrings))]
         public BigInteger Parse(BigIntegerData numberString) 
             => BigInteger.Parse(numberString.Text);
-        
+
+        [Benchmark]
+        [ArgumentsSource(nameof(NumberStrings))]
+        public string ToStringX(BigIntegerData numberString)
+            => numberString.Value.ToString("X");
+
+        [Benchmark]
+        [ArgumentsSource(nameof(NumberStrings))]
+        public string ToStringD(BigIntegerData numberString)
+            => numberString.Value.ToString("D");
+
         public IEnumerable<object> ValuesSameSize()
         {
             yield return new BigIntegers(new[] { 16, 16 });

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.DateTimeOffset.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.DateTimeOffset.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Collections.Generic;
+
+namespace System.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_DateTimeOffset
+    {
+        DateTimeOffset date1 = new DateTimeOffset(new DateTime(1996, 6, 3, 22, 15, 0), new TimeSpan(5, 0, 0));
+        DateTimeOffset date2 = new DateTimeOffset(new DateTime(1996, 12, 6, 13, 2, 0), new TimeSpan(5, 0, 0));
+        
+        [Benchmark]
+        public DateTimeOffset GetNow() => DateTimeOffset.Now;
+
+        [Benchmark]
+        public DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+
+        public static IEnumerable<string> ToString_MemberData()
+        {
+            yield return null;
+            yield return "G";
+            yield return "s";
+            yield return "r";
+            yield return "o";
+        }
+
+        [Benchmark(Description = "ToString")]
+        [ArgumentsSource(nameof(ToString_MemberData))]
+        public string ToString_str(string format) => date1.ToString(format);
+
+        [Benchmark]
+        public TimeSpan op_Subtraction() => date1 - date2;
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
@@ -26,11 +26,15 @@ namespace System.Tests
         [Benchmark]
         [ArgumentsSource(nameof(Int32Values))]
         public string ToString(int value) => value.ToString();
-        
+
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public int Parse(string value) => int.Parse(value);
+
 #if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(StringValues))]
-        public int Parse(string value) => int.Parse(value.AsSpan());
+        public int ParseSpan(string value) => int.Parse(value.AsSpan());
 
         [Benchmark]
         [ArgumentsSource(nameof(Int32Values))]

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 
 namespace System.Tests
@@ -35,6 +36,12 @@ namespace System.Tests
         [ArgumentsSource(nameof(TestStringSizes))]
         public string Concat_str_str_str_str(StringArguments size)
             => string.Concat(size.TestString1, size.TestString2, size.TestString3, size.TestString4);
+
+        private readonly static IEnumerable<char> s_longCharEnumerable = Enumerable.Range(0, 1000).Select(i => (char)('a' + i % 26));
+
+        [Benchmark]
+        public string Concat_CharEnumerable() =>
+            string.Concat(s_longCharEnumerable);
 
         [Benchmark]
         [ArgumentsSource(nameof(TestStringSizes))]
@@ -171,6 +178,13 @@ namespace System.Tests
         [Arguments(StringComparison.OrdinalIgnoreCase)]
         public int LastIndexOf(StringComparison options)
             => s_longString.LastIndexOf(s_tagName, options);
+
+        private static readonly char[] s_colonAndSemicolon = { ':', ';' };
+
+        [Benchmark]
+        public int IndexOfAny() =>
+            "All the world's a stage, and all the men and women merely players: they have their exits and their entrances; and one man in his time plays many parts, his acts being seven ages."
+            .IndexOfAny(s_colonAndSemicolon);
 
         private CultureInfo _cultureInfo;
         

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
@@ -84,6 +84,33 @@ namespace System.Tests
             return sb;
         }
 
+        [Benchmark]
+        public StringBuilder Append_ValueTypes()
+        {
+            var sb = new StringBuilder();
+
+            for (int j = 0; j < NUM_ITERS_APPEND; j++)
+            {
+                sb.Append(sbyte.MaxValue);
+                sb.Append(byte.MaxValue);
+                sb.Append(short.MaxValue);
+                sb.Append(ushort.MaxValue);
+                sb.Append(int.MaxValue);
+                sb.Append(uint.MaxValue);
+                sb.Append(long.MaxValue);
+                sb.Append(ulong.MaxValue);
+                sb.Append(double.MaxValue);
+                sb.Append(float.MaxValue);
+                sb.Append(decimal.MaxValue);
+                sb.Append(new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+                sb.Append(new DateTime(2018, 12, 14));
+                sb.Append(new DateTimeOffset(new DateTime(2018, 12, 14), default));
+                sb.Append(new TimeSpan(1, 2, 3));
+            }
+
+            return sb;
+        }
+
         [GlobalSetup(Target = nameof(StringBuilderToString))]
         public void SetupStringBuilderToString()
         {

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Uri.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Uri.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_Uri
+    {
+        [Benchmark]
+        public string ParseAbsoluteUri() => new Uri("http://127.0.0.1:80").AbsoluteUri;
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Rfc2898DeriveBytes.cs
+++ b/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Rfc2898DeriveBytes.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Security.Cryptography.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_Rfc2898DeriveBytes
+    {
+        private static readonly Rfc2898DeriveBytes s_db = new Rfc2898DeriveBytes("verysafepassword", 32, 10_000, HashAlgorithmName.SHA256);
+
+        [Benchmark]
+        public byte[] DeriveBytes() => s_db.GetBytes(32);
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Threading.Tasks/Perf.AsyncMethods.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Tasks/Perf.AsyncMethods.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+#pragma warning disable CS1998 // async methods without awaits
+
+namespace System.Threading.Tasks.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_AsyncMethods
+    {
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public async Task EmptyAsyncMethodInvocation()
+        {
+            for (int i = 0; i < 100_000; i++)
+            {
+                await EmptyAsync();
+            }
+
+            async Task EmptyAsync() { }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1_000)]
+        public async Task SingleYieldMethodInvocation()
+        {
+            for (int i = 0; i < 1_000; i++)
+            {
+                await Yield();
+            }
+
+            async Task Yield() => await Task.Yield();
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Threading/Perf.CancellationToken.cs
+++ b/src/benchmarks/micro/corefx/System.Threading/Perf.CancellationToken.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Threading.Tasks;
+
+namespace System.Threading.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_CancellationToken
+    {
+        private readonly CancellationToken _token = new CancellationTokenSource().Token;
+
+        [Benchmark]
+        public void RegisterAndUnregister_Serial() => _token.Register(() => { }).Dispose();
+
+        [Benchmark(OperationsPerInvoke = 1_000_000)]
+        public void RegisterAndUnregister_Parallel() =>
+            Parallel.For(0, 1_000_000, i => _token.Register(() => { }).Dispose());
+
+        [Benchmark]
+        public void Cancel()
+        {
+            var cts = new CancellationTokenSource();
+            cts.Token.Register(() => { });
+            cts.Cancel();
+        }
+
+        private CancellationToken _token1 = new CancellationTokenSource().Token;
+        private CancellationToken _token2 = new CancellationTokenSource().Token;
+        private CancellationToken[] _tokens = new[] { new CancellationTokenSource().Token, new CancellationTokenSource().Token, new CancellationTokenSource().Token };
+
+        [Benchmark]
+        public void CreateLinkedTokenSource1() =>
+            CancellationTokenSource.CreateLinkedTokenSource(_token1, default).Dispose();
+
+        [Benchmark]
+        public void CreateLinkedTokenSource2() =>
+            CancellationTokenSource.CreateLinkedTokenSource(_token1, _token2).Dispose();
+
+        [Benchmark]
+        public void CreateLinkedTokenSource3() =>
+            CancellationTokenSource.CreateLinkedTokenSource(_tokens).Dispose();
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Threading/Perf.ThreadStatic.cs
+++ b/src/benchmarks/micro/corefx/System.Threading/Perf.ThreadStatic.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Threading.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_ThreadStatic
+    {
+        [Benchmark]
+        public object GetThreadStatic() => t_threadStaticValue;
+
+        [Benchmark]
+        public void SetThreadStatic() => t_threadStaticValue = _obj;
+
+        private readonly object _obj = new object();
+
+        [ThreadStatic]
+        private static object t_threadStaticValue = null;
+    }
+}


### PR DESCRIPTION
Some of the benchmarks from https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/ are already covered, but a bunch aren't.  This adds the missing ones. (The only one I didn't add is Enum.HasFlags, as it ends up conflicting with the 2.0 PR I put up earlier today; that can be added later.)