### PR TITLE
fix breaking change introduced by latest Helix SDK

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -100,6 +100,7 @@ jobs:
             HelixPreCommands: $(HelixPreCommand)
             Creator: $(Creator)
             WorkItemTimeout: 4:00 # 4 hours
+            EnableAzurePipelinesReporter: false # this project runs benchmarks, not unit tests
             ${{ if eq(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
               WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\scripts\benchmarks_ci.py --csproj %HELIX_CORRELATION_PAYLOAD%\${{ parameters.csproj }} --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(_BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -15,6 +15,7 @@ jobs:
   parameters:
     enableTelemetry: false
     enablePublishBuildArtifacts: true
+    EnableAzurePipelinesReporter: false # this project runs benchmarks, not unit tests
     helixRepo: dotnet/performance
     jobs:
       - job: '${{ parameters.osName }}_${{ parameters.osVersion }}_${{ parameters.architecture }}_${{ parameters.kind }}'
@@ -100,7 +101,6 @@ jobs:
             HelixPreCommands: $(HelixPreCommand)
             Creator: $(Creator)
             WorkItemTimeout: 4:00 # 4 hours
-            EnableAzurePipelinesReporter: false # this project runs benchmarks, not unit tests
             ${{ if eq(parameters.osName, 'windows') }}:
               WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
               WorkItemCommand: 'py -3 %HELIX_CORRELATION_PAYLOAD%\scripts\benchmarks_ci.py --csproj %HELIX_CORRELATION_PAYLOAD%\${{ parameters.csproj }} --incremental no --architecture ${{ parameters.architecture }} -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(_BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)'


### PR DESCRIPTION
@dotnet-maestro-bot  has merged a breaking change in https://github.com/dotnet/performance/pull/372 and now our build is red.

this PR tries to fix it..

![obraz](https://user-images.githubusercontent.com/6011991/54124286-3b7a3980-4402-11e9-8a40-d8d4235726c4.png)
