### PR TITLE
Small bug fix, styling, and removing unnecessary parameters.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: $(_HelixQueue)
             WorkItemDirectory: $(Build.SourcesDirectory)\src\benchmarks\micro
-            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
+            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory %HELIX_WORKITEM_PAYLOAD% --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
             WorkItemTimeout: 14400 # 4 hours
             CorrelationPayloadDirectory: $(Build.SourcesDirectory)\scripts
             EnableXUnitReporter: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: $(_HelixQueue)
             WorkItemDirectory: $(Build.SourcesDirectory)\src\benchmarks\micro
-            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory %HELIX_WORKITEM_PAYLOAD% --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="--buildTimeout 300 $(BDNArguments)"
+            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory %HELIX_WORKITEM_PAYLOAD% --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
             WorkItemTimeout: 14400 # 4 hours
             CorrelationPayloadDirectory: $(Build.SourcesDirectory)\scripts
             EnableXUnitReporter: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: $(_HelixQueue)
             WorkItemDirectory: $(Build.SourcesDirectory)\src\benchmarks\micro
-            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory "%CD%" --bin-directory "%CD%\bin" --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
+            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory . --bin-directory ".\bin" --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
             WorkItemTimeout: 14400 # 4 hours
             CorrelationPayloadDirectory: $(Build.SourcesDirectory)\scripts
             EnableXUnitReporter: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: $(_HelixQueue)
             WorkItemDirectory: $(Build.SourcesDirectory)\src\benchmarks\micro
-            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory %HELIX_WORKITEM_PAYLOAD% --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
+            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
             WorkItemTimeout: 14400 # 4 hours
             CorrelationPayloadDirectory: $(Build.SourcesDirectory)\scripts
             EnableXUnitReporter: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: $(_HelixQueue)
             WorkItemDirectory: $(Build.SourcesDirectory)\src\benchmarks\micro
-            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory %HELIX_WORKITEM_PAYLOAD% --bin-directory %HELIX_WORKITEM_PAYLOAD% --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
+            WorkItemCommand: py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --benchview-submission-name "$(BenchviewCommitName)" --working-directory "%CD%" --bin-directory "%CD%\bin" --incremental no --category $(_Category) --architecture $(_Architecture) -f $(_Framework) --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(_RunType) $(UploadToBenchview) --bdn-arguments="$(BDNArguments)"
             WorkItemTimeout: 14400 # 4 hours
             CorrelationPayloadDirectory: $(Build.SourcesDirectory)\scripts
             EnableXUnitReporter: false

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -34,7 +34,6 @@ import sys
 from performance.common import push_dir
 from performance.common import validate_supported_runtime
 from performance.logger import setup_loggers
-from performance.common import get_repo_root_path
 
 import benchview
 import dotnet
