### PR TITLE
Add Partition filter

### DIFF
--- a/src/benchmarks/micro/CommandLineOptions.cs
+++ b/src/benchmarks/micro/CommandLineOptions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace MicroBenchmarks
+{
+    class CommandLineOptions
+    {
+        // Find and parse given parameter with expected int value, then remove it and its value from the list of arguments to then pass to BenchmarkDotNet
+        // Throws ArgumentException if the parameter does not have a value or that value is not parsable as an int
+        public static List<string> ParseAndRemoveIntParameter(List<string> argsList, string parameter, out int? parameterValue)
+        {
+            int parameterIndex = argsList.IndexOf(parameter);
+            parameterValue = null;
+
+            if (parameterIndex != -1)
+            {
+                if (parameterIndex + 1 < argsList.Count && Int32.TryParse(argsList[parameterIndex+1], out int parsedParameterValue))
+                {
+                    // remove --partition-count args
+                    parameterValue = parsedParameterValue;
+                    argsList.RemoveAt(parameterIndex+1);
+                    argsList.RemoveAt(parameterIndex);
+                }
+                else
+                {
+                    throw new ArgumentException(String.Format("{0} must be followed by an integer", parameter));
+                }
+            }
+
+            return argsList;
+        }
+    }
+}

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using BenchmarkDotNet.Running;
 using System.IO;
@@ -12,11 +14,35 @@ namespace MicroBenchmarks
     class Program
     {
         static int Main(string[] args)
-            => BenchmarkSwitcher
+        {
+            var argsList = new List<string>(args);
+            int? partitionCount;
+            int? partitionIndex;
+
+            // Parse and remove any additional parameters that we need that aren't part of BDN
+            try {
+                argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out partitionCount);
+                argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out partitionIndex);
+
+                if (!(partitionCount.HasValue == partitionIndex.HasValue))
+                {
+                    throw new ArgumentException ("If either --partition-count or --partition-index is specified, both must be specified");
+                }
+            }
+            catch (ArgumentException e)
+            {
+                Console.WriteLine("ArgumentException: {0}", e.Message);
+                return 1;
+            }
+
+            return BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(args, RecommendedConfig.Create(
+                .Run(argsList.ToArray(), RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")), 
-                    mandatoryCategories: ImmutableHashSet.Create(Categories.CoreFX, Categories.CoreCLR, Categories.ThirdParty)))
+                    mandatoryCategories: ImmutableHashSet.Create(Categories.CoreFX, Categories.CoreCLR, Categories.ThirdParty),
+                    partitionCount: partitionCount,
+                    partitionIndex: partitionIndex))
                 .ToExitCode();
+        }
     }
 }

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -24,10 +24,7 @@ namespace MicroBenchmarks
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out partitionCount);
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out partitionIndex);
 
-                if (!(partitionCount.HasValue == partitionIndex.HasValue))
-                {
-                    throw new ArgumentException ("If either --partition-count or --partition-index is specified, both must be specified");
-                }
+                CommandLineOptions.ValidatePartitionParameters(partitionCount, partitionIndex);
             }
             catch (ArgumentException e)
             {

--- a/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 
-namespace MicroBenchmarks
+namespace BenchmarkDotNet.Extensions
 {
-    class CommandLineOptions
+    public class CommandLineOptions
     {
         // Find and parse given parameter with expected int value, then remove it and its value from the list of arguments to then pass to BenchmarkDotNet
         // Throws ArgumentException if the parameter does not have a value or that value is not parsable as an int
@@ -28,6 +28,31 @@ namespace MicroBenchmarks
             }
 
             return argsList;
+        }
+
+        public static void ValidatePartitionParameters(int? count, int? index)
+        {
+            // Either count and index must both be specified or neither specified
+            if (!(count.HasValue == index.HasValue))
+            {
+                throw new ArgumentException("If either --partition-count or --partition-index is specified, both must be specified");
+            }
+            // Check values of count and index parameters
+            else if (count.HasValue && index.HasValue)
+            {
+                if (count < 2)
+                {
+                    throw new ArgumentException("When specified, value of --partition-index must be greater than 1");
+                }
+                else if (!(index < count))
+                {
+                    throw new ArgumentException("Value of --partition-index must be less than --partition-count");
+                }
+                else if (index < 0)
+                {
+                    throw new ArgumentException("Value of --partition-index must be greater than or equal to 0");
+                }
+            }
         }
     }
 }

