### PR TITLE
Move off the Perf queue for non-internal runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
       kind: micro
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.Amd64.ClientRS4.DevEx.15.8.Perf
+      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       categories: ['coreclr', 'corefx']
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
@@ -55,7 +55,7 @@ jobs:
       kind: micro
       architecture: x86
       pool: Hosted VS2017
-      queue: Windows.Amd64.ClientRS4.DevEx.15.8.Perf
+      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       categories: ['coreclr', 'corefx']
       frameworks: # for public jobs we want to make sure that the PRs don't break x86
@@ -151,7 +151,7 @@ jobs:
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.Amd64.ClientRS4.DevEx.15.8.Perf
+      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       categories: ['mldotnet']
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 only


### PR DESCRIPTION
All of the queues have python3 installed on them now, so we should be able to switch to a regular queue.