### PR TITLE
add TryGetValue benchmarks, fixes #371

### DIFF
--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -62,7 +62,7 @@ namespace System.Collections
         public bool IDictionary() => TryGetValue(_dictionary);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public bool TryGetValue(IDictionary<TKey, TValue> collection)
+        private bool TryGetValue(IDictionary<TKey, TValue> collection)
         {
             bool result = default;
             TKey[] notFound = _notFound;

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Collections
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    [GenericTypeArguments(typeof(int), typeof(int))] // value type
+    [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    public class TryGetValueFalse<TKey, TValue>
+    {
+        private TKey[] _notFound;
+        private Dictionary<TKey, TValue> _source;
+
+        private Dictionary<TKey, TValue> _dictionary;
+        private SortedList<TKey, TValue> _sortedList;
+        private SortedDictionary<TKey, TValue> _sortedDictionary;
+        private ConcurrentDictionary<TKey, TValue> _concurrentDictionary;
+        private ImmutableDictionary<TKey, TValue> _immutableDictionary;
+        private ImmutableSortedDictionary<TKey, TValue> _immutableSortedDictionary;
+
+        [Params(Utils.DefaultCollectionSize)]
+        public int Size;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var values = ValuesGenerator.ArrayOfUniqueValues<TKey>(Size * 2);
+            _notFound = values.Take(Size).ToArray();
+
+            _source = values.Skip(Size).Take(Size).ToDictionary(item => item, item => (TValue)(object)item);
+            _dictionary = new Dictionary<TKey, TValue>(_source);
+            _sortedList = new SortedList<TKey, TValue>(_source);
+            _sortedDictionary = new SortedDictionary<TKey, TValue>(_source);
+            _concurrentDictionary = new ConcurrentDictionary<TKey, TValue>(_source);
+            _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
+            _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
+        }
+
+        [Benchmark]
+        public bool Dictionary()
+        {
+            bool result = default;
+            var collection = _dictionary;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+        public bool IDictionary() => TryGetValue(_dictionary);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool TryGetValue(IDictionary<TKey, TValue> collection)
+        {
+            bool result = default;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedList()
+        {
+            bool result = default;
+            var collection = _sortedList;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedDictionary()
+        {
+            bool result = default;
+            var collection = _sortedDictionary;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ConcurrentDictionary()
+        {
+            bool result = default;
+            var collection = _concurrentDictionary;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ImmutableDictionary()
+        {
+            bool result = default;
+            var collection = _immutableDictionary;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ImmutableSortedDictionary()
+        {
+            bool result = default;
+            var collection = _immutableSortedDictionary;
+            var notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -50,8 +50,8 @@ namespace System.Collections
         public bool Dictionary()
         {
             bool result = default;
-            var collection = _dictionary;
-            var notFound = _notFound;
+            Dictionary<TKey, TValue> collection = _dictionary;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -65,7 +65,7 @@ namespace System.Collections
         public bool TryGetValue(IDictionary<TKey, TValue> collection)
         {
             bool result = default;
-            var notFound = _notFound;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -75,8 +75,8 @@ namespace System.Collections
         public bool SortedList()
         {
             bool result = default;
-            var collection = _sortedList;
-            var notFound = _notFound;
+            SortedList<TKey, TValue> collection = _sortedList;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -86,8 +86,8 @@ namespace System.Collections
         public bool SortedDictionary()
         {
             bool result = default;
-            var collection = _sortedDictionary;
-            var notFound = _notFound;
+            SortedDictionary<TKey, TValue> collection = _sortedDictionary;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -97,8 +97,8 @@ namespace System.Collections
         public bool ConcurrentDictionary()
         {
             bool result = default;
-            var collection = _concurrentDictionary;
-            var notFound = _notFound;
+            ConcurrentDictionary<TKey, TValue> collection = _concurrentDictionary;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -108,8 +108,8 @@ namespace System.Collections
         public bool ImmutableDictionary()
         {
             bool result = default;
-            var collection = _immutableDictionary;
-            var notFound = _notFound;
+            ImmutableDictionary<TKey, TValue> collection = _immutableDictionary;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;
@@ -119,8 +119,8 @@ namespace System.Collections
         public bool ImmutableSortedDictionary()
         {
             bool result = default;
-            var collection = _immutableSortedDictionary;
-            var notFound = _notFound;
+            ImmutableSortedDictionary<TKey, TValue> collection = _immutableSortedDictionary;
+            TKey[] notFound = _notFound;
             for (int i = 0; i < notFound.Length; i++)
                 result ^= collection.TryGetValue(notFound[i], out _);
             return result;

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -60,7 +60,7 @@ namespace System.Collections
         public bool IDictionary() => TryGetValue(_dictionary);
         
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public bool TryGetValue(IDictionary<TKey, TValue> collection)
+        private bool TryGetValue(IDictionary<TKey, TValue> collection)
         {
             bool result = default;
             TKey[] found = _found;

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Collections
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    [GenericTypeArguments(typeof(int), typeof(int))] // value type
+    [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    public class TryGetValueTrue<TKey, TValue>
+    {
+        private TKey[] _found;
+        private Dictionary<TKey, TValue> _source;
+        
+        private Dictionary<TKey, TValue> _dictionary;
+        private SortedList<TKey, TValue> _sortedList;
+        private SortedDictionary<TKey, TValue> _sortedDictionary;
+        private ConcurrentDictionary<TKey, TValue> _concurrentDictionary;
+        private ImmutableDictionary<TKey, TValue> _immutableDictionary;
+        private ImmutableSortedDictionary<TKey, TValue> _immutableSortedDictionary;
+
+        [Params(Utils.DefaultCollectionSize)]
+        public int Size;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _found = ValuesGenerator.ArrayOfUniqueValues<TKey>(Size);
+            _source = _found.ToDictionary(item => item, item => (TValue)(object)item);
+            _dictionary = new Dictionary<TKey, TValue>(_source);
+            _sortedList = new SortedList<TKey, TValue>(_source);
+            _sortedDictionary = new SortedDictionary<TKey, TValue>(_source);
+            _concurrentDictionary = new ConcurrentDictionary<TKey, TValue>(_source);
+            _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
+            _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
+        }
+
+        [Benchmark]
+        public bool Dictionary()
+        {
+            bool result = default;
+            var collection = _dictionary;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.CoreCLR, Categories.Virtual)]
+        public bool IDictionary() => TryGetValue(_dictionary);
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool TryGetValue(IDictionary<TKey, TValue> collection)
+        {
+            bool result = default;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedList()
+        {
+            bool result = default;
+            var collection = _sortedList;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedDictionary()
+        {
+            bool result = default;
+            var collection = _sortedDictionary;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ConcurrentDictionary()
+        {
+            bool result = default;
+            var collection = _concurrentDictionary;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ImmutableDictionary()
+        {
+            bool result = default;
+            var collection = _immutableDictionary;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+
+        [Benchmark]
+        public bool ImmutableSortedDictionary()
+        {
+            bool result = default;
+            var collection = _immutableSortedDictionary;
+            var found = _found;
+            for (int i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -48,8 +48,8 @@ namespace System.Collections
         public bool Dictionary()
         {
             bool result = default;
-            var collection = _dictionary;
-            var found = _found;
+            Dictionary<TKey, TValue> collection = _dictionary;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -63,7 +63,7 @@ namespace System.Collections
         public bool TryGetValue(IDictionary<TKey, TValue> collection)
         {
             bool result = default;
-            var found = _found;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -73,8 +73,8 @@ namespace System.Collections
         public bool SortedList()
         {
             bool result = default;
-            var collection = _sortedList;
-            var found = _found;
+            SortedList<TKey, TValue> collection = _sortedList;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -84,8 +84,8 @@ namespace System.Collections
         public bool SortedDictionary()
         {
             bool result = default;
-            var collection = _sortedDictionary;
-            var found = _found;
+            SortedDictionary<TKey, TValue> collection = _sortedDictionary;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -95,8 +95,8 @@ namespace System.Collections
         public bool ConcurrentDictionary()
         {
             bool result = default;
-            var collection = _concurrentDictionary;
-            var found = _found;
+            ConcurrentDictionary<TKey, TValue> collection = _concurrentDictionary;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -106,8 +106,8 @@ namespace System.Collections
         public bool ImmutableDictionary()
         {
             bool result = default;
-            var collection = _immutableDictionary;
-            var found = _found;
+            ImmutableDictionary<TKey, TValue> collection = _immutableDictionary;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;
@@ -117,8 +117,8 @@ namespace System.Collections
         public bool ImmutableSortedDictionary()
         {
             bool result = default;
-            var collection = _immutableSortedDictionary;
-            var found = _found;
+            ImmutableSortedDictionary<TKey, TValue> collection = _immutableSortedDictionary;
+            TKey[] found = _found;
             for (int i = 0; i < found.Length; i++)
                 result ^= collection.TryGetValue(found[i], out _);
             return result;


### PR DESCRIPTION
|                             Type |                    Method | Size |       Mean |     StdDev |
|--------------------------------- |-------------------------- |----- |-----------:|-----------:|
|   TryGetValueFalse<Int32, Int32> |                Dictionary |  512 |   7.377 us |  0.1738 us |
| TryGetValueFalse<String, String> |                Dictionary |  512 |  11.277 us |  0.0524 us |
|    TryGetValueTrue<Int32, Int32> |                Dictionary |  512 |   5.264 us |  0.0860 us |
|  TryGetValueTrue<String, String> |                Dictionary |  512 |  17.299 us |  1.2550 us |
|   TryGetValueFalse<Int32, Int32> |               IDictionary |  512 |   6.311 us |  0.3131 us |
| TryGetValueFalse<String, String> |               IDictionary |  512 |  12.309 us |  0.5233 us |
|    TryGetValueTrue<Int32, Int32> |               IDictionary |  512 |   7.351 us |  0.2442 us |
|  TryGetValueTrue<String, String> |               IDictionary |  512 |  16.916 us |  0.3923 us |
|   TryGetValueFalse<Int32, Int32> |                SortedList |  512 |  31.214 us |  0.7725 us |
| TryGetValueFalse<String, String> |                SortedList |  512 | 592.495 us | 18.5175 us |
|    TryGetValueTrue<Int32, Int32> |                SortedList |  512 |  31.001 us |  0.4571 us |
|  TryGetValueTrue<String, String> |                SortedList |  512 | 472.484 us | 30.5834 us |
|   TryGetValueFalse<Int32, Int32> |          SortedDictionary |  512 |  60.610 us |  0.4005 us |
| TryGetValueFalse<String, String> |          SortedDictionary |  512 | 706.629 us | 51.2005 us |
|    TryGetValueTrue<Int32, Int32> |          SortedDictionary |  512 |  55.691 us |  1.3485 us |
|  TryGetValueTrue<String, String> |          SortedDictionary |  512 | 526.923 us | 12.2692 us |
|   TryGetValueFalse<Int32, Int32> |      ConcurrentDictionary |  512 |   6.210 us |  0.2354 us |
| TryGetValueFalse<String, String> |      ConcurrentDictionary |  512 |  20.663 us |  0.6512 us |
|    TryGetValueTrue<Int32, Int32> |      ConcurrentDictionary |  512 |   6.174 us |  0.1445 us |
|  TryGetValueTrue<String, String> |      ConcurrentDictionary |  512 |  23.942 us |  1.3891 us |
|   TryGetValueFalse<Int32, Int32> |       ImmutableDictionary |  512 |  21.504 us |  0.2631 us |
| TryGetValueFalse<String, String> |       ImmutableDictionary |  512 |  46.049 us |  1.6524 us |
|    TryGetValueTrue<Int32, Int32> |       ImmutableDictionary |  512 |  24.911 us |  1.2669 us |
|  TryGetValueTrue<String, String> |       ImmutableDictionary |  512 |  56.956 us |  3.1367 us |
|   TryGetValueFalse<Int32, Int32> | ImmutableSortedDictionary |  512 |  35.945 us |  0.6413 us |
| TryGetValueFalse<String, String> | ImmutableSortedDictionary |  512 | 625.501 us | 46.8056 us |
|    TryGetValueTrue<Int32, Int32> | ImmutableSortedDictionary |  512 |  30.300 us |  0.3972 us |
|  TryGetValueTrue<String, String> | ImmutableSortedDictionary |  512 | 447.220 us |  7.9028 us |