### PR TITLE
for the correctness check, run the benchmarks exactly once, no warmup, no pilot, no overhead

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
           - name: Creator
             value: dotnet-performance
           - name: BDNArguments
-            value: --iterationCount 2
+            value: --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart
           - name: HelixApiAccessToken
             value: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.936" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.936" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.987" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.987" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />
@@ -20,12 +20,12 @@
     <PackageReference Include="protobuf-net" Version="2.3.7" />
     <PackageReference Include="System.Memory" Version="4.5.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="ZeroFormatter" Version="1.6.4" />


### PR DESCRIPTION
Fixes #258

BDN change and update was required because the possibility to disable overhead from console arguments level was missing  (https://github.com/dotnet/BenchmarkDotNet/commit/20744eaa4f38622f5350b582ec4c44a906341db7)