### PR TITLE
Artifact path fix

### DIFF
--- a/scripts/azcopy.py
+++ b/scripts/azcopy.py
@@ -74,13 +74,15 @@ class AzCopy:
 
     @staticmethod
     def upload_results(container_path: str, verbose: bool) -> None:
+        getLogger().info("Starting upload process")
         if os.getenv('PERFLAB_UPLOAD_TOKEN') and os.getenv("HELIX_CORRELATION_ID"):
-
-            # first find if we have any files at all
-            files = glob(path.join(
+            globpath = path.join(
                 get_artifacts_directory(),
                 '**',
-                '*perf-lab-report.json'), recursive=True)
+                '*perf-lab-report.json')
+            getLogger().info("Searching in {0}".format(globpath))
+            # first find if we have any files at all
+            files = glob(globpath, recursive=True)
 
             if files:
                 getLogger().info("Found {0} files".format(len(files)))
@@ -108,10 +110,7 @@ class AzCopy:
                             except (FileNotFoundError, OSError) as err:
                                 getLogger().error("Still failed to copy {0}".format(file))
 
-                renamed_files = glob(path.join(
-                                        get_artifacts_directory(),
-                                        '**',
-                                        '*perf-lab-report.json'), recursive=True)
+                renamed_files = glob(globpath, recursive=True)
 
 
                 dirname = path.dirname(renamed_files[0])
@@ -123,3 +122,8 @@ class AzCopy:
                 AzCopy(os.environ['PERFLAB_UPLOAD_TOKEN'],
                        container_path,
                        verbose).upload_files(path.join(dirname, '*perf-lab-report.json'))
+            else:
+                getLogger().warning("Found zero files to upload")
+        else:
+            getLogger().warning("Environment variables were unset, no uploading")
+

--- a/scripts/azcopy.py
+++ b/scripts/azcopy.py
@@ -73,11 +73,11 @@ class AzCopy:
         RunCommand(cmdline, verbose=self.verbose).run()
 
     @staticmethod
-    def upload_results(container_path: str, verbose: bool) -> None:
+    def upload_results(container_path: str, artifacts_path: str, verbose: bool) -> None:
         getLogger().info("Starting upload process")
         if os.getenv('PERFLAB_UPLOAD_TOKEN') and os.getenv("HELIX_CORRELATION_ID"):
             globpath = path.join(
-                get_artifacts_directory(),
+                get_artifacts_directory() if not artifacts_path else artifacts_path,
                 '**',
                 '*perf-lab-report.json')
             getLogger().info("Searching in {0}".format(globpath))

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -257,7 +257,7 @@ def __main(args: list) -> int:
         benchview.run_scripts(args, verbose, BENCHMARKS_CSPROJ)
 
         if args.upload_to_perflab_container: 
-            AzCopy.upload_results('', verbose=verbose)
+            AzCopy.upload_results('', args.bdn_artifacts, verbose=verbose)
         
 
         # TODO: Archive artifacts.


### PR DESCRIPTION
Uploading files on Linux was broken a while ago by #527. It happened to keep working on Windows by luck - we happen to have a default run directory that enabled `get_artifacts_directory()` to keep working. We didn't get lucky on Linux.