### PR TITLE
Set copyright and package license

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-  <PropertyGroup>
-    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
-      https://ci.appveyor.com/nuget/benchmarkdotnet;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      $(OverridePackageSource);
-      $(RestoreSources)
-    </RestoreSources>
+
+  <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
+    <Copyright>$(CopyrightNetFoundation)</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,8 +9,10 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
-      https:%2F%2Fdotnet.myget.org/F/symreader/api/v3/index.json;
+      https://dotnet.myget.org/F/symreader/api/v3/index.json;
+      https://ci.appveyor.com/nuget/benchmarkdotnet;
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Prepares repo for change https://github.com/dotnet/arcade/pull/2003 by setting `Copyright` and `PackageLicenseExpression` properties. These values will be required to be set by each repository once https://github.com/dotnet/arcade/pull/2003 is merged.

In order to not break the current builds this change sets the properties conditionally. This condition can be removed once all repos switch to Arcade that has https://github.com/dotnet/arcade/pull/2003.

@markwilkie
