### PR TITLE
filter the compared benchmark results by name using glob pattern(s)

### DIFF
--- a/src/tools/ResultsComparer/CommandLineOptions.cs
+++ b/src/tools/ResultsComparer/CommandLineOptions.cs
@@ -29,6 +29,9 @@ namespace ResultsComparer
         [Option("csv", HelpText = "Path to exported CSV results. Optional.")]
         public FileInfo CsvPath { get; set; }
 
+        [Option('f', "filter", HelpText = "Filter the benchmarks by name using glob pattern(s). Optional.")]
+        public IEnumerable<string> Filters { get; set; }
+
         [Usage(ApplicationAlias = "")]
         public static IEnumerable<Example> Examples
         {
@@ -40,6 +43,8 @@ namespace ResultsComparer
                     new CommandLineOptions { BasePath = @"C:\results\win", DiffPath = @"C:\results\unix", StatisticalTestThreshold = "5%", TopCount = 10 });
                 yield return new Example(@"Compare the results stored in 'C:\results\win' (base) vs 'C:\results\unix' (diff) using 5% threshold and 0.5ns noise filter.",
                     new CommandLineOptions { BasePath = @"C:\results\win", DiffPath = @"C:\results\unix", StatisticalTestThreshold = "5%", NoiseThreshold = "0.5ns" });
+                yield return new Example(@"Compare the System.Math benchmark results stored in 'C:\results\ubuntu16' (base) vs 'C:\results\ubuntu18' (diff) using 5% threshold.",
+                    new CommandLineOptions { Filters = new[] { "System.Math*" }, BasePath = @"C:\results\win", DiffPath = @"C:\results\unix", StatisticalTestThreshold = "5%" });
             }
         }
     }

--- a/src/tools/ResultsComparer/README.md
+++ b/src/tools/ResultsComparer/README.md
@@ -17,6 +17,7 @@ Optional arguments:
 * `--top` - filter the diff to top/bottom `N` results
 * `--noise` - noise threshold for Statistical Test. The difference for 1.0ns and 1.1ns is 10%, but it's just a noise. Examples: 0.5ns 1ns. The default value is 0.3ns.
 * `--csv` - path to exported CSV results. Optional.
+* `-f|--filter` - filter the benchmarks by name using glob pattern(s). Optional.
 
 Sample: compare the results stored in `C:\results\windows` vs `C:\results\ubuntu` using `1%` threshold and print only TOP 10.
 


### PR DESCRIPTION
@tannergooding I've run Ubuntu 16.04 vs 18.04 and used ResultsComparer to create the diff. The problem was that I could not easily filter the results to a selected namespace (`System.Math`). So I added `--filter` feature. It works the same as in BenchmarkDotNet so the users should be familiar with it.

```cmd
dotnet run --filter "System.Math*" --base "C:\results\lin_vs_win\new\vm_x64_ubuntu1604_netcoreapp30" --diff "C:\results\lin_vs_win\new\vm_x64_ubuntu1804_netcoreapp30" --threshold 5% 
```

| Faster                                      | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.MathBenchmarks.Single.Pow            |      4.21 |        370319.48 |         88028.83 |         |
| System.MathBenchmarks.Single.Log2           |      1.99 |         74172.81 |         37230.37 |         |
| System.MathBenchmarks.Single.Log            |      1.49 |         59161.99 |         39822.10 |         |
| System.MathBenchmarks.Single.Log10          |      1.46 |         88414.68 |         60756.87 |         |
| System.MathBenchmarks.Double.Cos            |      1.32 |        130478.89 |         99152.96 |         |
| System.MathBenchmarks.Single.Acosh          |      1.26 |        108585.75 |         86176.90 |         |
| System.MathBenchmarks.Single.Exp            |      1.23 |         56127.81 |         45725.58 |         |
| System.MathBenchmarks.Double.Atan2          |      1.21 |        163998.90 |        135590.54 |         |
| System.MathBenchmarks.Single.Cosh           |      1.13 |         75209.36 |         66663.49 |         |
| System.MathBenchmarks.Single.ScaleB         |      1.13 |         46640.16 |         41368.90 |         |
| System.MathBenchmarks.Double.Atan           |      1.10 |        112084.79 |        101927.86 |         |
| System.MathBenchmarks.MathTests.DivRemInt64 |      1.09 |            11.15 |            10.25 |         |
| System.MathBenchmarks.Double.Log            |      1.07 |        121338.60 |        113703.15 |         |
| System.MathBenchmarks.Double.Acos           |      1.07 |         80770.91 |         75768.25 |         |


I've used two AzureVM (D4s_v3), same .NET Core (3.0.100-preview8-013334) with same hardware: Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 4 logical and 2 physical cores
