### PR TITLE
Add System.IO.Pipelines benchmarks from AspNetCore repo, fixes #317

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="MessagePack" Version="1.7.3.7" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="MessagePack" Version="1.7.3.7" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />

--- a/src/benchmarks/micro/corefx/System.IO.Pipelines/PipeThroughputBenchmark.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Pipelines/PipeThroughputBenchmark.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Performance
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class PipeThroughputBenchmark
+    {
+        private const int InnerLoopCount = 512;
+
+        private PipeReader _reader;
+        private PipeWriter _writer;
+        private MemoryPool<byte> _memoryPool;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _memoryPool = KestrelMemoryPool.Create();
+
+            var chunkLength = Length / Chunks;
+            if (chunkLength > _memoryPool.MaxBufferSize)
+            {
+                // Parallel test will deadlock if too large (waiting for second Task to complete), so N/A that run
+                throw new InvalidOperationException();
+            }
+
+            if (Length != chunkLength * Chunks)
+            {
+                // Test will deadlock waiting for data so N/A that run
+                throw new InvalidOperationException();
+            }
+
+            var pipe = new Pipe(new PipeOptions(_memoryPool));
+            _reader = pipe.Reader;
+            _writer = pipe.Writer;
+        }
+
+        [GlobalCleanup]
+        public void Cleanup() => _memoryPool.Dispose();
+
+        [Params(128, 4096)]
+        public int Length { get; set; }
+
+        [Params(1, 16)]
+        public int Chunks { get; set; }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public Task Parse_ParallelAsync()
+        {
+            var writing = Task.Run(ParallelWriter);
+            var reading = Task.Run(ParallelReader);
+
+            return Task.WhenAll(writing, reading);
+        }
+
+        async Task ParallelWriter()
+        {
+            var chunks = Chunks;
+            var chunkLength = Length / chunks;
+
+            for (int i = 0; i<InnerLoopCount; i++)
+            {
+                for (var c = 0; c<chunks; c++)
+                {
+                    _writer.GetMemory(chunkLength);
+                    _writer.Advance(chunkLength);
+                }
+
+                await _writer.FlushAsync();
+            }
+        }
+
+        async Task ParallelReader()
+        {
+            long remaining = Length * InnerLoopCount;
+            while (remaining != 0)
+            {
+                var result = await _reader.ReadAsync();
+                remaining -= result.Buffer.Length;
+                _reader.AdvanceTo(result.Buffer.End, result.Buffer.End);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public async Task Parse_SequentialAsync()
+        {
+            var chunks = Chunks;
+            var chunkLength = Length / chunks;
+
+            for (int i = 0; i < InnerLoopCount; i++)
+            {
+                for (var c = 0; c < chunks; c++)
+                {
+                    _writer.GetMemory(chunkLength);
+                    _writer.Advance(chunkLength);
+                }
+
+                await _writer.FlushAsync();
+
+                var result = await _reader.ReadAsync();
+                _reader.AdvanceTo(result.Buffer.End, result.Buffer.End);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am doing 2.2  vs 3.0 and I need to make sure that we did not regress the Pipelines

The code is from https://github.com/aspnet/AspNetCore/pull/4535