### PR TITLE
add System.Activator.CreateInstance benchmarks

### DIFF
--- a/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
@@ -21,8 +21,10 @@ namespace System.Reflection
         [Benchmark]
         public object CreateInstanceType() => System.Activator.CreateInstance(typeof(T));
 
+#if NETFRAMEWORK || NETCOREAPP3_0 // API available in Full .NET Framework and .NET Core 3.0
         [Benchmark]
         public object CreateInstanceNames() => System.Activator.CreateInstance(_assemblyName, _typeName);
+#endif
     }
 
     public class EmptyClass { }

--- a/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.CoreCLR, Categories.Reflection)]
+    [GenericTypeArguments(typeof(EmptyStruct))] // value type
+    [GenericTypeArguments(typeof(EmptyClass))] // reference type
+    public class Activator<T>
+    {
+        private readonly string _assemblyName = typeof(T).Assembly.FullName;
+        private readonly string _typeName = typeof(T).FullName;
+
+        [Benchmark]
+        public T CreateInstanceGeneric() => System.Activator.CreateInstance<T>();
+
+        [Benchmark]
+        public object CreateInstanceType() => System.Activator.CreateInstance(typeof(T));
+
+        [Benchmark]
+        public object CreateInstanceNames() => System.Activator.CreateInstance(_assemblyName, _typeName);
+    }
+
+    public class EmptyClass { }
+    public struct EmptyStruct { }
+}


### PR DESCRIPTION
I saw https://github.com/dotnet/coreclr/pull/25145 and realized that we don't have any `System.Activator.CreateInstance` benchmarks.

```cmd
dotnet run -c Release -f netcoreapp3.0 --filter *Activator* --join
```

For .NET Core 3.0.0-preview6-27724-03 (CoreCLR 3.0.19.27471, CoreFX 4.700.19.27405), 64bit RyuJIT

|                   Type |                Method |        Mean | Allocated Memory/Op |
|----------------------- |---------------------- |------------:|--------------------:|
|  Activator&lt;EmptyClass&gt; | CreateInstanceGeneric |    49.47 ns |                24 B |
| Activator&lt;EmptyStruct&gt; | CreateInstanceGeneric |    39.06 ns |                24 B |
|  Activator&lt;EmptyClass&gt; |    CreateInstanceType |    42.95 ns |                24 B |
| Activator&lt;EmptyStruct&gt; |    CreateInstanceType |    42.45 ns |                24 B |
|  Activator&lt;EmptyClass&gt; |   CreateInstanceNames | 5,282.75 ns |               800 B |
| Activator&lt;EmptyStruct&gt; |   CreateInstanceNames | 4,721.69 ns |               504 B |

/cc @jkotas 