### PR TITLE
Make ArtifactsUploader more generic

### DIFF
--- a/src/tools/ArtifactsUploader/ArtifactsUploader.Tests/ArtifactsUploader.Tests.csproj
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader.Tests/ArtifactsUploader.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tools/ArtifactsUploader/ArtifactsUploader.Tests/CommandLineOptionsTests.cs
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader.Tests/CommandLineOptionsTests.cs
@@ -16,13 +16,12 @@ namespace ArtifactsUploader.Tests
     {
         private static readonly string[] CorrectArguments =
         {
-            "--project=CoreCLR", 
-            "--branch=master", 
-            "--job=veryNiceCiJobName",
-            "--isPr=false", 
+            "--container=CoreCLR", 
+            "--folderName=master", 
+            "--archiveName=veryNiceCiJobName",
             "--workplace=.",
             "--storageUrl=https://portal.azure.com/",
-            $"--artifacts={Directory.GetCurrentDirectory()}", 
+            $"--searchDirectory={Directory.GetCurrentDirectory()}", 
             "--searchPatterns", "*.log", "*.txt"
         };
         
@@ -57,18 +56,17 @@ namespace ArtifactsUploader.Tests
         {
             var loggerMock = LoggerMockHelpers.CreateLoggerMock();
             
-            var withUppercaseArgument = CorrectArguments.Select(arg => arg.Replace("--isPr=false", "--isPr=true")).ToArray();
+            var withUppercaseArgument = CorrectArguments.Select(arg => arg.Replace("--storageUrl = https://portal.azure.com/", "--storageurl=https://portal.azure.com/")).ToArray();
             
             var result = CommandLineOptions.Parse(withUppercaseArgument, loggerMock.Object);
             
             Assert.True(result.isSuccess);
-            Assert.True(result.options.IsPr);
             
             LoggerMockHelpers.AssertNothingWasWrittenToLog(loggerMock);
         }
 
         [Theory]
-        [InlineData("artifacts", "--artifacts=\"Z:\\not\\existing\\I\\hope\"")]
+        [InlineData("searchDirectory", "--searchDirectory=\"Z:\\not\\existing\\I\\hope\"")]
         [InlineData("workplace", "--workplace=\"Z:\\not\\existing\\I\\hope\"")]
         public void NonExistingDirectoriesAreReportedAsErrors(string argumentName, string invalidValue)
         {

--- a/src/tools/ArtifactsUploader/ArtifactsUploader/ArtifactsUploader.csproj
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader/ArtifactsUploader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tools/ArtifactsUploader/ArtifactsUploader/CommandLineOptions.cs
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader/CommandLineOptions.cs
@@ -11,20 +11,17 @@ namespace ArtifactsUploader
 {
     public class CommandLineOptions
     {
-        [Option("project", Required = true, HelpText = "Project name")]
-        public string ProjectName { get; set; }
+        [Option("container", Required = true, HelpText = "Container name")]
+        public string ContainerName { get; set; }
 
-        [Option("branch", Required = true, HelpText = "Branch name")]
-        public string BranchName { get; set; }
+        [Option("folderName", Required = false, HelpText = "Folder name within container")]
+        public string FolderName { get; set; }
 
-        [Option("job", Required = true, HelpText = "CI Job name, uploaded archive will have the same name!")]
-        public string JobName { get; set; }
+        [Option("archiveName", Required = false, HelpText = "Archive Name")]
+        public string ArchiveName { get; set; }
 
-        [Option("isPR", Required = true, HelpText = "True for PRs")]
-        public bool IsPr { get; set; }
-
-        [Option("artifacts", Required = true, HelpText = "Path to artifacts directory")]
-        public DirectoryInfo ArtifactsDirectory { get; set; }
+        [Option("searchDirectory", Required = true, HelpText = "Directory to search")]
+        public DirectoryInfo SearchDirectory { get; set; }
 
         [Option("searchPatterns", Required = true, HelpText = "Search patterns", Min = 1)]
         public IEnumerable<string> SearchPatterns { get; set; }
@@ -38,8 +35,11 @@ namespace ArtifactsUploader
         [Option("timeoutMinutes", Required = false, Default = 10, HelpText = "Timout for upload, in minutes")]
         public int TimeoutInMinutes { get; set; }
 
-        [Option("workplace", Required = true, HelpText = "Path to workplace directory where compressed artifacts will be stored")]
+        [Option("workplace", Required = false, HelpText = "Path to workplace directory where compressed artifacts will be stored")]
         public DirectoryInfo Workplace { get; set; }
+
+        [Option("skipCompression", Required = false, HelpText = "Skips compression and uploads discovered files individually")]
+        public bool SkipCompression { get; set; }
 
         public static (bool isSuccess, CommandLineOptions options) Parse(string[] args, ILogger log)
         {
@@ -58,13 +58,13 @@ namespace ArtifactsUploader
 
         private static bool Validate(CommandLineOptions options, ILogger log)
         {
-            if (!options.ArtifactsDirectory.Exists)
+            if (!options.SearchDirectory.Exists)
             {
-                log.Error($"Provided directory, [{options.ArtifactsDirectory.FullName}] does NOT exist. Unable to upload the artifacts!");
+                log.Error($"Provided directory, [{options.SearchDirectory.FullName}] does NOT exist. Unable to upload the artifacts!");
                 return false;
             }
 
-            if (!options.Workplace.Exists)
+            if (!(options.Workplace?.Exists ?? true))
             {
                 log.Error($"Provided directory, [{options.Workplace.FullName}] does NOT exist. Unable to upload the artifacts!");
                 return false;

--- a/src/tools/ArtifactsUploader/ArtifactsUploader/FilesHelper.cs
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader/FilesHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,7 +13,7 @@ namespace ArtifactsUploader
     {
         public static FileInfo GetNonExistingArchiveFile(DirectoryInfo workplace, string jobName)
         {
-            var fileInfo = new FileInfo(Path.Combine(workplace.FullName, $"{jobName}.zip")); // I assume that job name is unique
+            var fileInfo = new FileInfo(Path.Combine(workplace?.FullName ?? Path.GetTempPath(), $"{jobName}.zip")); // I assume that job name is unique
 
             if (fileInfo.Exists)
             {
@@ -22,7 +23,7 @@ namespace ArtifactsUploader
             return fileInfo;
         }
 
-        public static IEnumerable<FileInfo> GetFilesToArchive(DirectoryInfo artifactsDirectory, IEnumerable<string> searchPatterns)
+        public static IEnumerable<FileInfo> GetFilesToUpload(DirectoryInfo artifactsDirectory, IEnumerable<string> searchPatterns)
             => searchPatterns.SelectMany(searchPattern =>
                     artifactsDirectory.EnumerateFiles(searchPattern, SearchOption.AllDirectories));
     }

--- a/src/tools/ArtifactsUploader/ArtifactsUploader/Properties/launchSettings.json
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "ArtifactsUploader": {
-      "commandName": "Project",
-      "commandLineArgs": "--container results --branch csfiles --artifacts . --searchPatterns *cs --storageUrl https://pvscmdupload.blob.core.windows.net --token \"?sv=2018-03-28&ss=bf&srt=sco&sp=rwdlac&se=2019-05-24T07:15:29Z&st=2019-05-23T23:15:29Z&spr=https&sig=IjS1XEZdEm0dfieRK3hccg22%2Bh%2BX%2FrtwMDFMdBqNPYo%3D\" --job testjob --skipCompression true"
-    }
-  }
-}

--- a/src/tools/ArtifactsUploader/ArtifactsUploader/Properties/launchSettings.json
+++ b/src/tools/ArtifactsUploader/ArtifactsUploader/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "ArtifactsUploader": {
+      "commandName": "Project",
+      "commandLineArgs": "--container results --branch csfiles --artifacts . --searchPatterns *cs --storageUrl https://pvscmdupload.blob.core.windows.net --token \"?sv=2018-03-28&ss=bf&srt=sco&sp=rwdlac&se=2019-05-24T07:15:29Z&st=2019-05-23T23:15:29Z&spr=https&sig=IjS1XEZdEm0dfieRK3hccg22%2Bh%2BX%2FrtwMDFMdBqNPYo%3D\" --job testjob --skipCompression true"
+    }
+  }
+}


### PR DESCRIPTION
Since we're not using the benchview tools to prepare results uploads it makes sense to move away from that suite entirely. This uploader was very nice but needed a few things so it could be used more generally.

Changes:

Renamed several args, made some optional

Added --skipCompression to just upload loose files

Upgrade to 3.0

fix tests

Remove unused argument isPR