### PR TITLE
Methods for benchmarking TakeLast

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -10,6 +10,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <DefineConstants>NETFRAMEWORK</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
@@ -54,10 +58,6 @@
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Compile Remove="coreclr\Math\Functions\Single\**" />
   </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'netcoreapp3.0'">
-    <DefineConstants>NETCORE</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netcoreapp2.0'">
     <Compile Remove="corefx\System.IO.Compression\Brotli.cs" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -10,10 +10,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <DefineConstants>NETFRAMEWORK</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -55,6 +55,10 @@
     <Compile Remove="coreclr\Math\Functions\Single\**" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'netcoreapp3.0'">
+    <DefineConstants>NETCORE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netcoreapp2.0'">
     <Compile Remove="corefx\System.IO.Compression\Brotli.cs" />
     <Compile Remove="corefx\System.Net.Http\Perf.SocketsHttpHandler.cs" />

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -146,28 +146,12 @@ namespace System.Linq.Tests
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.Take(size - 1), _consumer);
 
 #if !NETFRAMEWORK
+
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
 
-        [Benchmark]
-        [ArgumentsSource(nameof(IterationSizeWrapperData))]
-        public int[] TakeLastToArray(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-        {
-            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
-
-            return source.TakeLast(size - 1).ToArray();
-        }
-
-        [Benchmark]
-        [ArgumentsSource(nameof(IterationSizeWrapperData))]
-        public List<int> TakeLastToList(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-        {
-            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
-
-            return source.TakeLast(size - 1).ToList();
-        }
 #endif
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Tests
         public void Take(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType) 
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.Take(size - 1), _consumer);
 
-#if NETCORE
+#if !NETFRAMEWORK
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -146,12 +146,10 @@ namespace System.Linq.Tests
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.Take(size - 1), _consumer);
 
 #if !NETFRAMEWORK
-
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
-
 #endif
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -145,6 +145,31 @@ namespace System.Linq.Tests
         public void Take(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType) 
             => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.Take(size - 1), _consumer);
 
+#if NETCORE
+        [Benchmark]
+        [ArgumentsSource(nameof(IterationSizeWrapperData))]
+        public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
+
+        [Benchmark]
+        [ArgumentsSource(nameof(IterationSizeWrapperData))]
+        public int[] TakeLastToArray(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
+
+            return source.TakeLast(size - 1).ToArray();
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(IterationSizeWrapperData))]
+        public List<int> TakeLastToList(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+        {
+            IEnumerable<int> source = Perf_LinqTestBase.Wrap(_sizeToPreallocatedArray[size], wrapType);
+
+            return source.TakeLast(size - 1).ToList();
+        }
+#endif
+
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public void SkipTake(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType) 


### PR DESCRIPTION
I've added methods for benchmarking System.Linq.TakeLast, however this needed constants definition, hence TakeLast is not available in net472. 

I've also thought about adding _WrapperType.IList_ to _IterationSizeWrapperData()_, but this produces the same results as _WrapperType.NoWrap_.