### PR TITLE
Run all benchmarks for both tiered and full_opt optimization levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,104 +20,92 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 
 ### Micro Benchmarks
 
-#### CoreFX
+#### Full_opt
 
 | Framework | Windows RS4 x64                                                                             | Windows RS4 x86                                                                             | Ubuntu 16.04 x64                                                                            | Ubuntu 16.04 ARM64                                                                              |
 | :-------- | :-----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
-| Core 3.0  | [![CoreFX_windows_RS4_x64_netcoreapp3.0_icon]][CoreFX_windows_RS4_x64_netcoreapp3.0_status] | [![CoreFX_windows_RS4_x86_netcoreapp3.0_icon]][CoreFX_windows_RS4_x86_netcoreapp3.0_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreFX_ubuntu_1604_x64_netcoreapp3.0_status] | [![CoreFX_ubuntu_1604_arm64_netcoreapp3.0_icon]][CoreFX_ubuntu_1604_arm64_netcoreapp3.0_status] |
-| Core 2.2  | [![CoreFX_windows_RS4_x64_netcoreapp2.2_icon]][CoreFX_windows_RS4_x64_netcoreapp2.2_status] | [![CoreFX_windows_RS4_x86_netcoreapp2.2_icon]][CoreFX_windows_RS4_x86_netcoreapp2.2_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                             |
-| Core 2.1  | [![CoreFX_windows_RS4_x64_netcoreapp2.1_icon]][CoreFX_windows_RS4_x64_netcoreapp2.1_status] | [![CoreFX_windows_RS4_x86_netcoreapp2.1_icon]][CoreFX_windows_RS4_x86_netcoreapp2.1_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                             |
-| Core 2.0  | [![CoreFX_windows_RS4_x64_netcoreapp2.0_icon]][CoreFX_windows_RS4_x64_netcoreapp2.0_status] | [![CoreFX_windows_RS4_x86_netcoreapp2.0_icon]][CoreFX_windows_RS4_x86_netcoreapp2.0_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp2.0_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.0_status] | N/A                                                                                             |
-| .NET      | [![CoreFX_windows_RS4_x64_net461_icon]][CoreFX_windows_RS4_x64_net461_status]               | [![CoreFX_windows_RS4_x86_net461_icon]][CoreFX_windows_RS4_x86_net461_status]               | N/A                                                                                         | N/A                                                                                             |
+| Core 3.0  | [![full_opt_windows_RS4_x64_netcoreapp3.0_icon]][full_opt_windows_RS4_x64_netcoreapp3.0_status] | [![full_opt_windows_RS4_x86_netcoreapp3.0_icon]][full_opt_windows_RS4_x86_netcoreapp3.0_status] | [![full_opt_ubuntu_1604_x64_netcoreapp3.0_icon]][full_opt_ubuntu_1604_x64_netcoreapp3.0_status] | [![full_opt_ubuntu_1604_arm64_netcoreapp3.0_icon]][full_opt_ubuntu_1604_arm64_netcoreapp3.0_status] |
+| Core 2.2  | [![full_opt_windows_RS4_x64_netcoreapp2.2_icon]][full_opt_windows_RS4_x64_netcoreapp2.2_status] | [![full_opt_windows_RS4_x86_netcoreapp2.2_icon]][full_opt_windows_RS4_x86_netcoreapp2.2_status] | [![full_opt_ubuntu_1604_x64_netcoreapp2.2_icon]][full_opt_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                             |
+| Core 2.1  | [![full_opt_windows_RS4_x64_netcoreapp2.1_icon]][full_opt_windows_RS4_x64_netcoreapp2.1_status] | [![full_opt_windows_RS4_x86_netcoreapp2.1_icon]][full_opt_windows_RS4_x86_netcoreapp2.1_status] | [![full_opt_ubuntu_1604_x64_netcoreapp2.1_icon]][full_opt_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                             |
+| Core 2.0  | [![full_opt_windows_RS4_x64_netcoreapp2.0_icon]][full_opt_windows_RS4_x64_netcoreapp2.0_status] | [![full_opt_windows_RS4_x86_netcoreapp2.0_icon]][full_opt_windows_RS4_x86_netcoreapp2.0_status] | [![full_opt_ubuntu_1604_x64_netcoreapp2.0_icon]][full_opt_ubuntu_1604_x64_netcoreapp2.0_status] | N/A                                                                                             |
+| .NET      | [![full_opt_windows_RS4_x64_net461_icon]][full_opt_windows_RS4_x64_net461_status]               | [![full_opt_windows_RS4_x86_net461_icon]][full_opt_windows_RS4_x86_net461_status]               | N/A                                                                                         | N/A                                                                                             |
 
 
-#### CoreCLR
+#### Tiered
 
 | Framework | Windows RS4 x64                                                                               | Windows RS4 x86                                                                               | Ubuntu 16.04 x64                                                                              | Ubuntu 16.04 ARM64                                                                                |
 | :-------- | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------: |
-| Core 3.0  | [![CoreCLR_windows_RS4_x64_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x64_netcoreapp3.0_status] | [![CoreCLR_windows_RS4_x86_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x86_netcoreapp3.0_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp3.0_status] | [![CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_icon]][CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_status] |
-| Core 2.2  | [![CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.2_status] | [![CoreCLR_windows_RS4_x86_netcoreapp2.2_icon]][CoreCLR_windows_RS4_x86_netcoreapp2.2_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                               |
-| Core 2.1  | [![CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.1_status] | [![CoreCLR_windows_RS4_x86_netcoreapp2.1_icon]][CoreCLR_windows_RS4_x86_netcoreapp2.1_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                               |
-| Core 2.0  | [![CoreCLR_windows_RS4_x64_netcoreapp2.0_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.0_status] | [![CoreCLR_windows_RS4_x86_netcoreapp2.0_icon]][CoreCLR_windows_RS4_x86_netcoreapp2.0_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.0_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.0_status] | N/A                                                                                               |
-| .NET      | [![CoreCLR_windows_RS4_x64_net461_icon]][CoreCLR_windows_RS4_x64_net461_status]               | [![CoreCLR_windows_RS4_x86_net461_icon]][CoreCLR_windows_RS4_x86_net461_status]               | N/A                                                                                           | N/A                                                                                               |
+| Core 3.0  | [![tiered_windows_RS4_x64_netcoreapp3.0_icon]][tiered_windows_RS4_x64_netcoreapp3.0_status] | [![tiered_windows_RS4_x86_netcoreapp3.0_icon]][tiered_windows_RS4_x86_netcoreapp3.0_status] | [![tiered_ubuntu_1604_x64_netcoreapp3.0_icon]][tiered_ubuntu_1604_x64_netcoreapp3.0_status] | [![tiered_ubuntu_1604_arm64_netcoreapp3.0_icon]][tiered_ubuntu_1604_arm64_netcoreapp3.0_status] |
+| Core 2.2  | [![tiered_windows_RS4_x64_netcoreapp2.2_icon]][tiered_windows_RS4_x64_netcoreapp2.2_status] | [![tiered_windows_RS4_x86_netcoreapp2.2_icon]][tiered_windows_RS4_x86_netcoreapp2.2_status] | [![tiered_ubuntu_1604_x64_netcoreapp2.2_icon]][tiered_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                               |
+| Core 2.1  | [![tiered_windows_RS4_x64_netcoreapp2.1_icon]][tiered_windows_RS4_x64_netcoreapp2.1_status] | [![tiered_windows_RS4_x86_netcoreapp2.1_icon]][tiered_windows_RS4_x86_netcoreapp2.1_status] | [![tiered_ubuntu_1604_x64_netcoreapp2.1_icon]][tiered_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                               |
 
 
-[//]: # (These are the CoreFX links)
+[//]: # (These are the full_opt links)
 
 [//]: # (These are the windows x64 links)
-[CoreFX_windows_RS4_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.0
-[CoreFX_windows_RS4_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_netcoreapp2.0
-[CoreFX_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_net461
-[CoreFX_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreFX_net461
+[full_opt_windows_RS4_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp3.0
+[full_opt_windows_RS4_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp3.0
+[full_opt_windows_RS4_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.2
+[full_opt_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.2
+[full_opt_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.1
+[full_opt_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.1
+[full_opt_windows_RS4_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.0
+[full_opt_windows_RS4_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_netcoreapp2.0
+[full_opt_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_net461
+[full_opt_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=full_opt_net461
 
 [//]: # (These are the windows x86 links)
-[CoreFX_windows_RS4_x86_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x86_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x86_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x86_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x86_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x86_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x86_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.0
-[CoreFX_windows_RS4_x86_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_netcoreapp2.0
-[CoreFX_windows_RS4_x86_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_net461
-[CoreFX_windows_RS4_x86_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreFX_net461
+[full_opt_windows_RS4_x86_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp3.0
+[full_opt_windows_RS4_x86_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp3.0
+[full_opt_windows_RS4_x86_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.2
+[full_opt_windows_RS4_x86_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.2
+[full_opt_windows_RS4_x86_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.1
+[full_opt_windows_RS4_x86_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.1
+[full_opt_windows_RS4_x86_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.0
+[full_opt_windows_RS4_x86_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_netcoreapp2.0
+[full_opt_windows_RS4_x86_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_net461
+[full_opt_windows_RS4_x86_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=full_opt_net461
 
 [//]: # (These are the ubuntu x64 links)
-[CoreFX_ubuntu_1604_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.2
-[CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.2
-[CoreFX_ubuntu_1604_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.1
-[CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.1
-[CoreFX_ubuntu_1604_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.0
-[CoreFX_ubuntu_1604_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreFX_netcoreapp2.0
+[full_opt_ubuntu_1604_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp3.0
+[full_opt_ubuntu_1604_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp3.0
+[full_opt_ubuntu_1604_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.2
+[full_opt_ubuntu_1604_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.2
+[full_opt_ubuntu_1604_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.1
+[full_opt_ubuntu_1604_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.1
+[full_opt_ubuntu_1604_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.0
+[full_opt_ubuntu_1604_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=full_opt_netcoreapp2.0
 
 [//]: # (These are the ubuntu arm64 links)
-[CoreFX_ubuntu_1604_arm64_netcoreapp3.0_status]:   https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_arm64_netcoreapp3.0_icon]:     https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64&configuration=CoreFX_netcoreapp3.0
+[full_opt_ubuntu_1604_arm64_netcoreapp3.0_status]:   https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64&configuration=full_opt_netcoreapp3.0
+[full_opt_ubuntu_1604_arm64_netcoreapp3.0_icon]:     https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64&configuration=full_opt_netcoreapp3.0
 
-[//]: # (These are the CoreCLR links)
+[//]: # (These are the tiered links)
 
 [//]: # (These are the windows x64 links)
-[CoreCLR_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x64_netcoreapp2.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_windows_RS4_x64_netcoreapp2.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_windows_RS4_x64_net461_status]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_net461
-[CoreCLR_windows_RS4_x64_net461_icon]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=CoreCLR_net461
+[tiered_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp3.0
+[tiered_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp3.0
+[tiered_windows_RS4_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp2.2
+[tiered_windows_RS4_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp2.2
+[tiered_windows_RS4_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp2.1
+[tiered_windows_RS4_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64&configuration=tiered_netcoreapp2.1
 
 [//]: # (These are the windows x86 links)
-[CoreCLR_windows_RS4_x86_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x86_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x86_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x86_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x86_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x86_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x86_netcoreapp2.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_windows_RS4_x86_netcoreapp2.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_windows_RS4_x86_net461_status]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_net461
-[CoreCLR_windows_RS4_x86_net461_icon]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=CoreCLR_net461
+[tiered_windows_RS4_x86_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp3.0
+[tiered_windows_RS4_x86_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp3.0
+[tiered_windows_RS4_x86_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp2.2
+[tiered_windows_RS4_x86_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp2.2
+[tiered_windows_RS4_x86_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp2.1
+[tiered_windows_RS4_x86_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86&configuration=tiered_netcoreapp2.1
 
 [//]: # (These are the ubuntu x64 links)
-[CoreCLR_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=CoreCLR_netcoreapp2.0
+[tiered_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp3.0
+[tiered_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp3.0
+[tiered_ubuntu_1604_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp2.2
+[tiered_ubuntu_1604_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp2.2
+[tiered_ubuntu_1604_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp2.1
+[tiered_ubuntu_1604_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64&configuration=tiered_netcoreapp2.1
 
 [//]: # (These are the ubuntu arm64 links)
-[CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_status]:  https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_icon]:    https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64&configuration=CoreCLR_netcoreapp3.0
+[tiered_ubuntu_1604_arm64_netcoreapp3.0_status]:  https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64&configuration=tiered_netcoreapp3.0
+[tiered_ubuntu_1604_arm64_netcoreapp3.0_icon]:    https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64&configuration=tiered_netcoreapp3.0

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -69,10 +69,11 @@ jobs:
                 _Framework: ${{ framework }}
                 _OptimizationLevel: full_opt
                 _BuildConfig: ${{ parameters.architecture }}_$(_OptimizationLevel)_$(_Framework)
-              tiered_${{ framework }}:
-                _Framework: ${{ framework }}
-                _OptimizationLevel: tiered
-                _BuildConfig: ${{ parameters.architecture }}_$(_OptimizationLevel)_$(_Framework)
+              ${{ if and(startsWith(framework, 'netcoreapp'), ne(framework, 'netcoreapp2.0')) }}: # Tiered JIT was introduced in .NET Core 2.1
+                tiered_${{ framework }}:
+                  _Framework: ${{ framework }}
+                  _OptimizationLevel: tiered
+                  _BuildConfig: ${{ parameters.architecture }}_$(_OptimizationLevel)_$(_Framework)
         steps:
         - checkout: self
           clean: true

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -85,7 +85,7 @@ jobs:
             HelixTargetQueues: ${{ parameters.queue }}
             HelixPreCommands: $(HelixPreCommand)
             Creator: $(Creator)
-            WorkItemTimeout: 4:00 # 4 hours
+            WorkItemTimeout: 5:00 # 5 hours
             ${{ if eq(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)\src\benchmarks\micro'
               WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --bin-directory ".\bin" --working-directory . --optimization-level $(_OptimizationLevel) --incremental no --filter * --architecture ${{ parameters.architecture }} -f $(_Framework) $(BenchmarkDotNetArguments) $(BenchViewArguments)'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -43,7 +43,7 @@ jobs:
             value: '.NET Performance - $(BenchViewRunType) - $(Build.SourceBranchName) $(Build.SourceVersion)'
           # for private runs we want to generate data (--generate-benchview-data ) and upload it (--upload-to-benchview-container specifies where)
           - name: BenchViewArguments
-            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(BenchViewRunType) --upload-to-benchview-container $(_Category)'
+            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(BenchViewRunType) --upload-to-benchview-container all'
           # for private runs we don't provide any custom BDN arguments (the ones from Program.Main are used)
           - name: BenchmarkDotNetArguments
             value: ''
@@ -65,14 +65,14 @@ jobs:
         strategy:
           matrix:
             ${{ each framework in parameters.frameworks }}:
-              coreclr_${{ framework }}:
-                _Category: coreclr
+              full_opt_${{ framework }}:
                 _Framework: ${{ framework }}
-                _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)
-              corefx_${{ framework }}:
-                _Category: corefx
+                _OptimizationLevel: full_opt
+                _BuildConfig: ${{ parameters.architecture }}_$(_OptimizationLevel)_$(_Framework)
+              tiered_${{ framework }}:
                 _Framework: ${{ framework }}
-                _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)
+                _OptimizationLevel: tiered
+                _BuildConfig: ${{ parameters.architecture }}_$(_OptimizationLevel)_$(_Framework)
         steps:
         - checkout: self
           clean: true
@@ -87,9 +87,9 @@ jobs:
             WorkItemTimeout: 4:00 # 4 hours
             ${{ if eq(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)\src\benchmarks\micro'
-              WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --bin-directory ".\bin" --working-directory . --incremental no --category $(_Category) --architecture ${{ parameters.architecture }} -f $(_Framework) $(BenchmarkDotNetArguments) $(BenchViewArguments)'
+              WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\benchmarks_ci.py --bin-directory ".\bin" --working-directory . --optimization-level $(_OptimizationLevel) --incremental no --filter * --architecture ${{ parameters.architecture }} -f $(_Framework) $(BenchmarkDotNetArguments) $(BenchViewArguments)'
               CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\scripts'
             ${{ if ne(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)/src/benchmarks/micro'
-              WorkItemCommand: 'python3.5 $HELIX_CORRELATION_PAYLOAD/benchmarks_ci.py --bin-directory "./bin" --working-directory . --incremental no --category $(_Category) --architecture ${{ parameters.architecture }} -f $(_Framework) $(BenchmarkDotNetArguments) $(BenchViewArguments)'
+              WorkItemCommand: 'python3.5 $HELIX_CORRELATION_PAYLOAD/benchmarks_ci.py --bin-directory "./bin" --working-directory . --optimization-level $(_OptimizationLevel) --incremental no --filter ''*'' --architecture ${{ parameters.architecture }} -f $(_Framework) $(BenchmarkDotNetArguments) $(BenchViewArguments)'
               CorrelationPayloadDirectory: '$(Build.SourcesDirectory)/scripts'

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -257,21 +257,12 @@ def __process_arguments(args: list):
     return parser.parse_args(args)
 
 
-def __get_coreclr_os_name():
+def __get_os_name():
     if sys.platform == 'win32':
-        return 'Windows_NT'
+        return 'Windows'
     elif sys.platform == 'linux':
         os_name, os_version, _ = platform.linux_distribution()
         return '{}{}'.format(os_name, os_version)
-    else:
-        return platform.platform()
-
-
-def __get_corefx_os_name():
-    if sys.platform == 'win32':
-        return 'Windows_NT'
-    elif sys.platform == 'linux':
-        return 'Linux'
     else:
         return platform.platform()
 
@@ -408,19 +399,11 @@ def __run_benchview_scripts(
         benchview_config['Configuration'] = args.configuration
 
     # Generate existing configs.
-    # TODO: Unify configs across all repos?
     submission_architecture = args.architecture
-    if args.category.casefold() == 'CoreClr'.casefold():
-        benchview_config['JitName'] = 'ryujit'  # FIXME: Remove this.
-        benchview_config['OS'] = __get_coreclr_os_name()
-        benchview_config['OptLevel'] = args.optimization_level  # Optimization
-        benchview_config['PGO'] = 'pgo'  # FIXME: Remove this? Enabled/Disabled
-        benchview_config['Profile'] = 'On' if args.enable_pmc else 'Off'
-    elif args.category.casefold() == 'CoreFx'.casefold():
-        submission_architecture = 'AnyCPU'
-        benchview_config['OS'] = __get_corefx_os_name()
-        benchview_config['RunType'] = \
-            'Diagnostic' if args.enable_pmc else 'Profile'
+    
+    benchview_config['OS'] = __get_os_name()
+    benchview_config['OptLevel'] = args.optimization_level
+    benchview_config['Profile'] = 'On' if args.enable_pmc else 'Off'
 
     # Find all measurement.json
     with push_dir(bin_directory):


### PR DESCRIPTION
This PR changes the way we run the benchmarks:

1. No separation for CoreFX and CoreCLR benchmarks, we run all benchmarks and export them to single BenchView container
2. Run the benchmarks not only for optimization-level `tiered` but also `full_opt`

I have also unified the reported BenchView config to: OS name + Optimization Level + Profile