### PR TITLE
Default value for the new argument which broke the script

### DIFF
--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -245,7 +245,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--bin-directory',
         dest='bin_directory',
         required=False,
-        default=None,
+        default=path.join(get_repo_root_path(), 'artifacts', 'bin'),
         type=str,
         help='Root of the bin directory',
     )


### PR DESCRIPTION
#173 introduced new argument called `--bin-directory`. The problem is that when we don't provide it, the script fails. The solution was to add the default value.

```log
Traceback (most recent call last):
  File ".\scripts\benchmarks_ci.py", line 524, in <module>
    __main(sys.argv[1:])
  File ".\scripts\benchmarks_ci.py", line 501, in __main
    csproj_file='MicroBenchmarks.csproj'
  File "C:\Projects\demo\scripts\dotnet.py", line 54, in __init__
    if not bin_directory and not path.isdir(bin_directory):
TypeError: _isdir: path should be string, bytes or os.PathLike, not NoneType
```