### PR TITLE
Serializers: Update packages versions in README

### DIFF
--- a/src/benchmarks/micro/Serializers/README.md
+++ b/src/benchmarks/micro/Serializers/README.md
@@ -20,11 +20,11 @@ Missing: ProtoBuff from Google and BOND from MS
 
 ## Data Contracts
 
-Data Contracts were copied from a real Web App � [allReady](https://github.com/HTBox/allReady/) to mimic real world scenarios.
+Data Contracts were copied from a real Web App - [allReady](https://github.com/HTBox/allReady/) to mimic real world scenarios.
 
-* [LoginViewModel](DataGenerator.cs#L120) � class, 3 properties
-* [Location](DataGenerator.cs#L133) � class, 9 properties
-* [IndexViewModel](DataGenerator.cs#L202) � class, nested class + list of 20 Events (8 properties each)
+* [LoginViewModel](DataGenerator.cs#L120) - class, 3 properties
+* [Location](DataGenerator.cs#L133) - class, 9 properties
+* [IndexViewModel](DataGenerator.cs#L202) - class, nested class + list of 20 Events (8 properties each)
 * [MyEventsListerViewModel](DataGenerator.cs#L224) - class, 3 lists of complex types, each type contains another list of complex types
 
 ## Design Decisions

--- a/src/benchmarks/micro/Serializers/README.md
+++ b/src/benchmarks/micro/Serializers/README.md
@@ -8,23 +8,23 @@ This folder contains benchmarks of the most popular serializers.
   * [XmlSerializer](https://docs.microsoft.com/en-us/dotnet/api/system.xml.serialization.xmlserializer) `4.3.0`
 * JSON
     * [DataContractJsonSerializer](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.json.datacontractjsonserializer) `4.3.0`
-    * [Jil](https://github.com/kevin-montrose/Jil) `2.15.4` 
-    * [JSON.NET](https://github.com/JamesNK/Newtonsoft.Json) `11.0.1` 
+    * [Jil](https://github.com/kevin-montrose/Jil) `2.17.0` 
+    * [JSON.NET](https://github.com/JamesNK/Newtonsoft.Json) `12.0.2` 
     * [Utf8Json](https://github.com/neuecc/Utf8Json) `1.3.7` 
 * Binary
     * [BinaryFormatter](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter) `4.3.0`
-    * [MessagePack](https://github.com/neuecc/MessagePack-CSharp) `1.7.3.4` 
-    * [protobuff-net](https://github.com/mgravell/protobuf-net) `2.3.7`
+    * [MessagePack](https://github.com/neuecc/MessagePack-CSharp) `1.7.3.7` 
+    * [protobuff-net](https://github.com/mgravell/protobuf-net) `2.4.0`
 
 Missing: ProtoBuff from Google and BOND from MS
 
 ## Data Contracts
 
-Data Contracts were copied from a real Web App – [allReady](https://github.com/HTBox/allReady/) to mimic real world scenarios.
+Data Contracts were copied from a real Web App ï¿½ [allReady](https://github.com/HTBox/allReady/) to mimic real world scenarios.
 
-* [LoginViewModel](DataGenerator.cs#L120) – class, 3 properties
-* [Location](DataGenerator.cs#L133) – class, 9 properties
-* [IndexViewModel](DataGenerator.cs#L202) – class, nested class + list of 20 Events (8 properties each)
+* [LoginViewModel](DataGenerator.cs#L120) ï¿½ class, 3 properties
+* [Location](DataGenerator.cs#L133) ï¿½ class, 9 properties
+* [IndexViewModel](DataGenerator.cs#L202) ï¿½ class, nested class + list of 20 Events (8 properties each)
 * [MyEventsListerViewModel](DataGenerator.cs#L224) - class, 3 lists of complex types, each type contains another list of complex types
 
 ## Design Decisions


### PR DESCRIPTION
The versions are up to date in the .csproj, just not the README. We're evaluating Jil vs. System.Text.Json and came across the discrepancy.

There was also some funky unicode dash usage on _some_ of the lines. This is normalized.