### PR TITLE
Faster dotnet run thanks to moving expensive logic to a setup method

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -11,11 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="img\**" />
-    <Compile Remove="Tests\**" />
     <EmbeddedResource Remove="img\**" />
     <None Remove="img\**" />
-    <None Remove="Tests\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -11,11 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Remove="img\**" />
-    <None Remove="img\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.3.936" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.936" />
     <PackageReference Include="Jil" Version="2.15.4" />

--- a/src/benchmarks/micro/common.props
+++ b/src/benchmarks/micro/common.props
@@ -4,8 +4,8 @@
     <UseSharedCompilation>false</UseSharedCompilation>
     <!-- The Python script can narrow down the TFMs to what the user has asked for -->
     <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <WarningLevel>4</WarningLevel>

--- a/src/benchmarks/micro/corefx/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -32,7 +32,7 @@ namespace System.IO.Compression
         public string file { get; set; } // this public property is called "file" to keep the benchmark ID in BenchView, do NOT rename it
 
         [Params(CompressionLevel.Optimal, CompressionLevel.Fastest)] // we don't test the performance of CompressionLevel.NoCompression on purpose
-        public CompressionLevel level { get; set; } // this public property is called "file" to keep the benchmark ID in BenchView, do NOT rename it
+        public CompressionLevel level { get; set; } // this public property is called "level" to keep the benchmark ID in BenchView, do NOT rename it
 
         protected CompressedFile CompressedFile;
 

--- a/src/benchmarks/micro/corefx/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -21,60 +21,47 @@ namespace System.IO.Compression
     }
     
     // Brotli has a dedicated file with more benchmarks
-    
+
     [BenchmarkCategory(Categories.CoreFX)]
     public abstract class CompressionStreamPerfTestBase
     {
         public abstract Stream CreateStream(Stream stream, CompressionMode mode);
         public abstract Stream CreateStream(Stream stream, CompressionLevel level);
 
-        public IEnumerable<object[]> Arguments()
-        {
-            foreach (string testFile in UncompressedTestFileNames())
-            {
-                yield return new object[] { new CompressedFile(testFile, CompressionLevel.Optimal, CreateStream), CompressionLevel.Optimal };
-                yield return new object[] { new CompressedFile(testFile, CompressionLevel.Fastest, CreateStream), CompressionLevel.Fastest };
-                // we don't test the performance of CompressionLevel.NoCompression on purpose
-            }
-        }
+        [ParamsSource(nameof(UncompressedTestFileNames))]
+        public string file { get; set; } // this public property is called "file" to keep the benchmark ID in BenchView, do NOT rename it
 
-        private IEnumerable<string> UncompressedTestFileNames()
+        [Params(CompressionLevel.Optimal, CompressionLevel.Fastest)] // we don't test the performance of CompressionLevel.NoCompression on purpose
+        public CompressionLevel level { get; set; } // this public property is called "file" to keep the benchmark ID in BenchView, do NOT rename it
+
+        protected CompressedFile CompressedFile;
+
+        [GlobalSetup]
+        public void Setup() => CompressedFile = new CompressedFile(file, level, CreateStream); // this logic is quite expensive, needs to be a part of Setup
+
+        public IEnumerable<string> UncompressedTestFileNames()
         {
-            // yield return "TestDocument.doc"; // 44.5 KB small test document with repeated paragraph
-            // yield return "TestDocument.docx"; // 17.2 KB small test document with repeated paragraph
             yield return "TestDocument.pdf"; // 199 KB small test document with repeated paragraph, PDF are common
-            // yield return "TestDocument.txt"; // 21.1 KB small test document with repeated paragraph
             yield return "alice29.txt"; // 145 KB, copy of "ALICE'S ADVENTURES IN WONDERLAND" book, an example of text file
-            // yield return "asyoulik.txt"; // 122 KB, copy if "As You Like It" by William Shakespeare
-            // yield return "cp.html"; // 24 KB, small HTML file
-            // yield return "fields.c"; // 10.8 KB, 430 lines of C code
-            // yield return "grammar.lsp"; // 3.63 KB, 90 lines of Lisp code
-            // yield return "kennedy.xls"; // 0.98 MB, invalid excel file..
-            // yield return "lcet10.txt"; // 409 KB, "The Project Gutenberg Etext of LOC WORKSHOP ON ELECTRONIC TEXTS", 7500 lines of text
-            // yield return "plrabn12.txt"; // 460 KB, "Paradise Lost by John Milton", 10700 lines of text
-            // yield return "ptt5"; // 501 KB, some binary content
             yield return "sum"; // 37.3 KB, some binary content, an example of binary file
-            // yield return "xargs.1"; // 4.12 KB, output of --help of some Linux tool
         }
 
         [Benchmark]
-        [ArgumentsSource(nameof(Arguments))]
-        public void Compress(CompressedFile file, CompressionLevel level)
+        public void Compress()
         {
-            file.CompressedDataStream.Position = 0; // all benchmarks invocation reuse the same stream, we set Postion to 0 to start at the beginning
+            CompressedFile.CompressedDataStream.Position = 0; // all benchmarks invocation reuse the same stream, we set Postion to 0 to start at the beginning
 
-            var compressor = CreateStream(file.CompressedDataStream, level);
-            compressor.Write(file.UncompressedData, 0, file.UncompressedData.Length);
+            var compressor = CreateStream(CompressedFile.CompressedDataStream, level);
+            compressor.Write(CompressedFile.UncompressedData, 0, CompressedFile.UncompressedData.Length);
         }
 
         [Benchmark]
-        [ArgumentsSource(nameof(Arguments))]
-        public int Decompress(CompressedFile file, CompressionLevel level) // the level argument is not used here, but it describes how the data was compressed
+        public int Decompress()
         {
-            file.CompressedDataStream.Position = 0;
+            CompressedFile.CompressedDataStream.Position = 0;
 
-            var compressor = CreateStream(file.CompressedDataStream, CompressionMode.Decompress);
-            return compressor.Read(file.UncompressedData, 0, file.UncompressedData.Length);
+            var compressor = CreateStream(CompressedFile.CompressedDataStream, CompressionMode.Decompress);
+            return compressor.Read(CompressedFile.UncompressedData, 0, CompressedFile.UncompressedData.Length);
         }
     }
 }


### PR DESCRIPTION
Fixes #201 

As some of you might observed, dotnet run was taking 7-8 seconds before we could see any output printed to the console. With every demo it was getting more and more annoying to me so I decided to profile it.

I have found out that most of the time was spend in the ctor of `CompressedFile`

Name | Exc % | Exc | Inc % | Inc | Fold | When
-- | -- | -- | -- | -- | -- | --
clrcompression!? | 83,1 | 4 798 | 84,4 | 4 874 | 0 | ______________699999999999A998__
microbenchmarks!System.IO.Compression.CompressedFile..ctor(class System.String,value class System.IO.Compression.CompressionLevel,class System.Func`3) | 2,3 | 131 | 86,7 | 5 009 | 131 | ______________699999999999AA992_

This PR moves the initialization logic to a Setup method. So it's done before running the benchmarks, not  when trying to figure out the benchmark names when applying filter to the benchmarks. (explanation: when a benchmark uses `ArgumentsSource` we call the method which provides `IEnumerable<object>` before running the benchmarks. The problem is that in this particular case the ctor contained expensive logic). Instead of using `ArgumentsSource` I have used `Params` and `[GlobalSetup]` here.