### PR TITLE
String Comparers benchmarks

### DIFF
--- a/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
+++ b/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Extensions;
 using MicroBenchmarks;
@@ -22,7 +21,7 @@ namespace System.Drawing.Tests
             new ImageTestData(ImageFormat.Gif)
         };
 
-        public IEnumerable<object> ImageFormats() => TestCases.Where(format => format.Stream != null);
+        public IEnumerable<object> ImageFormats() => TestCases;
 
         [Benchmark]
         [ArgumentsSource(nameof(ImageFormats))]
@@ -58,15 +57,7 @@ namespace System.Drawing.Tests
 
             public ImageTestData(ImageFormat format)
             {
-                try
-                {
-                    Stream = CreateTestImage(format);
-                }
-                catch (DllNotFoundException) // missing libgdiplus on some Linux distros
-                {
-                    Stream = null;
-                }
-                
+                Stream = CreateTestImage(format);
                 FormatName = format.ToString();
             }
 

--- a/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
+++ b/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Extensions;
 using MicroBenchmarks;
@@ -21,7 +22,7 @@ namespace System.Drawing.Tests
             new ImageTestData(ImageFormat.Gif)
         };
 
-        public IEnumerable<object> ImageFormats() => TestCases;
+        public IEnumerable<object> ImageFormats() => TestCases.Where(format => format.Stream != null);
 
         [Benchmark]
         [ArgumentsSource(nameof(ImageFormats))]
@@ -57,7 +58,15 @@ namespace System.Drawing.Tests
 
             public ImageTestData(ImageFormat format)
             {
-                Stream = CreateTestImage(format);
+                try
+                {
+                    Stream = CreateTestImage(format);
+                }
+                catch (DllNotFoundException) // missing libgdiplus on some Linux distros
+                {
+                    Stream = null;
+                }
+                
                 FormatName = format.ToString();
             }
 

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -18,7 +18,7 @@ namespace System.Tests
             StringComparison.InvariantCulture, StringComparison.InvariantCultureIgnoreCase)]
         public StringComparison Comparison { get; set; }
 
-        private string _input, _same, _lastCharacterDifferent;
+        private string _input, _same;
         private StringComparer _comparer;
 
         [GlobalSetup]
@@ -28,8 +28,6 @@ namespace System.Tests
             char[] characters = ValuesGenerator.Array<char>(Count);
             _input = new string(characters);
             _same = new string(characters);
-            characters[characters.Length - 1] = characters[characters.Length - 1]++;
-            _lastCharacterDifferent = new string(characters);
         }
 
         [Benchmark]
@@ -37,9 +35,6 @@ namespace System.Tests
 
         [Benchmark]
         public int CompareSame() => _comparer.Compare(_input, _same);
-
-        [Benchmark]
-        public int CompareLastCharDifferent() => _comparer.Compare(_input, _lastCharacterDifferent);
 
         private StringComparer GetStringComparer()
         {

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -10,7 +10,9 @@ namespace System.Tests
         [Params(10, 10_000_000)] // 10kk is bigger than the biggest array in ArrayPool.Shared, it's unhappy path for some of the methods
         public int Count { get; set; }
 
-        [Params(StringComparison.OrdinalIgnoreCase, StringComparison.InvariantCultureIgnoreCase)]
+        [Params(
+            StringComparison.Ordinal, StringComparison.OrdinalIgnoreCase,
+            StringComparison.InvariantCulture, StringComparison.InvariantCultureIgnoreCase)]
         public StringComparison Comparison { get; set; }
 
         private string _input, _same, _lastCharacterDifferent;

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -7,7 +7,7 @@ namespace System.Tests
     [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
     public class Perf_StringComparer
     {
-        [Params(10, 10_000_000)] // bigger than the biggest array in ArrayPool.Shared
+        [Params(10, 10_000_000)] // 10kk is bigger than the biggest array in ArrayPool.Shared, it's unhappy path for some of the methods
         public int Count { get; set; }
 
         [Params(StringComparison.OrdinalIgnoreCase, StringComparison.InvariantCultureIgnoreCase)]

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -1,0 +1,60 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
+    public class Perf_StringComparer
+    {
+        [Params(10, 10_000_000)] // bigger than the biggest array in ArrayPool.Shared
+        public int Count { get; set; }
+
+        [Params(StringComparison.OrdinalIgnoreCase, StringComparison.InvariantCultureIgnoreCase)]
+        public StringComparison Comparison { get; set; }
+
+        private string _input, _same, _lastCharacterDifferent;
+        private StringComparer _comparer;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _comparer = GetStringComparer();
+            char[] characters = ValuesGenerator.Array<char>(Count);
+            _input = new string(characters);
+            _same = new string(characters);
+            characters[characters.Length - 1] = characters[characters.Length - 1]++;
+            _lastCharacterDifferent = new string(characters);
+        }
+
+        [Benchmark]
+        public int GetStringHashCode() => _comparer.GetHashCode(_input);
+
+        [Benchmark]
+        public int CompareSame() => _comparer.Compare(_input, _same);
+
+        [Benchmark]
+        public int CompareLastCharDifferent() => _comparer.Compare(_input, _lastCharacterDifferent);
+
+        private StringComparer GetStringComparer()
+        {
+            switch (Comparison)
+            {
+                case StringComparison.CurrentCulture:
+                    return StringComparer.CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return StringComparer.CurrentCultureIgnoreCase;
+                case StringComparison.InvariantCulture:
+                    return StringComparer.InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return StringComparer.InvariantCultureIgnoreCase;
+                case StringComparison.Ordinal:
+                    return StringComparer.Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return StringComparer.OrdinalIgnoreCase;
+                default:
+                    throw new NotSupportedException($"{Comparison} is not supported");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -7,7 +7,10 @@ namespace System.Tests
     [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
     public class Perf_StringComparer
     {
-        [Params(10, 10_000_000)] // 10kk is bigger than the biggest array in ArrayPool.Shared, it's unhappy path for some of the methods
+        [Params(
+            128, // stackalloc path
+            1024 * 256, // ArrayPool.Shared.Rent without allocation 
+            2 * 1024 * 1024)] // ArrayPool.Shared.Rent WITH allocation
         public int Count { get; set; }
 
         [Params(


### PR DESCRIPTION
In https://github.com/dotnet/corefx/issues/37691 it turned out that we had a huge difference for Windows vs Linux for `StringComparer.InvariantCultureIgnoreCase`.

I added the `GetHashCode` benchmark for https://github.com/dotnet/corefx/issues/37691 and `Compare` benchmarks for https://github.com/dotnet/corefx/issues/29462

/cc @danmosemsft @mjsabby