### PR TITLE
Give the MathTests benchmarks a more meaningful name.

### DIFF
--- a/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class MathTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
     public partial class MathTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/DivRem.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class MathTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
@@ -4,34 +4,36 @@
 
 using System;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Abs(double) over 5000 iterations for the domain -1, +1
 
-        private const double absDoubleDelta = 0.0004;
-        private const double absDoubleExpectedResult = 2499.9999999999659;
+        private const double absDelta = 0.0004;
+        private const double absExpectedResult = 2499.9999999999659;
 
         [Benchmark]
-        public void AbsDoubleBenchmark() => AbsDoubleTest();
+        public void AbsBenchmark() => AbsTest();
 
-        public static void AbsDoubleTest()
+        public static void AbsTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += absDoubleDelta;
+                value += absDelta;
                 result += Math.Abs(value);
             }
 
-            var diff = Math.Abs(absDoubleExpectedResult - result);
+            var diff = Math.Abs(absExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {absDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {absExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class Double

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class DoublePrecisionTests

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
@@ -17,7 +17,7 @@ namespace Transcendental
         private const double absExpectedResult = 2499.9999999999659;
 
         [Benchmark]
-        public void AbsBenchmark() => AbsTest();
+        public void Abs() => AbsTest();
 
         public static void AbsTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AbsDouble.cs
@@ -9,7 +9,7 @@ using MicroBenchmarks;
 namespace Transcendental
 {
     [BenchmarkCategory(Categories.CoreCLR)]
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Abs(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Acos(double) over 5000 iterations for the domain -1, +1
 
-        private const double acosDoubleDelta = 0.0004;
-        private const double acosDoubleExpectedResult = 7852.4108380716079;
+        private const double acosDelta = 0.0004;
+        private const double acosExpectedResult = 7852.4108380716079;
 
         [Benchmark]
-        public void AcosDoubleBenchmark() => AcosDoubleTest();
+        public void AcosBenchmark() => AcosTest();
 
-        public static void AcosDoubleTest()
+        public static void AcosTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += acosDoubleDelta;
+                value += acosDelta;
                 result += Math.Acos(value);
             }
 
-            var diff = Math.Abs(acosDoubleExpectedResult - result);
+            var diff = Math.Abs(acosExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {acosDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {acosExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double acosExpectedResult = 7852.4108380716079;
 
         [Benchmark]
-        public void AcosBenchmark() => AcosTest();
+        public void Acos() => AcosTest();
 
         public static void AcosTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Acos(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AcosDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double asinExpectedResult = 1.5707959028763392;
 
         [Benchmark]
-        public void AsinBenchmark() => AsinTest();
+        public void Asin() => AsinTest();
 
         public static void AsinTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Asin(double) over 5000 iterations for the domain -1, +1
 
-        private const double asinDoubleDelta = 0.0004;
-        private const double asinDoubleExpectedResult = 1.5707959028763392;
+        private const double asinDelta = 0.0004;
+        private const double asinExpectedResult = 1.5707959028763392;
 
         [Benchmark]
-        public void AsinDoubleBenchmark() => AsinDoubleTest();
+        public void AsinBenchmark() => AsinTest();
 
-        public static void AsinDoubleTest()
+        public static void AsinTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += asinDoubleDelta;
+                value += asinDelta;
                 result += Math.Asin(value);
             }
 
-            var diff = Math.Abs(asinDoubleExpectedResult - result);
+            var diff = Math.Abs(asinExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {asinDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {asinExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Asin(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AsinDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const double atan2ExpectedResult = 3926.99081698702;
 
         [Benchmark]
-        public void Atan2Benchmark() => Atan2Test();
+        public void Atan2() => Atan2Test();
 
         public static void Atan2Test()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
@@ -5,34 +5,34 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Atan2(double, double) over 5000 iterations for the domain y: -1, +1; x: +1, -1
 
-        private const double atan2DoubleDeltaX = -0.0004;
-        private const double atan2DoubleDeltaY = 0.0004;
-        private const double atan2DoubleExpectedResult = 3926.99081698702;
+        private const double atan2DeltaX = -0.0004;
+        private const double atan2DeltaY = 0.0004;
+        private const double atan2ExpectedResult = 3926.99081698702;
 
         [Benchmark]
-        public void Atan2DoubleBenchmark() => Atan2DoubleTest();
+        public void Atan2Benchmark() => Atan2Test();
 
-        public static void Atan2DoubleTest()
+        public static void Atan2Test()
         {
             var result = 0.0; var valueX = 1.0; var valueY = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                valueX += atan2DoubleDeltaX; valueY += atan2DoubleDeltaY;
+                valueX += atan2DeltaX; valueY += atan2DeltaY;
                 result += Math.Atan2(valueY, valueX);
             }
 
-            var diff = Math.Abs(atan2DoubleExpectedResult - result);
+            var diff = Math.Abs(atan2ExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {atan2DoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {atan2ExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Atan2(double, double) over 5000 iterations for the domain y: -1, +1; x: +1, -1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Atan2Double.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Atan(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Atan(double) over 5000 iterations for the domain -1, +1
 
-        private const double atanDoubleDelta = 0.0004;
-        private const double atanDoubleExpectedResult = 0.78539816322061329;
+        private const double atanDelta = 0.0004;
+        private const double atanExpectedResult = 0.78539816322061329;
 
         [Benchmark]
-        public void AtanDoubleBenchmark() => AtanDoubleTest();
+        public void AtanBenchmark() => AtanTest();
 
-        public static void AtanDoubleTest()
+        public static void AtanTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += atanDoubleDelta;
+                value += atanDelta;
                 result += Math.Atan(value);
             }
 
-            var diff = Math.Abs(atanDoubleExpectedResult - result);
+            var diff = Math.Abs(atanExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {atanDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {atanExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double atanExpectedResult = 0.78539816322061329;
 
         [Benchmark]
-        public void AtanBenchmark() => AtanTest();
+        public void Atan() => AtanTest();
 
         public static void AtanTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/AtanDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Ceiling(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Ceiling(double) over 5000 iterations for the domain -1, +1
 
-        private const double ceilingDoubleDelta = 0.0004;
-        private const double ceilingDoubleExpectedResult = 2500;
+        private const double ceilingDelta = 0.0004;
+        private const double ceilingExpectedResult = 2500;
 
         [Benchmark]
-        public void CeilingDoubleBenchmark() => CeilingDoubleTest();
+        public void CeilingBenchmark() => CeilingTest();
 
-        public static void CeilingDoubleTest()
+        public static void CeilingTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += ceilingDoubleDelta;
+                value += ceilingDelta;
                 result += Math.Ceiling(value);
             }
 
-            var diff = Math.Abs(ceilingDoubleExpectedResult - result);
+            var diff = Math.Abs(ceilingExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {ceilingDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {ceilingExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double ceilingExpectedResult = 2500;
 
         [Benchmark]
-        public void CeilingBenchmark() => CeilingTest();
+        public void Ceiling() => CeilingTest();
 
         public static void CeilingTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CeilingDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double cosDoubleExpectedResult = -1.0000000005924159;
 
         [Benchmark]
-        public void CosBenchmark() => CosDoubleTest();
+        public void Cos() => CosDoubleTest();
 
         public static void CosDoubleTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
@@ -5,9 +5,9 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Cos(double) over 5000 iterations for the domain 0, PI
 
@@ -15,13 +15,13 @@ namespace Functions
         private const double cosDoubleExpectedResult = -1.0000000005924159;
 
         [Benchmark]
-        public void CosDoubleBenchmark() => CosDoubleTest();
+        public void CosBenchmark() => CosDoubleTest();
 
         public static void CosDoubleTest()
         {
             var result = 0.0; var value = 0.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += cosDoubleDelta;
                 result += Math.Cos(value);
@@ -29,7 +29,7 @@ namespace Functions
 
             var diff = Math.Abs(cosDoubleExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
                 throw new Exception($"Expected Result {cosDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CosDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Cos(double) over 5000 iterations for the domain 0, PI
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double coshExpectedResult = 5876.0060465657216;
 
         [Benchmark]
-        public void CoshBenchmark() => CoshTest();
+        public void Cosh() => CoshTest();
 
         public static void CoshTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Cosh(double) over 5000 iterations for the domain -1, +1
 
-        private const double coshDoubleDelta = 0.0004;
-        private const double coshDoubleExpectedResult = 5876.0060465657216;
+        private const double coshDelta = 0.0004;
+        private const double coshExpectedResult = 5876.0060465657216;
 
         [Benchmark]
-        public void CoshDoubleBenchmark() => CoshDoubleTest();
+        public void CoshBenchmark() => CoshTest();
 
-        public static void CoshDoubleTest()
+        public static void CoshTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += coshDoubleDelta;
+                value += coshDelta;
                 result += Math.Cosh(value);
             }
 
-            var diff = Math.Abs(coshDoubleExpectedResult - result);
+            var diff = Math.Abs(coshExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {coshDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {coshExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/CoshDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Cosh(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Exp(double) over 5000 iterations for the domain -1, +1
 
-        private const double expDoubleDelta = 0.0004;
-        private const double expDoubleExpectedResult = 5877.1812477590884;
+        private const double expDelta = 0.0004;
+        private const double expExpectedResult = 5877.1812477590884;
 
         [Benchmark]
-        public void ExpDoubleBenchmark() => ExpDoubleTest();
+        public void ExpBenchmark() => ExpTest();
 
-        public static void ExpDoubleTest()
+        public static void ExpTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += expDoubleDelta;
+                value += expDelta;
                 result += Math.Exp(value);
             }
 
-            var diff = Math.Abs(expDoubleExpectedResult - result);
+            var diff = Math.Abs(expExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {expDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {expExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double expExpectedResult = 5877.1812477590884;
 
         [Benchmark]
-        public void ExpBenchmark() => ExpTest();
+        public void Exp() => ExpTest();
 
         public static void ExpTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Exp(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/ExpDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Floor(double) over 5000 iterations for the domain -1, +1
 
-        private const double floorDoubleDelta = 0.0004;
-        private const double floorDoubleExpectedResult = -2500;
+        private const double floorDelta = 0.0004;
+        private const double floorExpectedResult = -2500;
 
         [Benchmark]
-        public void FloorDoubleBenchmark() => FloorDoubleTest();
+        public void FloorBenchmark() => FloorTest();
 
-        public static void FloorDoubleTest()
+        public static void FloorTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += floorDoubleDelta;
+                value += floorDelta;
                 result += Math.Floor(value);
             }
 
-            var diff = Math.Abs(floorDoubleExpectedResult - result);
+            var diff = Math.Abs(floorExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {floorDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {floorExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Floor(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double floorExpectedResult = -2500;
 
         [Benchmark]
-        public void FloorBenchmark() => FloorTest();
+        public void Floor() => FloorTest();
 
         public static void FloorTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/FloorDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
@@ -18,7 +18,7 @@ namespace Transcendental
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void Log10Benchmark() => Log10Test();
+        public void Log10() => Log10Test();
 
         public static void Log10Test()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Log10(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
@@ -5,36 +5,36 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Log10(double) over 5000 iterations for the domain -1, +1
 
-        private const double log10DoubleDelta = 0.0004;
-        private const double log10DoubleExpectedResult = -664.07384902184072;
+        private const double log10Delta = 0.0004;
+        private const double log10ExpectedResult = -664.07384902184072;
 
         /// <summary>
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void Log10DoubleBenchmark() => Log10DoubleTest();
+        public void Log10Benchmark() => Log10Test();
 
-        public static void Log10DoubleTest()
+        public static void Log10Test()
         {
             var result = 0.0; var value = 0.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += log10DoubleDelta;
+                value += log10Delta;
                 result += Math.Log10(value);
             }
 
-            var diff = Math.Abs(log10DoubleExpectedResult - result);
+            var diff = Math.Abs(log10ExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {log10DoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {log10ExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/Log10Double.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Log(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double logExpectedResult = -1529.0865454048721;
 
         [Benchmark]
-        public void LogBenchmark() => LogTest();
+        public void Log() => LogTest();
 
         public static void LogTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Log(double) over 5000 iterations for the domain -1, +1
 
-        private const double logDoubleDelta = 0.0004;
-        private const double logDoubleExpectedResult = -1529.0865454048721;
+        private const double logDelta = 0.0004;
+        private const double logExpectedResult = -1529.0865454048721;
 
         [Benchmark]
-        public void LogDoubleBenchmark() => LogDoubleTest();
+        public void LogBenchmark() => LogTest();
 
-        public static void LogDoubleTest()
+        public static void LogTest()
         {
             var result = 0.0; var value = 0.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += logDoubleDelta;
+                value += logDelta;
                 result += Math.Log(value);
             }
 
-            var diff = Math.Abs(logDoubleExpectedResult - result);
+            var diff = Math.Abs(logExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {logDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {logExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/LogDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Running;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Pow(double, double) over 5000 iterations for the domain x: +2, +1; y: -2, -1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
@@ -17,7 +17,7 @@ namespace Transcendental
         private const double powExpectedResult = 4659.4627376138733;
 
         [Benchmark]
-        public void PowBenchmark() => PowTest();
+        public void Pow() => PowTest();
 
         public static void PowTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/PowDouble.cs
@@ -6,34 +6,34 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Pow(double, double) over 5000 iterations for the domain x: +2, +1; y: -2, -1
 
-        private const double powDoubleDeltaX = -0.0004;
-        private const double powDoubleDeltaY = 0.0004;
-        private const double powDoubleExpectedResult = 4659.4627376138733;
+        private const double powDeltaX = -0.0004;
+        private const double powDeltaY = 0.0004;
+        private const double powExpectedResult = 4659.4627376138733;
 
         [Benchmark]
-        public void PowDoubleBenchmark() => PowDoubleTest();
+        public void PowBenchmark() => PowTest();
 
-        public static void PowDoubleTest()
+        public static void PowTest()
         {
             var result = 0.0; var valueX = 2.0; var valueY = -2.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                valueX += powDoubleDeltaX; valueY += powDoubleDeltaY;
+                valueX += powDeltaX; valueY += powDeltaY;
                 result += Math.Pow(valueX, valueY);
             }
 
-            var diff = Math.Abs(powDoubleExpectedResult - result);
+            var diff = Math.Abs(powExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {powDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {powExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double roundExpectedResult = 2;
 
         [Benchmark]
-        public void RoundBenchmark() => RoundTest();
+        public void Round() => RoundTest();
 
         public static void RoundTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
@@ -4,35 +4,34 @@
 
 using System;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Round(double) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const double roundDoubleDelta = 0.0006283185307180;
-        private const double roundDoubleExpectedResult = 2;
+        private const double roundDelta = 0.0006283185307180;
+        private const double roundExpectedResult = 2;
 
         [Benchmark]
-        public void RoundDoubleBenchmark() => RoundDoubleTest();
+        public void RoundBenchmark() => RoundTest();
 
-        public static void RoundDoubleTest()
+        public static void RoundTest()
         {
             var result = 0.0; var value = -1.5707963267948966;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += roundDoubleDelta;
+                value += roundDelta;
                 result += Math.Round(value);
             }
 
-            var diff = Math.Abs(roundDoubleExpectedResult - result);
+            var diff = Math.Abs(roundExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {roundDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {roundExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Round(double) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/RoundDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Running;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Sin(double) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const double sinExpectedResult = 1.0000000005445053;
 
         [Benchmark]
-        public void SinBenchmark() => SinTest();
+        public void Sin() => SinTest();
 
         public static void SinTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinDouble.cs
@@ -6,33 +6,33 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Sin(double) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const double sinDoubleDelta = 0.0006283185307180;
-        private const double sinDoubleExpectedResult = 1.0000000005445053;
+        private const double sinDelta = 0.0006283185307180;
+        private const double sinExpectedResult = 1.0000000005445053;
 
         [Benchmark]
-        public void SinDoubleBenchmark() => SinDoubleTest();
+        public void SinBenchmark() => SinTest();
 
-        public static void SinDoubleTest()
+        public static void SinTest()
         {
             var result = 0.0; var value = -1.5707963267948966;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sinDoubleDelta;
+                value += sinDelta;
                 result += Math.Sin(value);
             }
 
-            var diff = Math.Abs(sinDoubleExpectedResult - result);
+            var diff = Math.Abs(sinExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {sinDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {sinExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double sinhExpectedResult = 1.17520119337903;
 
         [Benchmark]
-        public void SinhBenchmark() => SinhTest();
+        public void Sinh() => SinhTest();
 
         public static void SinhTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Sinh(double) over 5000 iterations for the domain -1, +1
 
-        private const double sinhDoubleDelta = 0.0004;
-        private const double sinhDoubleExpectedResult = 1.17520119337903;
+        private const double sinhDelta = 0.0004;
+        private const double sinhExpectedResult = 1.17520119337903;
 
         [Benchmark]
-        public void SinhDoubleBenchmark() => SinhDoubleTest();
+        public void SinhBenchmark() => SinhTest();
 
-        public static void SinhDoubleTest()
+        public static void SinhTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sinhDoubleDelta;
+                value += sinhDelta;
                 result += Math.Sinh(value);
             }
 
-            var diff = Math.Abs(sinhDoubleExpectedResult - result);
+            var diff = Math.Abs(sinhExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {sinhDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {sinhExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Sinh(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SinhDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double sqrtExpectedResult = 5909.0605337797215;
 
         [Benchmark]
-        public void SqrtBenchmark() => SqrtTest();
+        public void Sqrt() => SqrtTest();
 
         public static void SqrtTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Sqrt(double) over 5000 iterations for the domain 0, PI
 
-        private const double sqrtDoubleDelta = 0.0006283185307180;
-        private const double sqrtDoubleExpectedResult = 5909.0605337797215;
+        private const double sqrtDelta = 0.0006283185307180;
+        private const double sqrtExpectedResult = 5909.0605337797215;
 
         [Benchmark]
-        public void SqrtDoubleBenchmark() => SqrtDoubleTest();
+        public void SqrtBenchmark() => SqrtTest();
 
-        public static void SqrtDoubleTest()
+        public static void SqrtTest()
         {
             var result = 0.0; var value = 0.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sqrtDoubleDelta;
+                value += sqrtDelta;
                 result += Math.Sqrt(value);
             }
 
-            var diff = Math.Abs(sqrtDoubleExpectedResult - result);
+            var diff = Math.Abs(sqrtExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {sqrtDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {sqrtExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Sqrt(double) over 5000 iterations for the domain 0, PI
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/SqrtDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Tan(double) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double tanExpectedResult = 1.5574077243051505;
 
         [Benchmark]
-        public void TanBenchmark() => TanTest();
+        public void Tan() => TanTest();
 
         public static void TanTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Tan(double) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const double tanDoubleDelta = 0.0004;
-        private const double tanDoubleExpectedResult = 1.5574077243051505;
+        private const double tanDelta = 0.0004;
+        private const double tanExpectedResult = 1.5574077243051505;
 
         [Benchmark]
-        public void TanDoubleBenchmark() => TanDoubleTest();
+        public void TanBenchmark() => TanTest();
 
-        public static void TanDoubleTest()
+        public static void TanTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += tanDoubleDelta;
+                value += tanDelta;
                 result += Math.Tan(value);
             }
 
-            var diff = Math.Abs(tanDoubleExpectedResult - result);
+            var diff = Math.Abs(tanExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {tanDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {tanExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const double tanhExpectedResult = 0.76159415578341827;
 
         [Benchmark]
-        public void TanhBenchmark() => TanhTest();
+        public void Tanh() => TanhTest();
 
         public static void TanhTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class DoublePrecisionTests
+    public partial class Double
     {
         // Tests Math.Tanh(double) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class DoublePrecisionTests
     {
         // Tests Math.Tanh(double) over 5000 iterations for the domain -1, +1
 
-        private const double tanhDoubleDelta = 0.0004;
-        private const double tanhDoubleExpectedResult = 0.76159415578341827;
+        private const double tanhDelta = 0.0004;
+        private const double tanhExpectedResult = 0.76159415578341827;
 
         [Benchmark]
-        public void TanhDoubleBenchmark() => TanhDoubleTest();
+        public void TanhBenchmark() => TanhTest();
 
-        public static void TanhDoubleTest()
+        public static void TanhTest()
         {
             var result = 0.0; var value = -1.0;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += tanhDoubleDelta;
+                value += tanhDelta;
                 result += Math.Tanh(value);
             }
 
-            var diff = Math.Abs(tanhDoubleExpectedResult - result);
+            var diff = Math.Abs(tanhExpectedResult - result);
 
-            if (diff > doubleEpsilon)
+            if (diff > MathTests.DoubleEpsilon)
             {
-                throw new Exception($"Expected Result {tanhDoubleExpectedResult,20:g17}; Actual Result {result,20:g17}");
+                throw new Exception($"Expected Result {tanhExpectedResult,20:g17}; Actual Result {result,20:g17}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Double
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Double/TanhDouble.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class DoublePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
@@ -5,7 +5,7 @@
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class MathTests
@@ -15,61 +15,19 @@ namespace Functions
         // single-precision machine epsilon as our epsilon should be 'good enough' for the purposes
         // of the perf testing as it ensures we get the expected value and that it is at least as precise
         // as we would have computed with the single-precision version of the function (without aggregation).
-        private const double doubleEpsilon = 1.19e-07;
+        public const double DoubleEpsilon = 1.19e-07;
 
         // 5000 iterations is enough to cover the full domain of inputs for certain functions (such
         // as Cos, which has a domain of 0 to PI) at reasonable intervals (in the case of Cos, the
         // interval is PI / 5000 which is 0.0006283185307180). It should also give reasonable coverage
         // for functions which have a larger domain (such as Atan, which covers the full set of real numbers).
-        private const int iterations = 5000;
+        public const int Iterations = 5000;
 
         // float has a machine epsilon of approx: 1.19e-07. However, due to floating-point precision
         // errors, this is too accurate when aggregating values of a set of iterations. Using the
         // half-precision machine epsilon as our epsilon should be 'good enough' for the purposes
         // of the perf testing as it ensures we get the expected value and that it is at least as precise
         // as we would have computed with the half-precision version of the function (without aggregation).
-        private const float singleEpsilon = 9.77e-04f;
-
-        // While iterations covers the domain of inputs, the full span of results doesn't run long enough
-        // to meet our siginificance criteria. So each test is repeated many times, using the factors below.
-        private const int AbsDoubleIterations = 200000;
-        private const int AcosDoubleIterations = 10000;
-        private const int AsinDoubleIterations = 10000;
-        private const int Atan2DoubleIterations = 6500;
-        private const int AtanDoubleIterations = 13000;
-        private const int CeilingDoubleIterations = 80000;
-        private const int CosDoubleIterations = 16000;
-        private const int CoshDoubleIterations = 8000;
-        private const int ExpDoubleIterations = 16000;
-        private const int FloorDoubleIterations = 80000;
-        private const int Log10DoubleIterations = 16000;
-        private const int LogDoubleIterations = 20000;
-        private const int PowDoubleIterations = 4000;
-        private const int RoundDoubleIterations = 35000;
-        private const int SinDoubleIterations = 16000;
-        private const int SinhDoubleIterations = 8000;
-        private const int SqrtDoubleIterations = 40000;
-        private const int TanDoubleIterations = 16000;
-        private const int TanhDoubleIterations = 17000;
-
-        private const int AbsSingleIterations = 200000;
-        private const int AcosSingleIterations = 15000;
-        private const int AsinSingleIterations = 15000;
-        private const int Atan2SingleIterations = 9000;
-        private const int AtanSingleIterations = 17000;
-        private const int CeilingSingleIterations = 80000;
-        private const int CosSingleIterations = 20000;
-        private const int CoshSingleIterations = 10000;
-        private const int ExpSingleIterations = 24000;
-        private const int FloorSingleIterations = 80000;
-        private const int Log10SingleIterations = 20000;
-        private const int LogSingleIterations = 30000;
-        private const int PowSingleIterations = 10000;
-        private const int RoundSingleIterations = 35000;
-        private const int SinSingleIterations = 20000;
-        private const int SinhSingleIterations = 10000;
-        private const int SqrtSingleIterations = 80000;
-        private const int TanSingleIterations = 25000;
-        private const int TanhSingleIterations = 20000;
+        public const float SingleEpsilon = 9.77e-04f;
     }
 }

--- a/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
@@ -5,7 +5,7 @@
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class MathTests

--- a/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/MathTests.cs
@@ -5,7 +5,7 @@
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class MathTests

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class Single

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
@@ -17,7 +17,7 @@ namespace Transcendental
         private const float absExpectedResult = 2500.03125f;
 
         [Benchmark]
-        public void AbsBenchmark() => AbsTest();
+        public void Abs() => AbsTest();
 
         public static void AbsTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
@@ -4,34 +4,36 @@
 
 using System;
 using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public partial class SinglePrecisionTests
     {
         // Tests Math.Abs(single) over 5000 iterations for the domain -1, +1
 
-        private const float absSingleDelta = 0.0004f;
-        private const float absSingleExpectedResult = 2500.03125f;
+        private const float absDelta = 0.0004f;
+        private const float absExpectedResult = 2500.03125f;
 
         [Benchmark]
-        public void AbsSingleBenchmark() => AbsSingleTest();
+        public void AbsBenchmark() => AbsTest();
 
-        public static void AbsSingleTest()
+        public static void AbsTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += absSingleDelta;
+                value += absDelta;
                 result += Math.Abs(value);
             }
 
-            var diff = Math.Abs(absSingleExpectedResult - result);
+            var diff = Math.Abs(absExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {absSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {absExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     [BenchmarkCategory(Categories.CoreCLR)]
     public partial class SinglePrecisionTests

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AbsSingle.cs
@@ -9,7 +9,7 @@ using MicroBenchmarks;
 namespace Transcendental
 {
     [BenchmarkCategory(Categories.CoreCLR)]
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests Math.Abs(single) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float acosExpectedResult = 7852.41084f;
 
         [Benchmark]
-        public void AcosBenchmark() => AcosTest();
+        public void Acos() => AcosTest();
 
         public static void AcosTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Acos(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AcosSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Acos(float) over 5000 iterations for the domain -1, +1
 
-        private const float acosSingleDelta = 0.0004f;
-        private const float acosSingleExpectedResult = 7852.41084f;
+        private const float acosDelta = 0.0004f;
+        private const float acosExpectedResult = 7852.41084f;
 
         [Benchmark]
-        public void AcosSingleBenchmark() => AcosSingleTest();
+        public void AcosBenchmark() => AcosTest();
 
-        public static void AcosSingleTest()
+        public static void AcosTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += acosSingleDelta;
+                value += acosDelta;
                 result += MathF.Acos(value);
             }
 
-            var diff = MathF.Abs(acosSingleExpectedResult - result);
+            var diff = MathF.Abs(acosExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {acosSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {acosExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float asinExpectedResult = 1.57079590f;
 
         [Benchmark]
-        public void AsinBenchmark() => AsinTest();
+        public void Asin() => AsinTest();
 
         public static void AsinTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Asin(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AsinSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Asin(float) over 5000 iterations for the domain -1, +1
 
-        private const float asinSingleDelta = 0.0004f;
-        private const float asinSingleExpectedResult = 1.57079590f;
+        private const float asinDelta = 0.0004f;
+        private const float asinExpectedResult = 1.57079590f;
 
         [Benchmark]
-        public void AsinSingleBenchmark() => AsinSingleTest();
+        public void AsinBenchmark() => AsinTest();
 
-        public static void AsinSingleTest()
+        public static void AsinTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += asinSingleDelta;
+                value += asinDelta;
                 result += MathF.Asin(value);
             }
 
-            var diff = MathF.Abs(asinSingleExpectedResult - result);
+            var diff = MathF.Abs(asinExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {asinSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {asinExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Atan2(float, float) over 5000 iterations for the domain y: -1, +1; x: +1, -1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
@@ -5,34 +5,34 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Atan2(float, float) over 5000 iterations for the domain y: -1, +1; x: +1, -1
 
-        private const float atan2SingleDeltaX = -0.0004f;
-        private const float atan2SingleDeltaY = 0.0004f;
-        private const float atan2SingleExpectedResult = 3930.14282f;
+        private const float atan2DeltaX = -0.0004f;
+        private const float atan2DeltaY = 0.0004f;
+        private const float atan2ExpectedResult = 3930.14282f;
 
         [Benchmark]
-        public void Atan2SingleBenchmark() => Atan2SingleTest();
+        public void Atan2Benchmark() => Atan2Test();
 
-        public static void Atan2SingleTest()
+        public static void Atan2Test()
         {
             var result = 0.0f; var valueX = 1.0f; var valueY = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                valueX += atan2SingleDeltaX; valueY += atan2SingleDeltaY;
+                valueX += atan2DeltaX; valueY += atan2DeltaY;
                 result += MathF.Atan2(valueY, valueX);
             }
 
-            var diff = MathF.Abs(atan2SingleExpectedResult - result);
+            var diff = MathF.Abs(atan2ExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {atan2SingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {atan2ExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const float atan2ExpectedResult = 3930.14282f;
 
         [Benchmark]
-        public void Atan2Benchmark() => Atan2Test();
+        public void Atan2() => Atan2Test();
 
         public static void Atan2Test()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Atan2Single.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Running;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Atan(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const float atanExpectedResult = 0.841940999f;
 
         [Benchmark]
-        public void AtanBenchmark() => AtanTest();
+        public void Atan() => AtanTest();
 
         public static void AtanTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
@@ -6,33 +6,33 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Atan(float) over 5000 iterations for the domain -1, +1
 
-        private const float atanSingleDelta = 0.0004f;
-        private const float atanSingleExpectedResult = 0.841940999f;
+        private const float atanDelta = 0.0004f;
+        private const float atanExpectedResult = 0.841940999f;
 
         [Benchmark]
-        public void AtanSingleBenchmark() => AtanSingleTest();
+        public void AtanBenchmark() => AtanTest();
 
-        public static void AtanSingleTest()
+        public static void AtanTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += atanSingleDelta;
+                value += atanDelta;
                 result += MathF.Atan(value);
             }
 
-            var diff = MathF.Abs(atanSingleExpectedResult - result);
+            var diff = MathF.Abs(atanExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {atanSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {atanExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/AtanSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float ceilingExpectedResult = 2502.0f;
 
         [Benchmark]
-        public void CeilingBenchmark() => CeilingTest();
+        public void Ceiling() => CeilingTest();
 
         public static void CeilingTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
@@ -4,35 +4,34 @@
 
 using System;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Ceiling(float) over 5000 iterations for the domain -1, +1
 
-        private const float ceilingSingleDelta = 0.0004f;
-        private const float ceilingSingleExpectedResult = 2502.0f;
+        private const float ceilingDelta = 0.0004f;
+        private const float ceilingExpectedResult = 2502.0f;
 
         [Benchmark]
-        public void CeilingSingleBenchmark() => CeilingSingleTest();
+        public void CeilingBenchmark() => CeilingTest();
 
-        public static void CeilingSingleTest()
+        public static void CeilingTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += ceilingSingleDelta;
+                value += ceilingDelta;
                 result += MathF.Ceiling(value);
             }
 
-            var diff = MathF.Abs(ceilingSingleExpectedResult - result);
+            var diff = MathF.Abs(ceilingExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {ceilingSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {ceilingExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Ceiling(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CeilingSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const float cosExpectedResult = -0.993487537f;
 
         [Benchmark]
-        public void CosBenchmark() => CosTest();
+        public void Cos() => CosTest();
 
         public static void CosTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
@@ -6,33 +6,33 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Cos(float) over 5000 iterations for the domain 0, PI
 
-        private const float cosSingleDelta = 0.000628318531f;
-        private const float cosSingleExpectedResult = -0.993487537f;
+        private const float cosDelta = 0.000628318531f;
+        private const float cosExpectedResult = -0.993487537f;
 
         [Benchmark]
-        public void CosSingleBenchmark() => CosSingleTest();
+        public void CosBenchmark() => CosTest();
 
-        public static void CosSingleTest()
+        public static void CosTest()
         {
             var result = 0.0f; var value = 0.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += cosSingleDelta;
+                value += cosDelta;
                 result += MathF.Cos(value);
             }
 
-            var diff = MathF.Abs(cosSingleExpectedResult - result);
+            var diff = MathF.Abs(cosExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {cosSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {cosExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CosSingle.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Running;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Cos(float) over 5000 iterations for the domain 0, PI
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
@@ -8,7 +8,7 @@ using BenchmarkDotNet.Running;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Cosh(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
@@ -6,33 +6,33 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Cosh(float) over 5000 iterations for the domain -1, +1
 
-        private const float coshSingleDelta = 0.0004f;
-        private const float coshSingleExpectedResult = 5876.02588f;
+        private const float coshDelta = 0.0004f;
+        private const float coshExpectedResult = 5876.02588f;
 
         [Benchmark]
-        public void CoshSingleBenchmark() => CoshSingleTest();
+        public void CoshBenchmark() => CoshTest();
 
-        public static void CoshSingleTest()
+        public static void CoshTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += coshSingleDelta;
+                value += coshDelta;
                 result += MathF.Cosh(value);
             }
 
-            var diff = MathF.Abs(coshSingleExpectedResult - result);
+            var diff = MathF.Abs(coshExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {coshSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {coshExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const float coshExpectedResult = 5876.02588f;
 
         [Benchmark]
-        public void CoshBenchmark() => CoshTest();
+        public void Cosh() => CoshTest();
 
         public static void CoshTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/CoshSingle.cs
@@ -6,7 +6,7 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Exp(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Exp(float) over 5000 iterations for the domain -1, +1
 
-        private const float expSingleDelta = 0.0004f;
-        private const float expSingleExpectedResult = 5877.28564f;
+        private const float expDelta = 0.0004f;
+        private const float expExpectedResult = 5877.28564f;
 
         [Benchmark]
-        public void ExpSingleBenchmark() => ExpSingleTest();
+        public void ExpBenchmark() => ExpTest();
 
-        public static void ExpSingleTest()
+        public static void ExpTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += expSingleDelta;
+                value += expDelta;
                 result += MathF.Exp(value);
             }
 
-            var diff = MathF.Abs(expSingleExpectedResult - result);
+            var diff = MathF.Abs(expExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {expSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {expExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float expExpectedResult = 5877.28564f;
 
         [Benchmark]
-        public void ExpBenchmark() => ExpTest();
+        public void Exp() => ExpTest();
 
         public static void ExpTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/ExpSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Floor(float) over 5000 iterations for the domain -1, +1
 
-        private const float floorSingleDelta = 0.0004f;
-        private const float floorSingleExpectedResult = -2498.0f;
+        private const float floorDelta = 0.0004f;
+        private const float floorExpectedResult = -2498.0f;
 
         [Benchmark]
-        public void FloorSingleBenchmark() => FloorSingleTest();
+        public void FloorBenchmark() => FloorTest();
 
-        public static void FloorSingleTest()
+        public static void FloorTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += floorSingleDelta;
+                value += floorDelta;
                 result += MathF.Floor(value);
             }
 
-            var diff = MathF.Abs(floorSingleExpectedResult - result);
+            var diff = MathF.Abs(floorExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {floorSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {floorExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Floor(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/FloorSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float floorExpectedResult = -2498.0f;
 
         [Benchmark]
-        public void FloorBenchmark() => FloorTest();
+        public void Floor() => FloorTest();
 
         public static void FloorTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Log10(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
@@ -5,36 +5,36 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Log10(float) over 5000 iterations for the domain -1, +1
 
-        private const float log10SingleDelta = 0.0004f;
-        private const float log10SingleExpectedResult = -664.094971f;
+        private const float log10Delta = 0.0004f;
+        private const float log10ExpectedResult = -664.094971f;
 
         /// <summary>
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void Log10SingleBenchmark() => Log10SingleTest();
+        public void Log10Benchmark() => Log10Test();
 
-        public static void Log10SingleTest()
+        public static void Log10Test()
         {
             var result = 0.0f; var value = 0.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += log10SingleDelta;
+                value += log10Delta;
                 result += MathF.Log10(value);
             }
 
-            var diff = MathF.Abs(log10SingleExpectedResult - result);
+            var diff = MathF.Abs(log10ExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {log10SingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {log10ExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
@@ -18,7 +18,7 @@ namespace Transcendental
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void Log10Benchmark() => Log10Test();
+        public void Log10() => Log10Test();
 
         public static void Log10Test()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/Log10Single.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Log(float) over 5000 iterations for the domain -1, +1
 
-        private const float logSingleDelta = 0.0004f;
-        private const float logSingleExpectedResult = -1529.14014f;
+        private const float logDelta = 0.0004f;
+        private const float logExpectedResult = -1529.14014f;
 
         [Benchmark]
-        public void LogSingleBenchmark() => LogSingleTest();
+        public void LogBenchmark() => LogTest();
 
-        public static void LogSingleTest()
+        public static void LogTest()
         {
             var result = 0.0f; var value = 0.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += logSingleDelta;
+                value += logDelta;
                 result += MathF.Log(value);
             }
 
-            var diff = MathF.Abs(logSingleExpectedResult - result);
+            var diff = MathF.Abs(logExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {logSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {logExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float logExpectedResult = -1529.14014f;
 
         [Benchmark]
-        public void LogBenchmark() => LogTest();
+        public void Log() => LogTest();
 
         public static void LogTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Log(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/LogSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
@@ -5,34 +5,34 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Pow(float, float) over 5000 iterations for the domain x: +2, +1; y: -2, -1
 
-        private const float powSingleDeltaX = -0.0004f;
-        private const float powSingleDeltaY = 0.0004f;
-        private const float powSingleExpectedResult = 4659.30762f;
+        private const float powDeltaX = -0.0004f;
+        private const float powDeltaY = 0.0004f;
+        private const float powExpectedResult = 4659.30762f;
 
         [Benchmark]
-        public void PowSingleBenchmark() => PowSingleTest();
+        public void PowBenchmark() => PowTest();
 
-        public static void PowSingleTest()
+        public static void PowTest()
         {
             var result = 0.0f; var valueX = 2.0f; var valueY = -2.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                valueX += powSingleDeltaX; valueY += powSingleDeltaY;
+                valueX += powDeltaX; valueY += powDeltaY;
                 result += MathF.Pow(valueX, valueY);
             }
 
-            var diff = MathF.Abs(powSingleExpectedResult - result);
+            var diff = MathF.Abs(powExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {powSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {powExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
@@ -16,7 +16,7 @@ namespace Transcendental
         private const float powExpectedResult = 4659.30762f;
 
         [Benchmark]
-        public void PowBenchmark() => PowTest();
+        public void Pow() => PowTest();
 
         public static void PowTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Pow(float, float) over 5000 iterations for the domain x: +2, +1; y: -2, -1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/PowSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float roundExpectedResult = 2.0f;
 
         [Benchmark]
-        public void RoundBenchmark() => RoundTest();
+        public void Round() => RoundTest();
 
         public static void RoundTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Round(float) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const float roundSingleDelta = 0.000628318531f;
-        private const float roundSingleExpectedResult = 2.0f;
+        private const float roundDelta = 0.000628318531f;
+        private const float roundExpectedResult = 2.0f;
 
         [Benchmark]
-        public void RoundSingleBenchmark() => RoundSingleTest();
+        public void RoundBenchmark() => RoundTest();
 
-        public static void RoundSingleTest()
+        public static void RoundTest()
         {
             var result = 0.0f; var value = -1.57079633f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += roundSingleDelta;
+                value += roundDelta;
                 result += MathF.Round(value);
             }
 
-            var diff = MathF.Abs(roundSingleExpectedResult - result);
+            var diff = MathF.Abs(roundExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {roundSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {roundExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Round(float) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/RoundSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float sinExpectedResult = 1.03592682f;
 
         [Benchmark]
-        public void SinBenchmark() => SinTest();
+        public void Sin() => SinTest();
 
         public static void SinTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Sin(float) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const float sinSingleDelta = 0.000628318531f;
-        private const float sinSingleExpectedResult = 1.03592682f;
+        private const float sinDelta = 0.000628318531f;
+        private const float sinExpectedResult = 1.03592682f;
 
         [Benchmark]
-        public void SinSingleBenchmark() => SinSingleTest();
+        public void SinBenchmark() => SinTest();
 
-        public static void SinSingleTest()
+        public static void SinTest()
         {
             var result = 0.0f; var value = -1.57079633f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sinSingleDelta;
+                value += sinDelta;
                 result += MathF.Sin(value);
             }
 
-            var diff = MathF.Abs(sinSingleExpectedResult - result);
+            var diff = MathF.Abs(sinExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {sinSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {sinExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Sin(float) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
@@ -5,36 +5,36 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Sinh(float) over 5000 iterations for the domain -1, +1
 
-        private const float sinhSingleDelta = 0.0004f;
-        private const float sinhSingleExpectedResult = 1.26028216f;
+        private const float sinhDelta = 0.0004f;
+        private const float sinhExpectedResult = 1.26028216f;
 
         /// <summary>
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void SinhSingleBenchmark() => SinhSingleTest();
+        public void SinhBenchmark() => SinhTest();
 
-        public static void SinhSingleTest()
+        public static void SinhTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sinhSingleDelta;
+                value += sinhDelta;
                 result += MathF.Sinh(value);
             }
 
-            var diff = MathF.Abs(sinhSingleExpectedResult - result);
+            var diff = MathF.Abs(sinhExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {sinhSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {sinhExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Sinh(float) over 5000 iterations for the domain -1, +1
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
@@ -18,7 +18,7 @@ namespace Transcendental
         /// this benchmark is dependent on loop alignment
         /// </summary>
         [Benchmark]
-        public void SinhBenchmark() => SinhTest();
+        public void Sinh() => SinhTest();
 
         public static void SinhTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SinhSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Sqrt(float) over 5000 iterations for the domain 0, PI
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Sqrt(float) over 5000 iterations for the domain 0, PI
 
-        private const float sqrtSingleDelta = 0.000628318531f;
-        private const float sqrtSingleExpectedResult = 5909.03027f;
+        private const float sqrtDelta = 0.000628318531f;
+        private const float sqrtExpectedResult = 5909.03027f;
 
         [Benchmark]
-        public void SqrtSingleBenchmark() => SqrtSingleTest();
+        public void SqrtBenchmark() => SqrtTest();
 
-        public static void SqrtSingleTest()
+        public static void SqrtTest()
         {
             var result = 0.0f; var value = 0.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += sqrtSingleDelta;
+                value += sqrtDelta;
                 result += MathF.Sqrt(value);
             }
 
-            var diff = MathF.Abs(sqrtSingleExpectedResult - result);
+            var diff = MathF.Abs(sqrtExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {sqrtSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {sqrtExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/SqrtSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float sqrtExpectedResult = 5909.03027f;
 
         [Benchmark]
-        public void SqrtBenchmark() => SqrtTest();
+        public void Sqrt() => SqrtTest();
 
         public static void SqrtTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float tanExpectedResult = 1.66717815f;
 
         [Benchmark]
-        public void TanBenchmark() => TanTest();
+        public void Tan() => TanTest();
 
         public static void TanTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Tan(float) over 5000 iterations for the domain -PI/2, +PI/2
 

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Tan(float) over 5000 iterations for the domain -PI/2, +PI/2
 
-        private const float tanSingleDelta = 0.0004f;
-        private const float tanSingleExpectedResult = 1.66717815f;
+        private const float tanDelta = 0.0004f;
+        private const float tanExpectedResult = 1.66717815f;
 
         [Benchmark]
-        public void TanSingleBenchmark() => TanSingleTest();
+        public void TanBenchmark() => TanTest();
 
-        public static void TanSingleTest()
+        public static void TanTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += tanSingleDelta;
+                value += tanDelta;
                 result += MathF.Tan(value);
             }
 
-            var diff = MathF.Abs(tanSingleExpectedResult - result);
+            var diff = MathF.Abs(tanExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {tanSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {tanExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Transcendental
+namespace System.MathBenchmarks
 {
     public partial class Single
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
@@ -5,33 +5,33 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace Functions
+namespace MathTests.FloatingPointTests
 {
-    public partial class MathTests
+    public partial class SinglePrecisionTests
     {
         // Tests MathF.Tanh(float) over 5000 iterations for the domain -1, +1
 
-        private const float tanhSingleDelta = 0.0004f;
-        private const float tanhSingleExpectedResult = 0.816701353f;
+        private const float tanhDelta = 0.0004f;
+        private const float tanhExpectedResult = 0.816701353f;
 
         [Benchmark]
-        public void TanhSingleBenchmark() => TanhSingleTest();
+        public void TanhBenchmark() => TanhTest();
 
-        public static void TanhSingleTest()
+        public static void TanhTest()
         {
             var result = 0.0f; var value = -1.0f;
 
-            for (var iteration = 0; iteration < iterations; iteration++)
+            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
-                value += tanhSingleDelta;
+                value += tanhDelta;
                 result += MathF.Tanh(value);
             }
 
-            var diff = MathF.Abs(tanhSingleExpectedResult - result);
+            var diff = MathF.Abs(tanhExpectedResult - result);
 
-            if (diff > singleEpsilon)
+            if (diff > MathTests.SingleEpsilon)
             {
-                throw new Exception($"Expected Result {tanhSingleExpectedResult,10:g9}; Actual Result {result,10:g9}");
+                throw new Exception($"Expected Result {tanhExpectedResult,10:g9}; Actual Result {result,10:g9}");
             }
         }
     }

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
@@ -15,7 +15,7 @@ namespace Transcendental
         private const float tanhExpectedResult = 0.816701353f;
 
         [Benchmark]
-        public void TanhBenchmark() => TanhTest();
+        public void Tanh() => TanhTest();
 
         public static void TanhTest()
         {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
@@ -5,7 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 
-namespace MathTests.FloatingPointTests
+namespace Transcendental
 {
     public partial class SinglePrecisionTests
     {

--- a/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/coreclr/Math/Functions/Single/TanhSingle.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Transcendental
 {
-    public partial class SinglePrecisionTests
+    public partial class Single
     {
         // Tests MathF.Tanh(float) over 5000 iterations for the domain -1, +1
 


### PR DESCRIPTION
## What is in this PR at the moment:

- Updated namespace from: `Functions`, to `MathTests.FloatingPointTests`
- Moved Double precision tests from the `MathTests` class to the `DoublePrecisionTests` class (maybe it should be `DoublePrecisionTranscendentalsTests`)
- Moved Single precision tests from the `MathTests` class to the `SinglePrecisionTests` class (maybe it should be `SinglePrecisionTranscendentalsTests`)
- Removed unused constants.

## What is missing:

- There is still a lot of code that could be simplified/cleaned up (a lot of duplication and using inner iterations).