### PR TITLE
handle missing libgdiplus

### DIFF
--- a/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
+++ b/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
@@ -5,8 +5,8 @@
 using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Extensions;
 using MicroBenchmarks;
 
 namespace System.Drawing.Tests
@@ -14,14 +14,10 @@ namespace System.Drawing.Tests
     [BenchmarkCategory(Categories.CoreFX)]
     public class Perf_Image_Load
     {
-        private static readonly ImageTestData[] TestCases = {
-            new ImageTestData(ImageFormat.Bmp),
-            new ImageTestData(ImageFormat.Jpeg),
-            new ImageTestData(ImageFormat.Png),
-            new ImageTestData(ImageFormat.Gif)
-        };
+        // this field is lazy to avoid the exception during static ctor initialization of this type (harder to catch and handle properly)
+        private static readonly Lazy<ImageTestData[]> LazyTestCases = new Lazy<ImageTestData[]>(CreateTestCases);
 
-        public IEnumerable<object> ImageFormats() => TestCases;
+        public IEnumerable<object> ImageFormats() => LazyTestCases.Value;
 
         [Benchmark]
         [ArgumentsSource(nameof(ImageFormats))]
@@ -47,6 +43,28 @@ namespace System.Drawing.Tests
         {
             using (Image.FromStream(format.Stream, false, false))
             {
+            }
+        }
+
+        private static ImageTestData[] CreateTestCases()
+        {
+            try
+            {
+                return new [] 
+                {
+                    new ImageTestData(ImageFormat.Bmp),
+                    new ImageTestData(ImageFormat.Jpeg),
+                    new ImageTestData(ImageFormat.Png),
+                    new ImageTestData(ImageFormat.Gif)
+                };
+            }
+            catch (Exception) when (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("libgdiplus is missing, you can install it by running 'apt-get install libgdiplus'");
+                Console.ResetColor();
+
+                return Array.Empty<ImageTestData>();
             }
         }
 

--- a/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
+++ b/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs
@@ -64,7 +64,7 @@ namespace System.Drawing.Tests
                 Console.WriteLine("libgdiplus is missing, you can install it by running 'apt-get install libgdiplus'");
                 Console.ResetColor();
 
-                return Array.Empty<ImageTestData>();
+                throw;
             }
         }
 


### PR DESCRIPTION
As of today, when we try to run the benchmarks on a Linux machine without `libgdiplus` installed the benchmark app crashes and does not run any benchmark.

An example from https://github.com/dotnet/performance/issues/517 :

```cmd
$/usr/share/dotnet/dotnet run -f netcoreapp3.0 -c Release -- --filter '*'
```

```log
Unhandled Exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.TypeInitializationException: The type initializer for 'System.Drawing.Tests.Perf_Image_Load' threw an exception. ---> System.TypeInitializationException: The type initializer for 'Gdip' threw an exception. ---> System.DllNotFoundException: Unable to load DLL 'libgdiplus': The specified module could not be found.
   at System.Runtime.InteropServices.FunctionWrapper`1.get_Delegate()
   at System.Drawing.SafeNativeMethods.Gdip.GdiplusStartup(IntPtr& token, StartupInput& input, StartupOutput& output)
   at System.Drawing.SafeNativeMethods.Gdip..cctor()
   --- End of inner exception stack trace ---
   at System.Drawing.SafeNativeMethods.Gdip.GdipCreateBitmapFromScan0(Int32 width, Int32 height, Int32 stride, Int32 format, HandleRef scan0, IntPtr& bitmap)
   at System.Drawing.Bitmap..ctor(Int32 width, Int32 height, PixelFormat format)
   at System.Drawing.Tests.Perf_Image_Load.ImageTestData.CreateTestImage(ImageFormat format) in /home/asoldatov/performance/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs:line 76
   at System.Drawing.Tests.Perf_Image_Load.ImageTestData..ctor(ImageFormat format) in /home/asoldatov/performance/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs:line 60
   at System.Drawing.Tests.Perf_Image_Load..cctor() in /home/asoldatov/performance/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs:line 17
   --- End of inner exception stack trace ---
   at System.Drawing.Tests.Perf_Image_Load.ImageFormats() in /home/asoldatov/performance/src/benchmarks/micro/corefx/System.Drawing/Perf_Image_Load.cs:line 24
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at BenchmarkDotNet.Running.BenchmarkConverter.GetValidValuesForParamsSource(Type parentType, String sourceName)
   at BenchmarkDotNet.Running.BenchmarkConverter.GetArgumentsDefinitions(MethodInfo benchmark, Type target)+MoveNext()
   at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at BenchmarkDotNet.Running.BenchmarkConverter.MethodsToBenchmarksWithFullConfig(Type containingType, MethodInfo[] benchmarkMethods, ImmutableConfig immutableConfig)
   at BenchmarkDotNet.Running.BenchmarkConverter.TypeToBenchmarks(Type type, IConfig config)
   at BenchmarkDotNet.Running.TypeFilter.<>c__DisplayClass1_0.<Filter>b__0(Type type)
   at System.Linq.Enumerable.SelectListIterator`2.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at BenchmarkDotNet.Running.TypeFilter.Filter(IConfig effectiveConfig, IEnumerable`1 types)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
   at MicroBenchmarks.Program.Main(String[] args) in /home/asoldatov/performance/src/benchmarks/micro/Program.cs:line 35
```

My proposal is to handle the exception, print a red warning with explanation (and a solution) and let the  other benchmarks run.