### PR TITLE
remove references to xunit packages that are referenced by SDK by default in implicit way and produce warnings when referenced

### DIFF
--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -4,10 +4,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\benchmarks\micro\MicroBenchmarks.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
fixes #399


```cmd
dotnet build -c Release
```

Before:

```log
PS C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests> dotnet build -c Release
Microsoft (R) Build Engine version 16.0.225-preview+g5ebeba52a1 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
  Restore completed in 37,96 ms for C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj.
  Restore completed in 38,5 ms for C:\Projects\performance\src\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj.
  Restore completed in 38,5 ms for C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj.
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\net461\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp3.0\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.0\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.2\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.1\BenchmarkDotNet.Extensions.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\net461\MicroBenchmarks.exe
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.0\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.2\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.1\MicroBenchmarks.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.0\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\net461\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp3.0\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.2\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.1\BenchmarkDotNet.Extensions.Tests.dll

Build succeeded.

C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
C:\Program Files\dotnet\sdk\3.0.100-preview-009812\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(256,5): warning NETSDK1023: A PackageReference for 'xunit.runner.visualstudio' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj]
    20 Warning(s)
    0 Error(s)

Time Elapsed 00:00:13.62
```

After:

```
PS C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests> dotnet build -c Release
Microsoft (R) Build Engine version 16.0.225-preview+g5ebeba52a1 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj...
  Restore completed in 35,5 ms for C:\Projects\performance\src\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj.
  Restore completed in 36,93 ms for C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj.
  Generating MSBuild file C:\Projects\performance\artifacts\obj\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj.nuget.g.props.
  Generating MSBuild file C:\Projects\performance\artifacts\obj\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj.nuget.g.targets.
  Restore completed in 1,31 sec for C:\Projects\performance\src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj.
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp3.0\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.0\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.1\BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\net461\BenchmarkDotNet.Extensions.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\MicroBenchmarks.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netcoreapp2.2\BenchmarkDotNet.Extensions.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.1\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\net461\MicroBenchmarks.exe
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.2\MicroBenchmarks.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp3.0\BenchmarkDotNet.Extensions.Tests.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp2.0\MicroBenchmarks.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.1\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\net461\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.2\BenchmarkDotNet.Extensions.Tests.dll
  BenchmarkDotNet.Extensions.Tests -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.0\BenchmarkDotNet.Extensions.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.18
```

And it still works ;)

```cmd
dotnet test -c Release
```

```log
Build started, please wait...
Build completed.

Test run for C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\net461\BenchmarkDotNet.Extensions.Tests.dll(.NETFramework,Version=v4.6.1)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 5. Passed: 5. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 1,4673 Seconds
Test run for C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.0\BenchmarkDotNet.Extensions.Tests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 5. Passed: 5. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 2,0592 Seconds
Test run for C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.1\BenchmarkDotNet.Extensions.Tests.dll(.NETCoreApp,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 5. Passed: 5. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 2,2020 Seconds
Test run for C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp2.2\BenchmarkDotNet.Extensions.Tests.dll(.NETCoreApp,Version=v2.2)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 5. Passed: 5. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 2,8883 Seconds
Test run for C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions.Tests\Release\netcoreapp3.0\BenchmarkDotNet.Extensions.Tests.dll(.NETCoreApp,Version=v3.0)
Microsoft (R) Test Execution Command Line Tool Version 15.9.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 5. Passed: 5. Failed: 0. Skipped: 0.
Test Run Successful.
```