@@ -68,7 +67,8 @@ def init_tools(
     '''
     getLogger().info('Installing tools.')
     channels = [
-        micro_benchmarks.FrameworkAction.get_channel(target_framework_moniker) or 'LTS'
+        micro_benchmarks.FrameworkAction.get_channel(
+            target_framework_moniker) or 'LTS'
         for target_framework_moniker in target_framework_monikers
     ]
     dotnet.install(
@@ -276,7 +276,10 @@ def __get_corefx_os_name():
         return platform.platform()
 
 
-def __get_build_info(args, target_framework_moniker: str) -> benchview.BuildInfo:
+def __get_build_info(
+        args,
+        target_framework_moniker: str
+) -> benchview.BuildInfo:
     # TODO: Improve complex scenarios.
     #   Could the --cli-* arguments take multiple build info objects from the
     #   command line interface?
@@ -296,7 +299,8 @@ def __get_build_info(args, target_framework_moniker: str) -> benchview.BuildInfo
             target_framework_moniker
         )
         if not branch:
-            err_msg = 'Cannot determine build information for "%s"' % target_framework_moniker
+            err_msg = 'Cannot determine build information for "%s"' % \
+                target_framework_moniker
             getLogger().error(err_msg)
             getLogger().error(
                 "Build information can be provided using the --cli-* options."
@@ -320,7 +324,11 @@ def __get_build_info(args, target_framework_moniker: str) -> benchview.BuildInfo
     )
 
 
-def __run_benchview_scripts(args: list, verbose: bool, BENCHMARKS_CSPROJ: dotnet.CSharpProject) -> None:
+def __run_benchview_scripts(
+        args: list,
+        verbose: bool,
+        BENCHMARKS_CSPROJ: dotnet.CSharpProject
+) -> None:
     '''Run BenchView scripts to collect performance data.'''
     if not args.generate_benchview_data:
         return
@@ -490,7 +498,9 @@ def __main(args: list) -> int:
     # to avoid a build failure when using older frameworks (error NETSDK1045:
     # The current .NET SDK does not support targeting .NET Core $XYZ)
     # we set the TFM to what the user has provided.
-    os.environ['PYTHON_SCRIPT_TARGET_FRAMEWORKS'] = ';'.join(target_framework_monikers)
+    os.environ['PYTHON_SCRIPT_TARGET_FRAMEWORKS'] = ';'.join(
+        target_framework_monikers
+    )
 
     # dotnet --info
     dotnet.info(verbose=verbose)
@@ -515,10 +525,17 @@ def __main(args: list) -> int:
     # Run micro-benchmarks
     if not args.build_only:
         for framework in args.frameworks:
-            micro_benchmarks.run(BENCHMARKS_CSPROJ, args.configuration, framework, verbose, args)
+            micro_benchmarks.run(
+                BENCHMARKS_CSPROJ,
+                args.configuration,
+                framework,
+                verbose,
+                args
+            )
 
         __run_benchview_scripts(args, verbose, BENCHMARKS_CSPROJ)
         # TODO: Archive artifacts.
+
 
 if __name__ == "__main__":
     __main(sys.argv[1:])

--- a/scripts/benchview.py
+++ b/scripts/benchview.py
@@ -114,6 +114,7 @@ class BenchView:
             '--append',
         ]
 
+        full_json_files = []
         with push_dir(working_directory):
             pattern = "BenchmarkDotNet.Artifacts/**/*-full.json"
             getLogger().info(
@@ -121,9 +122,11 @@ class BenchView:
             )
 
             for full_json_file in iglob(pattern, recursive=True):
-                cmdline = common_cmdline + [full_json_file]
-                RunCommand(cmdline, verbose=self.verbose).run(
-                    working_directory)
+                full_json_files.append(full_json_file)
+
+        for full_json_file in full_json_files:
+            cmdline = common_cmdline + [full_json_file]
+            RunCommand(cmdline, verbose=self.verbose).run(working_directory)
 
     def submission_metadata(self, working_directory: str, name: str) -> None:
         '''Wrapper around BenchView's submission-metadata.py'''

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse
 from urllib.request import urlopen, urlretrieve
 
 from performance.common import get_repo_root_path
-from performance.common import get_artifacts_directory
 from performance.common import get_tools_directory
 from performance.common import push_dir
 from performance.common import RunCommand
@@ -45,25 +44,37 @@ class CSharpProject:
             bin_directory: str,
             csproj_file: str):
         if not working_directory:
-            raise TypeError('Unspecified working directory.')
+            raise TypeError(
+                'working_directory should be string, not NoneType.'
+            )
+        if not bin_directory:
+            raise TypeError(
+                'bin_directory should be string, not NoneType.'
+            )
+        if not csproj_file:
+            raise TypeError(
+                'csproj_file should be string, not NoneType.'
+            )
+
         if not path.isdir(working_directory):
             raise ValueError(
                 'Specified working directory: {}, does not exist.'.format(
-                    working_directory))
-
-        if not bin_directory and not path.isdir(bin_directory):
-            raise ValueError(
-                'Specified bin directory: {}, does not exist.'.format(
-                    bin_directory))
+                    working_directory
+                )
+            )
 
         if path.isabs(csproj_file) and not path.exists(csproj_file):
             raise ValueError(
                 'Specified project file: {}, does not exist.'.format(
-                    csproj_file))
+                    csproj_file
+                )
+            )
         elif not path.exists(path.join(working_directory, csproj_file)):
             raise ValueError(
                 'Specified project file: {}, does not exist.'.format(
-                    csproj_file))
+                    csproj_file
+                )
+            )
 
         self.__working_directory = working_directory
         self.__bin_directory = bin_directory
