### PR TITLE
Adds benchmark tests for ReadOnlySequence<T>.FirstSpan 

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -38,13 +38,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Memory">
-      <HintPath>..\..\..\..\corefx\artifacts\bin\ref\netcoreapp\System.Memory.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="coreclr\BenchmarksGame\Inputs\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="protobuf-net" Version="2.3.7" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="protobuf-net" Version="2.3.7" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
@@ -36,6 +35,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Memory">
+      <HintPath>..\..\..\..\corefx\artifacts\bin\ref\netcoreapp\System.Memory.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
@@ -76,24 +76,24 @@ namespace System.Buffers.Tests
         public long SliceArray() => Slice(new ReadOnlySequence<T>(_array));
 
         [Benchmark]
-        public int IterateTryGetMemory() => IterateTryGet(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
+        public int IterateTryGetMemory() => IterateTryGet(new ReadOnlySequence<T>(_memory));
 
         [Benchmark]
-        public int IterateForEachMemory() => IterateForEach(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
+        public int IterateForEachMemory() => IterateForEach(new ReadOnlySequence<T>(_memory));
 
         [Benchmark]
-        public int IterateGetPositionMemory() => IterateGetPosition(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
+        public int IterateGetPositionMemory() => IterateGetPosition(new ReadOnlySequence<T>(_memory));
 
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstMemory() => First(new ReadOnlySequence<T>(_memory));
 
         [Benchmark(OperationsPerInvoke = 10)]
-        public long SliceMemory() => Slice(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
+        public long SliceMemory() => Slice(new ReadOnlySequence<T>(_memory));
 
         [GlobalSetup(Targets = new [] { nameof(IterateTryGetSingleSegment), nameof(IterateForEachSingleSegment), nameof(IterateGetPositionSingleSegment), nameof(FirstSingleSegment), nameof(SliceSingleSegment) })]
         public void SetupSingleSegment() => _startSegment = _endSegment = new BufferSegment<T>(new ReadOnlyMemory<T>(_array));
 
-        [GlobalSetup(Targets = new [] { nameof(FirstMemory) })]
+        [GlobalSetup(Targets = new [] { nameof(FirstMemory), nameof(SliceMemory), nameof(IterateTryGetMemory), nameof(IterateForEachMemory), nameof(IterateGetPositionMemory) })]
         public void MemorySegment() => _memory = new ReadOnlyMemory<T>(_array);
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
@@ -29,8 +29,48 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstArray() => First(new ReadOnlySequence<T>(_array));
 
+#if NETCOREAPP3_0
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstSpanArray() => FirstSpan(new ReadOnlySequence<T>(_array));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanMemory() => FirstSpan(new ReadOnlySequence<T>(_memory));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanSingleSegment()
+            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanTenSegments()
+            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size / 10));
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int FirstSpan(ReadOnlySequence<T> sequence)
+        {
+            int consume = 0;
+
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+
+            return consume;
+        }
+
+        [GlobalSetup(Targets = new [] { nameof(FirstSpanSingleSegment) })]
+        public void SetupFirstSpanSingleSegment() => SetupSingleSegment();
+
+        [GlobalSetup(Targets = new [] { nameof(FirstSpanMemory) })]
+        public void MemoryFirstSpanMemory() => MemorySegment();
+
+        [GlobalSetup(Targets = new [] { nameof(FirstSpanTenSegments) })]
+        public void SetupFirstSpanTenSegments() => SetupTenSegments();
+#endif
 
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceArray() => Slice(new ReadOnlySequence<T>(_array));
@@ -47,16 +87,13 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstMemory() => First(new ReadOnlySequence<T>(_memory));
 
-        [Benchmark(OperationsPerInvoke = 16)]
-        public int FirstSpanMemory() => FirstSpan(new ReadOnlySequence<T>(_memory));
-
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceMemory() => Slice(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
 
-        [GlobalSetup(Targets = new [] { nameof(IterateTryGetSingleSegment), nameof(IterateForEachSingleSegment), nameof(IterateGetPositionSingleSegment), nameof(FirstSingleSegment), nameof(FirstSpanSingleSegment), nameof(SliceSingleSegment) })]
+        [GlobalSetup(Targets = new [] { nameof(IterateTryGetSingleSegment), nameof(IterateForEachSingleSegment), nameof(IterateGetPositionSingleSegment), nameof(FirstSingleSegment), nameof(SliceSingleSegment) })]
         public void SetupSingleSegment() => _startSegment = _endSegment = new BufferSegment<T>(new ReadOnlyMemory<T>(_array));
 
-        [GlobalSetup(Targets = new [] { nameof(FirstMemory), nameof(FirstSpanMemory) })]
+        [GlobalSetup(Targets = new [] { nameof(FirstMemory) })]
         public void MemorySegment() => _memory = new ReadOnlyMemory<T>(_array);
 
         [Benchmark]
@@ -75,15 +112,11 @@ namespace System.Buffers.Tests
         public int FirstSingleSegment()
             => First(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
 
-        [Benchmark(OperationsPerInvoke = 16)]
-        public int FirstSpanSingleSegment()
-            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
-
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceSingleSegment()
             => Slice(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
 
-        [GlobalSetup(Targets = new [] { nameof(IterateTryGetTenSegments), nameof(IterateForEachTenSegments), nameof(IterateGetPositionTenSegments), nameof(FirstTenSegments), nameof(FirstSpanTenSegments), nameof(SliceTenSegments) })]
+        [GlobalSetup(Targets = new [] { nameof(IterateTryGetTenSegments), nameof(IterateForEachTenSegments), nameof(IterateGetPositionTenSegments), nameof(FirstTenSegments), nameof(SliceTenSegments) })]
         public void SetupTenSegments()
         {
             const int segmentsCount = 10;
@@ -111,10 +144,6 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstTenSegments()
             => First(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size / 10));
-
-        [Benchmark(OperationsPerInvoke = 16)]
-        public int FirstSpanTenSegments()
-            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size / 10));
 
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceTenSegments()
@@ -175,24 +204,6 @@ namespace System.Buffers.Tests
             consume += sequence.First.Length; consume += sequence.First.Length;
             consume += sequence.First.Length; consume += sequence.First.Length;
             consume += sequence.First.Length; consume += sequence.First.Length;
-
-            return consume;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int FirstSpan(ReadOnlySequence<T> sequence)
-        {
-            int consume = 0;
-
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
-            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
 
             return consume;
         }

--- a/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
@@ -15,6 +15,7 @@ namespace System.Buffers.Tests
 
         private readonly T[] _array = ValuesGenerator.Array<T>(Size);
         private BufferSegment<T> _startSegment, _endSegment;
+        private ReadOnlyMemory<T> _memory;
 
         [Benchmark]
         public int IterateTryGetArray() => IterateTryGet(new ReadOnlySequence<T>(_array));
@@ -27,6 +28,9 @@ namespace System.Buffers.Tests
 
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstArray() => First(new ReadOnlySequence<T>(_array));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanArray() => FirstSpan(new ReadOnlySequence<T>(_array));
 
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceArray() => Slice(new ReadOnlySequence<T>(_array));
@@ -41,13 +45,19 @@ namespace System.Buffers.Tests
         public int IterateGetPositionMemory() => IterateGetPosition(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
 
         [Benchmark(OperationsPerInvoke = 16)]
-        public int FirstMemory() => First(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
+        public int FirstMemory() => First(new ReadOnlySequence<T>(_memory));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanMemory() => FirstSpan(new ReadOnlySequence<T>(_memory));
 
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceMemory() => Slice(new ReadOnlySequence<T>(new ReadOnlyMemory<T>(_array)));
 
-        [GlobalSetup(Targets = new [] { nameof(IterateTryGetSingleSegment), nameof(IterateForEachSingleSegment), nameof(IterateGetPositionSingleSegment), nameof(FirstSingleSegment), nameof(SliceSingleSegment) })]
+        [GlobalSetup(Targets = new [] { nameof(IterateTryGetSingleSegment), nameof(IterateForEachSingleSegment), nameof(IterateGetPositionSingleSegment), nameof(FirstSingleSegment), nameof(FirstSpanSingleSegment), nameof(SliceSingleSegment) })]
         public void SetupSingleSegment() => _startSegment = _endSegment = new BufferSegment<T>(new ReadOnlyMemory<T>(_array));
+
+        [GlobalSetup(Targets = new [] { nameof(FirstMemory), nameof(FirstSpanMemory) })]
+        public void MemorySegment() => _memory = new ReadOnlyMemory<T>(_array);
 
         [Benchmark]
         public int IterateTryGetSingleSegment()
@@ -65,11 +75,15 @@ namespace System.Buffers.Tests
         public int FirstSingleSegment()
             => First(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
 
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanSingleSegment()
+            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
+
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceSingleSegment()
             => Slice(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size));
 
-        [GlobalSetup(Targets = new [] { nameof(IterateTryGetTenSegments), nameof(IterateForEachTenSegments), nameof(IterateGetPositionTenSegments), nameof(FirstTenSegments), nameof(SliceTenSegments) })]
+        [GlobalSetup(Targets = new [] { nameof(IterateTryGetTenSegments), nameof(IterateForEachTenSegments), nameof(IterateGetPositionTenSegments), nameof(FirstTenSegments), nameof(FirstSpanTenSegments), nameof(SliceTenSegments) })]
         public void SetupTenSegments()
         {
             const int segmentsCount = 10;
@@ -97,6 +111,10 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstTenSegments()
             => First(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size / 10));
+
+        [Benchmark(OperationsPerInvoke = 16)]
+        public int FirstSpanTenSegments()
+            => FirstSpan(new ReadOnlySequence<T>(startSegment: _startSegment, startIndex: 0, endSegment: _endSegment, endIndex: Size / 10));
 
         [Benchmark(OperationsPerInvoke = 10)]
         public long SliceTenSegments()
@@ -157,6 +175,24 @@ namespace System.Buffers.Tests
             consume += sequence.First.Length; consume += sequence.First.Length;
             consume += sequence.First.Length; consume += sequence.First.Length;
             consume += sequence.First.Length; consume += sequence.First.Length;
+
+            return consume;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int FirstSpan(ReadOnlySequence<T> sequence)
+        {
+            int consume = 0;
+
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
+            consume += sequence.FirstSpan.Length; consume += sequence.FirstSpan.Length;
 
             return consume;
         }


### PR DESCRIPTION
Adds benchmark tests for ReadOnlySequence<T>.FirstSpan covering all cases

Related to https://github.com/dotnet/corefx/issues/33029

cc: @adamsitnik @ahsonkhan 