### PR TITLE
Bug fixes and updating comments.

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -101,7 +101,7 @@ class CSharpProject:
               verbose: bool,
               *args) -> None:
         '''Calls dotnet to build the specified project.'''
-        if not target_framework_monikers:  # target framework monikers were not specified, the build all.
+        if not target_framework_monikers: # Build all supported frameworks.
             cmdline = [
                 'dotnet', 'build',
                 self.csproj_file,
@@ -268,7 +268,7 @@ def install(
     # Download appropriate dotnet install script
     dotnetInstallScriptExtension = '.ps1' if platform == 'win32' else '.sh'
     dotnetInstallScriptName = 'dotnet-install' + dotnetInstallScriptExtension
-    url = 'https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/'
+    url = 'https://dot.net/v1/'
     dotnetInstallScriptUrl = url + dotnetInstallScriptName
 
     dotnetInstallScriptPath = path.join(install_dir, dotnetInstallScriptName)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -77,7 +77,7 @@ class FrameworkAction(Action):
         '''
         dct = FrameworkAction.__get_target_framework_moniker_channel_map()
         return dct[target_framework_moniker] if target_framework_moniker in dct else None
-        
+
     @staticmethod
     def get_target_framework_moniker(framework: str) -> str:
         '''
@@ -86,7 +86,7 @@ class FrameworkAction(Action):
         the host process will build and run CoreRT benchmarks
         '''
         return 'netcoreapp3.0' if framework == 'corert' else framework
-        
+
     @staticmethod
     def get_target_framework_monikers(frameworks: list) -> list:
         '''
@@ -108,11 +108,13 @@ def get_supported_configurations() -> list:
     '''
     return ['Release', 'Debug']
 
+
 def get_packages_directory() -> str:
     '''
     The path to directory where packages should get restored
     '''
     return path.join(get_artifacts_directory(), 'packages')
+
 
 def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     '''
@@ -242,11 +244,8 @@ def __process_arguments(args: list) -> Tuple[list, bool]:
     parser = add_arguments(parser)
     return parser.parse_args(args)
 
-def __getBenchmarkDotNetArguments(
-        framework: str,
-        args: list
-        ) -> list:
 
+def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
     run_args = ['--']
     if args.category:
         run_args += ['--allCategories', args.category]
@@ -265,13 +264,13 @@ def __getBenchmarkDotNetArguments(
     # Extra BenchmarkDotNet cli arguments.
     if args.bdn_arguments:
         run_args += args.bdn_arguments
-        
+
     # we need to tell BenchmarkDotNet where to restore the packages
     # if we don't it's gonna restore to default global folder
     run_args += ['--packages', get_packages_directory()]
     # required for CoreRT where host process framework != benchmark process framework
     run_args += ['--runtimes', framework]
-        
+
     return run_args
 
 
@@ -314,9 +313,16 @@ def run(
         framework
     ))
     # dotnet run
-    run_args = __getBenchmarkDotNetArguments(framework, *args)
-    target_framework_moniker = FrameworkAction.get_target_framework_moniker(framework)
-    BENCHMARKS_CSPROJ.run(configuration, target_framework_moniker, verbose, *run_args)
+    run_args = __get_benchmarkdotnet_arguments(framework, *args)
+    target_framework_moniker = FrameworkAction.get_target_framework_moniker(
+        framework
+    )
+    BENCHMARKS_CSPROJ.run(
+        configuration,
+        target_framework_moniker,
+        verbose,
+        *run_args
+    )
 
 
 def __log_script_header(message: str):
@@ -341,7 +347,7 @@ def __main(args: list) -> int:
         frameworks = args.frameworks
         incremental = args.incremental
         verbose = args.verbose
-        target_framework_monikers = TargetAction.get_target_framework_monikers(frameworks)
+        target_framework_monikers = FrameworkAction.get_target_framework_monikers(frameworks)
 
         setup_loggers(verbose=verbose)
 

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -98,9 +98,11 @@ def get_tools_directory() -> str:
     '''Gets the default root directory where tools should be installed.'''
     return os.path.join(get_repo_root_path(), 'tools')
 
+
 def get_artifacts_directory() -> str:
     '''Gets the default artifacts directory where arcade builds the benchmarks.'''
     return os.path.join(get_repo_root_path(), 'artifacts')
+
 
 @contextmanager
 def push_dir(path: str = None) -> None:


### PR DESCRIPTION
- https://github.com/dotnet/performance/pull/218 introduced this bug:
```log
target_framework_moniker = FrameworkAction.get_target_framework_moniker(framework)
NameError: name 'FrameworkAction' is not defined
```
- Pull released `dotnet-install` script instead of latest from `dotnet/cli:master`.
- Minor fixing spacing and follow naming conventions: two lines between global functions, and camel case naming.
- Updated TODO/FIXME comments on the scripts.