### PR TITLE
Disable nightly Jenkins runs

### DIFF
--- a/perf.groovy
+++ b/perf.groovy
@@ -153,16 +153,6 @@ def projectFolder = projectName + '/' + Utilities.getFolderName(branch)
                     builder.triggerForBranch(branch)
                     builder.emitTrigger(newJob)
                 }
-                else {
-                    Utilities.addPeriodicTrigger(newJob, "@daily", true /*always run*/)
-                    newJob.with {
-                        wrappers {
-                            timeout {
-                                absolute(240)
-                            }
-                        }
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
Since we are now collecting data from Azure DevOps, we can disable the nightly runs for Jenkins.

I am leaving the PR runs for now, as we do not have PR runs on physical hardware yet.