### PR TITLE
docs/benchmarkdotnet: Added note for .NET Core 3.0 preview6+ in allocated memory

### DIFF
--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -230,7 +230,7 @@ The results include managed memory statistics from [Memory Diagnoser](http://ada
 |      0.0087 |           - |           - |                64 B |
 
 - Allocated contains the size of the allocated **managed** memory. **Stackalloc/native heap allocations are not -included.** It's per single invocation, **inclusive**.
-- **For .NET Core the Allocated Memory is only for the current thread**, see [#723](https://github.com/dotnet/BenchmarkDotNet/issues/723) for more.
+- **For .NET Core 3.0 preview6+ the Allocated Memory is for all threads that were live during the benchmark execution. Before .NET Core 3.0 preview6+ the Allocated Memory is only for the current thread**.
 - The `Gen X/1k Op` column contains the number of `Gen X` collections per ***1 000*** Operations. If the value is- equal 1, then it means that GC collects memory once per one thousand of benchmark invocations in generation -`X`. BenchmarkDotNet is using some heuristic when running benchmarks, so the number of invocations can be -different for different runs. Scaling makes the results comparable.
 - `-` in the Gen column means that no garbage collection was performed.
 


### PR DESCRIPTION
Cf. https://github.com/dotnet/BenchmarkDotNet/issues/723#issuecomment-498775280

/CC: @adamsitnik 