### PR TITLE
Stop benchmarks run on first error to make the CI fail fast

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -31,7 +31,7 @@ jobs:
             value: dotnet-performance
           # for public runs we want to run the benchmarks exactly once, no warmup, no pilot, no overhead
           - name: BenchmarkDotNetArguments
-            value: '--bdn-arguments="--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart"'
+            value: '--bdn-arguments="--iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true"'
           - name: HelixApiAccessToken
             value: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.987" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.987" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.1003" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.1003" />
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.6.0" />


### PR DESCRIPTION
We have 2k benchmarks, I think that it would be the best to fail on first error when we do a correctness check to provide fast answer.