### PR TITLE
Turn off generating benchview data for PR runs

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -27,9 +27,9 @@ jobs:
             value: private
           - name: BenchviewCommitName
             value: '.NET Performance - $(BenchViewRunType) - $(Build.SourceBranchName) $(System.PullRequest.PullRequestNumber)'
-          # for public runs we want to generate data (--generate-benchview-data ) but don't upload it (missing --upload-to-benchview-container)
+          # for public runs we do not want to generate data or upload it (missing --generate-benchview-data and --upload-to-benchview-container)
           - name: BenchViewArguments
-            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --generate-benchview-data --benchview-run-type $(BenchViewRunType)'
+            value: '--benchview-submission-name "$(BenchviewCommitName)" --benchview-machinepool perfsnake --benchview-run-type $(BenchViewRunType)'
           - name: Creator
             value: dotnet-performance
           # for public runs we want to run the benchmarks exactly once, no warmup, no pilot, no overhead

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -239,12 +239,17 @@ def __main(args: list) -> int:
         for framework in args.frameworks:
             #Before we run the benchmarks we need to set the CommitDate in the environment
             #for the nex reporting tool
-            if framework != 'net461':
+            if framework != 'net461' and args.generate_benchview_data:
                 target_framework_moniker = micro_benchmarks.FrameworkAction.get_target_framework_moniker(framework)
                 commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli)
                 source_timestamp = dotnet.get_commit_date(framework, commit_sha, args.cli_repository)
                 os.environ['PERFLAB_HASH'] = commit_sha
                 os.environ['PERFLAB_BUILDTIMESTAMP'] = source_timestamp
+
+            # ensure that if we aren't generating data we dont try to go down the perflab reporting path, since we'll be missing data.
+            if os.getenv('PERFLAB_INLAB') and not args.generate_benchview_data:
+                os.environ.pop('PERFLAB_INLAB')
+
             micro_benchmarks.run(
                 BENCHMARKS_CSPROJ,
                 args.configuration,


### PR DESCRIPTION
We're hitting up against the API limit for unauthorized access, which kills our PR runs. Until we implement a better plan let's just turn it off.