### PR TITLE
need to pass --architecture to ci_setup.py

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -108,7 +108,7 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/ci_setup.py --frameworks $(_Framework) --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
+        - script: $(Python) scripts/ci_setup.py --frameworks $(_Framework) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0
             displayName: Workaround to avoid locked file # https://github.com/dotnet/arcade/issues/2125


### PR DESCRIPTION
Right now we're logging x86 builds as x64 into the new DB.