### PR TITLE
Startup measurement tools

### DIFF
--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -88,5 +88,15 @@ namespace Reporting.Tests
             r.AddTest(t);
             Assert.Throws<Exception>(() => { r.AddTest(t); });
         }
+
+        [Fact]
+        public void AddCountersEnumerable()
+        {
+            Test t = new Test();
+            Counter c1 = new Counter { Name = "Counter1", DefaultCounter = true };
+            Counter c2 = new Counter { Name = "Counter2" };
+            t.AddCounter(new[] { c1, c2 });
+            Assert.Equal(2, t.Counters.Count);
+        }
     }
 }

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,6 +23,12 @@ namespace Reporting
             if (counter.DefaultCounter && Counters.Any(c => c.DefaultCounter))
                 throw new Exception($"Duplicate default counter, name: ${counter.Name}");
             Counters.Add(counter);
+        }
+
+        public void AddCounter(IEnumerable<Counter> counters)
+        {
+            foreach (var counter in counters)
+                AddCounter(counter);
         }
     }
 }

--- a/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
+++ b/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28801.201
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Startup", "Startup\Startup.csproj", "{756B0602-0D94-4EB7-A987-25BF1ED7B712}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Startup", "Startup\Startup.csproj", "{756B0602-0D94-4EB7-A987-25BF1ED7B712}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Util", "Util\Util.csproj", "{6B673656-6DE3-4971-A859-91AFDBFE5424}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Util", "Util\Util.csproj", "{6B673656-6DE3-4971-A859-91AFDBFE5424}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Reporting", "..\Reporting\Reporting\Reporting.csproj", "{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
+++ b/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28801.201
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Startup", "Startup\Startup.csproj", "{756B0602-0D94-4EB7-A987-25BF1ED7B712}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Util", "Util\Util.csproj", "{6B673656-6DE3-4971-A859-91AFDBFE5424}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{756B0602-0D94-4EB7-A987-25BF1ED7B712}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{756B0602-0D94-4EB7-A987-25BF1ED7B712}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{756B0602-0D94-4EB7-A987-25BF1ED7B712}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{756B0602-0D94-4EB7-A987-25BF1ED7B712}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B673656-6DE3-4971-A859-91AFDBFE5424}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7C86D749-5052-44A5-BBEC-DC01C3B6CD92}
+	EndGlobalSection
+EndGlobal

