### PR TITLE
Change the artifacts directory to be HELIX_WORKITEM_UPLOAD_ROOT

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -30,7 +30,7 @@ jobs:
           - name: Python
             value: 'py -3'
           - name: ArtifactsDirectory
-            value: '%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts'
+            value: '%HELIX_WORKITEM_UPLOAD_ROOT%\BenchmarkDotNet.Artifacts'
         - ${{ if ne(parameters.osName, 'windows') }}:
           - name: CliArguments
             value: '--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP'
@@ -39,7 +39,7 @@ jobs:
           - name: Python
             value: python3
           - name: ArtifactsDirectory
-            value: '$HELIX_WORKITEM_PAYLOAD/artifacts/BenchmarkDotNet.Artifacts'
+            value: '$HELIX_WORKITEM_UPLOAD_ROOT/BenchmarkDotNet.Artifacts'
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           - name: BenchViewRunType
             value: private


### PR DESCRIPTION
All files found in HELIX_WORKITEM_UPLOAD_ROOT will be uploaded to storage via the Helix API, so this will save away all of our output files.