### PR TITLE
Revert "make netcoreapp3.0 default TFM to simplify command line"

### DIFF
--- a/docs/benchmarking-workflow.md
+++ b/docs/benchmarking-workflow.md
@@ -1,4 +1,4 @@
-# .NET benchmarking workflow
+﻿# .NET benchmarking workflow
 
 ## Table of Contents
 
@@ -219,7 +219,7 @@ Pass the path to CoreRun using `--coreRun` argument. In both CoreCLR and CoreFX 
 Example: Run all CoreCLR benchmarks using "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
 
 ```cmd
-dotnet run -- --allCategories CoreCLR --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
+dotnet run -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
 ```
 
 If you want to use some non-default dotnet cli (or you just don't have a default dotnet cli) to build the benchmarks pass the path to cli via `--cli`.
@@ -228,7 +228,7 @@ If you want restore the packages to selected folder, pass it via `--packages`.
 Example: Run all CoreCLR benchmarks using "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe", restore the packages to C:\Projects\coreclr\packages and use "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" for building the benchmarks.
 
 ```cmd
-dotnet run -- --allCategories CoreCLR --coreRun "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe --cli "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" --packages "C:\Projects\coreclr\packages"
+dotnet run -f netcoreapp3.0 -- --allCategories CoreCLR --coreRun "C:\Projects\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\CoreRun.exe --cli "C:\Projects\coreclr\Tools\dotnetcli\dotnet.exe" --packages "C:\Projects\coreclr\packages"
 ```
 
 **VERY IMPORTANT**: CoreRun is a simple host that does NOT take any dependency on NuGet. BenchmarkDotNet just generates some boilerplate code, builds it and tells CoreRun.exe to run the benchmarks from the auto-generated library. CoreRun runs the benchmarks using the libraries that are placed in it's folder. When benchmarked code has a dependency to `System.ABC.dll` version 4.5 and CoreRun has `System.ABC.dll` version 4.5.1 in it's folder, then CoreRun is going to load and use `System.ABC.dll` version 4.5.1. This is why having a single clone of .NET Performance repository allows you to run benchmarks against private builds of CoreCLR/FX from many different locations.
@@ -256,9 +256,9 @@ By using the `DisassemblyDiagnoser` and `EtwProfiler` you should be able to get 
    5. run the benchmarks using given `CoreRun.exe` and save the results to a dedicated folder. An example:
 
         ```cmd
-        dotnet run -- \
-            --artifacts before \
-            --filter *Span* \
+        dotnet run -f netcoreapp3.0 -- 
+            --artifacts before 
+            --filter *Span* 
             --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
         ```
 
@@ -269,13 +269,13 @@ By using the `DisassemblyDiagnoser` and `EtwProfiler` you should be able to get 
 7. Run the benchmarks using given `CoreRun.exe` and save the results to a dedicated folder. **Different one that you used to store results previously!** Example:
 
     ```cmd
-    dotnet run -- --artifacts after --filter *Span* --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
+    dotnet run -f netcoreapp3.0 --  --artifacts after --filter *Span* --coreRun "C:\Projects\corefx\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
     ```
 
 8. Compare the results using [Results Comparer](../src/tools/ResultsComparer/README.md)
 
     ```cmd
-    dotnet run -p ..\..\tools\ResultsComparer\ResultsComparer.csproj -- --base .\before\ --diff .\after\ --threshold 3%
+    dotnet run -p ..\..\tools\ResultsComparer\ResultsComparer.csproj --base .\before\ --diff .\after\ --threshold 3%
     ```
 
 9. Repeat steps 3-8 until you get the desired speedup.
@@ -291,7 +291,7 @@ Example: run Mann–Whitney U test with an absolute ratio of 3 milliseconds and 
 The following commands are represented in a few lines to make it easier to read on GitHub. Please remove the new lines when copy-pasting to console.
 
 ```cmd
-dotnet run -- \
+dotnet run -f netcoreapp3.0 \
     --allCategories BenchmarksGame \
     --statisticalTest 3ms \
     --coreRun \
@@ -325,7 +325,7 @@ dotnet run -f netcoreapp2.1 -- --allCategories Span --runtimes netcoreapp2.1 net
 Example: run all `System.IO` benchmarks for .NET 4.7.2 vs .NET Core 3.0 preview using dotnet cli from given location:
 
 ```cmd
-dotnet run -f net461 -- --filter System.IO* --runtimes net472 netcoreapp3.0 --cli "C:\Downloads\3.0.0-preview1-03129-01\dotnet.exe"
+dotnet run -f net472 -- --filter System.IO* --runtimes net472 netcoreapp3.0 --cli "C:\Downloads\3.0.0-preview1-03129-01\dotnet.exe"
 ```
 
 Example: run all benchmarks for .NET Core 2.1 vs 2.2:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -61,9 +61,4 @@
     <Compile Remove="corefx\System.Security.Cryptography\Perf.Rfc2898DeriveBytes.cs" />
   </ItemGroup>
 
-  <Target Name="BuildConfigurationCheck" BeforeTargets="Build">
-    <Warning Condition="'$(Configuration)'=='Debug' AND '$(TargetFramework)' == $(DefaultTargetFramework)" 
-        Text="Configuration and Framework were not provided, optimized netcoreapp3.0 build will be used (defaults)." />
-  </Target>
-
 </Project>

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -39,10 +39,10 @@ Any public, non-sealed type with public `[Benchmark]` method in this assembly wi
 
 ## Running
 
-To run the benchmarks you have to execute `dotnet run -f net461|netcoreapp2.0|netcoreapp2.1|netcoreapp2.2|netcoreapp3.0` (choose one of the supported frameworks). If you don't provide the target framework moniker, the default one, `netcoreapp3.0` will be used.
+To run the benchmarks you have to execute `dotnet run -f net461|netcoreapp2.0|netcoreapp2.1|netcoreapp2.2|netcoreapp3.0` (choose one of the supported frameworks).
 
 ```cmd
-PS C:\Projects\performance\src\benchmarks> dotnet run
+PS C:\Projects\performance\src\benchmarks> dotnet run -f netcoreapp2.0
 Available Benchmarks:
   #0   Burgers
   #1   ByteMark
@@ -78,15 +78,15 @@ BenchmarkDotNet by default exports the results to GitHub markdown, so you can ju
 
 You can filter the benchmarks by namespace, category, type name and method name. Examples:
 
-* `dotnet run -- --allCategories CoreCLR Span` - will run all the benchmarks that belong to CoreCLR **AND** Span category
-* `dotnet run -- --anyCategories CoreCLR CoreFX` - will run all the benchmarks that belong to CoreCLR **OR** CoreFX category
-* `dotnet run -- --filter BenchmarksGame*` - will run all the benchmarks from BenchmarksGame namespace
-* `dotnet run -- --filter *.ToStream` - will run all the benchmarks with method name ToStream
-* `dotnet run -- --filter *.Richards.*` - will run all the benchmarks with type name Richards
-* `dotnet run -- --filter System.Collections*.Dictionary* *.Perf_Dictionary.*` - will run all the benchmarks with type name start with System.Collections and method name start with Dictionary plus all benchmarks of type name Perf_Dictionary
+* `dotnet run -f netcoreapp2.1 -- --allCategories CoreCLR Span` - will run all the benchmarks that belong to CoreCLR **AND** Span category
+* `dotnet run -f netcoreapp2.1 -- --anyCategories CoreCLR CoreFX` - will run all the benchmarks that belong to CoreCLR **OR** CoreFX category
+* `dotnet run -f netcoreapp2.1 -- --filter BenchmarksGame*` - will run all the benchmarks from BenchmarksGame namespace
+* `dotnet run -f netcoreapp2.1 -- --filter *.ToStream` - will run all the benchmarks with method name ToStream
+* `dotnet run -f netcoreapp2.1 -- --filter *.Richards.*` - will run all the benchmarks with type name Richards
+* `dotnet run -f netcoreapp2.1 -- --filter System.Collections*.Dictionary* *.Perf_Dictionary.*` - will run all the benchmarks with type name start with System.Collections and method name start with Dictionary plus all benchmarks of type name Perf_Dictionary
 
 **Note:** To print a single summary for all of the benchmarks, use `--join`.
-Example: `dotnet run -- --join --filter BenchmarksGame*` - will run all of the benchmarks from BenchmarksGame namespace and print a single summary.
+Example: `dotnet run -f netcoreapp2.1 -- --join -f BenchmarksGame*` - will run all of the benchmarks from BenchmarksGame namespace and print a single summary.
 
 ## Printing all available benchmarks
 
@@ -146,7 +146,7 @@ public class SomeType
 
 ## All Statistics
 
-By default BenchmarkDotNet displays only `Mean`, `Error` and `StdDev` in the results. If you want to see more statistics, please pass `--allStats` as an extra argument to the app: `dotnet run --allStats`. If you build your own config, please use `config.With(StatisticColumn.AllStatistics)`.
+By default BenchmarkDotNet displays only `Mean`, `Error` and `StdDev` in the results. If you want to see more statistics, please pass `--allStats` as an extra argument to the app: `dotnet run -f netcoreapp2.1 -- --allStats`. If you build your own config, please use `config.With(StatisticColumn.AllStatistics)`.
 
 |   Method |     Mean |     Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |        Op/s |  Gen 0 | Allocated |
 |--------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|------------:|-------:|----------:|
@@ -174,7 +174,7 @@ If you want to disassemble the benchmarked code, you need to use the [Disassembl
 
 You can do that by passing `--disassm` to the app or by using `[DisassemblyDiagnoser(printAsm: true, printSource: true)]` attribute or by adding it to your config with `config.With(DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig(printAsm: true, recursiveDepth: 1))`.
 
-Example: `dotnet run -- --filter System.Memory.Span<Int32>.Reverse -d`
+Example: `dotnet run -f netcoreapp2.0 -- --filter System.Memory.Span<Int32>.Reverse -d`
 
 ```assembly
 ; System.Runtime.InteropServices.MemoryMarshal.GetReference[[System.Byte, System.Private.CoreLib]](System.Span`1<Byte>)
@@ -204,7 +204,7 @@ You can do that by passing `-p ETW` or `--profiler ETW` to the app.
 
 ## How to run In Process
 
-If you want to run the benchmarks in process, without creating a dedicated executable and process-level isolation, please pass `--inProcess` (or just `-i`) as an extra argument to the app: `dotnet run --inProcess`. If you build your own config, please use `config.With(Job.Default.With(InProcessToolchain.Instance))`. Please use this option only when you are sure that the benchmarks you want to run have no side effects.
+If you want to run the benchmarks in process, without creating a dedicated executable and process-level isolation, please pass `--inProcess` (or just `-i`) as an extra argument to the app: `dotnet run -f netcoreapp2.1 -- --inProcess`. If you build your own config, please use `config.With(Job.Default.With(InProcessToolchain.Instance))`. Please use this option only when you are sure that the benchmarks you want to run have no side effects.
 
 ## How to compare different Runtimes
 
@@ -220,7 +220,7 @@ dotnet run -- --runtimes net472 netcoreapp2.1
 
 It's possible to benchmark private builds of CoreCLR/FX using CoreRun. You just need to pass the path(s) to CoreRun to BenchmarkDotNet. You can do that by either using `--coreRun $thePath` as an arugment or `job.With(new CoreRunToolchain(coreRunPath: "$thePath"))` in the code.
 
-So if you made a change in CoreCLR/FX and want to measure the performance, you can run the benchmarks with `dotnet run --coreRun $thePath`.
+So if you made a change in CoreCLR/FX and want to measure the performance, you can run the benchmarks with `dotnet run -f netcoreapp3.0 -- --coreRun $thePath`.
 
 **Note:** You can provide more than 1 path to CoreRun. In such case, the first path will be the baseline and all the benchmarks are going to be executed for all CoreRuns you have specified.
 
@@ -247,20 +247,20 @@ You can also use any dotnet cli to build and run the benchmarks. To do that you 
 Example: run the benchmarks for .NET Core 3.0 using dotnet cli from `C:\Projects\performance\.dotnet\dotnet.exe`:
 
 ```cmd
-dotnet run -- --cli "C:\Projects\performance\.dotnet\dotnet.exe"
+dotnet run -- -r netcoreapp3.0 --cli "C:\Projects\performance\.dotnet\dotnet.exe"
 ```
 
 ## Benchmarking private CLR build
 
 It's possible to benchmark a private build of .NET Runtime. You just need to pass the value of `COMPLUS_Version` to BenchmarkDotNet. You can do that by either using `--clrVersion $theVersion` as an arugment or `Job.ShortRun.With(new ClrRuntime(version: "$theVersiong"))` in the code.
 
-So if you made a change in CLR and want to measure the difference, you can run the benchmarks with `dotnet run -f net461 -- --clrVersion $theVersion`. More info can be found [here](https://github.com/dotnet/BenchmarkDotNet/issues/706).
+So if you made a change in CLR and want to measure the difference, you can run the benchmarks with `dotnet run -f net472 -- --clrVersion $theVersion`. More info can be found [here](https://github.com/dotnet/BenchmarkDotNet/issues/706).
 
 ## Benchmarking private CoreRT build
 
 To run benchmarks with private CoreRT build you need to provide the `IlcPath`.
 
-Sample arguments: `dotnet run -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release`
+Sample arguments: `dotnet run -f netcoreapp2.1 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release`
 
 ## Statistical Test
 

--- a/src/benchmarks/micro/common.props
+++ b/src/benchmarks/micro/common.props
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <UseSharedCompilation>false</UseSharedCompilation>
     <!-- The Python script can narrow down the TFMs to what the user has asked for -->
-    <DefaultTargetFramework>netcoreapp3.0</DefaultTargetFramework>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>


### PR DESCRIPTION
Reverts dotnet/performance#246

It worked fine for .NET Core 3.0 but not for 2.0/2.1.

I wasted a lot of time trying to make it work and I have failed so I am reverting these changes. 

```cmd
dotnet build -f netcoreapp2.0
```

```log
PS C:\Projects\performance\src\benchmarks\micro> dotnet build -f netcoreapp2.0
Microsoft (R) Build Engine version 16.0.225-preview+g5ebeba52a1 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 49,56 ms for C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj.
  Restore completed in 41,87 ms for C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj.
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Debug\netcoreapp2.0\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Debug\netcoreapp3.0\MicroBenchmarks.dll
CSC : error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(16,61): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(27,34): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(43,34): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(47,45): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(56,27): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]

Build FAILED.

CSC : error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(16,61): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(27,34): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(43,34): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(47,45): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
UniqueValuesGeneratorTests.cs(56,27): error CS1705: Assembly 'MicroBenchmarks' with identity 'MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null' uses 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' which has a higher version than referenced assembly 'System.Runtime' with identity 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' [C:\Projects\performance\src\tests\benchmarks\micro\Tests.csproj]
    0 Warning(s)
    6 Error(s)

Time Elapsed 00:00:02.94
```