### PR TITLE
set Optimize to true for all configurations 

### DIFF
--- a/docs/benchmarking-workflow.md
+++ b/docs/benchmarking-workflow.md
@@ -79,7 +79,7 @@ Sample commands:
 - See the list of all available .NET Core 2.1 System.Linq benchmarks:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- -f System.Linq* --list flat
+dotnet run -f netcoreapp2.1 -- -f System.Linq* --list flat
 ```
 
 ```log
@@ -108,7 +108,7 @@ System.Linq.Tests.Perf_Linq.Range
 - See a hierarchy tree of all available .NET Core 3.0 System.IO.Compression benchmarks:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 -- -f System.IO.Compression* --list tree
+dotnet run -f netcoreapp3.0 -- -f System.IO.Compression* --list tree
 ```
 
 ```log
@@ -133,7 +133,7 @@ System
 - See a list of all the benchmarks which belong to BenchmarksGame category:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- --allCategories BenchmarksGame --list flat
+dotnet run -f netcoreapp2.1 -- --allCategories BenchmarksGame --list flat
 ```
 
 ```log
@@ -170,7 +170,7 @@ Just specify the target framework moniker for `dotnet run`.
 Example: run `System.Collections.CopyTo<Int32>.Array` benchmarks against .NET Core 2.1 installed on your machine:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- -f System.Collections.CopyTo<Int32>.Array
+dotnet run -f netcoreapp2.1 -- -f System.Collections.CopyTo<Int32>.Array
 ```
 
 ### Against multiple runtimes
@@ -180,7 +180,7 @@ You need to specify the target framework monikers via `--runtimes` or just `-r` 
 Example: run `System.Collections.CopyTo<Int32>.Array` benchmarks against .NET Core 2.0 and 2.1 installed on your machine:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.0 -- -f System.Collections.CopyTo<Int32>.Array --runtimes netcoreapp2.0 netcoreapp2.1
+dotnet run -f netcoreapp2.0 -- -f System.Collections.CopyTo<Int32>.Array --runtimes netcoreapp2.0 netcoreapp2.1
 ```
 
 **Important:** when comparing few different .NET runtimes please always use the lowest common API denominator as the host process. What does it mean? BDN needs to detect and build these benchmarks. If you run the host process as .NET Core 2.1 it won't be able to detect benchmarks that use newer APIs are available only for .NET Core 3.0.
@@ -188,13 +188,13 @@ dotnet run -c Release -f netcoreapp2.0 -- -f System.Collections.CopyTo<Int32>.Ar
 Example: run benchmarks for APIs available in .NET Core 2.1 using .NET Core 3.0
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- -r netcoreapp3.0
+dotnet run -f netcoreapp2.1 -- -r netcoreapp3.0
 ```
 
 Example: run benchmarks for APIs available in .NET Core 3.0 using .NET Core 3.0
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0
+dotnet run -f netcoreapp3.0
 ```
 
 ### Against single runtime using given dotnet cli
@@ -204,7 +204,7 @@ Specify the target framework moniker for `dotnet run` and the path to `dotnet cl
 Example: run `System.Collections.CopyTo<Int32>.Array` benchmarks against .NET Core 3.0 downloaded to a given location:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 -- -f System.Collections.CopyTo<Int32>.Array --cli C:\tmp\dotnetcli\dotnet.exe
+dotnet run -f netcoreapp3.0 -- -f System.Collections.CopyTo<Int32>.Array --cli C:\tmp\dotnetcli\dotnet.exe
 ```
 
 ### Against private runtime build
@@ -219,7 +219,7 @@ Pass the path to CoreRun using `--coreRun` argument. In both CoreCLR and CoreFX 
 Example: Run all CoreCLR benchmarks using "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
+dotnet run -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
 ```
 
 If you want to use some non-default dotnet cli (or you just don't have a default dotnet cli) to build the benchmarks pass the path to cli via `--cli`.
@@ -228,7 +228,7 @@ If you want restore the packages to selected folder, pass it via `--packages`.
 Example: Run all CoreCLR benchmarks using "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe", restore the packages to C:\Projects\coreclr\packages and use "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" for building the benchmarks.
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe --cli "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" --packages "C:\Projects\coreclr\packages"
+dotnet run -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe --cli "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" --packages "C:\Projects\coreclr\packages"
 ```
 
 **VERY IMPORTANT**: CoreRun is a simple host that does NOT take any dependency on NuGet. BenchmarkDotNet just generates some boilerplate code, builds it and tells CoreRun.exe to run the benchmarks from the auto-generated library. CoreRun runs the benchmarks using the libraries that are placed in it's folder. When benchmarked code has a dependency to `System.ABC.dll` version 4.5 and CoreRun has `System.ABC.dll` version 4.5.1 in it's folder, then CoreRun is going to load and use `System.ABC.dll` version 4.5.1. This is why having a single clone of .NET Performance repository allows you to run benchmarks against private builds of CoreCLR/FX from many different locations.
