### PR TITLE
Revert "Add private runs for netcoreapp2.2"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,6 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
-        - netcoreapp2.2
       
 # Windows x86 micro benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -118,7 +117,6 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
-        - netcoreapp2.2
         
 # Ubuntu 1604 x64 micro benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -154,7 +152,6 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
-        - netcoreapp2.2
         
 # # Ubuntu 1804 ARM64 micro benchmarks, private correctness job
 # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Reverts dotnet/performance#570.

We have several runs all at the same hash for netcoreapp2.2, so we can revert this now.