### PR TITLE
if we fail to do the full build, we try with --no-dependencies

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.921" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.921" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.931" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.931" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />


### PR DESCRIPTION
In #218 I have introduced a regression introduced in BDN in [#1013](https://github.com/dotnet/BenchmarkDotNet/pull/1013/files#diff-83177b9866652943fa5d5bb8f80d847aL83)

Which got our CI failing.

This change updates BDN to a version with following fix: 
https://github.com/dotnet/BenchmarkDotNet/commit/6ee21bb6356f7199425edb788a6acd85aec95b7b
