### PR TITLE
Make it possible to publish --self-contained MicroBenchmarks.csproj

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -30,6 +30,9 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
+    <!-- following two dependencies must point to version 4.3.0 or newer to make it possible to publish MicroBenchmarks.csproj -->
+    <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As of today, it's impossible to publish a self-contained version of `MicroBenchmarks.csproj` due to a package downgrade issue.

```cmd
PS C:\Projects\performance\src\benchmarks\micro> dotnet publish -c Release -f netcoreapp3.0 --self-contained -r win10-x64 MicroBenchmarks.csproj 
```

```log
Microsoft (R) Build Engine version 16.3.0-preview-19321-02+a5a222491 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 26,44 ms for C:\Projects\performance\src\tools\Reporting\Reporting\Reporting.csproj.
  Restore completed in 34,16 ms for C:\Projects\performance\src\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj.
  Restore completed in 12,24 ms for C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj.
  Reporting -> C:\Projects\performance\artifacts\bin\Reporting\Release\netstandard2.0\Reporting.dll
  BenchmarkDotNet.Extensions -> C:\Projects\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netstandard2.0\BenchmarkDotNet.Extensions.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\win10-x64\MicroBenchmarks.dll
  MicroBenchmarks -> C:\Projects\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\win10-x64\publish\
PS C:\Projects\performance\src\benchmarks\micro> start powershell
PS C:\Projects\performance\src\benchmarks\micro> dotnet publish -c Release -f netcoreapp3.0 --self-contained -r win10-x64 MicroBenchmarks.csproj
Microsoft (R) Build Engine version 16.3.0-preview-19321-02+a5a222491 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 489,86 ms for C:\Projects\performance\src\tools\Reporting\Reporting\Reporting.csproj.
  Restore completed in 816,55 ms for C:\Projects\performance\src\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj.
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605: Detected package downgrade: Microsoft.Win32.Primitives from 4.3.0 to 4.0.1-rc2-24027. Reference the package directly from the project to select a different version.
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> System.Net.Primitives 4.0.11-rc2-24027 -> runtime.win.System.Net.Primitives 4.3.0 -> Microsoft.Win32.Primitives (>= 4.3.0)
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> Microsoft.Win32.Primitives (>= 4.0.1-rc2-24027)
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605: Detected package downgrade: System.Net.Primitives from 4.3.0 to 4.0.11-rc2-24027. Reference the package directly from the project to select a different version.
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> System.Net.Sockets 4.1.0-rc2-24027 -> runtime.win.System.Net.Sockets 4.3.0 -> System.Net.Primitives (>= 4.3.0)
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> System.Net.Primitives (>= 4.0.11-rc2-24027)
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605: Detected package downgrade: Microsoft.Win32.Primitives from 4.3.0 to 4.0.1-rc2-24027. Reference the package directly from the project to select a different version.
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> System.Net.Sockets 4.1.0-rc2-24027 -> runtime.win.System.Net.Sockets 4.3.0 -> System.Security.Principal.Windows 4.3.0 -> Microsoft.Win32.Primitives (>= 4.3.0)
C:\Projects\performance\src\benchmarks\micro\MicroBenchmarks.csproj : error NU1605:  MicroBenchmarks -> Jil 2.17.0 -> Sigil 4.7.0 -> NETStandard.Library 1.5.0-rc2-24027 -> Microsoft.Win32.Primitives (>= 4.0.1-rc2-24027)
```

The source of issues are the 3rd party JSON serializer benchmarks that use Jil, which uses Sigil which uses a very old version of `NETStandard.Library 1.5.0-rc2-24027` which references `Microsoft.Win32.Primitives  4.0.1-rc2-24027`. 

We can't update Jil because we already use the latest version. I think that we should rather not remove it because it's one of the fastest JSON serializers and it's good to have it for competitive comparison with System.Text.Json.

So my proposal is just to listen to the compiler and add both references in explicit way.

@billwert this is going to help me with making it possible to run the performance repo microbenchmarks with @sebastienros infrastructure and in the future might become usefull if we decide to separate benchmarks build and run into two separate steps (we are going to need a publish, self-contained project then)