### PR TITLE
CoreRT support

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -343,7 +343,7 @@ def __run_benchview_scripts(args: list, verbose: bool) -> None:
 
     for framework in args.frameworks:
         target_framework_moniker = FrameworkAction.get_target_framework_moniker(framework)
-        buildinfo = __get_build_info(args, )
+        buildinfo = __get_build_info(args, target_framework_moniker)
 
         # BenchView build.py
         benchviewpy.build(

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -476,33 +476,7 @@ def __main(args: list) -> int:
 
     # Run micro-benchmarks
     for framework in args.frameworks:
-        run_args = [
-            '--'
-        ]
-        if args.category:
-            run_args += ['--allCategories', args.category]
-        if args.corerun:
-            run_args += ['--coreRun'] + args.corerun
-        if args.cli:
-            run_args += ['--cli', args.cli]
-        if args.enable_pmc:
-            run_args += [
-                '--counters',
-                'BranchMispredictions+CacheMisses+InstructionRetired',
-            ]
-        if args.filter:
-            run_args += ['--filter'] + args.filter
-
-        # Extra BenchmarkDotNet cli arguments.
-        if args.bdn_arguments:
-            run_args += args.bdn_arguments
-
-        # we need to tell BenchmarkDotNet where to restore the packages
-        # if we don't it's gonna restore to default global folder
-        run_args += ['--packages', micro_benchmarks.get_packages_directory()]
-        run_args += ['--runtimes', framework] # the --packages requires this argument to work (BDN limitaiton)
-
-        micro_benchmarks.run(args.configuration, framework, verbose, *run_args)
+        micro_benchmarks.run(args.configuration, framework, verbose, args)
 
     __run_benchview_scripts(args, verbose)
     # TODO: Archive artifacts.

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -97,11 +97,11 @@ class CSharpProject:
 
     def build(self,
               configuration: str,
-              frameworks: list,
+              target_framework_monikers: list,
               verbose: bool,
               *args) -> None:
         '''Calls dotnet to build the specified project.'''
-        if not frameworks:  # Frameworks were not specified, the build all.
+        if not target_framework_monikers:  # target framework monikers were not specified, the build all.
             cmdline = [
                 'dotnet', 'build',
                 self.csproj_file,
@@ -113,12 +113,12 @@ class CSharpProject:
             RunCommand(cmdline, verbose=verbose).run(
                 self.working_directory)
         else:  # Only build specified frameworks
-            for framework in frameworks:
+            for target_framework_moniker in target_framework_monikers:
                 cmdline = [
                     'dotnet', 'build',
                     self.csproj_file,
                     '--configuration', configuration,
-                    '--framework', framework,
+                    '--framework', target_framework_moniker,
                     '--no-restore',
                 ]
                 if args:
@@ -128,7 +128,7 @@ class CSharpProject:
 
     def run(self,
             configuration: str,
-            framework: str,
+            target_framework_moniker: str,
             verbose: bool,
             *args) -> None:
         '''
@@ -139,7 +139,7 @@ class CSharpProject:
             'dotnet', 'run',
             '--project', self.csproj_file,
             '--configuration', configuration,
-            '--framework', framework,
+            '--framework', target_framework_moniker,
             '--no-restore', '--no-build',
         ]
 
@@ -205,7 +205,7 @@ def get_commit_date(commit_sha: str, repository: str = None) -> str:
 def get_build_directory(
         bin_directory: str,
         configuration: str,
-        framework: str) -> None:
+        target_framework_moniker: str) -> None:
     '''
     Gets the  output directory where the built artifacts are in with
     respect to the specified bin_directory.
@@ -215,21 +215,21 @@ def get_build_directory(
             bin_directory,
             __find_build_directory(
                 configuration=configuration,
-                framework=framework,
+                target_framework_moniker=target_framework_moniker,
             )
         )
 
 
 def __find_build_directory(
         configuration: str,
-        framework: str) -> str:
+        target_framework_moniker: str) -> str:
     '''
     Attempts to get the output directory where the built artifacts are in
     with respect to the current working directory.
     '''
     pattern = '**/{Configuration}/{TargetFramework}'.format(
         Configuration=configuration,
-        TargetFramework=framework
+        TargetFramework=target_framework_moniker
     )
 
     for path_name in iglob(pattern, recursive=True):

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -105,7 +105,8 @@ class FrameworkAction(Action):
             FrameworkAction.get_target_framework_moniker(framework)
             for framework in frameworks
         ]
-        return monikers
+        ## --frameworks netcoreapp3.0 corert should be translated to single moniker: netcoreapp3.0
+        return list(set(monikers))
 
 
 def get_supported_configurations() -> list:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.909" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.909" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.921" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.921" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.889" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.889" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.909" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.909" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />


### PR DESCRIPTION
There is a throughput difference for PlainText TechEmpower benchmark for CoreRT vs .NET Core 3.0 on Linux. It's big enough that the benchmarks should show where the problem is.

This PR adds CoreRT support. BenchmarkDotNet supported CoreRT for a while, but I needed to fix some minor issues (https://github.com/dotnet/BenchmarkDotNet/pull/1001) and update our scripts to support it.

@jorive CoreRT does not support full reflection, so to run the benchmarks for CoreRT we need to run the host process as .NET Core process let is use reflection etc to build a CoreRT benchmark process. This is why I needed to differentiate framework and target framework moniker in the Python scripts. When we want to run .NET Core benchmarks, framework = moniker. When we want to run the CoreRT ones, framework = CoreRT, but moniker is netcoreapp3.0.

@jkotas to run all our benchmarks for CoreRT we now just need to run following command:

```cmd
.\scripts\benchmarks_ci.py --frameworks corert --filter *
```

this script downloads .NET Core 3.0 cli from Azure, setups everything and run the benchmarks using BenchmarkDotNet. I am going to run them for Linux and share the results soon
