### PR TITLE
[NO MERGE] test one benchmark

### DIFF
--- a/src/benchmarks/micro/corefx/System.Text.Json/Serializer/ReadJson.cs
+++ b/src/benchmarks/micro/corefx/System.Text.Json/Serializer/ReadJson.cs
@@ -53,4 +53,17 @@ namespace System.Text.Json.Serialization.Tests
         [GlobalCleanup]
         public void Cleanup() => _memoryStream.Dispose();
     }
+
+    public class ReadJson
+    {
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark(Baseline = true)]
+        public string StackallocConst()
+        {
+            Span<char> result = stackalloc char[256];
+
+            result[0] = 'a';
+            return result.Slice(0, 1).ToString();
+        }
+    }
 }


### PR DESCRIPTION
This particular benchmark works on my machine but throws on @ahsonkhan 

```log
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidProgramException: Common Language Runtime detected an invalid program.
   at System.Text.Json.Serialization.Tests.ReadJson.StackallocConst()
   at BenchmarkDotNet.Autogenerated.Runnable_0.WorkloadActionNoUnroll(Int64 invokeCount) in E:\GitHub\Fork\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\7bbe8627-9afc-49fc-a823-eeaf4faf7d61\7bbe8627-9afc-49fc-a823-eeaf4faf7d61.notcs:line 486
   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
   at BenchmarkDotNet.Autogenerated.Runnable_0.Run(IHost host, String benchmarkName) in E:\GitHub\Fork\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\7bbe8627-9afc-49fc-a823-eeaf4faf7d61\7bbe8627-9afc-49fc-a823-eeaf4faf7d61.notcs:line 163
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) in F:\workspace\_work\1\s\src\System.Private.CoreLib\src\System\Reflection\RuntimeMethodInfo.cs:line 466
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters) in F:\workspace\_work\1\s\src\System.Private.CoreLib\shared\System\Reflection\MethodBase.cs:line 54
   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in E:\GitHub\Fork\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\7bbe8627-9afc-49fc-a823-eeaf4faf7d61\7bbe8627-9afc-49fc-a823-eeaf4faf7d61.notcs:line 48
```

I just want our CI to run it with latest bits for Windows and Linux to see where the problem is.

Please don't merge it.