### PR TITLE
add int.TryParse long.Parse long.TryParse benchmarks

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
@@ -31,6 +31,10 @@ namespace System.Tests
         [ArgumentsSource(nameof(StringValues))]
         public int Parse(string value) => int.Parse(value);
 
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public bool TryParse(string value) => int.TryParse(value, out _);
+
 #if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(StringValues))]
@@ -39,6 +43,10 @@ namespace System.Tests
         [Benchmark]
         [ArgumentsSource(nameof(Int32Values))]
         public bool TryFormat(int value) => value.TryFormat(new Span<char>(_destination), out _);
+
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public bool TryParseSpan(string value) => int.TryParse(value.AsSpan(), out _);
 #endif
     }
 }

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Int64.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Int64.cs
@@ -27,6 +27,14 @@ namespace System.Tests
         [ArgumentsSource(nameof(Int64Values))]
         public string ToString(long value) => value.ToString();
 
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public long Parse(string value) => long.Parse(value);
+
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public bool TryParse(string value) => long.TryParse(value, out _);
+
 #if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(Int64Values))]
@@ -34,7 +42,11 @@ namespace System.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(StringValues))]
-        public long Parse(string value) => long.Parse(value.AsSpan());
+        public long ParseSpan(string value) => long.Parse(value.AsSpan());
+
+        [Benchmark]
+        [ArgumentsSource(nameof(StringValues))]
+        public bool TryParseSpan(string value) => long.TryParse(value.AsSpan(), out _);
 #endif
     }
 }


### PR DESCRIPTION
@stephentoub today I tried to compare the perf of `long.Parse` for all the frameworks that we support for the purpose of https://github.com/dotnet/corefx/issues/35814 and I realized that:

- for long we had `Parse(Span)` but not `Parse(string)`, which made it impossible to compare parsing for Full Framework vs Core
- we were missing `TryParse` for both `int` and `long`