### PR TITLE
Add option to specify Dotnet Version

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -143,24 +143,6 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
             "%%Y-%%m-%%dT%%H:%%M:%%SZ").'''
     )
 
-    def __is_valid_sdk_version(version:str) -> str:
-        try:
-            if version is None or re.search('\d\.\d+\.\d+', version):
-                return version
-            else:
-                raise ValueError
-        except ValueError:
-            raise ArgumentTypeError(
-                'Version "{}" is in the wrong format'.format(version))
-
-    parser.add_argument(
-        '--version',
-        required=False,
-        default=None,
-        type=__is_valid_sdk_version,
-        help='Version of the dotnet cli to install in the A.B.C format'
-    )
-
     # Generic arguments.
     parser.add_argument(
         '-q', '--quiet',
@@ -220,7 +202,7 @@ def __main(args: list) -> int:
     # Acquire necessary tools (dotnet, and BenchView)
     init_tools(
         architecture=args.architecture,
-        version=args.version,
+        version=args.dotnet_version,
         target_framework_monikers=target_framework_monikers,
         verbose=verbose
     )

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -27,7 +27,6 @@ from logging import getLogger
 import os
 import platform
 import sys
-import re
 
 from performance.common import validate_supported_runtime
 from performance.logger import setup_loggers

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -547,7 +547,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
 
     def __is_valid_sdk_version(version:str) -> str:
         try:
-            if version is None or re.search('\d\.\d+\.\d+', version):
+            if version is None or re.search('^\d\.\d+\.\d+', version):
                 return version
             else:
                 raise ValueError
@@ -599,14 +599,6 @@ def __process_arguments(args: list):
         default=[SUPPORTED_CHANNELS[0]],
         choices=SUPPORTED_CHANNELS,
         help='Download DotNet Cli from the Channel specified.'
-    )
-
-    install_parser.add_argument(
-        '--version',
-        dest='version',
-        required=False,
-        default=None,
-        help='Download DotNet Cli at the specified version.'
     )
 
     install_parser = add_arguments(install_parser)

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -442,6 +442,7 @@ def __get_directory(architecture: str) -> str:
 def install(
         architecture: str,
         channels: list,
+        version: str,
         verbose: bool,
         install_dir: str = None) -> None:
     '''
@@ -477,16 +478,27 @@ def install(
         dotnetInstallScriptPath
     ] if platform == 'win32' else [dotnetInstallScriptPath]
 
-    # Install Runtime/SDKs
-    for channel in channels:
+    # If Version is supplied, pull down the specified version
+    if version is not None:
         cmdline_args = dotnetInstallInterpreter + [
             '-InstallDir', install_dir,
             '-Architecture', architecture,
-            '-Channel', channel,
+            '-Version', version,
         ]
         RunCommand(cmdline_args, verbose=verbose).run(
             get_repo_root_path()
         )
+    else:
+        # Install Runtime/SDKs
+        for channel in channels:
+            cmdline_args = dotnetInstallInterpreter + [
+                '-InstallDir', install_dir,
+                '-Architecture', architecture,
+                '-Channel', channel,
+            ]
+            RunCommand(cmdline_args, verbose=verbose).run(
+                get_repo_root_path()
+            )
 
     # Set DotNet Cli environment variables.
     environ['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
@@ -568,6 +580,14 @@ def __process_arguments(args: list):
         help='Download DotNet Cli from the Channel specified.'
     )
 
+    install_parser.add_argument(
+        '--version',
+        dest='version',
+        required=False,
+        default=None,
+        help='Download DotNet Cli at the specified version.'
+    )
+
     install_parser = add_arguments(install_parser)
 
     # private install arguments.
@@ -596,6 +616,7 @@ def __main(args: list) -> int:
     install(
         architecture=args.architecture,
         channels=args.channels,
+        version=args.version,
         verbose=args.verbose,
         install_dir=args.install_dir,
     )


### PR DESCRIPTION
This will enable us to specify which version of the dotnet sdk we want to use based on what we get from darc updates.