@@ -256,7 +256,7 @@ By using the `DisassemblyDiagnoser` and `EtwProfiler` you should be able to get 
    5. run the benchmarks using given `CoreRun.exe` and save the results to a dedicated folder. An example:
 
         ```cmd
-        dotnet run -c Release -f netcoreapp3.0 -- 
+        dotnet run -f netcoreapp3.0 -- 
             --artifacts before 
             --filter *Span* 
             --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
@@ -269,7 +269,7 @@ By using the `DisassemblyDiagnoser` and `EtwProfiler` you should be able to get 
 7. Run the benchmarks using given `CoreRun.exe` and save the results to a dedicated folder. **Different one that you used to store results previously!** Example:
 
     ```cmd
-    dotnet run -c Release -f netcoreapp3.0 --  --artifacts after --filter *Span* --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
+    dotnet run -f netcoreapp3.0 --  --artifacts after --filter *Span* --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
     ```
 
 8. Compare the results using [Results Comparer](../src/tools/ResultsComparer/README.md)
@@ -291,7 +291,7 @@ Example: run Mann–Whitney U test with an absolute ratio of 3 milliseconds and 
 The following commands are represented in a few lines to make it easier to read on GitHub. Please remove the new lines when copy-pasting to console.
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 \
+dotnet run -f netcoreapp3.0 \
     --allCategories BenchmarksGame \
     --statisticalTest 3ms \
     --coreRun \
@@ -302,7 +302,7 @@ dotnet run -c Release -f netcoreapp3.0 \
 Example: run all benchmarks for .NET Core 2.1 vs 2.2 and use Mann–Whitney U test with a relative ratio of 5%.
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 --
+dotnet run -f netcoreapp2.1 --
     --filter *
     --statisticalTest 5%
     --runtimes netcoreapp2.1 netcoreapp2.2
@@ -319,19 +319,19 @@ A must read is [running benchmarks against multiple runtimes](#Against-multiple-
 Example: run all `Span` benchmarks for .NET Core 2.1 vs 3.0:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- --allCategories Span --runtimes netcoreapp2.1 netcoreapp3.0
+dotnet run -f netcoreapp2.1 -- --allCategories Span --runtimes netcoreapp2.1 netcoreapp3.0
 ```
 
 Example: run all `System.IO` benchmarks for .NET 4.7.2 vs .NET Core 3.0 preview using dotnet cli from given location:
 
 ```cmd
-dotnet run -c Release -f net472 -- --filter System.IO* --runtimes net472 netcoreapp3.0 --cli "C:\Downloads\3.0.0-preview1-03129-01\dotnet.exe"
+dotnet run -f net472 -- --filter System.IO* --runtimes net472 netcoreapp3.0 --cli "C:\Downloads\3.0.0-preview1-03129-01\dotnet.exe"
 ```
 
 Example: run all benchmarks for .NET Core 2.1 vs 2.2:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- -f * --runtimes netcoreapp2.1 netcoreapp2.2
+dotnet run -f netcoreapp2.1 -- -f * --runtimes netcoreapp2.1 netcoreapp2.2
 ```
 
 ### New API

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -8,7 +8,6 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)\common.props" />
 
@@ -8,6 +8,7 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -39,10 +39,10 @@ Any public, non-sealed type with public `[Benchmark]` method in this assembly wi
 
 ## Running
 
-To run the benchmarks you have to execute `dotnet run -c Release -f net461|netcoreapp2.0|netcoreapp2.1|netcoreapp2.2|netcoreapp3.0` (choose one of the supported frameworks).
+To run the benchmarks you have to execute `dotnet run -f net461|netcoreapp2.0|netcoreapp2.1|netcoreapp2.2|netcoreapp3.0` (choose one of the supported frameworks).
 
 ```cmd
-PS C:\Projects\performance\src\benchmarks> dotnet run -c Release -f netcoreapp2.0
+PS C:\Projects\performance\src\benchmarks> dotnet run -f netcoreapp2.0
 Available Benchmarks:
   #0   Burgers
   #1   ByteMark
@@ -78,21 +78,21 @@ BenchmarkDotNet by default exports the results to GitHub markdown, so you can ju
 
 You can filter the benchmarks by namespace, category, type name and method name. Examples:
 
