### PR TITLE
make sure all StringComparison are tested, remove one Count permutation to not reach the test cases limit

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.StringComparer.cs
@@ -9,13 +9,10 @@ namespace System.Tests
     {
         [Params(
             128, // stackalloc path
-            1024 * 256, // ArrayPool.Shared.Rent without allocation 
-            2 * 1024 * 1024)] // ArrayPool.Shared.Rent WITH allocation
+            1024 * 256)] // ArrayPool.Shared.Rent without allocation 
         public int Count { get; set; }
 
-        [Params(
-            StringComparison.Ordinal, StringComparison.OrdinalIgnoreCase,
-            StringComparison.InvariantCulture, StringComparison.InvariantCultureIgnoreCase)]
+        [ParamsAllValues]
         public StringComparison Comparison { get; set; }
 
         private string _input, _same;


### PR DESCRIPTION
I realized that when I added the `StringComparison` benchmarks I did not add the test cases for `StringComparison.CurrentCulture` and `StringComparison.CurrentCultureIgnoreCase`.

To make sure that we test all of them I have used `[ParamsAllValues]` which is a BDN way of saying generate Params for all values of a given enum.

Our limit for test cases is 16, with only this change we would have 18.

In order to reduce the number of test cases, I have removed the `Count=2 * 1024 * 1024` test case. So we have 12 instead of 18 test cases.