### PR TITLE
Set DOTNET_ROOT to install_dir to ensure the correct runtime is picked.

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -548,6 +548,7 @@ def install(
     environ['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
     environ['DOTNET_MULTILEVEL_LOOKUP'] = '0'
     environ['UseSharedCompilation'] = 'false'
+    environ['DOTNET_ROOT'] = install_dir
 
     # Add installed dotnet cli to PATH
     environ["PATH"] = install_dir + pathsep + environ["PATH"]


### PR DESCRIPTION

Fixes #517