### PR TITLE
Work around a perf issue in a StringBuilder benchmark

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringBuilder.cs
@@ -139,7 +139,7 @@ namespace System.Tests
         public string StringBuilderToString() => _bigStringBuilder.ToString();
 
         [Benchmark]
-        public StringBuilder AppendMemory()
+        public int AppendMemory()
         {
             ReadOnlyMemory<char> memory = _string100.AsMemory();
             StringBuilder builder = new StringBuilder();
@@ -147,7 +147,7 @@ namespace System.Tests
             for (int j = 0; j < NUM_ITERS_APPEND; j++)
                 builder.Append(memory); // Appends a string of length "length" to an increasingly large StringBuilder
 
-            return builder;
+            return builder.Length;
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/dotnet/coreclr/issues/23060
- Worked around a perf issue in a `StringBuilder` benchmark when `QuickJitForLoops` is enabled