### PR TITLE
[Comparer]Take last result 

### DIFF
--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -102,8 +102,8 @@ namespace ResultsComparer
 
         private static IEnumerable<(string id, Benchmark baseResult, Benchmark diffResult)> ReadResults(CommandLineOptions args)
         {
-            var baseFiles = GetFilesToParse(args.BasePath);
-            var diffFiles = GetFilesToParse(args.DiffPath);
+            var baseFiles = GetFilesToParse(args.BasePath).OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1);
+            var diffFiles = GetFilesToParse(args.DiffPath).OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1);
 
             if (!baseFiles.Any() || !diffFiles.Any())
                 throw new ArgumentException($"Provided paths contained no {FullBdnJsonFileExtension} files.");

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -102,11 +102,14 @@ namespace ResultsComparer
 
         private static IEnumerable<(string id, Benchmark baseResult, Benchmark diffResult)> ReadResults(CommandLineOptions args)
         {
-            var baseFiles = GetFilesToParse(args.BasePath).OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1);
-            var diffFiles = GetFilesToParse(args.DiffPath).OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1);
+            var baseFiles = GetFilesToParse(args.BasePath);
+            var diffFiles = GetFilesToParse(args.DiffPath);
 
             if (!baseFiles.Any() || !diffFiles.Any())
                 throw new ArgumentException($"Provided paths contained no {FullBdnJsonFileExtension} files.");
+
+            baseFiles = baseFiles.OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1).ToArray();
+            diffFiles = diffFiles.OrderBy(f => new FileInfo(f).CreationTimeUtc).TakeLast(1).ToArray();
 
             var baseResults = baseFiles.Select(ReadFromFile);
             var diffResults = diffFiles.Select(ReadFromFile);


### PR DESCRIPTION
When you specify result folders and not -full.json file and you've more than one results comparer throw.
My strategy is to take last result so it's not a problem if you specify full path or directory.

/cc @adamsitnik @jorive 