### PR TITLE
make it explicit that latest daily build of .NET Core SDK is required to compile the benchmarks

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -18,10 +18,10 @@ The python scripts in this repository support python version 3.5 or greater.
 
 - [Downloads](https://www.python.org/downloads/)
 
-### [.NET Core command-line interface (CLI) tools](https://docs.microsoft.com/en-us/dotnet/core/tools/?tabs=netcore2x)
+### .NET Core SDK
 
-Used to build the .NET Performance projects, and they can be downloaded here:
+The .NET Core SDK contains both the .NET Core runtime and CLI tools. .NET Performance projects test the performance of daily builds of .NET Core Runtime. **You need to install the latest daily build of .NET Core SDK to be able to build the projects**. It can be downloaded here:
 
-- [Downloads](https://dotnet.microsoft.com/download)
+- [Downloads](https://github.com/dotnet/core-sdk#installers-and-binaries)
 
 Optionally, you could use [dotnet.py](../scripts/dotnet.py) to to download the DotNet Cli locally.


### PR DESCRIPTION
At least a few users have hit an issue related to API changes between .NET Core 3.0 previews (#560, #612)

I think that we should just make it clear that this repo tests master and you need to have latest .NET Core SDK to be able to build it.