### PR TITLE
Use more relevant test for TakeLast

### DIFF
--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -149,7 +149,7 @@ namespace System.Linq.Tests
         [Benchmark]
         [ArgumentsSource(nameof(IterationSizeWrapperData))]
         public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
+            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size / 2), _consumer);
 #endif
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -14,7 +14,6 @@ namespace System.Linq.Tests
     {
         private const int DefaultSize = 100;
         private const int DefaulIterationCount = 1000;
-
         private readonly Consumer _consumer = new Consumer();
         private readonly IEnumerable<int> _range0to10 = Enumerable.Range(0, 10);
         private readonly IEnumerable<int> _tenMillionToZero = Enumerable.Range(0, 10_000_000).Reverse();

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -14,22 +14,25 @@ namespace System.Linq.Tests
     {
         private const int DefaultSize = 100;
         private const int DefaulIterationCount = 1000;
-        private static readonly int[] DefaultMultipleSizes = new int[] { 6, 100 };
 
         private readonly Consumer _consumer = new Consumer();
         private readonly IEnumerable<int> _range0to10 = Enumerable.Range(0, 10);
         private readonly IEnumerable<int> _tenMillionToZero = Enumerable.Range(0, 10_000_000).Reverse();
 
-        private static IEnumerable<object[]> GetIterationSizeWrapperData(int size)
+        public static IEnumerable<object[]> IterationSizeWrapperData()
         {
-            yield return new object[] { size, DefaulIterationCount, Perf_LinqTestBase.WrapperType.NoWrap };
-            yield return new object[] { size, DefaulIterationCount, Perf_LinqTestBase.WrapperType.IEnumerable };
-            yield return new object[] { size, DefaulIterationCount, Perf_LinqTestBase.WrapperType.IReadOnlyCollection };
-            yield return new object[] { size, DefaulIterationCount, Perf_LinqTestBase.WrapperType.ICollection };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.NoWrap };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.IEnumerable };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.IReadOnlyCollection };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.ICollection };
         }
 
