### PR TITLE
Stop supporting netcoreapp2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 | Core 3.0  | [![CoreFX_windows_RS4_x64_netcoreapp3.0_icon]][CoreFX_windows_RS4_x64_netcoreapp3.0_status] | [![CoreFX_windows_RS4_x86_netcoreapp3.0_icon]][CoreFX_windows_RS4_x86_netcoreapp3.0_status] | [![CoreFX_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreFX_ubuntu_1604_x64_netcoreapp3.0_status] | Disabled |
 | Core 2.2  | [![CoreFX_windows_RS4_x64_netcoreapp2.2_icon]][CoreFX_windows_RS4_x64_netcoreapp2.2_status] |                                                                                             | [![CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                             |
 | Core 2.1  | [![CoreFX_windows_RS4_x64_netcoreapp2.1_icon]][CoreFX_windows_RS4_x64_netcoreapp2.1_status] |                                                                                             | [![CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                             |
-| Core 2.0  | [![CoreFX_windows_RS4_x64_netcoreapp2.0_icon]][CoreFX_windows_RS4_x64_netcoreapp2.0_status] |                                                                                             | [![CoreFX_ubuntu_1604_x64_netcoreapp2.0_icon]][CoreFX_ubuntu_1604_x64_netcoreapp2.0_status] | N/A                                                                                             |
 | .NET      | [![CoreFX_windows_RS4_x64_net461_icon]][CoreFX_windows_RS4_x64_net461_status]               |                                                                                             | N/A                                                                                         | N/A                                                                                             |
 
 
@@ -40,7 +39,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 | Core 3.0  | [![CoreCLR_windows_RS4_x64_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x64_netcoreapp3.0_status] | [![CoreCLR_windows_RS4_x86_netcoreapp3.0_icon]][CoreCLR_windows_RS4_x86_netcoreapp3.0_status] | [![CoreCLR_ubuntu_1604_x64_netcoreapp3.0_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp3.0_status] | Disabled |
 | Core 2.2  | [![CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.2_status] |                                                                                               | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.2_status] | N/A                                                                                               |
 | Core 2.1  | [![CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.1_status] |                                                                                               | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status] | N/A                                                                                               |
-| Core 2.0  | [![CoreCLR_windows_RS4_x64_netcoreapp2.0_icon]][CoreCLR_windows_RS4_x64_netcoreapp2.0_status] |                                                                                               | [![CoreCLR_ubuntu_1604_x64_netcoreapp2.0_icon]][CoreCLR_ubuntu_1604_x64_netcoreapp2.0_status] | N/A                                                                                               |
 | .NET      | [![CoreCLR_windows_RS4_x64_net461_icon]][CoreCLR_windows_RS4_x64_net461_status]               |                                                                                               | N/A                                                                                           | N/A                                                                                               |
 
 [//]: # (These are the repo links)
@@ -67,8 +65,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [CoreFX_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.2
 [CoreFX_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.1
 [CoreFX_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.1
-[CoreFX_windows_RS4_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.0
-[CoreFX_windows_RS4_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_netcoreapp2.0
 [CoreFX_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_net461
 [CoreFX_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreFX_net461
 
@@ -83,8 +79,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [CoreFX_ubuntu_1604_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.2
 [CoreFX_ubuntu_1604_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.1
 [CoreFX_ubuntu_1604_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.1
-[CoreFX_ubuntu_1604_x64_netcoreapp2.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.0
-[CoreFX_ubuntu_1604_x64_netcoreapp2.0_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreFX_netcoreapp2.0
 
 [//]: # (These are the ubuntu arm64 links)
 [CoreFX_ubuntu_1604_arm64_netcoreapp3.0_status]:   https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreFX_netcoreapp3.0
@@ -99,8 +93,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [CoreCLR_windows_RS4_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
 [CoreCLR_windows_RS4_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
 [CoreCLR_windows_RS4_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_windows_RS4_x64_netcoreapp2.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_windows_RS4_x64_netcoreapp2.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_netcoreapp2.0
 [CoreCLR_windows_RS4_x64_net461_status]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_net461
 [CoreCLR_windows_RS4_x64_net461_icon]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=CoreCLR_net461
 
@@ -115,8 +107,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [CoreCLR_ubuntu_1604_x64_netcoreapp2.2_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.2
 [CoreCLR_ubuntu_1604_x64_netcoreapp2.1_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
 [CoreCLR_ubuntu_1604_x64_netcoreapp2.1_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.1
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.0
-[CoreCLR_ubuntu_1604_x64_netcoreapp2.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20micro&configuration=CoreCLR_netcoreapp2.0
 
 [//]: # (These are the ubuntu arm64 links)
 [CoreCLR_ubuntu_1604_arm64_netcoreapp3.0_status]:  https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20arm64%20micro&configuration=CoreCLR_netcoreapp3.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,6 @@ jobs:
         - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
-        - netcoreapp2.0
         - net461
 
 # Windows x86 micro benchmarks, public correctness job
@@ -120,7 +119,6 @@ jobs:
         - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
-        - netcoreapp2.0
 
 # Ubuntu 1604 x64 micro benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -70,7 +70,7 @@ dotnet build -c Release
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [common.props](../build/common.props) file.
 
 ```diff
--<TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+-<TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
 +<TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 ```
 
@@ -162,7 +162,7 @@ To print the list of all available benchmarks you need to pass `--list [tree/fla
 Example: Show the tree of all the benchmarks from System.Threading namespace that can be run for .NET Core 2.0:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.0 --list tree --filter System.Threading*
+dotnet run -c Release -f netcoreapp2.1 --list tree --filter System.Threading*
 ```
 
 ```log
@@ -257,7 +257,7 @@ If you want to disassemble the benchmarked code, you need to use the [Disassembl
 
 You can do that by passing `--disassm` to the app or by using `[DisassemblyDiagnoser(printAsm: true, printSource: true)]` attribute or by adding it to your config with `config.With(DisassemblyDiagnoser.Create(new DisassemblyDiagnoserConfig(printAsm: true, recursiveDepth: 1))`.
 
-Example: `dotnet run -c Release -f netcoreapp2.0 -- --filter System.Memory.Span<Int32>.Reverse -d`
+Example: `dotnet run -c Release -f netcoreapp2.1 -- --filter System.Memory.Span<Int32>.Reverse -d`
 
 ```assembly
 ; System.Runtime.InteropServices.MemoryMarshal.GetReference[[System.Byte, System.Private.CoreLib]](System.Span`1<Byte>)
@@ -283,7 +283,7 @@ M00_L00:
 
 The `--runtimes` or just `-r` allows you to run the benchmarks for **multiple Runtimes**.
 
-Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp2.0, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0.
+Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0.
 
 Example: run the benchmarks for .NET Core 2.2 and 3.0:
 

--- a/docs/benchmarking-workflow.md
+++ b/docs/benchmarking-workflow.md
@@ -41,8 +41,8 @@ To build the benchmarks you need to have the right `dotnet cli`. This repository
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [common.props](../src/benchmarks/micro/common.props) file.
 
 ```diff
--     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
-+     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+-     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
++     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
 ```
 
 Once you have it, you can build the [MicroBenchmarks](../src/benchmarks/micro/MicroBenchmarks.csproj) project. Please do remember that the default configuration for `dotnet cli` is `Debug`. Running benchmarks in `Debug` makes no sense, so please **always build and run it in `Release` mode**.
@@ -178,7 +178,7 @@ You need to specify the target framework monikers via `--runtimes` or just `-r` 
 Example: run `System.Collections.CopyTo<Int32>.Array` benchmarks against .NET Core 2.0 and 2.1 installed on your machine:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.0 -- -f System.Collections.CopyTo<Int32>.Array --runtimes netcoreapp2.0 netcoreapp2.1
+dotnet run -c Release -f netcoreapp2.1 -- -f System.Collections.CopyTo<Int32>.Array --runtimes netcoreapp2.1
 ```
 
 **Important:** when comparing few different .NET runtimes please always use the lowest common API denominator as the host process. What does it mean? BDN needs to detect and build these benchmarks. If you run the host process as .NET Core 2.1 it won't be able to detect benchmarks that use newer APIs are available only for .NET Core 3.0.

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -7,7 +7,7 @@ parameters:
   queue: ''            # required -- name of the Helix queue
   container: ''        # optional -- id of the container
   csproj: ''           # required -- relative path to csproj with benchmarks
-  frameworks: []       # required -- list of frameworks. Allowed values: net461, netcoreapp2.0, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0, corert
+  frameworks: []       # required -- list of frameworks. Allowed values: net461, netcoreapp2.1, netcoreapp2.2, netcoreapp3.0, corert
   categories: []       # required -- list of categories
 
 jobs:
@@ -82,7 +82,7 @@ jobs:
                   ${{ if not(startsWith(framework, 'netcoreapp')) }}: # we don't want to upload non-.NET Core results to BenchView
                     _BenchViewArguments: ''
                 ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}: # to reduce the number of CI legs for every PR
-                  ${{ if and(startsWith(framework, 'netcoreapp'), ne(framework, 'netcoreapp2.0')) }}: # Tiered JIT was introduced in .NET Core 2.1
+                  ${{ if startsWith(framework, 'netcoreapp') }}: # Tiered JIT was introduced in .NET Core 2.1
                     ${{ category }}_${{ framework }}_tiered:
                       _Category: ${{ category }}
                       _Framework: ${{ framework }}

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -555,7 +555,6 @@ def __process_arguments(args: list):
         'master',  # Default channel
         '2.2',
         '2.1',
-        '2.0',
         'LTS',
     ]
     install_parser.add_argument(

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -66,7 +66,6 @@ class FrameworkAction(Action):
             'netcoreapp3.0': 'master',
             'netcoreapp2.2': '2.2',
             'netcoreapp2.1': '2.1',
-            'netcoreapp2.0': '2.0',
             # For Full Framework download the LTS for dotnet cli.
             'net461': 'LTS',
         }
@@ -92,7 +91,6 @@ class FrameworkAction(Action):
             'netcoreapp3.0': 'master',
             'netcoreapp2.2': 'release/2.2',
             'netcoreapp2.1': 'release/2.1',
-            'netcoreapp2.0': 'release/2.0.0',
             # For Full Framework download the LTS for dotnet cli.
             'net461': 'LTS',
         }

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -57,7 +57,7 @@
     <Compile Remove="coreclr\Math\Functions\Single\**" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Remove="corefx\System.IO.Compression\Brotli.cs" />
     <Compile Remove="corefx\System.Net.Http\Perf.SocketsHttpHandler.cs" />
     <Compile Remove="corefx\System.Net.Sockets\Perf.Socket.SendReceive.cs" />
@@ -88,10 +88,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0'">
     <Compile Remove="corefx\System.Text.Json\*\*.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <Compile Remove="corefx\System.Drawing\Perf_Graphics*.cs" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.0' OR '$(IsARM)' == 'true'">

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -10,7 +10,7 @@ We use BenchmarkDotNet as the benchmarking tool, you can read more about it in [
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.0|netcoreapp2.1|netcoreapp2.2|netcoreapp3.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp3.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp2.2|netcoreapp3.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp3.0` as the target framework.
 
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 

--- a/src/benchmarks/micro/corefx/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/Base64Tests.cs
@@ -69,7 +69,7 @@ namespace System.Buffers.Text.Tests
         [Benchmark]
         public OperationStatus Base64DecodeDetinationTooSmall() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [GlobalSetup(Target = nameof(ConvertTryFromBase64Chars))]
         public void SetupConvertTryFromBase64Chars()
         {

--- a/src/benchmarks/micro/corefx/System.Memory/Constructors.cs
+++ b/src/benchmarks/micro/corefx/System.Memory/Constructors.cs
@@ -88,7 +88,7 @@ namespace System.Memory
         [Benchmark]
         public System.Memory<T> ArrayAsMemoryStartLength() => _nonEmptyArray.AsMemory(start: 0, length: Size);
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1 https://github.com/dotnet/coreclr/issues/16126
+#if !NETFRAMEWORK // API added in .NET Core 2.1 https://github.com/dotnet/coreclr/issues/16126
         [Benchmark]
         public System.Span<T> MemoryMarshalCreateSpan() => MemoryMarshal.CreateSpan<T>(ref _field, Size);
     

--- a/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.Primitives/IPAddressPerformanceTests.cs
@@ -47,7 +47,7 @@ namespace System.Net.Primitives.Tests
         [Benchmark]
         public long NetworkToHostOrder() => IPAddress.NetworkToHostOrder(s_addr);
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(ByteAddresses))]
         public IPAddress Ctor_Span(byte[] address)

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Int32.cs
@@ -35,7 +35,7 @@ namespace System.Tests
         [ArgumentsSource(nameof(StringValues))]
         public bool TryParse(string value) => int.TryParse(value, out _);
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(StringValues))]
         public int ParseSpan(string value) => int.Parse(value.AsSpan());

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Int64.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Int64.cs
@@ -35,7 +35,7 @@ namespace System.Tests
         [ArgumentsSource(nameof(StringValues))]
         public bool TryParse(string value) => long.TryParse(value, out _);
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(Values))]
         public bool TryFormat(long value) => value.TryFormat(new Span<char>(_destination), out _);

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
@@ -330,7 +330,7 @@ namespace System.Tests
             return str[index];
         }
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [Arguments("This is a very nice sentence", "bad", StringComparison.CurrentCultureIgnoreCase)]
         [Arguments("This is a very nice sentence", "bad", StringComparison.Ordinal)]

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.UInt32.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.UInt32.cs
@@ -28,7 +28,7 @@ namespace System.Tests
         [ArgumentsSource(nameof(Values))]
         public string ToString(uint value) => value.ToString();
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(Values))]
         public bool TryFormat(uint value) => value.TryFormat(new Span<char>(_destination), out _);

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.UInt64.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.UInt64.cs
@@ -28,7 +28,7 @@ namespace System.Tests
         [ArgumentsSource(nameof(Values))]
         public string ToString(ulong value) => value.ToString();
 
-#if !NETFRAMEWORK && !NETCOREAPP2_0 // API added in .NET Core 2.1
+#if !NETFRAMEWORK // API added in .NET Core 2.1
         [Benchmark]
         [ArgumentsSource(nameof(Values))]
         public bool TryFormat(ulong value) => value.TryFormat(new Span<char>(_destination), out _);

--- a/src/common.props
+++ b/src/common.props
@@ -8,8 +8,8 @@
     <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
     
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     
     <!-- Use the latest C# compiler features -->
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
2.0 has gone out of support for .Net Core, so we should stop supporting
it in our performance testing framework. In particular, when you pull
down dotnet with -Channel 2.0, you are actually pulling down a dotnet at
version 2.1.200. There is an issue with this version where, if you run
on a machine where another run has executed nuget in the last 30 minutes,
you will get various errors of the "error NU3004: The package is not
signed" variety, which is causing a large number of our builds to fail.
Additionally, since netcoreapp2.0 is officially no longer supported, we
are not even running functional testing on the release/2.0 branches out
of coreclr or corefx. Therefore, we should not be running functional
testing of our performance tests for the netcoreapp2.0 bits.

This change removes netcoreapp2.0 support from the performance repo and
updates docs to reflect this.