### PR TITLE
Move to the new perf queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,11 +89,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS5
+      osVersion: 19H1
       kind: micro
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
@@ -119,11 +119,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS5
+      osVersion: 19H1
       kind: micro
       architecture: x86
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
@@ -171,7 +171,7 @@ jobs:
       kind: micro
       architecture: x64
       pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
@@ -231,11 +231,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS5
+      osVersion: 19H1
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
@@ -281,7 +281,7 @@ jobs:
       kind: mlnet
       architecture: x64
       pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
@@ -324,11 +324,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS5
+      osVersion: 19H1
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
@@ -374,7 +374,7 @@ jobs:
       kind: roslyn
       architecture: x64
       pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ jobs:
       kind: micro
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
@@ -109,23 +109,23 @@ jobs:
       kind: micro
       architecture: x86
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         
-# Ubuntu 1604 x64 micro benchmarks, public correctness job
+# Ubuntu 1804 x64 micro benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Open
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
@@ -134,16 +134,16 @@ jobs:
         - netcoreapp2.2
         - netcoreapp2.1
 
-# Ubuntu 1604 x64 micro benchmarks, private job
+# Ubuntu 1804 x64 micro benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
@@ -159,7 +159,7 @@ jobs:
 #       osVersion: 1804
 #       kind: micro
 #       architecture: arm64
-#       pool: Hosted Ubuntu 1604
+#       pool: Hosted Ubuntu 1804
 #       queue: Ubuntu.1804.Arm64.Perf
 #       container: ubuntu_x64_build_container
 #       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -192,39 +192,39 @@ jobs:
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
         
-# Ubuntu 1604 x64 ML.NET benchmarks, public correctness job
+# Ubuntu 1804 x64 ML.NET benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Open
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'mldotnet'
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 only
         - netcoreapp3.0
 
-# Ubuntu 1604 x64 ML.NET benchmarks, private job
+# Ubuntu 1804 x64 ML.NET benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
@@ -256,39 +256,39 @@ jobs:
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
+      queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
 
-# Ubuntu 1604 x64 Roslyn benchmarks, public correctness job
+# Ubuntu 1804 x64 Roslyn benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Open
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'roslyn'
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 only
         - netcoreapp3.0
 
-# Ubuntu 1604 x64 Roslyn benchmarks, private job
+# Ubuntu 1804 x64 Roslyn benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
-      osVersion: 1604
+      osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Hosted Ubuntu 1604
-      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      pool: Hosted Ubuntu 1804
+      queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,11 +42,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS4
+      osVersion: RS5
       kind: micro
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.Open
+      queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx' 
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
@@ -74,11 +74,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS4
+      osVersion: RS5
       kind: micro
       architecture: x86
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.Open
+      queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       frameworks: # for public jobs we want to make sure that the PRs don't break x86
@@ -89,7 +89,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS5
       kind: micro
       architecture: x64
       pool: Hosted VS2017
@@ -99,10 +99,11 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
-    - template: /eng/performance/benchmark_jobs.yml
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+  - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS1
       kind: micro
       architecture: x64
       pool: Hosted VS2017
@@ -118,7 +119,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs5
+      osVersion: RS5
       kind: micro
       architecture: x86
       pool: Hosted VS2017
@@ -128,10 +129,11 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs1
+      osVersion: RS1
       kind: micro
       architecture: x86
       pool: Hosted VS2017
@@ -176,6 +178,7 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
@@ -213,11 +216,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS4
+      osVersion: RS5
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.Open
+      queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 only
@@ -228,7 +231,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs5
+      osVersion: RS5
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
@@ -238,10 +241,11 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs1
+      osVersion: RS1
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
@@ -284,6 +288,7 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu
@@ -304,11 +309,11 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: RS4
+      osVersion: RS5
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.Open
+      queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 only
@@ -319,7 +324,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs5
+      osVersion: RS5
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
@@ -329,10 +334,11 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10-clientrs1
+      osVersion: RS1
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
@@ -375,6 +381,7 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: ubuntu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,7 @@ jobs:
       osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -142,7 +142,7 @@ jobs:
       osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -159,7 +159,7 @@ jobs:
 #       osVersion: 1804
 #       kind: micro
 #       architecture: arm64
-#       pool: Hosted Ubuntu 1804
+#       pool: Hosted Ubuntu 1604
 #       queue: Ubuntu.1804.Arm64.Perf
 #       container: ubuntu_x64_build_container
 #       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -207,7 +207,7 @@ jobs:
       osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'mldotnet'
@@ -223,7 +223,7 @@ jobs:
       osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -271,7 +271,7 @@ jobs:
       osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'roslyn'
@@ -287,7 +287,7 @@ jobs:
       osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Hosted Ubuntu 1804