@@ -82,10 +93,7 @@ class CSharpProject:
     @property
     def bin_path(self) -> str:
         '''Gets the directory in which the built binaries will be placed.'''
-        if not self.__bin_directory:
-            return path.join(get_artifacts_directory(), 'bin')
-        else:
-            return path.join(self.__bin_directory, 'bin')
+        return self.__bin_directory
 
     def restore(self, packages_path: str, verbose: bool) -> None:
         '''
@@ -111,7 +119,7 @@ class CSharpProject:
               verbose: bool,
               *args) -> None:
         '''Calls dotnet to build the specified project.'''
-        if not target_framework_monikers: # Build all supported frameworks.
+        if not target_framework_monikers:  # Build all supported frameworks.
             cmdline = [
                 'dotnet', 'build',
                 self.csproj_file,

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -245,12 +245,19 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='The directory where MicroBenchmarks.csproj can be found',
     )
 
+    def __absolute_path(file_path: str) -> str:
+        '''
+        Return a normalized absolutized version of the specified file_path
+        path.
+        '''
+        return path.abspath(file_path)
+
     parser.add_argument(
         '--bin-directory',
         dest='bin_directory',
         required=False,
         default=path.join(get_repo_root_path(), 'artifacts', 'bin'),
-        type=str,
+        type=__absolute_path,
         help='Root of the bin directory',
     )
 

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -76,14 +76,16 @@ class FrameworkAction(Action):
         DotNet Cli tools.
         '''
         dct = FrameworkAction.__get_target_framework_moniker_channel_map()
-        return dct[target_framework_moniker] if target_framework_moniker in dct else None
+        return dct[target_framework_moniker] \
+            if target_framework_moniker in dct \
+            else None
 
     @staticmethod
     def get_target_framework_moniker(framework: str) -> str:
         '''
         Translates framework name to target framework moniker (TFM)
-        To run CoreRT benchmarks we need to run the host BDN process as latest .NET Core
-        the host process will build and run CoreRT benchmarks
+        To run CoreRT benchmarks we need to run the host BDN process as latest
+        .NET Core the host process will build and run CoreRT benchmarks
         '''
         return 'netcoreapp3.0' if framework == 'corert' else framework
 
@@ -91,13 +93,15 @@ class FrameworkAction(Action):
     def get_target_framework_monikers(frameworks: list) -> list:
         '''
         Translates framework names to target framework monikers (TFM)
-        Required to run CoreRT benchmarks where the host process must be .NET Core, not CoreRT
+        Required to run CoreRT benchmarks where the host process must be .NET
+        Core, not CoreRT.
         '''
         monikers = [
             FrameworkAction.get_target_framework_moniker(framework)
             for framework in frameworks
         ]
-        ## --frameworks netcoreapp3.0 corert should be translated to single moniker: netcoreapp3.0
+
+        # ['netcoreapp3.0', 'corert'] should become ['netcoreapp3.0']
         return list(set(monikers))
 
 
@@ -293,7 +297,9 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
     # we need to tell BenchmarkDotNet where to restore the packages
     # if we don't it's gonna restore to default global folder
     run_args += ['--packages', get_packages_directory()]
-    # required for CoreRT where host process framework != benchmark process framework
+
+    # Required for CoreRT where:
+    #   host process framework != benchmark process framework
     run_args += ['--runtimes', framework]
 
     return run_args
@@ -357,6 +363,7 @@ def __log_script_header(message: str):
     getLogger().info(message)
     getLogger().info('-' * len(message))
 
