### PR TITLE
Generalize scripting to prepare for cross-repo use

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -246,10 +246,6 @@ def __main(args: list) -> int:
     # Run micro-benchmarks
     if not args.build_only:
         for framework in args.frameworks:
-            # ensure that if we aren't generating data we dont try to go down the perflab reporting path, since we'll be missing data.
-            if os.getenv('PERFLAB_INLAB') and not args.generate_benchview_data:
-                os.environ.pop('PERFLAB_INLAB')
-
             micro_benchmarks.run(
                 BENCHMARKS_CSPROJ,
                 args.configuration,

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -150,9 +150,10 @@ class RunCommand:
         '''Enables/Disables verbosity.'''
         return self.__verbose
 
-    def run(self, working_directory: str = None) -> None:
+    def run(self, working_directory: str = None) -> str:
         '''Executes specified shell command.'''
         should_pipe = self.verbose
+        output = []
         with push_dir(working_directory):
             quoted_cmdline = '$ '
             quoted_cmdline += list2cmdline(self.cmdline)
@@ -173,6 +174,7 @@ class RunCommand:
                             for line in iter(proc.stdout.readline, ''):
                                 line = line.rstrip()
                                 getLogger().info(line)
+                                output = output + [line]
 
                     proc.wait()
 
@@ -181,3 +183,4 @@ class RunCommand:
                             "Process exited with status %s", proc.returncode)
                         raise CalledProcessError(
                             proc.returncode, quoted_cmdline)
+        return os.linesep.join(output)

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -150,10 +150,9 @@ class RunCommand:
         '''Enables/Disables verbosity.'''
         return self.__verbose
 
-    def run(self, working_directory: str = None) -> str:
+    def run(self, working_directory: str = None) -> None:
         '''Executes specified shell command.'''
         should_pipe = self.verbose
-        output = []
         with push_dir(working_directory):
             quoted_cmdline = '$ '
             quoted_cmdline += list2cmdline(self.cmdline)
@@ -174,7 +173,6 @@ class RunCommand:
                             for line in iter(proc.stdout.readline, ''):
                                 line = line.rstrip()
                                 getLogger().info(line)
-                                output = output + [line]
 
                     proc.wait()
 
@@ -183,4 +181,3 @@ class RunCommand:
                             "Process exited with status %s", proc.returncode)
                         raise CalledProcessError(
                             proc.returncode, quoted_cmdline)
-        return os.linesep.join(output)


### PR DESCRIPTION
This change does the following:

1. Adds a --get-perf-hash, which will get the hash of the performance
repo where the script running resides. This will be used when running in
the product repos. This will cause us to run git rev-parse HEAD to get
the hash.
2. Changes the config string to not add quotes for windows (quotes are
needed in bash, but not cmd. Currently, windows configs are being added
as key: "CompilationMode; value: Tiered". We'll need to fix it in the
database.