### PR TITLE
update Helix to the latest version

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19108.1",
-    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.18629.1"
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19108.1"
   },
   "native-tools": {
     "python3": "3.7.1"


### PR DESCRIPTION
in #265 it turned out that we had an old version of Helix that had some bugs and did not allow us to push linux jobs to Helix

https://github.com/dotnet/arcade/issues/1274#issuecomment-462664482