+      pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,17 +99,43 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+    - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: windows
+      osVersion: 10
+      kind: micro
+      architecture: x64
+      pool: Hosted VS2017
+      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
+      csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
       
 # Windows x86 micro benchmarks, private job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: 10-clientrs5
       kind: micro
       architecture: x86
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: windows
+      osVersion: 10-clientrs1
+      kind: micro
+      architecture: x86
+      pool: Hosted VS2017
+      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
@@ -144,6 +170,20 @@ jobs:
       architecture: x64
       pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      container: ubuntu_x64_build_container
+      csproj: src/benchmarks/micro/MicroBenchmarks.csproj
+      runCategories: 'coreclr corefx'
+      benchviewCategory: 'coreclr'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: ubuntu
+      osVersion: 1604
+      kind: micro
+      architecture: x64
+      pool: Hosted Ubuntu 1604
+      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
@@ -188,11 +228,24 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: 10-clientrs5
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+      runCategories: 'mldotnet'
+      benchviewCategory: 'mldotnet'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: windows
+      osVersion: 10-clientrs1
+      kind: mlnet
+      architecture: x64
+      pool: Hosted VS2017
+      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
@@ -231,6 +284,20 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
         - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: ubuntu
+      osVersion: 1604
+      kind: mlnet
+      architecture: x64
+      pool: Hosted Ubuntu 1604
+      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      container: ubuntu_x64_build_container
+      csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+      runCategories: 'mldotnet'
+      benchviewCategory: 'mldotnet'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
 
 # Windows x64 Roslyn benchmarks, public correctness job
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -252,11 +319,24 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: 10-clientrs5
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017
       queue: Windows.10.Amd64.ClientRS5.Perf # using a dedicated private Helix queue (perfsnakes)
+      csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+      runCategories: 'roslyn'
+      benchviewCategory: 'roslyn'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: windows
+      osVersion: 10-clientrs1
+      kind: roslyn
+      architecture: x64
+      pool: Hosted VS2017
+      queue: Windows.10.Amd64.ClientRS1.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
@@ -289,6 +369,20 @@ jobs:
       architecture: x64
       pool: Hosted Ubuntu 1604
       queue: Ubuntu.1804.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
+      container: ubuntu_x64_build_container
+      csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+      runCategories: 'roslyn'
+      benchviewCategory: 'roslyn'
+      frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
+        - netcoreapp3.0
+  - template: /eng/performance/benchmark_jobs.yml
+    parameters:
+      osName: ubuntu
+      osVersion: 1604
+      kind: roslyn
+      architecture: x64
+      pool: Hosted Ubuntu 1604
+      queue: Ubuntu.1604.Amd64.Perf # using a dedicated private Helix queue (perfsnakes)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -29,8 +29,12 @@ jobs:
             value: 'call %HELIX_CORRELATION_PAYLOAD%\tools\machine-setup.cmd'
           - name: Python
             value: 'py -3'
-          - name: ArtifactsDirectory
-            value: '%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts'
+          - ${{ if ne(parameters.osVersion, 'RS1')}}:
+            - name: ArtifactsDirectory
+              value: '%HELIX_WORKITEM_UPLOAD_ROOT%\BenchmarkDotNet.Artifacts'
+          - ${{ if eq(parameters.osVersion, 'RS1')}}:
+            - name: ArtifactsDirectory
+              value: '%HELIX_CORRELATION_PAYLOAD%\artifacts\BenchmarkDotNet.Artifacts'
         - ${{ if ne(parameters.osName, 'windows') }}:
           - name: CliArguments
             value: '--dotnet-versions $DOTNET_VERSION --cli-source-info args --cli-branch $PERFLAB_BRANCH --cli-commit-sha $PERFLAB_HASH --cli-repository https://github.com/$PERFLAB_REPO --cli-source-timestamp $PERFLAB_BUILDTIMESTAMP'
@@ -38,8 +42,12 @@ jobs:
             value: 'chmod +x ./tools/machine-setup.sh;. ./tools/machine-setup.sh'
           - name: Python
             value: python3
-          - name: ArtifactsDirectory
-            value: '$HELIX_WORKITEM_PAYLOAD/artifacts/BenchmarkDotNet.Artifacts'
+          - ${{ if eq(parameters.osVersion, '1804')}}:
+            - name: ArtifactsDirectory
+              value: '$HELIX_WORKITEM_UPLOAD_ROOT/BenchmarkDotNet.Artifacts'
+          - ${{ if eq(parameters.osVersion, '1604')}}:
+            - name: ArtifactsDirectory
+              value: '$HELIX_WORKITEM_PAYLOAD/artifacts/BenchmarkDotNet.Artifacts'
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           - name: BenchViewRunType
             value: private


### PR DESCRIPTION
Move to the new perf queues. The linux queue has 25 machines and the windows queue has 30 machines, with more being added daily.