### PR TITLE
New reporting library

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.3.1003" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\Reporting\Reporting\Reporting.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using Reporting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace BenchmarkDotNet.Extensions
+{
+    internal class PerfLabExporter : ExporterBase
+    {
+        protected override string FileExtension => "json";
+        protected override string FileCaption => "perf-lab-report";
+        public PerfLabExporter()
+        {
+        }
+        public override void ExportToLog(Summary summary, ILogger logger)
+        {
+            var reporter = Reporter.CreateReporter();
+            if (reporter == null) // not running in the perf lab
+                return;
+
+            var nameDelegate = typeof(BenchmarkCase).Assembly.GetType("BenchmarkDotNet.Exporters.FullNameProvider").GetMethod("GetBenchmarkName", BindingFlags.Static | BindingFlags.NonPublic);
+
+
+            foreach (var report in summary.Reports)
+            {
+                var test = new Test();
+                //test.Name = FullNameProvider.GetBenchmarkName(report.BenchmarkCase);
+                test.Name = (string)nameDelegate.Invoke(null, new[] { report.BenchmarkCase });
+                test.Categories = report.BenchmarkCase.Descriptor.Categories;
+                var results = from result in report.AllMeasurements
+                              where result.IterationMode == Engines.IterationMode.Workload && result.IterationStage == Engines.IterationStage.Result
+                              orderby result.LaunchIndex, result.IterationIndex
+                              select new { result.Nanoseconds, result.Operations };
+                test.Counters.Add(new Counter
+                {
+                    Name = "Duration of single invocation",
+                    TopCounter = true,
+                    DefaultCounter = true,
+                    HigherIsBetter = false,
+                    MetricName = "ns",
+                    Results = (from result in results
+                               select result.Nanoseconds / result.Operations).ToList()
+                });
+                test.Counters.Add(new Counter
+                {
+                    Name = "Duration",
+                    TopCounter = true,
+                    DefaultCounter = false,
+                    HigherIsBetter = false,
+                    MetricName = "ms",
+                    Results = (from result in results
+                               select result.Nanoseconds).ToList()
+                });
+
+                test.Counters.Add(new Counter
+                {
+                    Name = "Operations",
+                    TopCounter = false,
+                    DefaultCounter = false,
+                    HigherIsBetter = true,
+                    MetricName = "Count",
+                    Results = (from result in results
+                               select  (double)result.Operations).ToList()
+                });
+
+                foreach (var metric in report.Metrics.Keys)
+                {
+                    var m = report.Metrics[metric];
+                    test.Counters.Add(new Counter
+                    {
+                        Name = m.Descriptor.DisplayName,
+                        TopCounter = false,
+                        DefaultCounter = false,
+                        HigherIsBetter = m.Descriptor.TheGreaterTheBetter,
+                        MetricName = m.Descriptor.Unit,
+                        Results = new[] { m.Value }
+                    });
+                }
+
+                reporter.AddTest(test);
+            }
+
+            logger.WriteLine(reporter.GetJson());
+        }
+    }
+}

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -24,6 +24,7 @@ namespace BenchmarkDotNet.Extensions
                 .With(new OperatingSystemFilter())
                 .With(new PartitionFilter(partitionCount, partitionIndex))
                 .With(JsonExporter.Full) // make sure we export to Json (for BenchView integration purpose)
+                .With(new PerfLabExporter())
                 .With(StatisticColumn.Median, StatisticColumn.Min, StatisticColumn.Max)
                 .With(TooManyTestCasesValidator.FailOnError)
                 .With(new UniqueArgumentsValidator()) // don't allow for duplicated arguments #404

