### PR TITLE
Disable SourceLink

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,10 @@
     
     <!-- we are testing latest bits and we must use preview SDK version -->
     <SuppressNETCoreSdkPreviewMessage>True</SuppressNETCoreSdkPreviewMessage>
+
+    <!-- Disable SourceLink -->
+    <EnableSourceLink>false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     
     <!-- Explicit disable signing the built assemblies here to stop Arcade attempting to sign them -->
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
The test machines we run on do not have git, which SourceLink looks for.
This can cause us to get an error during build, since it tries to
Path.Combine the path to git (null) with another folder, throwing an
exception. We do not need SourceLink for the perf repo, so explicitly
disable it.