### PR TITLE
Improve parsing test

### DIFF
--- a/src/benchmarks/real-world/Roslyn/Helpers.cs
+++ b/src/benchmarks/real-world/Roslyn/Helpers.cs
@@ -14,7 +14,6 @@ namespace CompilerBenchmarks
         public static Compilation CreateReproCompilation()
         {
             var projectDir = Environment.GetEnvironmentVariable(TestProjectEnvVarName);
-            var cmdLineParser = new CSharpCommandLineParser();
             var responseFile = Path.Combine(projectDir, "repro.rsp");
             var compiler = new MockCSharpCompiler(responseFile, projectDir, Array.Empty<string>());
             var output = new StringWriter();

--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -18,7 +18,7 @@ namespace CompilerBenchmarks
     {
         private static IConfig CustomConfig(DirectoryInfo artifactsPath, ImmutableHashSet<string> mandatoryCategories, int? partitionCount = null, int? partitionIndex = null)
             => DefaultConfig.Instance
-                .With(Job.Default) // tell BDN that this are our default settings
+                .With(Job.Default.AsDefault()) // tell BDN that this are our default settings
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -17,7 +17,7 @@ using System.Text;
 
 namespace BenchmarkDotNet.Extensions
 {
-    internal class PerfLabExporter : ExporterBase
+    public class PerfLabExporter : ExporterBase
     {
         protected override string FileExtension => "json";
         protected override string FileCaption => "perf-lab-report";


### PR DESCRIPTION
The current parsing test includes all the file IO for reading
the files off disk instead of just the parsing. The new version
of the test only parses. The test config is also adapted to
adjust to the shortened total time of the test.