### PR TITLE
CI legs for both NoTiering and Tiered Compilation Modes, fixes #339

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -107,4 +107,4 @@ jobs:
               CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
             ${{ if ne(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)'
-              WorkItemCommand: 'python3.5 scripts/benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'
+              WorkItemCommand: 'python3 scripts/benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -68,11 +68,24 @@ jobs:
               coreclr_${{ framework }}:
                 _Category: coreclr
                 _Framework: ${{ framework }}
+                _CompilationMode: NoTiering
                 _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)
               corefx_${{ framework }}:
                 _Category: corefx
                 _Framework: ${{ framework }}
+                _CompilationMode: NoTiering
                 _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)
+              ${{ if and(startsWith(framework, 'netcoreapp'), ne(framework, 'netcoreapp2.0')) }}: # Tiered JIT was introduced in .NET Core 2.1
+                coreclr_${{ framework }}_tiered:
+                  _Category: coreclr
+                  _Framework: ${{ framework }}
+                  _CompilationMode: Tiered
+                  _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)_$(_CompilationMode)
+                corefx_${{ framework }}_tiered:
+                  _Category: corefx
+                  _Framework: ${{ framework }}
+                  _CompilationMode: Tiered
+                  _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)_$(_CompilationMode)
         steps:
         - checkout: self
           clean: true
@@ -90,8 +103,8 @@ jobs:
             WorkItemTimeout: 4:00 # 4 hours
             ${{ if eq(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
-              WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\scripts\benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments)'
+              WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\scripts\benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'
               CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
             ${{ if ne(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)'
-              WorkItemCommand: 'python3.5 scripts/benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments)'
+              WorkItemCommand: 'python3.5 scripts/benchmarks_ci.py --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -75,17 +75,18 @@ jobs:
                 _Framework: ${{ framework }}
                 _CompilationMode: NoTiering
                 _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)
-              ${{ if and(startsWith(framework, 'netcoreapp'), ne(framework, 'netcoreapp2.0')) }}: # Tiered JIT was introduced in .NET Core 2.1
-                coreclr_${{ framework }}_tiered:
-                  _Category: coreclr
-                  _Framework: ${{ framework }}
-                  _CompilationMode: Tiered
-                  _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)_$(_CompilationMode)
-                corefx_${{ framework }}_tiered:
-                  _Category: corefx
-                  _Framework: ${{ framework }}
-                  _CompilationMode: Tiered
-                  _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)_$(_CompilationMode)
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}: # to reduce the number of CI legs for every PR
+                ${{ if and(startsWith(framework, 'netcoreapp'), ne(framework, 'netcoreapp2.0')) }}: # Tiered JIT was introduced in .NET Core 2.1
+                  coreclr_${{ framework }}_tiered:
+                    _Category: coreclr
+                    _Framework: ${{ framework }}
+                    _CompilationMode: Tiered
+                    _BuildConfig: ${{ parameters.architecture }}_coreclr_$(_Framework)_$(_CompilationMode)
+                  corefx_${{ framework }}_tiered:
+                    _Category: corefx
+                    _Framework: ${{ framework }}
+                    _CompilationMode: Tiered
+                    _BuildConfig: ${{ parameters.architecture }}_corefx_$(_Framework)_$(_CompilationMode)
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
Long story short: run NoTiering for all frameworks we support (some frameworks don't have a concept of Tiered JIT like Full .NET Framework or CoreRT) and run Tiered for all the frameworks that support it (2.1, 2.2, 3.0)