### PR TITLE
Allow more than one CoreRun benchmarks_ci.py script

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -482,7 +482,7 @@ def __main(args: list) -> int:
         if args.category:
             run_args += ['--allCategories', args.category]
         if args.corerun:
-            run_args += ['--coreRun', args.corerun]
+            run_args += ['--coreRun'] + args.corerun
         if args.cli:
             run_args += ['--cli', args.cli]
         if args.enable_pmc:

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -173,6 +173,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--corerun',
         dest='corerun',
         required=False,
+        nargs='*',
         type=__valid_file_path,
         help='Full path to CoreRun.exe (corerun on Unix)',
     )

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -173,7 +173,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--corerun',
         dest='corerun',
         required=False,
-        nargs='*',
+        nargs='+',
         type=__valid_file_path,
         help='Full path to CoreRun.exe (corerun on Unix)',
     )

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -299,7 +299,7 @@ def __main(args: list) -> int:
             if args.category:
                 run_args += ['--allCategories', args.category]
             if args.corerun:
-                run_args += ['--coreRun', args.corerun]
+                run_args += ['--coreRun'] + args.corerun
             if args.cli:
                 run_args += ['--cli', args.cli]
             if args.enable_pmc:


### PR DESCRIPTION
Contributes to https://github.com/dotnet/performance/issues/209
This PR allows to have more than one `--corerun` runner, for instance:
```
.\scripts\benchmarks_ci.py --frameworks netcoreapp3.0 --filter *.Perf_Dictionary.* --corerun D:\git\corefxupstream\artifacts\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\9.9.9\CoreRun.exe D:\git\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\9.9.9\CoreRun.exe --bdn-arguments \"--join\"
```

/cc @adamsitnik @jorive 