-* `dotnet run -c Release -f netcoreapp2.1 -- --allCategories CoreCLR Span` - will run all the benchmarks that belong to CoreCLR **AND** Span category
-* `dotnet run -c Release -f netcoreapp2.1 -- --anyCategories CoreCLR CoreFX` - will run all the benchmarks that belong to CoreCLR **OR** CoreFX category
-* `dotnet run -c Release -f netcoreapp2.1 -- --filter BenchmarksGame*` - will run all the benchmarks from BenchmarksGame namespace
-* `dotnet run -c Release -f netcoreapp2.1 -- --filter *.ToStream` - will run all the benchmarks with method name ToStream
-* `dotnet run -c Release -f netcoreapp2.1 -- --filter *.Richards.*` - will run all the benchmarks with type name Richards
-* `dotnet run -c Release -f netcoreapp2.1 -- --filter System.Collections*.Dictionary* *.Perf_Dictionary.*` - will run all the benchmarks with type name start with System.Collections and method name start with Dictionary plus all benchmarks of type name Perf_Dictionary
+* `dotnet run -f netcoreapp2.1 -- --allCategories CoreCLR Span` - will run all the benchmarks that belong to CoreCLR **AND** Span category
+* `dotnet run -f netcoreapp2.1 -- --anyCategories CoreCLR CoreFX` - will run all the benchmarks that belong to CoreCLR **OR** CoreFX category
+* `dotnet run -f netcoreapp2.1 -- --filter BenchmarksGame*` - will run all the benchmarks from BenchmarksGame namespace
+* `dotnet run -f netcoreapp2.1 -- --filter *.ToStream` - will run all the benchmarks with method name ToStream
+* `dotnet run -f netcoreapp2.1 -- --filter *.Richards.*` - will run all the benchmarks with type name Richards
+* `dotnet run -f netcoreapp2.1 -- --filter System.Collections*.Dictionary* *.Perf_Dictionary.*` - will run all the benchmarks with type name start with System.Collections and method name start with Dictionary plus all benchmarks of type name Perf_Dictionary
 
 **Note:** To print a single summary for all of the benchmarks, use `--join`.
-Example: `dotnet run -c Release -f netcoreapp2.1 -- --join -f BenchmarksGame*` - will run all of the benchmarks from BenchmarksGame namespace and print a single summary.
+Example: `dotnet run -f netcoreapp2.1 -- --join -f BenchmarksGame*` - will run all of the benchmarks from BenchmarksGame namespace and print a single summary.
 
 ## Printing all available benchmarks
 
 To print the list of all available benchmarks you need to pass `--list [tree/flat]` argument. It can also be combined with `--filter` option.
 
