### PR TITLE
Add SpanJson to the JSON microbenchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(MSBuildThisFileDirectory)\..\..\common.props" />
 
@@ -30,6 +30,10 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="SpanJson" Version="2.0.12" />
   </ItemGroup>
 
   <ItemGroup>
@@ -65,6 +69,10 @@
     <Compile Remove="coreclr\Math\Functions\Double\Atanh.cs" />
     <Compile Remove="coreclr\Math\Functions\Double\Cbrt.cs" />
     <Compile Remove="coreclr\Math\Functions\Single\**\*.cs" />
+    <Compile Remove="Serializers\Json_FromStream.netcoreapp.cs" />
+    <Compile Remove="Serializers\Json_FromString.netcoreapp.cs" />
+    <Compile Remove="Serializers\Json_ToStream.netcoreapp.cs" />
+    <Compile Remove="Serializers\Json_ToString.netcoreapp.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0')">

--- a/src/benchmarks/micro/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace MicroBenchmarks.Serializers
@@ -14,7 +15,7 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
     [GenericTypeArguments(typeof(CollectionsOfPrimitives))]
-    public class Json_FromStream<T>
+    public partial class Json_FromStream<T>
     {
         private readonly T value;
 

--- a/src/benchmarks/micro/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.cs
@@ -5,7 +5,6 @@
 using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace MicroBenchmarks.Serializers

--- a/src/benchmarks/micro/Serializers/Json_FromStream.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace MicroBenchmarks.Serializers

--- a/src/benchmarks/micro/Serializers/Json_FromStream.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.netcoreapp.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace MicroBenchmarks.Serializers
+{
+    public partial class Json_FromStream<T>
+    {
+        [GlobalSetup(Target = nameof(SpanJson_))]
+        public ValueTask SetupSpanJson_()
+        {
+            memoryStream.Position = 0;
+            return SpanJson.JsonSerializer.Generic.Utf8.SerializeAsync<T>(value, memoryStream);
+        }
+
+
+        [BenchmarkCategory(Categories.ThirdParty)]
+        [Benchmark(Description = "SpanJson")]
+        public ValueTask<T> SpanJson_()
+        {
+            memoryStream.Position = 0;
+            return SpanJson.JsonSerializer.Generic.Utf8.DeserializeAsync<T>(memoryStream);
+        }
+    }
+}

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -11,7 +11,7 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
     [GenericTypeArguments(typeof(CollectionsOfPrimitives))]
-    public class Json_FromString<T>
+    public partial class Json_FromString<T>
     {
         private readonly T value;
         private string serialized;

--- a/src/benchmarks/micro/Serializers/Json_FromString.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 
 namespace MicroBenchmarks.Serializers
 {

--- a/src/benchmarks/micro/Serializers/Json_FromString.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.netcoreapp.cs
@@ -1,0 +1,14 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace MicroBenchmarks.Serializers
+{
+    public partial class Json_FromString<T>
+    {
+        [GlobalSetup(Target = nameof(SpanJson_))]
+        public void SerializeSpanJson_() => serialized = SpanJson.JsonSerializer.Generic.Utf16.Serialize(value);
+
+        [BenchmarkCategory(Categories.ThirdParty)]
+        [Benchmark(Description = "SpanJson")]
+        public T SpanJson_() => SpanJson.JsonSerializer.Generic.Utf16.Deserialize<T>(serialized);
+    }
+}

--- a/src/benchmarks/micro/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.cs
@@ -14,7 +14,7 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
     [GenericTypeArguments(typeof(CollectionsOfPrimitives))]
-    public class Json_ToStream<T>
+    public partial class Json_ToStream<T>
     {
         private readonly T value;
 

--- a/src/benchmarks/micro/Serializers/Json_ToStream.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.netcoreapp.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Threading.Tasks;
+
+namespace MicroBenchmarks.Serializers
+{
+    public partial class Json_ToStream<T>
+    {
+        [BenchmarkCategory(Categories.ThirdParty)]
+        [Benchmark(Description = "SpanJson")]
+        public ValueTask SpanJson_()
+        {
+            memoryStream.Position = 0;
+            return SpanJson.JsonSerializer.Generic.Utf8.SerializeAsync(value, memoryStream);
+        }
+    }
+}

--- a/src/benchmarks/micro/Serializers/Json_ToStream.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 using System.Threading.Tasks;
 
 namespace MicroBenchmarks.Serializers

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -11,7 +11,7 @@ namespace MicroBenchmarks.Serializers
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
     [GenericTypeArguments(typeof(CollectionsOfPrimitives))]
-    public class Json_ToString<T>
+    public partial class Json_ToString<T>
     {
         private readonly T value;
 

--- a/src/benchmarks/micro/Serializers/Json_ToString.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.netcoreapp.cs
@@ -1,4 +1,8 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 
 namespace MicroBenchmarks.Serializers
 {

--- a/src/benchmarks/micro/Serializers/Json_ToString.netcoreapp.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.netcoreapp.cs
@@ -1,0 +1,11 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace MicroBenchmarks.Serializers
+{
+    public partial class Json_ToString<T>
+    {
+        [BenchmarkCategory(Categories.ThirdParty)]
+        [Benchmark(Description = "SpanJson")]
+        public string SpanJson_() => SpanJson.JsonSerializer.Generic.Utf16.Serialize(value);
+    }
+}

--- a/src/benchmarks/micro/Serializers/README.md
+++ b/src/benchmarks/micro/Serializers/README.md
@@ -11,7 +11,7 @@ This folder contains benchmarks of the most popular serializers.
     * [Jil](https://github.com/kevin-montrose/Jil) `2.15.4` 
     * [JSON.NET](https://github.com/JamesNK/Newtonsoft.Json) `11.0.1` 
     * [Utf8Json](https://github.com/neuecc/Utf8Json) `1.3.7` 
-	* [SpanJson](https://github.com/Tornhoof/SpanJson) `2.0.12` 
+    * [SpanJson](https://github.com/Tornhoof/SpanJson) `2.0.12` 
 * Binary
     * [BinaryFormatter](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) `4.3.0`
     * [MessagePack](https://github.com/neuecc/MessagePack-CSharp) `1.7.3.4` 

--- a/src/benchmarks/micro/Serializers/README.md
+++ b/src/benchmarks/micro/Serializers/README.md
@@ -11,6 +11,7 @@ This folder contains benchmarks of the most popular serializers.
     * [Jil](https://github.com/kevin-montrose/Jil) `2.15.4` 
     * [JSON.NET](https://github.com/JamesNK/Newtonsoft.Json) `11.0.1` 
     * [Utf8Json](https://github.com/neuecc/Utf8Json) `1.3.7` 
+	* [SpanJson](https://github.com/Tornhoof/SpanJson) `2.0.12` 
 * Binary
     * [BinaryFormatter](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) `4.3.0`
     * [MessagePack](https://github.com/neuecc/MessagePack-CSharp) `1.7.3.4` 


### PR DESCRIPTION
Motivation:
Even closer in a technology to corefx than e.g. Utf8Json or JIL.
- The value parsers in SpanJson are pretty much direct from corefx, except for DateTime
- Similar methods to reduce memory allocations as in the corefx serializer (Span etc.)

Initial Performance comparison:
- SpanJson has apparently performance problems with the string in FormattedDate in  ``MyEventsListerViewModel``, it's a bit slow there, not yet looked into that in detail.
- Memory allocations in that generic Dictionary<int,string> case are not ideal, I specifically added support for integer keys for in 2.0.12, this was not supported before.
- In general serialization performance is about the same as Utf8Json, deserialization is usually a bit faster

As SpanJson only supports .NET Core 2.1+, the source code is only included for that TargetFrameworkIdentifier. The source code files are partial classes with name netcoreapp (this namiong appears to be used in other repositories). For the _ToStream and _FromStream implementations it uses the Async API of SpanJson, SpanJson does not provide a sync version for them.
