### PR TITLE
Explain our Categories policy and enforce it using a Validator

### DIFF
--- a/src/benchmarks/micro/Categories.cs
+++ b/src/benchmarks/micro/Categories.cs
@@ -6,6 +6,20 @@ namespace MicroBenchmarks
 {
     public static class Categories
     {
+        /// <summary>
+        /// benchmarks belonging to this category are not going to be executed as part of our daily CI runs
+        /// but we are going to run them before every .NET Framework release to make sure we don't regress 3rd party libraries
+        /// </summary>
+        public const string ThirdParty = "ThirdParty";
+        
+        /// <summary>
+        /// benchmarks belonging to this category are executed for CoreFX CI jobs
+        /// </summary>
+        public const string CoreFX = "CoreFX";
+        
+        /// <summary>
+        /// benchmarks belonging to this category are executed for CoreCLR CI jobs
+        /// </summary>
         public const string CoreCLR = "CoreCLR";
             public const string BenchmarksGame = "BenchmarksGame";
             public const string Benchstones = "Benchstones";
@@ -15,8 +29,6 @@ namespace MicroBenchmarks
             public const string V8 = "V8";
             public const string Perflab = "Perflab";
             public const string Virtual = "Virtual";
-        
-        public const string CoreFX = "CoreFX";
 
         public const string LINQ = "LINQ";
         public const string Reflection = "Reflection";

--- a/src/benchmarks/micro/Categories.cs
+++ b/src/benchmarks/micro/Categories.cs
@@ -8,7 +8,7 @@ namespace MicroBenchmarks
     {
         /// <summary>
         /// benchmarks belonging to this category are not going to be executed as part of our daily CI runs
-        /// but we are going to run them before every .NET Framework release to make sure we don't regress 3rd party libraries
+        /// we are going to run them periodically to make sure we don't regress any of the most popular 3rd party libraries.
         /// </summary>
         public const string ThirdParty = "ThirdParty";
         

--- a/src/benchmarks/micro/Harness/MandatoryCategoryValidator.cs
+++ b/src/benchmarks/micro/Harness/MandatoryCategoryValidator.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Validators;
+
+namespace MicroBenchmarks
+{
+    /// <summary>
+    /// this class makes sure that every benchmark belongs to either a CoreFX, CoreCLR or ThirdParty category
+    /// for CoreCLR CI jobs we want to run only benchmarks form CoreCLR category
+    /// the same goes for CoreFX
+    /// </summary>
+    public class MandatoryCategoryValidator : IValidator
+    {
+        public static readonly IValidator FailOnError = new MandatoryCategoryValidator();
+
+        public bool TreatsWarningsAsErrors => true;
+
+        public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+            => validationParameters.Benchmarks
+                .Where(benchmark => !benchmark.Descriptor.Categories.Any(category => category == Categories.CoreFX || category == Categories.CoreCLR || category == Categories.ThirdParty))
+                .Select(benchmark => benchmark.Descriptor.GetFilterName())
+                .Distinct()
+                .Select(benchmarkId =>
+                    new ValidationError(
+                        isCritical: TreatsWarningsAsErrors,
+                        $"{benchmarkId} does not belong to one of the mandatory categories: {Categories.CoreCLR}, {Categories.CoreFX}, {Categories.ThirdParty}. Use [BenchmarkCategory(Categories.$)]")
+                );
+    }
+}

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -35,6 +35,7 @@ namespace MicroBenchmarks
                 .With(new OperatingSystemFilter())
                 .With(JsonExporter.Full) // make sure we export to Json (for BenchView integration purpose)
                 .With(StatisticColumn.Median, StatisticColumn.Min, StatisticColumn.Max)
-                .With(TooManyTestCasesValidator.FailOnError);
+                .With(TooManyTestCasesValidator.FailOnError)
+                .With(MandatoryCategoryValidator.FailOnError);
     }
 }

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -128,6 +128,21 @@ System
  │     └─ReadOnlySpan
 ```
 
+## Categories
+
+Every benchmark should belong to either CoreCLR, CoreFX or ThirdParty library. It allows us for proper filtering for CI runs:
+
+* CoreCLR - benchmarks belonging to this category are executed for CoreCLR CI jobs
+* CoreFX - benchmarks belonging to this category are executed for CoreFX CI jobs
+* ThirdParty - benchmarks belonging to this category are not going to be executed as part of our daily CI runs. We are going to run them before every .NET Framework release to make sure we don't regress any of the most popular 3rd party libraries.
+
+Adding given type/method to particular category requires using a `[BenchmarkCategory]` attribute:
+
+```cs
+[BenchmarkCategory(Categories.CoreFX)]
+public class SomeType
+```
+
 ## All Statistics
 
 By default BenchmarkDotNet displays only `Mean`, `Error` and `StdDev` in the results. If you want to see more statistics, please pass `--allStats` as an extra argument to the app: `dotnet run -c Release -f netcoreapp2.1 -- --allStats`. If you build your own config, please use `config.With(StatisticColumn.AllStatistics)`.

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -130,11 +130,11 @@ System
 
 ## Categories
 
-Every benchmark should belong to either CoreCLR, CoreFX or ThirdParty library. It allows us for proper filtering for CI runs:
+Every benchmark should belong to either CoreCLR, CoreFX or ThirdParty library. It allows for proper filtering for CI runs:
 
 * CoreCLR - benchmarks belonging to this category are executed for CoreCLR CI jobs
 * CoreFX - benchmarks belonging to this category are executed for CoreFX CI jobs
-* ThirdParty - benchmarks belonging to this category are not going to be executed as part of our daily CI runs. We are going to run them before every .NET Framework release to make sure we don't regress any of the most popular 3rd party libraries.
+* ThirdParty - benchmarks belonging to this category are not going to be executed as part of our daily CI runs. We are going to run them periodically to make sure we don't regress any of the most popular 3rd party libraries.
 
 Adding given type/method to particular category requires using a `[BenchmarkCategory]` attribute:
 

--- a/src/benchmarks/micro/Serializers/Binary_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_FromStream.cs
@@ -68,6 +68,7 @@ namespace MicroBenchmarks.Serializers
             return (T)binaryFormatter.Deserialize(memoryStream);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "protobuf-net")]
         public T ProtoBuffNet()
         {
@@ -75,6 +76,7 @@ namespace MicroBenchmarks.Serializers
             return ProtoBuf.Serializer.Deserialize<T>(memoryStream);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "ZeroFormatter_Naive")]
         public T ZeroFormatter_Naive()
         {
@@ -87,6 +89,7 @@ namespace MicroBenchmarks.Serializers
         /// they are deserialized for real when they are used for the first time
         /// if we don't touch the properites, they are not being deserialized and the result is skewed
         /// </summary>
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "ZeroFormatter_Real")]
         public long ZeroFormatter_Real()
         {
@@ -97,6 +100,7 @@ namespace MicroBenchmarks.Serializers
             return deserialized.TouchEveryProperty();
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "MessagePack")]
         public T MessagePack_()
         {

--- a/src/benchmarks/micro/Serializers/Binary_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_FromStream.cs
@@ -60,6 +60,7 @@ namespace MicroBenchmarks.Serializers
             MessagePack.MessagePackSerializer.Serialize<T>(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.CoreFX)]
         [Benchmark(Description = nameof(BinaryFormatter))]
         public T BinaryFormatter_()
         {

--- a/src/benchmarks/micro/Serializers/Binary_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_ToStream.cs
@@ -32,6 +32,7 @@ namespace MicroBenchmarks.Serializers
             ProtoBuf.Meta.RuntimeTypeModel.Default.Add(typeof(DateTimeOffset), false).SetSurrogate(typeof(DateTimeOffsetSurrogate)); // https://stackoverflow.com/a/7046868
         }
 
+        [BenchmarkCategory(Categories.CoreFX)]
         [Benchmark(Description = nameof(BinaryFormatter))]
         public void BinaryFormatter_()
         {

--- a/src/benchmarks/micro/Serializers/Binary_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_ToStream.cs
@@ -40,6 +40,7 @@ namespace MicroBenchmarks.Serializers
             binaryFormatter.Serialize(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "protobuf-net")]
         public void ProtoBuffNet()
         {
@@ -47,6 +48,7 @@ namespace MicroBenchmarks.Serializers
             ProtoBuf.Serializer.Serialize(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "ZeroFormatter")]
         public void ZeroFormatter_()
         {
@@ -54,6 +56,7 @@ namespace MicroBenchmarks.Serializers
             ZeroFormatter.ZeroFormatterSerializer.Serialize<T>(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "MessagePack")]
         public void MessagePack_()
         {

--- a/src/benchmarks/micro/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.cs
@@ -72,6 +72,7 @@ namespace MicroBenchmarks.Serializers
             dataContractJsonSerializer.WriteObject(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public T Jil_()
         {
@@ -81,7 +82,7 @@ namespace MicroBenchmarks.Serializers
                 return Jil.JSON.Deserialize<T>(reader);
         }
 
-        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX, Categories.ThirdParty)] // JSON.NET is so popular that despite being 3rd Party lib we run the benchmarks for CoreFX and CoreCLR CI
         [Benchmark(Description = "JSON.NET")]
         public T JsonNet_()
         {
@@ -91,6 +92,7 @@ namespace MicroBenchmarks.Serializers
                 return (T)newtonSoftJsonSerializer.Deserialize(reader, typeof(T));
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public T Utf8Json_()
         {

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -27,13 +27,15 @@ namespace MicroBenchmarks.Serializers
         [GlobalSetup(Target = nameof(Utf8Json_))]
         public void SerializeUtf8Json_() => serialized = Utf8Json.JsonSerializer.ToJsonString(value);
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public T Jil_() => Jil.JSON.Deserialize<T>(serialized);
 
-        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX, Categories.ThirdParty)]
         [Benchmark(Description = "JSON.NET")]
         public T JsonNet_() => Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serialized);
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public T Utf8Json_() => Utf8Json.JsonSerializer.Deserialize<T>(serialized);
     }

--- a/src/benchmarks/micro/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.cs
@@ -36,6 +36,7 @@ namespace MicroBenchmarks.Serializers
             newtonSoftJsonSerializer = new Newtonsoft.Json.JsonSerializer();
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public void Jil_()
         {
@@ -43,7 +44,7 @@ namespace MicroBenchmarks.Serializers
             Jil.JSON.Serialize<T>(value, streamWriter);
         }
 
-        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX, Categories.ThirdParty)]
         [Benchmark(Description = "JSON.NET")]
         public void JsonNet_()
         {
@@ -51,6 +52,7 @@ namespace MicroBenchmarks.Serializers
             newtonSoftJsonSerializer.Serialize(streamWriter, value);
         }
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public void Utf8Json_()
         {

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -17,13 +17,15 @@ namespace MicroBenchmarks.Serializers
 
         public Json_ToString() => value = DataGenerator.Generate<T>();
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public string Jil_() => Jil.JSON.Serialize<T>(value);
 
-        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX, Categories.ThirdParty)]
         [Benchmark(Description = "JSON.NET")]
         public string JsonNet_() => Newtonsoft.Json.JsonConvert.SerializeObject(value);
 
+        [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public string Utf8Json_() => Utf8Json.JsonSerializer.ToJsonString(value);
 

--- a/src/benchmarks/micro/Serializers/Xml_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_FromStream.cs
@@ -18,7 +18,6 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(XmlElement))]
     [GenericTypeArguments(typeof(SimpleStructWithProperties))]
     [GenericTypeArguments(typeof(ClassImplementingIXmlSerialiable))]
-    [BenchmarkCategory(Categories.CoreFX)]
     public class Xml_FromStream<T>
     {
         private readonly T value;
@@ -48,6 +47,7 @@ namespace MicroBenchmarks.Serializers
             dataContractSerializer.WriteObject(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
         [Benchmark(Description = nameof(XmlSerializer))]
         public T XmlSerializer_()
         {
@@ -55,6 +55,7 @@ namespace MicroBenchmarks.Serializers
             return (T)xmlSerializer.Deserialize(memoryStream);
         }
 
+        [BenchmarkCategory(Categories.CoreFX)]
         [Benchmark(Description = nameof(DataContractSerializer))]
         public T DataContractSerializer_()
         {

--- a/src/benchmarks/micro/Serializers/Xml_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_ToStream.cs
@@ -18,7 +18,6 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(XmlElement))]
     [GenericTypeArguments(typeof(SimpleStructWithProperties))]
     [GenericTypeArguments(typeof(ClassImplementingIXmlSerialiable))]
-    [BenchmarkCategory(Categories.CoreFX)]
     public class Xml_ToStream<T>
     {
         private readonly T value;
@@ -34,6 +33,7 @@ namespace MicroBenchmarks.Serializers
             memoryStream = new MemoryStream(capacity: short.MaxValue);
         }
 
+        [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
         [Benchmark(Description = nameof(XmlSerializer))]
         public void XmlSerializer_()
         {
@@ -41,6 +41,7 @@ namespace MicroBenchmarks.Serializers
             xmlSerializer.Serialize(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.CoreFX)]
         [Benchmark(Description = nameof(DataContractSerializer))]
         public void DataContractSerializer_()
         {

--- a/src/benchmarks/micro/corefx/System.ComponentModel.TypeConverter/Perf.TypeDescriptorTests.cs
+++ b/src/benchmarks/micro/corefx/System.ComponentModel.TypeConverter/Perf.TypeDescriptorTests.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.ComponentModel.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_TypeDescriptorTests
     {
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Console/Perf.Console.cs
+++ b/src/benchmarks/micro/corefx/System.Console/Perf.Console.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using MicroBenchmarks;
 
 namespace System.ConsoleTests
 {
@@ -14,6 +14,7 @@ namespace System.ConsoleTests
     /// - OpenStandardInput, OpenStandardOutput, OpenStandardError
     /// - ForegroundColor, BackgroundColor, ResetColor
     /// </summary>
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Console
     {
         private readonly Consumer consumer = new Consumer();

--- a/src/benchmarks/micro/corefx/System.Diagnostics/Perf_Process.cs
+++ b/src/benchmarks/micro/corefx/System.Diagnostics/Perf_Process.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Diagnostics
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Process
     {
         private readonly string _nonExistingName = Guid.NewGuid().ToString();

--- a/src/benchmarks/micro/corefx/System.Globalization/Perf.CompareInfo.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/Perf.CompareInfo.cs
@@ -4,9 +4,11 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Globalization.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_CompareInfo
     {
         private static string GenerateInputString(char source, int count, char replaceChar, int replacePos)

--- a/src/benchmarks/micro/corefx/System.Globalization/Perf.CultureInfo.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/Perf.CultureInfo.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Globalization.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_CultureInfo
     {
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Globalization/Perf.DateTimeCultureInfo.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/Perf.DateTimeCultureInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Globalization.Tests
 {
@@ -12,6 +13,7 @@ namespace System.Globalization.Tests
     /// 
     /// Primary methods affected: Parse, ToString
     /// </summary>
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_DateTimeCultureInfo
     {
         private readonly DateTime _time = DateTime.Now;

--- a/src/benchmarks/micro/corefx/System.Globalization/Perf.NumberCultureInfo.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/Perf.NumberCultureInfo.cs
@@ -4,12 +4,14 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Globalization.Tests
 {
     /// <summary>
     /// Performance tests for converting numbers to different CultureInfos
     /// </summary>
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_NumberCultureInfo
     {
         public IEnumerable<object> Cultures()

--- a/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Compression
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Brotli : CompressionStreamPerfTestBase
     {
         private const int Window = 22;

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.Directory.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.Directory.cs
@@ -7,9 +7,11 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Directory
     {
         private const int CreateInnerIterations = 10;

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.File.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.File.cs
@@ -4,9 +4,11 @@
 
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_File
     {
         private const int DeleteteInnerIterations = 10;

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileInfo.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileInfo.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_FileInfo
     {
         private readonly string _path = FileUtils.GetTestFilePath();

--- a/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/corefx/System.IO.FileSystem/Perf.FileStream.cs
@@ -4,9 +4,11 @@
 
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_FileStream
     {
         private const int DefaultBufferSize = 4096;

--- a/src/benchmarks/micro/corefx/System.IO.MemoryMappedFiles/Perf.MemoryMappedFile.cs
+++ b/src/benchmarks/micro/corefx/System.IO.MemoryMappedFiles/Perf.MemoryMappedFile.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.MemoryMappedFiles.Tests
 {
     /// <summary>
     /// Performance tests for the construction and disposal of MemoryMappedFiles of varying sizes
     /// </summary>
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_MemoryMappedFile
     {
         private TempFile _file;

--- a/src/benchmarks/micro/corefx/System.Net.Primitives/CredentialCacheTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.Primitives/CredentialCacheTests.cs
@@ -5,9 +5,11 @@
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using MicroBenchmarks;
 
 namespace System.Net.Primitives.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class CredentialCacheTests
     {
         private const string UriPrefix = "http://name";

--- a/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
@@ -5,11 +5,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 #pragma warning disable CS0618 // obsolete
 
 namespace System.Net.Primitives.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class IPAddressPerformanceTests
     {
         public static IEnumerable<object> ByteAddresses()

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Array.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Array.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Tests
 {
+    [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
     public class Perf_Array
     {
         private static Array s_arr1;

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
@@ -6,9 +6,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Tests
 {
+    [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
     public class Perf_String
     {
         public static IEnumerable<object> TestStringSizes()
@@ -37,7 +39,7 @@ namespace System.Tests
         public string Concat_str_str_str_str(StringArguments size)
             => string.Concat(size.TestString1, size.TestString2, size.TestString3, size.TestString4);
 
-        private readonly static IEnumerable<char> s_longCharEnumerable = Enumerable.Range(0, 1000).Select(i => (char)('a' + i % 26));
+        private static readonly IEnumerable<char> s_longCharEnumerable = Enumerable.Range(0, 1000).Select(i => (char)('a' + i % 26));
 
         [Benchmark]
         public string Concat_CharEnumerable() =>

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
@@ -5,9 +5,11 @@
 using System.Linq;
 using System.Text;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
     public class Perf_StringBuilder
     {
         private readonly string _string0 = "";

--- a/src/benchmarks/micro/corefx/System.Security.Cryptography.Primitives/Perf.FixedTimeEquals.cs
+++ b/src/benchmarks/micro/corefx/System.Security.Cryptography.Primitives/Perf.FixedTimeEquals.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Security.Cryptography;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 using Test.Cryptography;
 
 namespace System.Security.Cryptography.Primitives.Tests.Performance
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_FixedTimeEquals
     {
         byte[] baseValue, errorVector;

--- a/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Hashing.cs
+++ b/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.Hashing.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Security.Cryptography.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Hashing
     {
-        private readonly byte[] _data = MicroBenchmarks.ValuesGenerator.Array<byte>(100 * 1024 * 1024);
+        private readonly byte[] _data = ValuesGenerator.Array<byte>(100 * 1024 * 1024);
 
         private readonly SHA1 _sha1 = SHA1.Create();
         private readonly SHA256 _sha256 = SHA256.Create();

--- a/src/benchmarks/micro/corefx/System.Text.Encoding/Perf.Encoding.cs
+++ b/src/benchmarks/micro/corefx/System.Text.Encoding/Perf.Encoding.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.Text.Tests
 {
+    [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Encoding
     {
         [Params(16, 512)]

--- a/src/benchmarks/micro/corefx/System/Hashing.cs
+++ b/src/benchmarks/micro/corefx/System/Hashing.cs
@@ -4,9 +4,11 @@
 
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System
 {
+    [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX)]
     public class Hashing
     {
         private string _string;


### PR DESCRIPTION
@stephentoub this is a follow up to our yesterday's conversation

I described our policy in the docs and added a Validator that is going to enforce it.

Sample error message:

```log
PS C:\Projects\performance> dotnet run -c Release -f netcoreapp2.1 -p .\src\benchmarks\micro\MicroBenchmarks.csproj --filter *
// Validating benchmarks:
MicroBenchmarks.Serializers.Binary_FromStream<LoginViewModel>.ProtoBuffNet does not belong to one of the mandatory categories: CoreCLR, CoreFX, ThirdParty. Use [BenchmarkCategory(Categories.$)]
MicroBenchmarks.Serializers.Binary_FromStream<LoginViewModel>.ZeroFormatter_Naive does not belong to one of the mandatory categories: CoreCLR, CoreFX, ThirdParty. Use [BenchmarkCategory(Categories.$)]
MicroBenchmarks.Serializers.Binary_FromStream<LoginViewModel>.ZeroFormatter_Real does not belong to one of the mandatory categories: CoreCLR, CoreFX, ThirdParty. Use [BenchmarkCategory(Categories.$)]
```

I have of course added all missing categories, so there is 0 errors as if today.