### PR TITLE
[Linux/ARM] Set proper name for ARM architecture

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -2,7 +2,7 @@ parameters:
   osName: ''            # required -- windows | linux | macos
   osVersion: ''         # required -- OS version
   kind: ''              # required -- benchmark kind. As of today, only "micro" and "mlnet" benchmarks are supported, we plan to add "scenarios" soon
-  architecture: ''      # required -- Architecture. Allowed values: x64, x86, arm32, arm64
+  architecture: ''      # required -- Architecture. Allowed values: x64, x86, arm, arm64
   pool: ''              # required -- name of the Helix pool
   queue: ''             # required -- name of the Helix queue
   container: ''         # optional -- id of the container

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -533,7 +533,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     SUPPORTED_ARCHITECTURES = [
         'x64',  # Default architecture
         'x86',
-        'arm32',
+        'arm',
         'arm64',
     ]
     parser.add_argument(


### PR DESCRIPTION
DotNet Cli accepts `arm` value for ARM32 architecture. While scripts from benchmark
pass incorrect value which cause crash on installation:
```
python3 scripts/benchmarks_ci.py -f netcoreapp3.0 --architecture arm32 --filter '*'
[2019/05/29 17:00:51][INFO] ----------------------------------------------
[2019/05/29 17:00:51][INFO] Initializing logger 2019-05-29 17:00:51.006599
[2019/05/29 17:00:51][INFO] ----------------------------------------------
[2019/05/29 17:00:51][INFO] Installing tools.
[2019/05/29 17:00:51][INFO] ----------------------
[2019/05/29 17:00:51][INFO] Downloading DotNet Cli
[2019/05/29 17:00:51][INFO] ----------------------
[2019/05/29 17:00:51][INFO] DotNet Install Path: '/home/asoldatov/performance/tools/dotnet/arm32'
[2019/05/29 17:00:51][INFO] Downloading https://dot.net/v1/dotnet-install.sh
[2019/05/29 17:00:52][INFO] $ pushd "/home/asoldatov/performance"
[2019/05/29 17:00:52][INFO] $ /home/asoldatov/performance/tools/dotnet/arm32/dotnet-install.sh -InstallDir /home/asoldatov/performance/tools/dotnet/arm32 -Architecture arm32 -Channel master
[2019/05/29 17:00:52][INFO] dotnet_install: Error: Architecture `arm32` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues
[2019/05/29 17:00:52][ERROR] Process exited with status 1
[2019/05/29 17:00:52][INFO] $ popd
Traceback (most recent call last):
  File "scripts/benchmarks_ci.py", line 278, in <module>
    __main(sys.argv[1:])
  File "scripts/benchmarks_ci.py", line 213, in __main
    verbose=verbose
  File "scripts/benchmarks_ci.py", line 76, in init_tools
    verbose=verbose,
  File "/home/asoldatov/performance/scripts/dotnet.py", line 513, in install
    get_repo_root_path()
  File "/home/asoldatov/performance/scripts/performance/common.py", line 183, in run
    proc.returncode, quoted_cmdline)
subprocess.CalledProcessError: Command '$ /home/asoldatov/performance/tools/dotnet/arm32/dotnet-install.sh -InstallDir /home/asoldatov/performance/tools/dotnet/arm32 -Architecture arm32 -Channel master' returned non-zero exit status 1
```