### PR TITLE
SetupMulticastDelegateCombineInvoke should be a Global, not IterationSetup

### DIFF
--- a/src/benchmarks/micro/coreclr/perflab/DelegatePerf.cs
+++ b/src/benchmarks/micro/coreclr/perflab/DelegatePerf.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
@@ -44,7 +43,7 @@ namespace PerfLabTests
             return ret;
         }
         
-        [IterationSetup(Target = nameof(MulticastDelegateCombineInvoke))]
+        [GlobalSetup(Target = nameof(MulticastDelegateCombineInvoke))]
         public void SetupMulticastDelegateCombineInvoke()
         {
             md1Field = new MultiDelegate(this.Invocable2);


### PR DESCRIPTION
The `MulticastDelegateCombineInvoke` benchmark does not modify any of the fields initialized by `SetupMulticastDelegateCombineInvoke` so the `SetupMulticastDelegateCombineInvoke ` can be a `[GlobalSetup]` instead of `[IterationSetup]`

https://github.com/adamsitnik/performance/blob/c6be4bb11efcaafd75b4afbeb9a6dee23e9939b7/src/benchmarks/micro/coreclr/perflab/DelegatePerf.cs#L46-L92

@billwert a single invocation of `MulticastDelegateCombineInvoke` takes more than 100ms and this change does not affect the reported time. I just want to make sure we don't use `[IterationSetup]` if we don't have to.