--- a/src/tools/Reporting/Reporting.Tests/EnvironmentProviderMock.cs
+++ b/src/tools/Reporting/Reporting.Tests/EnvironmentProviderMock.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Reporting.Tests
+{
+    internal class EnvironmentProviderMockBase : IEnvironment
+    {
+        public Dictionary<string, string> Vars { get; set; }
+        public string GetEnvironmentVariable(string variable)
+        {
+            return Vars?[variable];
+        }
+    }
+    internal class PerfLabEnvironmentProviderMock : EnvironmentProviderMockBase
+    {
+        public PerfLabEnvironmentProviderMock()
+        {
+            Vars = new Dictionary<string, string>()
+            {
+                {"PERFLAB_INLAB", "1" },
+                {"HELIX_CORRELATION_ID","testCorrelationId" },
+                {"PERFLAB_PERFHASH","testPerfHash" },
+                {"PERFLAB_QUEUE","testQueue" },
+                {"PERFLAB_REPO","testRepo" },
+                {"PEFRFLAB_BRANCH","testBranch" },
+                {"PERFLAB_BUILDARCH","testBuildArch" },
+                {"PERFLAB_LOCALE","testLocale" },
+                {"PERFLAB_HASH","testHash" },
+                {"PERFLAB_BUILDNUM", "testBuildNum" },
+                {"PERFLAB_HIDDEN", "false" },
+                {"PERFLAB_RUNNAME", "testRunName" },
+                {"PERFLAB_CONFIGS", "KEY1=VALUE1;KEY2=VALUE2" },
+                {"PERFLAB_BUILDTIMESTAMP", new DateTime(1970,1,1).ToString("o") },
+            };
+        }
+
+    }
+
+    internal class NonPerfLabEnvironmentProviderMock : PerfLabEnvironmentProviderMock
+    {
+        public NonPerfLabEnvironmentProviderMock() : base()
+        {
+            var dict = new Dictionary<string, string>();
+            foreach (var key in Vars.Keys)
+                dict[key] = null;
+            Vars = dict;
+        }
+
+    }
+}

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Reporting.Tests
+{
+    public class ReporterTests
+    {
+        [Fact]
+        public void GetReporterWithUnsetEnvironmentReturnsNull()
+        {
+            var reporter = Reporter.CreateReporter(new NonPerfLabEnvironmentProviderMock());
+            Assert.Null(reporter);
+        }
+
+        [Fact]
+        public void JsonCanBeGenerated()
+        {
+            PerfLabEnvironmentProviderMock environment = new PerfLabEnvironmentProviderMock();
+            var reporter = Reporter.CreateReporter(environment);
+            var test = new Test();
+            test.Name = "Test Test";
+            test.Categories.Add("UnitTest");
+            var counter = new Counter();
+            counter.DefaultCounter = true;
+            counter.HigherIsBetter = false;
+            counter.MetricName = "ns";
+            counter.Name = "CounterName";
+            counter.Results = new[] { 1.1 };
+            test.AddCounter(counter);
+            reporter.AddTest(test);
+            var jsonString = reporter.GetJson();
+            var jsonType = new
+            {
+                Build = default(Build),
+                Os = default(Os),
+                Run = default(Run),
+                Tests = default(Test[])
+            };
+            var jsonObj = JsonConvert.DeserializeAnonymousType(jsonString, jsonType);
+
+            Assert.Equal(environment.GetEnvironmentVariable("HELIX_CORRELATION_ID"), jsonObj.Run.CorrelationId);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_PERFHASH"), jsonObj.Run.PerfRepoHash);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_QUEUE"), jsonObj.Run.Queue);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_REPO"), jsonObj.Build.Repo);
+            Assert.Equal(environment.GetEnvironmentVariable("PEFRFLAB_BRANCH"), jsonObj.Build.Branch);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_BUILDARCH"), jsonObj.Build.Architecture);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_LOCALE"), jsonObj.Build.Locale);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_HASH"), jsonObj.Build.GitHash);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_BUILDNUM"), jsonObj.Build.BuildName);
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP"), jsonObj.Build.TimeStamp.ToString("o"));
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_HIDDEN"), jsonObj.Run.Hidden.ToString().ToLower());
+            Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_RUNNAME"), jsonObj.Run.Name);
+
+            Assert.Collection(jsonObj.Run.Configurations,
+                              a => { Assert.Equal("KEY1", a.Key); Assert.Equal("VALUE1", a.Value); },
+                              a => { Assert.Equal("KEY2", a.Key); Assert.Equal("VALUE2", a.Value); });
+            Assert.Equal(RuntimeInformation.OSArchitecture.ToString(), jsonObj.Os.Architecture);
+            Assert.Equal("Test Test", jsonObj.Tests[0].Name);
+            Assert.Equal("UnitTest", jsonObj.Tests[0].Categories[0]);
+            var retCounter = jsonObj.Tests[0].Counters[0];
+            Assert.Equal("CounterName", retCounter.Name);
+            Assert.Equal("ns", retCounter.MetricName);
+            Assert.Equal(1.1, retCounter.Results[0]);
+        }
+
+        [Fact]
+        public void EnforceDefaultCounterConstraint()
+        {
+            Test t = new Test();
+            Counter c = new Counter();
+            c.DefaultCounter = true;
+            t.AddCounter(c);
+            Assert.Throws<Exception>(() => t.AddCounter(c));
+        }
+
+        [Fact]
+        public void EnforceUniqueTestNames()
+        {
+            Reporter r = Reporter.CreateReporter(new PerfLabEnvironmentProviderMock());
+            Test t = new Test();
+            t.Name = "Duplicate";
+            r.AddTest(t);
+            Assert.Throws<Exception>(() => { r.AddTest(t); });
+        }
+    }
+}

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Reporting\Reporting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/Reporting/Reporting.sln
+++ b/src/tools/Reporting/Reporting.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting", "Reporting\Reporting.csproj", "{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting.Tests", "Reporting.Tests\Reporting.Tests.csproj", "{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|x64.Build.0 = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|x64.ActiveCfg = Release|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|x64.Build.0 = Release|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E576B00-C1AA-4AFD-8355-1F4BFA921A86}.Release|x86.Build.0 = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|x64.Build.0 = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Debug|x86.Build.0 = Debug|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|x64.ActiveCfg = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|x64.Build.0 = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|x86.ActiveCfg = Release|Any CPU
+		{1EE524E6-11A6-4E00-9EBA-30A3D7CCE105}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/tools/Reporting/Reporting/Build.cs
+++ b/src/tools/Reporting/Reporting/Build.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Reporting
+{
+    public sealed class Build
+    {
+        public string Repo { get; set; }
+
+        public string Branch { get; set; }
+
+        public string Architecture { get; set; }
+
+        public string Locale { get; set; }
+
+        public string GitHash { get; set; }
+
+        public string BuildName { get; set; }
+
+        public DateTime TimeStamp { get; set; }
+    }
+}

--- a/src/tools/Reporting/Reporting/Counter.cs
+++ b/src/tools/Reporting/Reporting/Counter.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Reporting
+{
+    public class Counter
+    {
+        public string Name { get; set; }
+
+        public bool TopCounter { get; set; }
+
+        public bool DefaultCounter { get; set; }
+
+        public bool HigherIsBetter { get; set; }
+
+        public string MetricName { get; set; }
+
+        public IList<double> Results { get; set; }
+    }
+}

--- a/src/tools/Reporting/Reporting/EnvironmentProvider.cs
+++ b/src/tools/Reporting/Reporting/EnvironmentProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Reporting
+{
+    public class EnvironmentProvider : IEnvironment
+    {
+        public string GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
+    }
+}

--- a/src/tools/Reporting/Reporting/IEnvironment.cs
+++ b/src/tools/Reporting/Reporting/IEnvironment.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Reporting
+{
+    public interface IEnvironment
+    {
+        string GetEnvironmentVariable(string variable);
+    }
+}

--- a/src/tools/Reporting/Reporting/Os.cs
+++ b/src/tools/Reporting/Reporting/Os.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Reporting
+{
+    public class Os
+    {
+        public string Locale { get; set; }
+
+        public string Architecture { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -1,0 +1,119 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
+
+namespace Reporting
+{
+    public class Reporter
+    {
+        private Run run;
+        private Os os;
+        private Build build;
+        private List<Test> tests = new List<Test>();
+        protected IEnvironment environment;
+
+        private Reporter() { }
+
+        public void AddTest(Test test)
+        {
+            if (tests.Any(t => t.Name.Equals(test.Name)))
+                throw new Exception($"Duplicate test name, {test.Name}");
+            tests.Add(test);
+        }
+
+        /// <summary>
+        /// Get a Reporter. Relies on environment variables.
+        /// </summary>
+        /// <param name="environment">Optional environment variable provider</param>
+        /// <returns>A Reporter instance or null if the environment is incorrect.</returns>
+        public static Reporter CreateReporter(IEnvironment environment = null)
+        {
+            var ret = new Reporter();
+            ret.environment = environment == null ? new EnvironmentProvider() : environment;
+            if (!ret.CheckEnvironment())
+            {
+                return null;
+            }
+                        
+            ret.Init();
+            return ret;
+        }
+
+        private void Init()
+        {
+            run = new Run
+            {
+                CorrelationId = environment.GetEnvironmentVariable("HELIX_CORRELATION_ID"),
+                PerfRepoHash = environment.GetEnvironmentVariable("PERFLAB_PERFHASH"),
+                Name = environment.GetEnvironmentVariable("PERFLAB_RUNNAME"),
+                Queue = environment.GetEnvironmentVariable("PERFLAB_QUEUE"),
+            };
+            Boolean.TryParse(environment.GetEnvironmentVariable("PERFLAB_HIDDEN"), out bool hidden);
+            run.Hidden = hidden;
+            var configs = environment.GetEnvironmentVariable("PERFLAB_CONFIGS");
+            if (!String.IsNullOrEmpty(configs)) // configs should be optional.
+            {
+                foreach (var kvp in configs.Split(';'))
+                {
+                    var split = kvp.Split('=');
+                    run.Configurations.Add(split[0], split[1]);
+                } 
+            }
+
+            os = new Os()
+            {
+                Name = $"{RuntimeEnvironment.OperatingSystem} {RuntimeEnvironment.OperatingSystemVersion}",
+                Architecture = RuntimeInformation.OSArchitecture.ToString(),
+                Locale = CultureInfo.CurrentUICulture.ToString()
+            };
+
+            build = new Build
+            {
+                Repo = environment.GetEnvironmentVariable("PERFLAB_REPO"),
+                Branch = environment.GetEnvironmentVariable("PEFRFLAB_BRANCH"),
+                Architecture = environment.GetEnvironmentVariable("PERFLAB_BUILDARCH"),
+                Locale = environment.GetEnvironmentVariable("PERFLAB_LOCALE"),
+                GitHash = environment.GetEnvironmentVariable("PERFLAB_HASH"),
+                BuildName = environment.GetEnvironmentVariable("PERFLAB_BUILDNUM"),
+                TimeStamp = DateTime.Parse(environment.GetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP")),
+            };
+        }
+        public string GetJson()
+        {
+            var jsonobj = new
+            {
+                build,
+                os,
+                run,
+                tests
+            };
+            return JsonConvert.SerializeObject(jsonobj,
+                                               Formatting.Indented,
+                                               new JsonSerializerSettings
+                                               {
+                                                   ContractResolver = new DefaultContractResolver
+                                                   {
+                                                       NamingStrategy = new CamelCaseNamingStrategy
+                                                       {
+                                                           ProcessDictionaryKeys = false
+                                                       }
+                                                   }
+                                               });
+
+        }
+
+        private bool CheckEnvironment()
+        {
+            return environment.GetEnvironmentVariable("PERFLAB_INLAB")?.Equals("1") ?? false;
+        }
+    }
+}

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -96,19 +96,11 @@ namespace Reporting
                 run,
                 tests
             };
-            return JsonConvert.SerializeObject(jsonobj,
-                                               Formatting.Indented,
-                                               new JsonSerializerSettings
-                                               {
-                                                   ContractResolver = new DefaultContractResolver
-                                                   {
-                                                       NamingStrategy = new CamelCaseNamingStrategy
-                                                       {
-                                                           ProcessDictionaryKeys = false
-                                                       }
-                                                   }
-                                               });
-
+            var settings = new JsonSerializerSettings();
+            var resolver = new DefaultContractResolver();
+            resolver.NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false };
+            settings.ContractResolver = resolver;
+            return JsonConvert.SerializeObject(jsonobj, Formatting.Indented, settings);
         }
 
         private bool CheckEnvironment()

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+  
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/tools/Reporting/Reporting/Run.cs
+++ b/src/tools/Reporting/Reporting/Run.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Reporting
+{
+    public class Run
+    {
+        public bool Hidden { get; set; }
+
+        public string CorrelationId { get; set; }
+
+        public string PerfRepoHash { get; set; }
+
+        public string Name { get; set; }
+
+        public string Queue { get; set; }
+        public IDictionary<string, string> Configurations { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Reporting
+{
+    public class Test
+    {
+        public IList<string> Categories { get; set; } = new List<string>();
+
+        public string Name { get; set; }
+
+        public IList<Counter> Counters { get; set; } = new List<Counter>();
+
+        public void AddCounter(Counter counter)
+        {
+            if (counter.DefaultCounter && Counters.Any(c => c.DefaultCounter))
+                throw new Exception($"Duplicate default counter, name: ${counter.Name}");
+            Counters.Add(counter);
+        }
+    }
+}


### PR DESCRIPTION
This library enables writing results to the new database.

This commit also modifies the BenchmarkDotNet.Extensions library to additonally
write out the new format.