### PR TITLE
Fixing the `dotnet.py install --channels` option.

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -54,7 +54,7 @@ if sys.platform == 'linux' and "linux_distribution" not in dir(platform):
 
 def init_tools(
         architecture: str,
-        version: str,
+        dotnet_versions: str,
         target_framework_monikers: list,
         verbose: bool) -> None:
     '''
@@ -71,7 +71,7 @@ def init_tools(
     dotnet.install(
         architecture=architecture,
         channels=channels,
-        version=version,
+        versions=dotnet_versions,
         verbose=verbose,
     )
     benchview.install()
@@ -201,7 +201,7 @@ def __main(args: list) -> int:
     # Acquire necessary tools (dotnet, and BenchView)
     init_tools(
         architecture=args.architecture,
-        version=args.dotnet_version,
+        dotnet_versions=args.dotnet_versions,
         target_framework_monikers=target_framework_monikers,
         verbose=verbose
     )


### PR DESCRIPTION
## Issue

`dotnet.py install -v --channels master LTS` fails to build the right command line to be executed.

## Additions

Modified the `--dotnet-version` option to `--dotnet-versions` in order to allow downloading multiple versions of the runtime (for example, preview4 vs. preview5 in one command instead of invoking the script twice)