### PR TITLE
Use the partition filter to split the Microbenchmarks legs into multiple Helix Work Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,12 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 
 ### Micro Benchmarks
 
-#### CoreFX
-
 | Framework | Windows RS4 x64                                                                             | Windows RS4 x86                                                                             | Ubuntu 16.04 x64                                                                            | Ubuntu 16.04 ARM64                                                                              |
 | :-------- | :-----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
-| Core 3.0  | [![CoreFX_windows_RS4_x64_netcoreapp3.0_icon]][CoreFX_windows_RS4_x64_netcoreapp3.0_status] | [![CoreFX_windows_RS4_x86_netcoreapp3.0_icon]][CoreFX_windows_RS4_x86_netcoreapp3.0_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreFX_ubuntu_1604_x64_netcoreapp3.0_status] | Disabled |
-| Core 2.2  | [![CoreFX_windows_RS4_x64_netcoreapp2.2_icon]][CoreFX_windows_RS4_x64_netcoreapp2.2_status] |                                                                                             | [![CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                             |
-| Core 2.1  | [![CoreFX_windows_RS4_x64_netcoreapp2.1_icon]][CoreFX_windows_RS4_x64_netcoreapp2.1_status] |                                                                                             | [![CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                             |
-| .NET      | [![CoreFX_windows_RS4_x64_net461_icon]][CoreFX_windows_RS4_x64_net461_status]               |                                                                                             | N/A                                                                                         | N/A                                                                                             |
-
-
-#### CoreCLR
-
-| Framework | Windows RS4 x64                                                                               | Windows RS4 x86                                                                               | Ubuntu 16.04 x64                                                                              | Ubuntu 16.04 ARM64                                                                                |
-| :-------- | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------: |
-| Core 3.0  | [![CoreCLR_windows_RS4_x64_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x64_netcoreapp3.0_status] | [![CoreCLR_windows_RS4_x86_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x86_netcoreapp3.0_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp3.0_status] | Disabled |
-| Core 2.2  | [![CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.2_status] |                                                                                               | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                               |
-| Core 2.1  | [![CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.1_status] |                                                                                               | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                               |
-| .NET      | [![CoreCLR_windows_RS4_x64_net461_icon]][CoreCLR_windows_RS4_x64_net461_status]               |                                                                                               | N/A                                                                                           | N/A                                                                                               |
+| Core 3.0  | [![micro_windows_RS4_x64_netcoreapp3.0_icon]][micro_windows_RS4_x64_netcoreapp3.0_status] | [![micro_windows_RS4_x86_netcoreapp3.0_icon]][micro_windows_RS4_x86_netcoreapp3.0_status] | [![micro_ubuntu_1604_x64_netcoreapp3.0_icon]][micro_ubuntu_1604_x64_netcoreapp3.0_status] | Disabled |
+| Core 2.2  | [![micro_windows_RS4_x64_netcoreapp2.2_icon]][micro_windows_RS4_x64_netcoreapp2.2_status] |                                                                                             | [![micro_ubuntu_1604_x64_netcoreapp2.2_icon]][micro_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                             |
+| Core 2.1  | [![micro_windows_RS4_x64_netcoreapp2.1_icon]][micro_windows_RS4_x64_netcoreapp2.1_status] |                                                                                             | [![micro_ubuntu_1604_x64_netcoreapp2.1_icon]][micro_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                             |
+| .NET      | [![micro_windows_RS4_x64_net461_icon]][micro_windows_RS4_x64_net461_status]               |                                                                                             | N/A                                                                                         | N/A                                                                                             |
 
 [//]: # (These are the repo links)
 
@@ -56,68 +44,40 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 | :-------- | :---------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
 | Core 3.0  | [![mldotnet_windows_RS4_x64_netcoreapp3.0_icon]][mldotnet_windows_RS4_x64_netcoreapp3.0_status] | [![mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]][mldotnet_ubuntu_1604_x64_netcoreapp3.0_status] |
 
-[//]: # (These are the CoreFX links)
+[//]: # (These are the micro links)
 
 [//]: # (These are the windows x64 links)
-[CoreFX_windows_RS4_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.2
-[CoreFX_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_net461
-[CoreFX_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_net461
+[micro_windows_RS4_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp3.0
+[micro_windows_RS4_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp3.0
+[micro_windows_RS4_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.2
+[micro_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.2
+[micro_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.1
+[micro_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.1
+[micro_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20net461
+[micro_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20net461
 
 [//]: # (These are the windows x86 links)
-[CoreFX_windows_RS4_x86_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_windows_RS4_x86_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=CoreFX_netcoreapp3.0
+[micro_windows_RS4_x86_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=windows%20RS4%20x86%20micro%20netcoreapp3.0
+[micro_windows_RS4_x86_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=windows%20RS4%20x86%20micro%20netcoreapp3.0
 
 [//]: # (These are the ubuntu x64 links)
-[CoreFX_ubuntu_1604_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.2
-[CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.2
-[CoreFX_ubuntu_1604_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.1
-[CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.1
+[micro_ubuntu_1604_x64_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp3.0
+[micro_ubuntu_1604_x64_netcoreapp3.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp3.0
+[micro_ubuntu_1604_x64_netcoreapp2.2_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp2.2
+[micro_ubuntu_1604_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp2.2
+[micro_ubuntu_1604_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp2.1
+[micro_ubuntu_1604_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=ubuntu%201604%20x64%20micro%20netcoreapp2.1
 
 [//]: # (These are the ubuntu arm64 links)
-[CoreFX_ubuntu_1604_arm64_netcoreapp3.0_status]:   https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreFX_netcoreapp3.0
-[CoreFX_ubuntu_1604_arm64_netcoreapp3.0_icon]:     https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreFX_netcoreapp3.0
-
-[//]: # (These are the CoreCLR links)
-
-[//]: # (These are the windows x64 links)
-[CoreCLR_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_windows_RS4_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x64_net461_status]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_net461
-[CoreCLR_windows_RS4_x64_net461_icon]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_net461
-
-[//]: # (These are the windows x86 links)
-[CoreCLR_windows_RS4_x86_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_windows_RS4_x86_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=CoreCLR_netcoreapp3.0
-
-[//]: # (These are the ubuntu x64 links)
-[CoreCLR_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.2_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-
-[//]: # (These are the ubuntu arm64 links)
-[CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_status]:  https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreCLR_netcoreapp3.0
-[CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_icon]:    https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreCLR_netcoreapp3.0
+[micro_ubuntu_1604_arm64_netcoreapp3.0_status]:   https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=ubuntu%201604%20arm64%20micro%20netcoreapp3.0
+[micro_ubuntu_1604_arm64_netcoreapp3.0_icon]:     https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=ubuntu%201604%20arm64%20micro%20netcoreapp3.0
 
 [//]: # (These are the ML.NET links)
 
 [//]: # (These are the windows x64 links)
-[mldotnet_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=mldotnet_netcoreapp3.0
-[mldotnet_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=mldotnet_netcoreapp3.0
+[mldotnet_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=windows%20RS4%20x64%20mlnet%20mldotnet_netcoreapp3.0
+[mldotnet_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=windows%20RS4%20x64%20mlnet%20mldotnet_netcoreapp3.0
 
 [//]: # (These are the ubuntu x64 links)
-[mldotnet_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=mldotnet_netcoreapp3.0
-[mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=mldotnet_netcoreapp3.0
+[mldotnet_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=ubuntu%201604%20x64%20mlnet%20mldotnet_netcoreapp3.0
+[mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=ubuntu%201604%20x64%20mlnet%20mldotnet_netcoreapp3.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,14 +48,28 @@ jobs:
       kind: micro
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+      queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx' 
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
-        - net461
+
+ # Windows x64 micro benchmarks net461, public correctness job
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: windows
+      osVersion: RS4
+      kind: micro_net461
+      architecture: x64
+      pool: Hosted VS2017
+      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+      csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+      runCategories: 'coreclr corefx'
+      frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+        - net461 
 
 # Windows x86 micro benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -66,9 +80,9 @@ jobs:
       kind: micro
       architecture: x86
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+      queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx'
       frameworks: # for public jobs we want to make sure that the PRs don't break x86
         - netcoreapp3.0
 
@@ -83,7 +97,8 @@ jobs:
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
       
@@ -98,7 +113,8 @@ jobs:
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         
@@ -114,7 +130,7 @@ jobs:
       queue: Ubuntu.1604.Amd64.Open
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx'
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp3.0
         - netcoreapp2.2
@@ -132,7 +148,8 @@ jobs:
       queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
-      categories: ['coreclr', 'corefx']
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         
@@ -148,7 +165,7 @@ jobs:
 #       queue: Ubuntu.1604.Arm64.Open
 #       container: ubuntu_1604_arm64_cross_container
 #       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
-#       categories: ['coreclr', 'corefx']
+#       runCategories: 'coreclr corefx'
 #       frameworks: # currently ARM64 is supported only by .NET Core 3.0 https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md
 #         - netcoreapp3.0
 
@@ -161,9 +178,9 @@ jobs:
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+      queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-      categories: ['mldotnet']
+      runCategories: 'mldotnet'
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 only
         - netcoreapp3.0
 
@@ -178,7 +195,8 @@ jobs:
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-      categories: ['mldotnet']
+      runCategories: 'mldotnet'
+      benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         
@@ -193,8 +211,8 @@ jobs:
       pool: Hosted Ubuntu 1604
       queue: Ubuntu.1604.Amd64.Open
       container: ubuntu_x64_build_container
+      runCategories: 'mldotnet'
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
-      categories: ['mldotnet']
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 only
         - netcoreapp3.0
 
@@ -210,7 +228,8 @@ jobs:
       queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
-      categories: ['mldotnet']
+      runCategories: 'mldotnet'
+      benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
 
@@ -223,9 +242,9 @@ jobs:
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+      queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-      categories: ['roslyn']
+      runCategories: 'roslyn'
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 only
         - netcoreapp3.0
 
@@ -240,7 +259,8 @@ jobs:
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-      categories: ['roslyn']
+      runCategories: 'roslyn'
+      benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -1,14 +1,15 @@
 parameters:
-  osName: ''           # required -- windows | linux | macos
-  osVersion: ''        # required -- OS version
-  kind: ''             # required -- benchmark kind. As of today, only "micro" and "mlnet" benchmarks are supported, we plan to add "scenarios" soon
-  architecture: ''     # required -- Architecture. Allowed values: x64, x86, arm32, arm64
-  pool: ''             # required -- name of the Helix pool
-  queue: ''            # required -- name of the Helix queue
-  container: ''        # optional -- id of the container
-  csproj: ''           # required -- relative path to csproj with benchmarks
-  frameworks: []       # required -- list of frameworks. Allowed values: net461, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0, corert
-  categories: []       # required -- list of categories
+  osName: ''            # required -- windows | linux | macos
+  osVersion: ''         # required -- OS version
+  kind: ''              # required -- benchmark kind. As of today, only "micro" and "mlnet" benchmarks are supported, we plan to add "scenarios" soon
+  architecture: ''      # required -- Architecture. Allowed values: x64, x86, arm32, arm64
+  pool: ''              # required -- name of the Helix pool
+  queue: ''             # required -- name of the Helix queue
+  container: ''         # optional -- id of the container
+  csproj: ''            # required -- relative path to csproj with benchmarks
+  frameworks: []        # required -- list of frameworks. Allowed values: net461, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0, corert
+  runCategories: ''     # required -- string of space separated categories supplied to benchmark dotnet
+  benchviewCategory: '' # optional -- category for benchview upload container
 
 jobs:
 - template: ../common/templates/jobs/jobs.yml
@@ -33,7 +34,7 @@ jobs:
             value: dotnet-performance
           # for public runs we want to run the benchmarks exactly once, no warmup, no pilot, no overhead
           - name: BenchmarkDotNetArguments
-            value: '--allCategories $(_Category) --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true'
+            value: '--anyCategories ${{ parameters.runCategories }} --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true'
           - name: HelixApiAccessToken
             value: ''
           - name: HelixPreCommand
@@ -47,10 +48,10 @@ jobs:
             value: '.NET Performance - $(BenchViewRunType) - $(Build.SourceBranchName) $(Build.SourceVersion)'
           # for private runs we want to generate data (--generate-benchview-data ) and upload it (--upload-to-benchview-container specifies where)
           - name: BenchViewArguments
-            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(BenchViewRunType) --upload-to-benchview-container $(_Category)'
+            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(BenchViewRunType) --upload-to-benchview-container ${{ parameters.benchviewCategory}}'
           # for private runs we don't provide any custom BDN arguments (the ones from Program.Main are used)
           - name: BenchmarkDotNetArguments
-            value: '--allCategories $(_Category)'
+            value: '--anyCategories ${{ parameters.runCategories }}'
           - name: Creator
             value: ''
           - ${{ if eq(parameters.osName, 'windows') }}:
@@ -71,24 +72,21 @@ jobs:
         strategy:
           matrix:
             ${{ each framework in parameters.frameworks }}:
-              ${{ each category in parameters.categories }}:
-                ${{ category }}_${{ framework }}:
-                  _Category: ${{ category }}
-                  _Framework: ${{ framework }}
-                  _CompilationMode: NoTiering
-                  _BuildConfig: ${{ parameters.architecture }}_${{ category }}_$(_Framework)_${{ parameters.kind }} # needs to be unique to avoid logs overwriting in mc.dot.net
-                  ${{ if startsWith(framework, 'netcoreapp') }}:
+              ${{ framework }}:
+                _Framework: ${{ framework }}
+                _CompilationMode: NoTiering
+                _BuildConfig: ${{ parameters.architecture }}_$(_Framework)_${{ parameters.kind }} # needs to be unique to avoid logs overwriting in mc.dot.net
+                ${{ if startsWith(framework, 'netcoreapp') }}:
+                  _BenchViewArguments: $(BenchViewArguments)
+                ${{ if not(startsWith(framework, 'netcoreapp')) }}: # we don't want to upload non-.NET Core results to BenchView
+                  _BenchViewArguments: ''
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}: # to reduce the number of CI legs for every PR
+                ${{ if startsWith(framework, 'netcoreapp') }}: # Tiered JIT was introduced in .NET Core 2.1
+                  ${{ framework }}_tiered:
+                    _Framework: ${{ framework }}
+                    _CompilationMode: Tiered
+                    _BuildConfig: ${{ parameters.architecture }}_$(_Framework)_$(_CompilationMode)_${{ parameters.kind }}
                     _BenchViewArguments: $(BenchViewArguments)
-                  ${{ if not(startsWith(framework, 'netcoreapp')) }}: # we don't want to upload non-.NET Core results to BenchView
-                    _BenchViewArguments: ''
-                ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}: # to reduce the number of CI legs for every PR
-                  ${{ if startsWith(framework, 'netcoreapp') }}: # Tiered JIT was introduced in .NET Core 2.1
-                    ${{ category }}_${{ framework }}_tiered:
-                      _Category: ${{ category }}
-                      _Framework: ${{ framework }}
-                      _CompilationMode: Tiered
-                      _BuildConfig: ${{ parameters.architecture }}_${{ category }}_$(_Framework)_$(_CompilationMode)_${{ parameters.kind }}
-                      _BenchViewArguments: $(BenchViewArguments)
         steps:
         - checkout: self
           clean: true

--- a/eng/performance/helix.proj
+++ b/eng/performance/helix.proj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">
-    <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(_Framework) --bdn-arguments="$(BenchmarkDotNetArguments)" $(_BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(_Framework) $(_BenchViewArguments) --dotnet-compilation-mode $(_CompilationMode)</WorkItemCommand>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +18,32 @@
     </HelixCorrelationPayload>
   </ItemGroup>
 
+  <PropertyGroup>
+    <PartitionCount>5</PartitionCount>
+  </PropertyGroup>
   <ItemGroup>
+    <Partition Include="Partition0" Index="0" />
+    <Partition Include="Partition1" Index="1" />
+    <Partition Include="Partition2" Index="2" />
+    <Partition Include="Partition3" Index="3" />
+    <Partition Include="Partition4" Index="4" />
+  </ItemGroup>
+
+  <!-- 
+    Partition the Microbenchamrks project, but nothing else
+    TODO: only for oficial builds 
+  -->
+  <ItemGroup Condition="$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
+    <HelixWorkItem Include="@(Partition)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>$(WorkItemCommand) --bdn-arguments="$(BenchmarkDotNetArguments) --partition-count $(PartitionCount) --partition-index %(HelixWorkItem.Index)"</Command>
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <Command>$(WorkItemCommand)</Command>
+      <Command>$(WorkItemCommand) --bdn-arguments="$(BenchmarkDotNetArguments)"</Command>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/performance/helix.proj
+++ b/eng/performance/helix.proj
@@ -31,7 +31,6 @@
 
   <!-- 
     Partition the Microbenchamrks project, but nothing else
-    TODO: only for oficial builds 
   -->
   <ItemGroup Condition="$(TargetCsproj.Contains('MicroBenchmarks.csproj'))">
     <HelixWorkItem Include="@(Partition)">

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -14,7 +14,7 @@ from stat import S_IRWXU
 from subprocess import check_output
 from sys import argv, platform
 from urllib.parse import urlparse
-from urllib.request import urlopen, urlretrieve
+from urllib.request import urlopen, urlretrieve, Request
 
 import re
 

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -14,7 +14,7 @@ from stat import S_IRWXU
 from subprocess import check_output
 from sys import argv, platform
 from urllib.parse import urlparse
-from urllib.request import urlopen, urlretrieve, Request
+from urllib.request import urlopen, urlretrieve
 
 import re
 


### PR DESCRIPTION
This change uses the PartitionFilter to split the microbenchmark legs into multiple HelixWorkItems. For right now, I am just testing this to see how it works. We will need to make sure it still works with Benchview upload before checking it in.