### PR TITLE
enforce 30 warmup iterations for Base64EncodeDecodeInPlaceTests to make sure it's promoted to Tier 1

### DIFF
--- a/src/benchmarks/micro/corefx/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/Base64Tests.cs
@@ -87,6 +87,7 @@ namespace System.Buffers.Text.Tests
     // To make the results stable the Iteration needs to last at least 100ms, this is why we are using bigger value for NumberOfBytes
     // Due to limitation of BDN, where Params have no Target and are applied to entire class the benchmarks live in a separate class.
     [BenchmarkCategory(Categories.CoreFX)]
+    [WarmupCount(30)] // make sure it's promoted to Tier 1
     public class Base64EncodeDecodeInPlaceTests
     {
         [Params(1000 * 1000 * 200)] // allows for stable iteraiton around 200ms


### PR DESCRIPTION
@billwert I've continued my `[IterationSetup]` cleanup and figured out that methods from `Base64EncodeDecodeInPlaceTests` are executed only once per iteration and once during warmup and they are never promoted to Tier 1.

If we compare the performance for 2 runtimes, we can see a regression:

```cmd
dotnet run -c Release -f netcoreapp2.2 --filter *Base64DecodeInPlace* --join --runtimes netcoreapp2.2 netcoreapp3.0
```

|              Method |     Toolchain | NumberOfBytes |     Mean |
|-------------------- |-------------- |-------------- |---------:|
| Base64DecodeInPlace | netcoreapp2.2 |     200000000 | 168.5 ms |
| Base64DecodeInPlace | netcoreapp3.0 |     200000000 | 460.9 ms |

With this change:

```log
WorkloadWarmup   1: 1 op, 461986400.00 ns, 461.9864 ms/op
WorkloadWarmup   2: 1 op, 462728200.00 ns, 462.7282 ms/op
WorkloadWarmup   3: 1 op, 456886200.00 ns, 456.8862 ms/op
WorkloadWarmup   4: 1 op, 458170100.00 ns, 458.1701 ms/op
WorkloadWarmup   5: 1 op, 457636700.00 ns, 457.6367 ms/op
WorkloadWarmup   6: 1 op, 461874100.00 ns, 461.8741 ms/op
WorkloadWarmup   7: 1 op, 456898800.00 ns, 456.8988 ms/op
WorkloadWarmup   8: 1 op, 458063200.00 ns, 458.0632 ms/op
WorkloadWarmup   9: 1 op, 457471300.00 ns, 457.4713 ms/op
WorkloadWarmup  10: 1 op, 458767400.00 ns, 458.7674 ms/op
WorkloadWarmup  11: 1 op, 456662900.00 ns, 456.6629 ms/op
WorkloadWarmup  12: 1 op, 459743400.00 ns, 459.7434 ms/op
WorkloadWarmup  13: 1 op, 458085500.00 ns, 458.0855 ms/op
WorkloadWarmup  14: 1 op, 461621200.00 ns, 461.6212 ms/op
WorkloadWarmup  15: 1 op, 457948400.00 ns, 457.9484 ms/op
WorkloadWarmup  16: 1 op, 456323900.00 ns, 456.3239 ms/op
WorkloadWarmup  17: 1 op, 458770200.00 ns, 458.7702 ms/op
WorkloadWarmup  18: 1 op, 457658800.00 ns, 457.6588 ms/op
WorkloadWarmup  19: 1 op, 457155100.00 ns, 457.1551 ms/op
WorkloadWarmup  20: 1 op, 455714900.00 ns, 455.7149 ms/op
WorkloadWarmup  21: 1 op, 457236900.00 ns, 457.2369 ms/op
WorkloadWarmup  22: 1 op, 460007700.00 ns, 460.0077 ms/op
WorkloadWarmup  23: 1 op, 456098400.00 ns, 456.0984 ms/op
WorkloadWarmup  24: 1 op, 457985500.00 ns, 457.9855 ms/op
WorkloadWarmup  25: 1 op, 461993100.00 ns, 461.9931 ms/op
WorkloadWarmup  26: 1 op, 461049300.00 ns, 461.0493 ms/op
WorkloadWarmup  27: 1 op, 454327700.00 ns, 454.3277 ms/op
WorkloadWarmup  28: 1 op, 455722800.00 ns, 455.7228 ms/op
WorkloadWarmup  29: 1 op, 455981500.00 ns, 455.9815 ms/op
WorkloadWarmup  30: 1 op, 162911100.00 ns, 162.9111 ms/op // got promoted to Tier 1
```

|              Method |     Toolchain | NumberOfBytes |     Mean |
|-------------------- |-------------- |-------------- |---------:|
| Base64DecodeInPlace | netcoreapp2.2 |     200000000 | 166.1 ms |
| Base64DecodeInPlace | netcoreapp3.0 |     200000000 | 161.2 ms |
