### PR TITLE
Minor improvement: Fix build status page and add Roslyn to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [micro_windows_RS4_x64_netcoreapp2.2_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.2
 [micro_windows_RS4_x64_netcoreapp2.1_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.1
 [micro_windows_RS4_x64_netcoreapp2.1_icon]:       https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20netcoreapp2.1
-[micro_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20net461
-[micro_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro&configuration=windows%20RS4%20x64%20micro%20net461
+[micro_windows_RS4_x64_net461_status]:            https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20micro_net461
+[micro_windows_RS4_x64_net461_icon]:              https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20micro_net461
+
 
 [//]: # (These are the windows x86 links)
 [micro_windows_RS4_x86_netcoreapp3.0_status]:     https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x86%20micro&configuration=windows%20RS4%20x86%20micro%20netcoreapp3.0

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 | :-------- | :---------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
 | Core 3.0  | [![mldotnet_windows_RS4_x64_netcoreapp3.0_icon]][mldotnet_windows_RS4_x64_netcoreapp3.0_status] | [![mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]][mldotnet_ubuntu_1604_x64_netcoreapp3.0_status] |
 
+#### Roslyn
+
+| Framework | Windows RS4 x64                                                                             |
+| :-------- | :-----------------------------------------------------------------------------------------: |
+| Core 3.0  | [![roslyn_windows_RS4_x64_netcoreapp3.0_icon]][roslyn_windows_RS4_x64_netcoreapp3.0_status] |
+
 [//]: # (These are the micro links)
 
 [//]: # (These are the windows x64 links)
@@ -82,3 +88,10 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [//]: # (These are the ubuntu x64 links)
 [mldotnet_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20mlnet
 [mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20mlnet
+
+
+[//]: # (These are the Roslyn links)
+
+[//]: # (These are the windows x64 links)
+[roslyn_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20roslyn
+[roslyn_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20roslyn

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [//]: # (These are the ML.NET links)
 
 [//]: # (These are the windows x64 links)
-[mldotnet_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=windows%20RS4%20x64%20mlnet%20mldotnet_netcoreapp3.0
-[mldotnet_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20mlnet&configuration=windows%20RS4%20x64%20mlnet%20mldotnet_netcoreapp3.0
+[mldotnet_windows_RS4_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=windows%20RS4%20x64%20mlnet
+[mldotnet_windows_RS4_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=windows%20RS4%20x64%20mlnet
 
 [//]: # (These are the ubuntu x64 links)
-[mldotnet_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=ubuntu%201604%20x64%20mlnet%20mldotnet_netcoreapp3.0
-[mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20mlnet&configuration=ubuntu%201604%20x64%20mlnet%20mldotnet_netcoreapp3.0
+[mldotnet_ubuntu_1604_x64_netcoreapp3.0_status]:    https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=master&jobName=ubuntu%201604%20x64%20mlnet
+[mldotnet_ubuntu_1604_x64_netcoreapp3.0_icon]:      https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=master&jobName=ubuntu%201604%20x64%20mlnet


### PR DESCRIPTION
I just realized that the build status page was not showing Roslyn and fixed it.

![obraz](https://user-images.githubusercontent.com/6011991/58061591-15e27c80-7b77-11e9-87ba-d1657fcfd4ca.png)
