### PR TITLE
Lowercase BuildConfig names to get correct helix urls

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -57,14 +57,14 @@ jobs:
         strategy:
           matrix:
             ${{ each framework in parameters.frameworks }}:
-              CoreCLR_${{ framework }}:
+              coreclr_${{ framework }}:
                 _Category: coreclr
                 _Framework: ${{ framework }}
-                _BuildConfig: ${{ parameters.architecture }}_CoreCLR_$(_Framework)
-              CoreFX_${{ framework }}:
+                _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)
+              corefx_${{ framework }}:
                 _Category: corefx
                 _Framework: ${{ framework }}
-                _BuildConfig: ${{ parameters.architecture }}_CoreFX_$(_Framework)
+                _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
Even with the update of the Helix SDK version, we are still getting bad links to logs because we have uppercase letters in our _BuildConfig. This change changes it to be all lowercase so that we get the correct links, as Helix creates the MC links as lowercase (but returns them to us with the capitalization _BuildConfig uses). This is a bypass, but may be just good practice to avoid this kind of issue in the future.