-        public static IEnumerable<object[]> IterationSizeWrapperData() => GetIterationSizeWrapperData(DefaultSize);
-        public static IEnumerable<object[]> IterationMultipleSizesWrapperData() => DefaultMultipleSizes.SelectMany(x => GetIterationSizeWrapperData(x));
+        public static IEnumerable<object[]> IterationSizeReducedWrapperData()
+        {
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.NoWrap };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.IEnumerable };
+            yield return new object[] { DefaultSize, DefaulIterationCount, Perf_LinqTestBase.WrapperType.ICollection };
+        }
 
         public class BaseClass
         {
@@ -44,9 +47,6 @@ namespace System.Linq.Tests
         {
             { DefaultSize, Enumerable.Range(0, DefaultSize).ToArray() }
         };
-
-        private static readonly IReadOnlyDictionary<int, int[]> _multipleSizesToPreallocatedArray = DefaultMultipleSizes.ToDictionary(k => k, v => Enumerable.Range(0, v).ToArray());
-
 
         private readonly ChildClass[] _childClassArrayOfTenElements = Enumerable.Repeat(new ChildClass() { Value = 1, ChildValue = 2 }, 10).ToArray();
         private readonly int[] _intArrayOfTenElements = Enumerable.Repeat(1, 10).ToArray();
@@ -154,19 +154,19 @@ namespace System.Linq.Tests
 
 #if !NETFRAMEWORK
         [Benchmark]
-        [ArgumentsSource(nameof(IterationMultipleSizesWrapperData))]
+        [ArgumentsSource(nameof(IterationSizeReducedWrapperData))]
         public void TakeLastOne(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-            => Perf_LinqTestBase.Measure(_multipleSizesToPreallocatedArray[size], wrapType, col => col.TakeLast(1), _consumer);
+            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(1), _consumer);
 
         [Benchmark]
-        [ArgumentsSource(nameof(IterationMultipleSizesWrapperData))]
-        public void TakeLast(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-            => Perf_LinqTestBase.Measure(_multipleSizesToPreallocatedArray[size], wrapType, col => col.TakeLast(size / 2), _consumer);
+        [ArgumentsSource(nameof(IterationSizeReducedWrapperData))]
+        public void TakeLastHalf(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
+            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size / 2), _consumer);
 
         [Benchmark]
-        [ArgumentsSource(nameof(IterationMultipleSizesWrapperData))]
+        [ArgumentsSource(nameof(IterationSizeReducedWrapperData))]
         public void TakeLastFull(int size, int iteration, Perf_LinqTestBase.WrapperType wrapType)
-            => Perf_LinqTestBase.Measure(_multipleSizesToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
+            => Perf_LinqTestBase.Measure(_sizeToPreallocatedArray[size], wrapType, col => col.TakeLast(size - 1), _consumer);
 #endif
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Linq.cs
@@ -14,6 +14,7 @@ namespace System.Linq.Tests
     {
         private const int DefaultSize = 100;
         private const int DefaulIterationCount = 1000;
+
         private readonly Consumer _consumer = new Consumer();
         private readonly IEnumerable<int> _range0to10 = Enumerable.Range(0, 10);
         private readonly IEnumerable<int> _tenMillionToZero = Enumerable.Range(0, 10_000_000).Reverse();


### PR DESCRIPTION
I've played a little more with TakeLast method and looks like testing may be better - taking almost all the collection is not relevant for ICollection source, where we can take advantage of having the Count property. 
Here is a difference between taking half/full (Count-1) collection:

``` ini

BenchmarkDotNet=v0.11.3.1003-nightly, OS=Windows 10.0.17763.379 (1809/October2018Update/Redstone5)
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.105
  [Host]     : .NET Core 2.1.9 (CoreCLR 4.6.27414.06, CoreFX 4.6.27415.01), 64bit RyuJIT
  Job-NUUCXS : .NET Core cd01132e-c21e-4542-a7b5-280fd76ce48a (CoreCLR 4.6.27513.77, CoreFX 4.7.19.17001), 64bit RyuJIT
  Job-OCUQKL : .NET Core de772c68-afb5-4ad9-ae49-71ca9083ee7f (CoreCLR 4.6.27513.77, CoreFX 4.7.19.17101), 64bit RyuJIT

Runtime=Core  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
|       Method |                                                                                                              Toolchain | size | iteration |            wrapType |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------- |----------------------------------------------------------------------------------------------------------------------- |----- |---------- |-------------------- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
| **TakeLastFull** | **before** |  **100** |      **1000** |              **NoWrap** | **1,843.9 ns** | **34.345 ns** | **30.446 ns** | **1,837.5 ns** | **1,790.7 ns** | **1,896.1 ns** |  **1.00** |    **0.00** |      **0.3234** |           **-** |           **-** |              **1376 B** |
| TakeLastFull |        after |  100 |      1000 |              NoWrap |   985.8 ns |  6.878 ns |  6.434 ns |   985.0 ns |   976.1 ns |   998.3 ns |  0.54 |    0.01 |      0.0315 |           - |           - |               136 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| TakeLastHalf | before |  100 |      1000 |              NoWrap | 1,614.0 ns | 26.925 ns | 25.185 ns | 1,615.0 ns | 1,571.6 ns | 1,664.3 ns |  1.00 |    0.00 |      0.1954 |           - |           - |               840 B |
| TakeLastHalf |        after |  100 |      1000 |              NoWrap |   512.3 ns |  4.349 ns |  3.632 ns |   511.9 ns |   507.6 ns |   518.0 ns |  0.32 |    0.01 |      0.0310 |           - |           - |               136 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| **TakeLastFull** | **before** |  **100** |      **1000** |         **IEnumerable** | **1,784.7 ns** | **12.315 ns** | **11.520 ns** | **1,784.3 ns** | **1,766.0 ns** | **1,800.8 ns** |  **1.00** |    **0.00** |      **0.3343** |           **-** |           **-** |              **1400 B** |
| TakeLastFull |        after |  100 |      1000 |         IEnumerable | 1,902.3 ns | 37.360 ns | 34.946 ns | 1,908.0 ns | 1,834.4 ns | 1,970.8 ns |  1.07 |    0.02 |      0.3304 |           - |           - |              1400 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| TakeLastHalf | before |  100 |      1000 |         IEnumerable | 1,606.3 ns | 26.728 ns | 22.319 ns | 1,599.4 ns | 1,578.9 ns | 1,654.2 ns |  1.00 |    0.00 |      0.2012 |           - |           - |               864 B |
| TakeLastHalf |        after |  100 |      1000 |         IEnumerable | 1,638.9 ns | 16.036 ns | 14.216 ns | 1,635.8 ns | 1,621.8 ns | 1,665.7 ns |  1.02 |    0.01 |      0.2030 |           - |           - |               864 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| **TakeLastFull** | **before** |  **100** |      **1000** | **IReadOnlyCollection** | **1,963.1 ns** | **20.663 ns** | **19.328 ns** | **1,969.8 ns** | **1,921.8 ns** | **1,982.8 ns** |  **1.00** |    **0.00** |      **0.3308** |           **-** |           **-** |              **1400 B** |
| TakeLastFull |        after |  100 |      1000 | IReadOnlyCollection | 1,950.8 ns | 26.565 ns | 24.849 ns | 1,956.8 ns | 1,906.7 ns | 1,981.7 ns |  0.99 |    0.02 |      0.0552 |           - |           - |               256 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| TakeLastHalf | before |  100 |      1000 | IReadOnlyCollection | 1,559.6 ns | 23.049 ns | 21.560 ns | 1,557.5 ns | 1,528.7 ns | 1,603.9 ns |  1.00 |    0.00 |      0.2033 |           - |           - |               864 B |
| TakeLastHalf |        after |  100 |      1000 | IReadOnlyCollection | 1,325.0 ns | 72.026 ns | 82.945 ns | 1,370.6 ns | 1,190.1 ns | 1,411.2 ns |  0.87 |    0.04 |      0.0587 |           - |           - |               256 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| **TakeLastFull** | **before** |  **100** |      **1000** |         **ICollection** | **1,881.5 ns** | **10.885 ns** | **10.181 ns** | **1,882.5 ns** | **1,863.5 ns** | **1,894.7 ns** |  **1.00** |    **0.00** |      **0.3306** |           **-** |           **-** |              **1400 B** |
| TakeLastFull |        after |  100 |      1000 |         ICollection | 1,901.4 ns | 17.330 ns | 16.211 ns | 1,902.3 ns | 1,860.1 ns | 1,926.4 ns |  1.01 |    0.01 |      0.0537 |           - |           - |               256 B |
|              |                                                                                                                        |      |           |                     |            |           |           |            |            |            |       |         |             |             |             |                     |
| TakeLastHalf | before |  100 |      1000 |         ICollection | 1,544.1 ns | 22.777 ns | 21.306 ns | 1,535.6 ns | 1,514.6 ns | 1,579.1 ns |  1.00 |    0.00 |      0.2015 |           - |           - |               864 B |
| TakeLastHalf |        after |  100 |      1000 |         ICollection | 1,158.0 ns | 48.974 ns | 56.398 ns | 1,128.4 ns | 1,105.3 ns | 1,291.8 ns |  0.75 |    0.03 |      0.0583 |           - |           - |               256 B |

If you compare TakeLastFull for corerun before/after - there is no change in Mean time, but if you compare TakeLastHalf, you can see the difference.