### PR TITLE
Fix Arm64 runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,6 @@ resources:
   containers:
     - container: ubuntu_x64_build_container
       image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
-    - container: ubuntu_1604_arm64_cross_container
-      image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
 
 # CI Trigger on master branch
 trigger:
@@ -163,7 +161,7 @@ jobs:
       architecture: arm64
       pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Arm64.Perf
-      container: ubuntu_1604_arm64_cross_container
+      container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -112,22 +112,20 @@ jobs:
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0
             displayName: Workaround to avoid locked file # https://github.com/dotnet/arcade/issues/2125
-
-        - ${{ if ne(parameters.architecture, 'arm64') }}:
-          - template: /eng/performance/send-to-helix.yml
-            parameters:
-              HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-              HelixType: 'test/performance_$(_BuildConfig)/'
-              HelixAccessToken: $(HelixApiAccessToken)
-              HelixTargetQueues: ${{ parameters.queue }}
-              HelixPreCommands: $(HelixPreCommand)
-              Creator: $(Creator)
-              Architecture: ${{ parameters.architecture }}
-              TargetCsproj: ${{ parameters.csproj }}
-              WorkItemTimeout: 4:00 # 4 hours
-              Python: $(Python)
-              ${{ if eq(parameters.osName, 'windows') }}:
-                WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
-                CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
-              ${{ if ne(parameters.osName, 'windows') }}:
-                WorkItemDirectory: '$(Build.SourcesDirectory)'
+        - template: /eng/performance/send-to-helix.yml
+          parameters:
+            HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
+            HelixType: 'test/performance_$(_BuildConfig)/'
+            HelixAccessToken: $(HelixApiAccessToken)
+            HelixTargetQueues: ${{ parameters.queue }}
+            HelixPreCommands: $(HelixPreCommand)
+            Creator: $(Creator)
+            Architecture: ${{ parameters.architecture }}
+            TargetCsproj: ${{ parameters.csproj }}
+            WorkItemTimeout: 4:00 # 4 hours
+            Python: $(Python)
+            ${{ if eq(parameters.osName, 'windows') }}:
+              WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
+              CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
+            ${{ if ne(parameters.osName, 'windows') }}:
+              WorkItemDirectory: '$(Build.SourcesDirectory)'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -112,20 +112,22 @@ jobs:
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0
             displayName: Workaround to avoid locked file # https://github.com/dotnet/arcade/issues/2125
-        - template: /eng/performance/send-to-helix.yml
-          parameters:
-            HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-            HelixType: 'test/performance_$(_BuildConfig)/'
-            HelixAccessToken: $(HelixApiAccessToken)
-            HelixTargetQueues: ${{ parameters.queue }}
-            HelixPreCommands: $(HelixPreCommand)
-            Creator: $(Creator)
-            Architecture: ${{ parameters.architecture }}
-            TargetCsproj: ${{ parameters.csproj }}
-            WorkItemTimeout: 4:00 # 4 hours
-            Python: $(Python)
-            ${{ if eq(parameters.osName, 'windows') }}:
-              WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
-              CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
-            ${{ if ne(parameters.osName, 'windows') }}:
-              WorkItemDirectory: '$(Build.SourcesDirectory)'
+
+        - ${{ if ne(parameters.architecture, 'arm64') }}:
+          - template: /eng/performance/send-to-helix.yml
+            parameters:
+              HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
+              HelixType: 'test/performance_$(_BuildConfig)/'
+              HelixAccessToken: $(HelixApiAccessToken)
+              HelixTargetQueues: ${{ parameters.queue }}
+              HelixPreCommands: $(HelixPreCommand)
+              Creator: $(Creator)
+              Architecture: ${{ parameters.architecture }}
+              TargetCsproj: ${{ parameters.csproj }}
+              WorkItemTimeout: 4:00 # 4 hours
+              Python: $(Python)
+              ${{ if eq(parameters.osName, 'windows') }}:
+                WorkItemDirectory: '$(Build.SourcesDirectory)\docs' # WorkItemDirectory can not be empty, so we send it some docs to keep it happy
+                CorrelationPayloadDirectory: '$(Build.SourcesDirectory)\notLocked' # it gets checked out to a folder with shorter path than WorkItemDirectory so we can avoid file name too long exceptions
+              ${{ if ne(parameters.osName, 'windows') }}:
+                WorkItemDirectory: '$(Build.SourcesDirectory)'

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -170,10 +170,11 @@ def __main(args: list) -> int:
     target_framework_monikers = micro_benchmarks \
         .FrameworkAction \
         .get_target_framework_monikers(args.frameworks)
+
     # Acquire necessary tools (dotnet, and BenchView)
-    # For arm64 run, download the x64 version so we can get the information we need, but set all variables
-    # as if we were running normal. This is a workaround due to the fact that arm64 binaries cannot run
-    # in the cross containers, so we are running in a normal ubuntu container
+    # For arm64 runs, download the x64 version so we can get the information we need, but set all variables
+    # as if we were running normally. This is a workaround due to the fact that arm64 binaries cannot run
+    # in the cross containers, so we are running the ci setup script in a normal ubuntu container
     architecture = 'x64' if args.architecture == 'arm64' else args.architecture
 
     init_tools(

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -171,8 +171,13 @@ def __main(args: list) -> int:
         .FrameworkAction \
         .get_target_framework_monikers(args.frameworks)
     # Acquire necessary tools (dotnet, and BenchView)
+    # For arm64 run, download the x64 version so we can get the information we need, but set all variables
+    # as if we were running normal. This is a workaround due to the fact that arm64 binaries cannot run
+    # in the cross containers, so we are running in a normal ubuntu container
+    architecture = 'x64' if args.architecture == 'arm64' else args.architecture
+
     init_tools(
-        architecture=args.architecture,
+        architecture=architecture,
         dotnet_versions=args.dotnet_versions,
         target_framework_monikers=target_framework_monikers,
         verbose=verbose
@@ -235,7 +240,7 @@ def __main(args: list) -> int:
     # On non-windows platforms, delete dotnet, so that we don't have to deal with chmoding it on the helix machines
     # This is only necessary for netcoreapp3.0
     if sys.platform != 'win32' and is_netcoreapp_30:
-        dotnet.remove_dotnet(args.architecture)
+        dotnet.remove_dotnet(architecture)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The ci setup script was trying to run an arm64 dotnet in a cross
container, which was causing a failure, because the container is not,
itself arm64. The workaround is to run the ci setup script in a normal
container, pull down the x64 dotnet to get the information out of it,
but then on the helix machine, pull down the correct dotnet. Since we
already remove dotnet on linux machines, we have to download dotnet again
on the helix machines, so this change only affects the dotnet on the
build machine.