### PR TITLE
Use BuildConfig in the name of the work item

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -115,7 +115,7 @@ jobs:
         - template: /eng/performance/send-to-helix.yml
           parameters:
             HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-            HelixType: 'test/performance_$(_BuildConfig)/'
+            HelixType: 'test/performance/'
             HelixAccessToken: $(HelixApiAccessToken)
             HelixTargetQueues: ${{ parameters.queue }}
             HelixPreCommands: $(HelixPreCommand)

--- a/eng/performance/helix.proj
+++ b/eng/performance/helix.proj
@@ -26,11 +26,11 @@
     <PartitionCount>5</PartitionCount>
   </PropertyGroup>
   <ItemGroup>
-    <Partition Include="Partition0" Index="0" />
-    <Partition Include="Partition1" Index="1" />
-    <Partition Include="Partition2" Index="2" />
-    <Partition Include="Partition3" Index="3" />
-    <Partition Include="Partition4" Index="4" />
+    <Partition Include="$(_BuildConfig).Partition0" Index="0" />
+    <Partition Include="$(_BuildConfig).Partition1" Index="1" />
+    <Partition Include="$(_BuildConfig).Partition2" Index="2" />
+    <Partition Include="$(_BuildConfig).Partition3" Index="3" />
+    <Partition Include="$(_BuildConfig).Partition4" Index="4" />
   </ItemGroup>
 
   <!-- 
@@ -44,7 +44,7 @@
     </HelixWorkItem>
   </ItemGroup>
   <ItemGroup Condition="!$(TargetCsproj.Contains('MicroBenchmarks.csproj')) Or '$(Architecture)' == 'arm64'">
-    <HelixWorkItem Include="WorkItem">
+    <HelixWorkItem Include="$(_BuildConfig).WorkItem">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>$(WorkItemCommand) --bdn-arguments="$(BenchmarkDotNetArguments)"</Command>
       <Timeout>4:00</Timeout>


### PR DESCRIPTION
Currently, we set the HelixType to be _BuildConfig. This is messy, and causes us to have a bunch of MC.net pages to go look at. Instead, we can name the test runs according to _BuildConfig, and have everything in mc.net point to test/performance/. It is much neater. See: https://mc.dot.net/#/user/dotnet-performance/pr~2Fdotnet~2Fperformance~2Frefs~2Fpull~2F590~2Fmerge/test~2Fperformance~2F/20190626.2