### PR TITLE
Remove --no-build for run verb in dotnet.py

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -140,7 +140,7 @@ class CSharpProject:
             '--project', self.csproj_file,
             '--configuration', configuration,
             '--framework', framework,
-            '--no-restore', '--no-build',
+            # '--no-build' temporary disabled due to BDN issue https://github.com/dotnet/performance/issues/209#issuecomment-451759735
         ]
 
         if args:


### PR DESCRIPTION
Check comment https://github.com/dotnet/performance/issues/209#issuecomment-451759735

From guide https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore21
```
--no-build

Doesn't build the project before running. It also implicit sets the --no-restore flag.
```

/cc @adamsitnik @jorive 
