### PR TITLE
Make it possible to build MicroBenchmarks.sln from Visual Studio

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="benchmarkdotnet-ci-feed" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
-    <add key="dotnet-myget-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
   </packageSources>
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
     <RestoreSources>
       $(RestoreSources);
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
+      https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json;
       https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
       https://dotnet.myget.org/F/symreader/api/v3/index.json;
       https://ci.appveyor.com/nuget/benchmarkdotnet;

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -255,6 +255,7 @@ class CSharpProject:
               configuration: str,
               target_framework_monikers: list,
               verbose: bool,
+              packages_path: str,
               *args) -> None:
         '''Calls dotnet to build the specified project.'''
         if not target_framework_monikers:  # Build all supported frameworks.
@@ -263,6 +264,7 @@ class CSharpProject:
                 self.csproj_file,
                 '--configuration', configuration,
                 '--no-restore',
+                "/p:NuGetPackageRoot={}".format(packages_path),
             ]
             if args:
                 cmdline = cmdline + list(args)
@@ -276,6 +278,7 @@ class CSharpProject:
                     '--configuration', configuration,
                     '--framework', target_framework_moniker,
                     '--no-restore',
+                    "/p:NuGetPackageRoot={}".format(packages_path),
                 ]
                 if args:
                     cmdline = cmdline + list(args)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -374,7 +374,8 @@ def build(
     build_title = "Building .NET micro benchmarks for '{}'".format(
         ' '.join(target_framework_monikers))
     __log_script_header(build_title)
-    BENCHMARKS_CSPROJ.build(configuration, target_framework_monikers, verbose)
+    BENCHMARKS_CSPROJ.build(
+        configuration, target_framework_monikers, verbose, packages)
 
 
 def run(

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,7 @@
 <Project>
+  <!-- Microsoft.DotNet.Arcade.Sdk must be imported in explict way in every Directory.Build.props file -->
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <PropertyGroup>
-    <!-- don't import settings from root/Directory.Build.props and root/Directory.Build.targets (Arcade) 
-        which add some dependencies and settings to all the projects in the repo and breaks benchmarks -->
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
-  
     <!-- Avoid spawning any-long living compiler processes to avoid BenchmarkDotNet issues with "file in use",
          and automation failing to clean up the folders once the runs are over -->
     <UseSharedCompilation>false</UseSharedCompilation>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,15 +1,13 @@
 <Project>
   <PropertyGroup>
+    <!-- don't import settings from root/Directory.Build.props and root/Directory.Build.targets (Arcade) 
+        which add some dependencies and settings to all the projects in the repo and breaks benchmarks -->
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  
     <!-- Avoid spawning any-long living compiler processes to avoid BenchmarkDotNet issues with "file in use",
          and automation failing to clean up the folders once the runs are over -->
     <UseSharedCompilation>false</UseSharedCompilation>
-    
-    <!-- Used by Python script to narrow down the the specified target frameworks to test, and avoid downloading all supported SDKs -->
-    <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
-    
-    <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     
     <!-- Use the latest C# compiler features -->
     <LangVersion>latest</LangVersion>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\common.props" />
-
   <PropertyGroup>
+    <!-- Used by Python script to narrow down the the specified target frameworks to test, and avoid downloading all supported SDKs -->
+    <TargetFrameworks>$(PYTHON_SCRIPT_TARGET_FRAMEWORKS)</TargetFrameworks>
+    <!-- Supported target frameworks -->
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>

--- a/src/benchmarks/micro/MicroBenchmarks.sln
+++ b/src/benchmarks/micro/MicroBenchmarks.sln
@@ -6,9 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MicroBenchmarks", "MicroBenchmarks.csproj", "{D99F63AE-3154-4F13-9424-FA5F9D032D1D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkDotNet.Extensions.Tests", "..\..\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj", "{0A02797B-B016-4F5C-AADB-11EE2653BA92}"
-	ProjectSection(ProjectDependencies) = postProject
-		{D99F63AE-3154-4F13-9424-FA5F9D032D1D} = {D99F63AE-3154-4F13-9424-FA5F9D032D1D}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkDotNet.Extensions", "..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj", "{D44B5BFC-F333-4165-8830-437FBC8DF6BE}"
 EndProject

--- a/src/benchmarks/micro/MicroBenchmarks.sln
+++ b/src/benchmarks/micro/MicroBenchmarks.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkDotNet.Extensions.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkDotNet.Extensions", "..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj", "{D44B5BFC-F333-4165-8830-437FBC8DF6BE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Reporting", "..\..\tools\Reporting\Reporting\Reporting.csproj", "{384EC85F-C645-4123-A13D-B8E7B40F2A23}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{D44B5BFC-F333-4165-8830-437FBC8DF6BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D44B5BFC-F333-4165-8830-437FBC8DF6BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D44B5BFC-F333-4165-8830-437FBC8DF6BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{384EC85F-C645-4123-A13D-B8E7B40F2A23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{384EC85F-C645-4123-A13D-B8E7B40F2A23}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{384EC85F-C645-4123-A13D-B8E7B40F2A23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{384EC85F-C645-4123-A13D-B8E7B40F2A23}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -8,9 +8,9 @@
     <IsShipping>false</IsShipping>
     <!-- this app is using internal Roslyn API and needs to be signed -->
     <SignAssembly>true</SignAssembly>
-    <!-- ignore warning about BenchmarkDotNet.Extensions being not signed -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
+    <!-- ignore warning about BenchmarkDotNet.Extensions being not signed -->
+    <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -6,6 +6,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsShipping>false</IsShipping>
+    <!-- this app is using internal Roslyn API and needs to be signed -->
+    <SignAssembly>true</SignAssembly>
+    <!-- ignore warning about BenchmarkDotNet.Extensions being not signed -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
   </PropertyGroup>
 

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\common.props" />
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -4,6 +4,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\..\benchmarks\micro\MicroBenchmarks.csproj" />
+    <ProjectReference Include="..\..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -8,10 +8,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-  </ItemGroup>
 </Project>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,10 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
+
   <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\common.props" />
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Today I have tried to open `MicroBenchmarks.sln` from a fresh copy of the repo (no previous builds or restores) and I have failed.

I really want to make it easy for devs to work with the existing benchmarks and add new ones so I decided to fix it.

This PR simplifies few things and makes it work again.

Before:

![before](https://user-images.githubusercontent.com/6011991/60244905-b71dca80-98bb-11e9-8942-2581e750ee47.gif)

After:

![after](https://user-images.githubusercontent.com/6011991/60244913-bd13ab80-98bb-11e9-832b-45c201d376ba.gif)
