### PR TITLE
Revert "Change the artifacts directory to be HELIX_WORKITEM_UPLOAD_ROOT"

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -30,7 +30,7 @@ jobs:
           - name: Python
             value: 'py -3'
           - name: ArtifactsDirectory
-            value: '%HELIX_WORKITEM_UPLOAD_ROOT%\BenchmarkDotNet.Artifacts'
+            value: '%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts'
         - ${{ if ne(parameters.osName, 'windows') }}:
           - name: CliArguments
             value: '--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP'
@@ -39,7 +39,7 @@ jobs:
           - name: Python
             value: python3
           - name: ArtifactsDirectory
-            value: '$HELIX_WORKITEM_UPLOAD_ROOT/BenchmarkDotNet.Artifacts'
+            value: '$HELIX_WORKITEM_PAYLOAD/artifacts/BenchmarkDotNet.Artifacts'
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           - name: BenchViewRunType
             value: private


### PR DESCRIPTION
Reverts dotnet/performance#585

Unfortunately, the Os Onboarding rollout does not automatically rollout to on-prem machines, so we are now failing our internal jobs. https://github.com/dotnet/core-eng/issues/6801 tracks updating the perf machines. When that goes in, we will check that back in.