+
 def __main(args: list) -> int:
     try:
         validate_supported_runtime()
@@ -366,7 +373,8 @@ def __main(args: list) -> int:
         frameworks = args.frameworks
         incremental = args.incremental
         verbose = args.verbose
-        target_framework_monikers = FrameworkAction.get_target_framework_monikers(frameworks)
+        target_framework_monikers = FrameworkAction. \
+            get_target_framework_monikers(frameworks)
 
         setup_loggers(verbose=verbose)
 
@@ -375,15 +383,28 @@ def __main(args: list) -> int:
 
         BENCHMARKS_CSPROJ = dotnet.CSharpProject(
             working_directory=args.working_directory,
-            csproj_file='MicroBenchmarks.csproj'
+            csproj_file='MicroBenchmarks.csproj',
+            bin_directory=args.bin_directory
         )
 
         # dotnet build
-        build(BENCHMARKS_CSPROJ, configuration, target_framework_monikers, incremental, verbose)
+        build(
+            BENCHMARKS_CSPROJ,
+            configuration,
+            target_framework_monikers,
+            incremental,
+            verbose
+        )
 
         for framework in frameworks:
             # dotnet run
-            run(BENCHMARKS_CSPROJ, configuration, framework, verbose, *args)
+            run(
+                BENCHMARKS_CSPROJ,
+                configuration,
+                framework,
+                verbose,
+                args
+            )
 
         return 0
     except CalledProcessError as ex:

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -115,8 +115,9 @@ def push_dir(path: str = None) -> None:
     if path:
         prev = os.getcwd()
         try:
-            getLogger().info('$ pushd "%s"', path)
-            os.chdir(path)
+            abspath = path if os.path.isabs(path) else os.path.abspath(path)
+            getLogger().info('$ pushd "%s"', abspath)
+            os.chdir(abspath)
             yield
         finally:
             getLogger().info('$ popd')

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -100,7 +100,9 @@ def get_tools_directory() -> str:
 
 
 def get_artifacts_directory() -> str:
-    '''Gets the default artifacts directory where arcade builds the benchmarks.'''
+    '''
+    Gets the default artifacts directory where arcade builds the benchmarks.
+    '''
     return os.path.join(get_repo_root_path(), 'artifacts')
 
 


### PR DESCRIPTION
- Remove `--buildTimeout 300` from CI
- Fixed runtime error on python script that was introduced as part of Arcade changes, where: the default `bin` folder was not defined on groovy and the given default value was incorrect.
```log
[2019/01/23 20:53:38][INFO] $ pushd "C:\J\w\coreclr_perf_---d8f56ecc\artifacts\bin\bin"
[2019/01/23 20:53:38][INFO] $ popd
Traceback (most recent call last):
  File ".\scripts\benchmarks_ci.py", line 524, in <module>
    __main(sys.argv[1:])
  File ".\scripts\benchmarks_ci.py", line 520, in __main
    __run_benchview_scripts(args, verbose, BENCHMARKS_CSPROJ)
  File ".\scripts\benchmarks_ci.py", line 357, in __run_benchview_scripts
    name=submission_name)
  File "C:\J\w\coreclr_perf_---d8f56ecc\scripts\benchview.py", line 137, in submission_metadata
    RunCommand(cmdline, verbose=self.verbose).run(working_directory)
  File "C:\J\w\coreclr_perf_---d8f56ecc\scripts\performance\common.py", line 171, in run
    with push_dir(working_directory):
  File "C:\Python35\lib\contextlib.py", line 59, in __enter__
    return next(self.gen)
  File "C:\J\w\coreclr_perf_---d8f56ecc\scripts\performance\common.py", line 117, in push_dir
    os.chdir(path)
FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\J\\w\\coreclr_perf_---d8f56ecc\\artifacts\\bin\\bin'
```
- Fixed `micro_benchmarks.py` script.
- Autoformatted some of the scripts for styling.