### PR TITLE
Remove Optimize define

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -4,9 +4,6 @@
          and automation failing to clean up the folders once the runs are over -->
     <UseSharedCompilation>false</UseSharedCompilation>
     
-    <!-- to make sure that the users don't always need to specify -c Release when using dotnet run -->
-    <Optimize>true</Optimize>
-    
     <!-- Used by Python script to narrow down the the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
     


### PR DESCRIPTION
Defining Optimize in the project file is not precisely the same as specifying -c Release. (For example, DEBUG is defined instead of RELEASE, so any code which has tracing will include that tracing.) Instead of continuing to chase down all the ways it is different I think just pulling this out and requiring users to pass -c Release is a good path.