-Example: Show the tree of all the benchmarks which contain "Span" in the name and can be run for .NET Core 2.0: `dotnet run -c Release -f netcoreapp2.0 -- --filter *Span* --list tree`
+Example: Show the tree of all the benchmarks which contain "Span" in the name and can be run for .NET Core 2.0: `dotnet run -f netcoreapp2.0 -- --filter *Span* --list tree`
 
 ```log
 System
@@ -146,7 +146,7 @@ public class SomeType
 
 ## All Statistics
 
-By default BenchmarkDotNet displays only `Mean`, `Error` and `StdDev` in the results. If you want to see more statistics, please pass `--allStats` as an extra argument to the app: `dotnet run -c Release -f netcoreapp2.1 -- --allStats`. If you build your own config, please use `config.With(StatisticColumn.AllStatistics)`.
+By default BenchmarkDotNet displays only `Mean`, `Error` and `StdDev` in the results. If you want to see more statistics, please pass `--allStats` as an extra argument to the app: `dotnet run -f netcoreapp2.1 -- --allStats`. If you build your own config, please use `config.With(StatisticColumn.AllStatistics)`.
 
 |   Method |     Mean |     Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |        Op/s |  Gen 0 | Allocated |
 |--------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|------------:|-------:|----------:|
@@ -174,7 +174,7 @@ If you want to disassemble the benchmarked code, you need to use the [Disassembl
 
 You can do that by passing `--disassm` to the app or by using `[DisassemblyDiagnoser(printAsm: true, printSource: true)]` attribute or by adding it to your config with `config.With(DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig(printAsm: true, recursiveDepth: 1))`.
 
-Example: `dotnet run -c Release -f netcoreapp2.0 -- --filter System.Memory.Span<Int32>.Reverse -d`
+Example: `dotnet run -f netcoreapp2.0 -- --filter System.Memory.Span<Int32>.Reverse -d`
 
 ```assembly
 ; System.Runtime.InteropServices.MemoryMarshal.GetReference[[System.Byte, System.Private.CoreLib]](System.Span`1<Byte>)
@@ -204,7 +204,7 @@ You can do that by passing `-p ETW` or `--profiler ETW` to the app.
 
 ## How to run In Process
 
-If you want to run the benchmarks in process, without creating a dedicated executable and process-level isolation, please pass `--inProcess` (or just `-i`) as an extra argument to the app: `dotnet run -c Release -f netcoreapp2.1 -- --inProcess`. If you build your own config, please use `config.With(Job.Default.With(InProcessToolchain.Instance))`. Please use this option only when you are sure that the benchmarks you want to run have no side effects.
+If you want to run the benchmarks in process, without creating a dedicated executable and process-level isolation, please pass `--inProcess` (or just `-i`) as an extra argument to the app: `dotnet run -f netcoreapp2.1 -- --inProcess`. If you build your own config, please use `config.With(Job.Default.With(InProcessToolchain.Instance))`. Please use this option only when you are sure that the benchmarks you want to run have no side effects.
 
 ## How to compare different Runtimes
 
@@ -213,14 +213,14 @@ The `--runtimes` or just `-r` allows you to run the benchmarks for selected Runt
 Example: run the benchmarks for .NET 4.7.2 and .NET Core 2.1:
 
 ```cmd
-dotnet run -c Release -- --runtimes net472 netcoreapp2.1
+dotnet run -- --runtimes net472 netcoreapp2.1
 ```
 
 ## Benchmarking private CoreCLR and CoreFX builds using CoreRun
 
 It's possible to benchmark private builds of CoreCLR/FX using CoreRun. You just need to pass the path(s) to CoreRun to BenchmarkDotNet. You can do that by either using `--coreRun $thePath` as an arugment or `job.With(new CoreRunToolchain(coreRunPath: "$thePath"))` in the code.
 
-So if you made a change in CoreCLR/FX and want to measure the performance, you can run the benchmarks with `dotnet run -c Release -f netcoreapp3.0 -- --coreRun $thePath`.
+So if you made a change in CoreCLR/FX and want to measure the performance, you can run the benchmarks with `dotnet run -f netcoreapp3.0 -- --coreRun $thePath`.
 
 **Note:** You can provide more than 1 path to CoreRun. In such case, the first path will be the baseline and all the benchmarks are going to be executed for all CoreRuns you have specified.
 
@@ -247,20 +247,20 @@ You can also use any dotnet cli to build and run the benchmarks. To do that you 
 Example: run the benchmarks for .NET Core 3.0 using dotnet cli from `C:\Projects\performance\.dotnet\dotnet.exe`:
 
 ```cmd
-dotnet run -c Release -- -r netcoreapp3.0 --cli "C:\Projects\performance\.dotnet\dotnet.exe"
+dotnet run -- -r netcoreapp3.0 --cli "C:\Projects\performance\.dotnet\dotnet.exe"
 ```
 
 ## Benchmarking private CLR build
 
 It's possible to benchmark a private build of .NET Runtime. You just need to pass the value of `COMPLUS_Version` to BenchmarkDotNet. You can do that by either using `--clrVersion $theVersion` as an arugment or `Job.ShortRun.With(new ClrRuntime(version: "$theVersiong"))` in the code.
 
-So if you made a change in CLR and want to measure the difference, you can run the benchmarks with `dotnet run -c Release -f net472 -- --clrVersion $theVersion`. More info can be found [here](https://github.com/dotnet/BenchmarkDotNet/issues/706).
+So if you made a change in CLR and want to measure the difference, you can run the benchmarks with `dotnet run -f net472 -- --clrVersion $theVersion`. More info can be found [here](https://github.com/dotnet/BenchmarkDotNet/issues/706).
 
 ## Benchmarking private CoreRT build
 
 To run benchmarks with private CoreRT build you need to provide the `IlcPath`.
 
-Sample arguments: `dotnet run -c Release -f netcoreapp2.1 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release`
+Sample arguments: `dotnet run -f netcoreapp2.1 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release`
 
 ## Statistical Test
 
@@ -271,7 +271,7 @@ To perform a Mann–Whitney U Test and display the results in a dedicated column
 Example: run Mann–Whitney U test with relative ratio of 5% for `BinaryTrees_2` for .NET Core 2.1 (base) vs .NET Core 2.2 (diff). .NET Core 2.1 will be baseline because it was first.
 
 ```cmd
-dotnet run -c Release -- --filter *BinaryTrees_2* --runtimes netcoreapp2.1 netcoreapp2.2 --statisticalTest 5%
+dotnet run -- --filter *BinaryTrees_2* --runtimes netcoreapp2.1 netcoreapp2.2 --statisticalTest 5%
 ```
 
 |        Method |     Toolchain |     Mean | MannWhitney(5%) |

--- a/src/benchmarks/micro/common.props
+++ b/src/benchmarks/micro/common.props
@@ -11,6 +11,8 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <SignAssembly>false</SignAssembly>
+    <!-- to make sure that the users don't always need to specify -c Release when using dotnet run -->
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We always want to run the benchmarks with Optimization enabled, but the default Configuration for dotnet cli is Debug. Which means that we always had to run `dotnet run` with ` -c Release`.

If we set Optimize=true for all configurations, we no longer need to do that. This simplifies the docs and the command.

It's part of making the docs and process simpler after the demo for @vancem 