### PR TITLE
Perform more than one warmup iteration to reduce noise

### DIFF
--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -24,8 +24,9 @@ namespace MicroBenchmarks
         private static IConfig GetConfig()
             => DefaultConfig.Instance
                 .With(Job.Default
-                    .WithWarmupCount(1) // 1 warmup is enough for our purpose
                     .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slighlty too much for us
+                    .WithMinWarmupCount(4)
+                    .WithMaxWarmupCount(8)
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
                     .AsDefault()) // tell BDN that this are our default settings


### PR DESCRIPTION
I wanted to see a comparison between tiering off (`NoTier` in the results below) as the baseline, with tiering on (`Tier`) and tiering on but with tier 0 JIT disabled (`NoTier0Jit`). See [results](https://1drv.ms/t/s!AvtRwG9CobRTpxuzkcIUF2apKnmr). It looks like the `NoTier0Jit` mode eliminated all of the issues with cold methods with hot loops. However, there are still many, what look like, large regressions in the last `Diff %` column. On random local reruns of those results, it looks like in many if not most of these cases, the issue is noise in the measurement and performing more warmup iterations seems to solve the issue.

@adamsitnik @jorive 