--- a/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Running;
+
+
+public class PartitionFilter : IFilter
+{
+    private readonly int? _partitionsCount;
+    private readonly int? _partitionIndex; // indexed from 0
+    private int _counter = 0;
+ 
+    public PartitionFilter()
+    {
+        _partitionsCount = ReadFromEnvironmentVariable("PARTITIONS_COUNT");
+        _partitionIndex = ReadFromEnvironmentVariable("PARTITION_INDEX");
+    }
+ 
+    public bool Predicate(BenchmarkCase benchmarkCase)
+    {
+        if (!_partitionsCount.HasValue || !_partitionIndex.HasValue)
+            return true; // the filter is not enabled so it does not filter anything out and can be added to RecommendedConfig
+
+        return _counter++ % _partitionsCount.Value == _partitionIndex.Value; // will return true only for benchmarks that belong to it’s partition
+    }
+ 
+    private int? ReadFromEnvironmentVariable(string key)
+        => int.TryParse(Environment.GetEnvironmentVariable(key), out int partitionsCount)
+            ? (int?)partitionsCount
+            : null;
+}

--- a/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
@@ -11,10 +11,10 @@ public class PartitionFilter : IFilter
     private readonly int? _partitionIndex; // indexed from 0
     private int _counter = 0;
  
-    public PartitionFilter()
+    public PartitionFilter(int? partitionCount, int? partitionIndex)
     {
-        _partitionsCount = ReadFromEnvironmentVariable("PARTITIONS_COUNT");
-        _partitionIndex = ReadFromEnvironmentVariable("PARTITION_INDEX");
+        _partitionsCount = partitionCount;
+        _partitionIndex = partitionIndex;
     }
  
     public bool Predicate(BenchmarkCase benchmarkCase)
@@ -24,9 +24,4 @@ public class PartitionFilter : IFilter
 
         return _counter++ % _partitionsCount.Value == _partitionIndex.Value; // will return true only for benchmarks that belong to it’s partition
     }
- 
-    private int? ReadFromEnvironmentVariable(string key)
-        => int.TryParse(Environment.GetEnvironmentVariable(key), out int partitionsCount)
-            ? (int?)partitionsCount
-            : null;
 }

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -11,7 +11,7 @@ namespace BenchmarkDotNet.Extensions
 {
     public static class RecommendedConfig
     {
-        public static IConfig Create(DirectoryInfo artifactsPath, ImmutableHashSet<string> mandatoryCategories)
+        public static IConfig Create(DirectoryInfo artifactsPath, ImmutableHashSet<string> mandatoryCategories, int? partitionCount = null, int? partitionIndex = null)
             => DefaultConfig.Instance
                 .With(Job.Default
                     .WithWarmupCount(1) // 1 warmup is enough for our purpose
@@ -22,7 +22,7 @@ namespace BenchmarkDotNet.Extensions
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())
-                .With(new PartitionFilter())
+                .With(new PartitionFilter(partitionCount, partitionIndex))
                 .With(JsonExporter.Full) // make sure we export to Json (for BenchView integration purpose)
                 .With(StatisticColumn.Median, StatisticColumn.Min, StatisticColumn.Max)
                 .With(TooManyTestCasesValidator.FailOnError)

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -22,6 +22,7 @@ namespace BenchmarkDotNet.Extensions
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())
+                .With(new PartitionFilter())
                 .With(JsonExporter.Full) // make sure we export to Json (for BenchView integration purpose)
                 .With(StatisticColumn.Median, StatisticColumn.Min, StatisticColumn.Max)
                 .With(TooManyTestCasesValidator.FailOnError)

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/CommandLineOptionsTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/CommandLineOptionsTests.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Extensions;
+using Xunit;
+
+namespace Tests
+{
+    public class CommandLineOptionsTests
+    {
+        [Fact]
+        public void ArgsListContainsPartitionsCountAndIndex()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-count",
+                "10",
+                "--partition-index",
+                "0"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            CommandLineOptions.ValidatePartitionParameters(count, index);
+
+            Assert.Equal(10, count);
+            Assert.Equal(0, count);
+        }
+        [Fact]
+        public void ArgsListContainsNeitherPartitionsCountAndIndex()
+        {
+            List<string> argsList = new List<string> {};
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            CommandLineOptions.ValidatePartitionParameters(count, index);
+
+            Assert.Null(count);
+            Assert.Null(index);
+        }
+        [Fact]
+        public void ArgsListContainsPartitionsCount()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-count",
+                "10"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
+        }
+        [Fact]
+        public void ArgsListContainsPartitionsIndex()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-index",
+                "10"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
+        }
+        [Fact]
+        public void BadPartitionCountValue()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-count",
+                "0",
+                "--partition-index",
+                "0"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
+        }
+        [Fact]
+        public void BadPartitionIndexValue()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-count",
+                "10",
+                "--partition-index",
+                "-1"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
+        }
+        [Fact]
+        public void PartitionIndexValueGreaterThanCount()
+        {
+            List<string> argsList = new List<string> {
+                "--partition-count",
+                "10",
+                "--partition-index",
+                "11"
+            };
+
+            int? count;
+            int? index;
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out count);
+            CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out index);
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
+        }
+    }
+}


### PR DESCRIPTION
The partition filter will allow us to do things like splitting our helix jobs into multiple work items based on a total number of partitions and a partition index.