--- a/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Reporting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ScenarioMeasurement
+{
+    // [EventSource(Guid = "9bb228bd-1033-5cf0-1a56-c2dbbe0ebc86")]
+    // class PerfLabGenericEventSource : EventSource
+    // {
+    //     public static PerfLabGenericEventSource Log = new PerfLabGenericEventSource();
+    //     public void Startup() => WriteEvent(1);
+    // }
+
+    internal class GenericStartupParser : IParser
+    {
+        public void EnableKernelProvider(TraceEventSession kernel)
+        {
+            kernel.EnableKernelProvider((KernelTraceEventParser.Keywords)(KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.Thread | KernelTraceEventParser.Keywords.ContextSwitch));
+        }
+
+        public void EnableUserProviders(TraceEventSession user)
+        {
+            user.EnableProvider("PerfLabGenericEventSource");
+        }
+
+        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        {
+            var results = new List<double>();
+            var threadTimes = new List<double>();
+            double threadTime = 0;
+            var ins = new Dictionary<int, double?>();
+            double start = -1;
+            int? pid = null;
+            using (var source = new ETWTraceEventSource(mergeTraceFile))
+            {
+
+                source.Kernel.ProcessStart += evt =>
+                {
+                    if (evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (pid.HasValue)
+                        {
+                            throw new Exception("found a start when we already had a start");
+                        }
+                        pid = evt.ProcessID;
+                        start = evt.TimeStampRelativeMSec;
+                    }
+                };
+
+                source.Kernel.ThreadCSwitch += evt =>
+                {
+                    if (!pid.HasValue) // we're currently in a measurement interval
+                        return;
+
+                    if (evt.NewProcessID != pid && evt.OldProcessID != pid) // but this isn't it
+                        return;
+
+                    if (evt.OldProcessID == pid && ins.ContainsKey(evt.OldThreadID))
+                    {
+                        if (!ins[evt.OldThreadID].HasValue)
+                        {
+                            return;
+                        }
+                        threadTime += evt.TimeStampRelativeMSec - ins[evt.OldThreadID].Value;
+                        ins.Remove(evt.OldThreadID);
+                    }
+                    else
+                    {
+                        ins[evt.NewThreadID] = evt.TimeStampRelativeMSec;
+                    }
+
+                };
+
+                source.Dynamic.AddCallbackForProviderEvent("PerfLabGenericEventSource", "Startup", evt =>
+                {
+                    if (!evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                        return;
+                    if (pid.HasValue)
+                    {
+                        if (pid != evt.ProcessID)
+                        {
+                            throw new Exception("found mismatched end");
+                        }
+                        results.Add(evt.TimeStampRelativeMSec - start);
+                        threadTimes.Add(threadTime);
+                        pid = null;
+                        threadTime = 0;
+                        start = 0;
+                    }
+                });
+
+                source.Process();
+            }
+            return new[] {
+                new Counter() { Name = "Generic Startup", MetricName = "ms", Results = results.ToArray() },
+                new Counter() { Name = "Time on Thread", MetricName = "ms", Results = threadTimes.ToArray() }
+            };
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/IParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/IParser.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using System.Collections.Generic;
+using Reporting;
+
+namespace ScenarioMeasurement
+{
+    internal interface IParser
+    {
+        void EnableUserProviders(TraceEventSession user);
+        void EnableKernelProvider(TraceEventSession kernel);
+        IList<Counter> Parse(string mergeTraceFile, string processName);
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using ScenarioMeasurement;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Reporting;
+
+namespace ScenarioMeasurement
+{
+    internal class ProfileParser : IParser
+    {
+        IParser other;
+        public ProfileParser(IParser other) => this.other = other;
+
+        public void EnableKernelProvider(TraceEventSession kernel)
+        {
+            kernel.StackCompression = true;
+            var keywords = KernelTraceEventParser.Keywords.Default;
+            kernel.EnableKernelProvider(keywords, keywords);
+        }
+
+        public void EnableUserProviders(TraceEventSession user)
+        {
+            // make sure we turn on whatever the user wanted so the start/stops are findable.
+            other.EnableUserProviders(user);
+            user.EnableProvider(ClrTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)ClrTraceEventParser.Keywords.Default);
+            user.EnableProvider(ClrPrivateTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)(ClrPrivateTraceEventParser.Keywords.GC
+                | ClrPrivateTraceEventParser.Keywords.Binding
+                | ClrPrivateTraceEventParser.Keywords.Fusion
+                | ClrPrivateTraceEventParser.Keywords.MulticoreJit
+                | ClrPrivateTraceEventParser.Keywords.Startup
+                | ClrPrivateTraceEventParser.Keywords.Stack));
+
+            // Microsoft-Windows-Kernel-File, for stacks on file creates etc.
+            var stacksEnabled = new TraceEventProviderOptions { StacksEnabled = true };
+            user.EnableProvider(new Guid("EDD08927-9CC4-4E65-B970-C2560FB5C289"), Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, 0x80, stacksEnabled);
+
+            //.NET Tasks
+            var options = new TraceEventProviderOptions { StacksEnabled = true };
+            if(TraceEventProviderOptions.FilteringSupported)
+            {
+                options.EventIDStacksToEnable = new List<int>() { 7, 10, 12 };
+            }
+            user.EnableProvider(TplEtwProviderTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)TplEtwProviderTraceEventParser.Keywords.Default, options);
+
+            // .NETFramework
+            user.EnableProvider(FrameworkEventSourceTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)(
+                                   FrameworkEventSourceTraceEventParser.Keywords.ThreadPool |
+                                   FrameworkEventSourceTraceEventParser.Keywords.ThreadTransfer |
+                                   FrameworkEventSourceTraceEventParser.Keywords.NetClient),
+                                   stacksEnabled);
+
+        }
+
+        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        {
+            throw new NotImplementedException("Parsing is not supported on ProfileParser");
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Reporting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ScenarioMeasurement
+{
+    enum MetricType
+    {
+        TimeToMain,
+        GenericStartup,
+        WPF
+    }
+    class Startup
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="appExe">Full path to test executable</param>
+        /// <param name="metricType">Type of interval measurement</param>
+        /// <param name="scenarioName">Scenario name for reporting</param>
+        /// <param name="processWillExit">true: process exits on its own. False: process does not exit, send close.</param>
+        /// <param name="iterations">Number of measured iterations</param>
+        /// <param name="timeout">Max wait for process to exit</param>
+        /// <param name="measurementDelay">Allowed time for startup window</param>
+        /// <param name="appArgs">optional arguments to test executable</param>
+        /// <param name="logFileName">optional log file. Default is appExe.startup.log</param>
+        /// <param name="workingDir">optional working directory</param>
+        /// <param name="warmup">enables/disables warmup iteration</param>
+        /// <param name="traceFileName">trace file name</param>
+        /// <param name="guiApp">true: app under test is a GUI app, false: console</param>
+        /// <param name="skipProfileIteration">true: skip full results iteration</param>
+        /// <param name="reportJsonPath">path to save report json</param>
+        /// <returns></returns>
+        static int Main(string appExe,
+                        MetricType metricType,
+                        string scenarioName,
+                        string traceFileName,
+                        bool processWillExit = false,
+                        int iterations = 5,
+                        int timeout = 60,
+                        int measurementDelay = 15,
+                        string appArgs = "",
+                        string logFileName = "",
+                        string workingDir = "",
+                        bool warmup = true,
+                        bool guiApp = true,
+                        bool skipProfileIteration = false,
+                        string reportJsonPath = "")
+        {
+            Logger logger = new Logger(String.IsNullOrEmpty(logFileName) ? $"{appExe}.startup.log" : logFileName);
+            static void checkArg(string arg, string name)
+            {
+                if (String.IsNullOrEmpty(arg))
+                    throw new ArgumentException(name);
+            };
+            checkArg(scenarioName, nameof(scenarioName));
+            checkArg(appExe, nameof(appExe));
+            checkArg(traceFileName, nameof(traceFileName));
+
+            bool failed = false;
+            logger.Log($"Running {appExe} (args: \"{appArgs}\")");
+            var procHelper = new ProcessHelper()
+            {
+                ProcessWillExit = processWillExit,
+                Timeout = timeout,
+                MeasurementDelay = measurementDelay,
+                Executable = appExe,
+                Arguments = appArgs,
+                WorkingDirectory = workingDir,
+                GuiApp = guiApp
+            };
+            Util.Init();
+
+            if (warmup)
+            {
+                procHelper.Run();
+            }
+
+            string kernelTraceFile = Path.ChangeExtension(traceFileName, "perflabkernel.etl");
+            string userTraceFile = Path.ChangeExtension(traceFileName, "perflabuser.etl");
+            IParser parser = null;
+            switch (metricType)
+            {
+                case MetricType.TimeToMain:
+                    parser = new TimeToMainParser();
+                    break;
+                case MetricType.GenericStartup:
+                    parser = new GenericStartupParser();
+                    break;
+                    //case MetricType.WPF:
+                    //    parser = new WPFParser();
+                    //    break;
+            }
+            using (var kernel = new TraceEventSession(KernelTraceEventParser.KernelSessionName, kernelTraceFile))
+            {
+                parser.EnableKernelProvider(kernel);
+                using (var user = new TraceEventSession("StartupSession", userTraceFile))
+                {
+                    parser.EnableUserProviders(user);
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        var result = procHelper.Run();
+                        if (result != ProcessHelper.Result.Success)
+                        {
+                            logger.Log($"failed. result: {result}");
+                            failed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!failed)
+            {
+                logger.Log("Parsing..");
+                TraceEventSession.Merge(new[] { kernelTraceFile, userTraceFile }, traceFileName);
+                var counters = parser.Parse(traceFileName, Path.GetFileNameWithoutExtension(appExe));
+                foreach (var counter in counters)
+                {
+                    logger.Log($"{counter.Name,-15}: {counter.Results.Average():F3} {counter.MetricName}");
+                }
+
+                var reporter = Reporter.CreateReporter();
+                if (reporter != null)
+                {
+                    var test = new Test();
+                    test.Categories.Add("Startup");
+                    test.Name = scenarioName;
+                    test.AddCounter(counters);
+                    reporter.AddTest(test);
+                    if (!String.IsNullOrEmpty(reportJsonPath))
+                    {
+                        File.WriteAllText(reportJsonPath, reporter.GetJson());
+                    }
+                }
+             
+            }
+
+            File.Delete(kernelTraceFile);
+            File.Delete(userTraceFile);
+
+            if (!skipProfileIteration)
+            {
+                string profileTraceFileName = $"{Path.GetFileNameWithoutExtension(traceFileName)}_profile.etl";
+                string profileKernelTraceFile = Path.ChangeExtension(profileTraceFileName, ".kernel.etl");
+                string profileUserTraceFile = Path.ChangeExtension(profileTraceFileName, ".user.etl");
+                ProfileParser profiler = new ProfileParser(parser);
+                using (var kernel = new TraceEventSession(KernelTraceEventParser.KernelSessionName, profileKernelTraceFile))
+                {
+                    profiler.EnableKernelProvider(kernel);
+                    using (var user = new TraceEventSession("ProfileSession", profileUserTraceFile))
+                    {
+                        profiler.EnableUserProviders(user);
+                        var result = procHelper.Run();
+                        if (result != ProcessHelper.Result.Success)
+                        {
+                            logger.Log($"failed. result: {result}");
+                            failed = true;
+                        }
+                    }
+                }
+                if (!failed)
+                {
+                    logger.Log("Merging profile..");
+                    TraceEventSession.Merge(new[] { profileKernelTraceFile, profileUserTraceFile }, profileTraceFileName);
+                }
+                File.Delete(profileKernelTraceFile);
+                File.Delete(profileUserTraceFile);
+            }
+
+            return (failed ? -1 : 0);
+
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>Preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.41" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19213.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Util\Util.csproj" />
+    <ProjectReference Include="..\..\Reporting\Reporting\Reporting.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.41" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.44" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19213.1" />
   </ItemGroup>
 

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Reporting;
+using System;
+using System.Collections.Generic;
+
+namespace ScenarioMeasurement
+{
+    internal class TimeToMainParser : IParser
+    {
+        public void EnableKernelProvider(TraceEventSession kernel)
+        {
+            kernel.EnableKernelProvider((KernelTraceEventParser.Keywords)(KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.Thread | KernelTraceEventParser.Keywords.ContextSwitch));
+        }
+
+        public void EnableUserProviders(TraceEventSession user)
+        {
+            user.EnableProvider(ClrPrivateTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)ClrPrivateTraceEventParser.Keywords.Startup);
+        }
+
+        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        {
+            var results = new List<double>();
+            double threadTime = 0;
+            var threadTimes = new List<double>();
+            var ins = new Dictionary<int, double?>();
+            double start = -1;
+            int? pid = null;
+            using (var source = new ETWTraceEventSource(mergeTraceFile))
+            {
+                
+                source.Kernel.ProcessStart += evt =>
+                {
+                    if(evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if(pid.HasValue)
+                        {
+                            throw new Exception("found a start when we already had a start");
+                        }
+                        pid = evt.ProcessID;
+                        start = evt.TimeStampRelativeMSec;
+                    }
+                };
+
+                source.Kernel.ThreadCSwitch += evt =>
+                {
+                    if (!pid.HasValue) // we're currently in a measurement interval
+                        return;
+
+                    if (evt.NewProcessID != pid && evt.OldProcessID != pid) // but this isn't it
+                        return;
+
+                    if (evt.OldProcessID == pid && ins.ContainsKey(evt.OldProcessID))
+                    {
+                        if (!ins[evt.OldThreadID].HasValue)
+                        {
+                            return;
+                        }
+                        threadTime += evt.TimeStampRelativeMSec - ins[evt.OldThreadID].Value;
+                        ins.Remove(evt.OldThreadID);
+                    }
+                    else
+                    {
+                        ins[evt.NewThreadID] = evt.TimeStampRelativeMSec;
+                    }
+
+                };
+
+                ClrPrivateTraceEventParser clrpriv = new ClrPrivateTraceEventParser(source);
+                clrpriv.StartupMainStart += evt =>
+                {
+                    if(pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        results.Add(evt.TimeStampRelativeMSec - start);
+                        pid = null;
+                        threadTimes.Add(threadTime);
+                        threadTime = 0;
+                        start = 0;
+                    }
+                };
+                source.Process();
+            }
+            return new[] { new Counter() { Name = "Time To Main", Results = results.ToArray(), TopCounter = true, DefaultCounter = true, HigherIsBetter = false, MetricName = "ms"},
+                           new Counter() { Name = "Time on Thread", Results = threadTimes.ToArray(), TopCounter = true, DefaultCounter = false, HigherIsBetter = false, MetricName = "ms" }
+            };
+
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using Reporting;
+using System.Collections.Generic;
+
+namespace ScenarioMeasurement
+{
+    internal class WPFParser : IParser
+    {
+        public void EnableKernelProvider(TraceEventSession kernel)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void EnableUserProviders(TraceEventSession user)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Util/Logger.cs
+++ b/src/tools/ScenarioMeasurement/Util/Logger.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ScenarioMeasurement
+{
+    public class Logger
+    {
+        public Logger(string fileName)
+        {
+
+        }
+        public void Log(string message)
+        {
+            Console.WriteLine(message);
+        }
+
+        public void LogVerbose(string message)
+        {
+            Console.WriteLine("message");
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Util/Logger.cs
+++ b/src/tools/ScenarioMeasurement/Util/Logger.cs
@@ -17,7 +17,7 @@ namespace ScenarioMeasurement
 
         public void LogVerbose(string message)
         {
-            Console.WriteLine("message");
+            Console.WriteLine(message);
         }
     }
 }

--- a/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
+++ b/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace ScenarioMeasurement
+{
+    public class ProcessHelper
+    {
+        /// <summary>
+        /// Specifies whether the app exits on its own
+        /// true: App will exit, Timeout specifies how long to wait before terminating the process.
+        /// false: App will be closed after MeasurementDelay.
+        /// </summary>
+        public bool ProcessWillExit { get; set; } = false;
+        /// <summary>
+        /// Max time to wait for app to close (seconds)
+        /// </summary>
+        public int Timeout { get; set; } = 60;
+        /// <summary>
+        /// Time to wait before closing app (seconds)
+        /// </summary>
+        public int MeasurementDelay { get; set; } = 15;
+
+        public string Executable { get; set; }
+
+        public string Arguments { get; set; } = String.Empty;
+        public string WorkingDirectory { get; set; } = String.Empty;
+
+        public bool GuiApp { get; set; } = false;
+
+        /// <summary>
+        /// Runs the specified process and waits for it to exit.
+        /// </summary>
+        /// <param name="appExe">Full path to executable</param>
+        /// <param name="appArgs">Optional arguments</param>
+        /// <param name="workingDirectory">Optional working directory (defaults to current directory)</param>
+        /// <returns></returns>
+        public Result Run()
+        {
+            var psi = new ProcessStartInfo();
+            psi.FileName = Executable;
+            psi.Arguments = Arguments;
+            psi.WorkingDirectory = WorkingDirectory;
+            psi.UseShellExecute = GuiApp;
+            if (!GuiApp)
+            {
+                psi.RedirectStandardOutput = true;
+                psi.RedirectStandardError = true;
+            }
+            else
+            {
+                psi.WindowStyle = ProcessWindowStyle.Maximized;
+            }
+            StringBuilder output = new StringBuilder();
+            StringBuilder error = new StringBuilder();
+            using (var process = new Process())
+            {
+                process.StartInfo = psi;
+                if (!GuiApp)
+                {
+                    process.OutputDataReceived += (s, e) =>
+                    {
+                        output.AppendLine(e.Data);
+                    };
+                    process.ErrorDataReceived += (s, e) =>
+                    {
+                        error.AppendLine(e.Data);
+                    };
+                }
+                process.Start();
+                if (!GuiApp)
+                {
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+                }
+
+                if (ProcessWillExit)
+                {
+                    bool exited = process.WaitForExit(Timeout * 1000);
+                    if (!exited)
+                    {
+                        process.Kill();
+                        return Result.TimeoutExceeded;
+                    }
+                }
+                else
+                {
+                    Thread.Sleep(MeasurementDelay * 1000);
+                    if (!process.HasExited) { process.CloseMainWindow(); }
+                    else
+                    {
+                        return Result.ExitedEarly;
+                    }
+                    bool exited = process.WaitForExit(5000);
+                    if (!exited)
+                    {
+                        process.Kill();
+                        return Result.CloseFailed;
+                    }
+                }
+                using (var sw = new StreamWriter($"testlog_{Path.GetFileName(Executable)}_{process.Id}.log"))
+                {
+                    sw.WriteLine("Standard output:");
+                    sw.WriteLine(output.ToString());
+                    sw.WriteLine("Standard error:");
+                    sw.WriteLine(error.ToString());
+                }
+                return Result.Success;
+            }
+        }
+        public enum Result
+        {
+            Success,
+            TimeoutExceeded,
+            ExitedEarly,
+            CloseFailed
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/Util/Util.cs
+++ b/src/tools/ScenarioMeasurement/Util/Util.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ScenarioMeasurement
+{
+
+    public class Util
+    {
+        [DllImport("User32.Dll")]
+        private static extern long SetCursorPos(int x, int y);
+        
+        
+        public static void Init()
+        {
+            SetCursorPos(0, 0);
+        }
+
+        public static void TakeScreenshot()
+        {
+
+        }
+        
+    }
+}

--- a/src/tools/ScenarioMeasurement/Util/Util.csproj
+++ b/src/tools/ScenarioMeasurement/Util/Util.csproj
@@ -4,9 +4,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>ScenarioMeasurement</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.41" />
-  </ItemGroup>
-
 </Project>

--- a/src/tools/ScenarioMeasurement/Util/Util.csproj
+++ b/src/tools/ScenarioMeasurement/Util/Util.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>ScenarioMeasurement</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.41" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This tool is the mechanical part of enabling startup time testing.

There are a handful of things it still needs. I'm checking this MVP in
to unblock teammates.

I'll open an issue to track these known issues:
1) needs to choose TFM dynamically (similar to microbenchmarks) to enable tests on 2.2
2) WPF parser isn't done
3) Refactoring opportunities between the parsers.