### PR TITLE
Serializers: Add System.Text.Json benchmarks for comparison.

### DIFF
--- a/src/benchmarks/micro/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.cs
@@ -108,6 +108,27 @@ namespace MicroBenchmarks.Serializers
             return (T)dataContractJsonSerializer.ReadObject(memoryStream);
         }
 
+#if NETCOREAPP3_0 // API Available in .NET Core 3.0+
+        [GlobalSetup(Target = nameof(SystemTextJson_))]
+        public void SetupSystemTextJson_()
+        {
+            memoryStream.Position = 0;
+
+            using (var writer = new System.Text.Json.Utf8JsonWriter(memoryStream))
+            {
+                System.Text.Json.JsonSerializer.Serialize<T>(writer, value);
+            }
+        }
+
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark(Description = "System.Text.Json")]
+        public System.Threading.Tasks.ValueTask<T> SystemTextJson_()
+        {
+            memoryStream.Position = 0;
+            return System.Text.Json.JsonSerializer.DeserializeAsync<T>(memoryStream);
+        }
+#endif
+
         private StreamReader CreateNonClosingReaderWithDefaultSizes()
             => new StreamReader(
                 memoryStream, 

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -38,5 +38,14 @@ namespace MicroBenchmarks.Serializers
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public T Utf8Json_() => Utf8Json.JsonSerializer.Deserialize<T>(serialized);
+
+#if NETCOREAPP3_0 // API Available in .NET Core 3.0+
+        [GlobalSetup(Target = nameof(SystemTextJson_))]
+        public void SerializeSystemTextJson() => serialized = System.Text.Json.JsonSerializer.Serialize<T>(value);
+
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark(Description = "System.Text.Json")]
+        public T SystemTextJson_() => System.Text.Json.JsonSerializer.Deserialize<T>(serialized);
+#endif
     }
 }

--- a/src/benchmarks/micro/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.cs
@@ -68,6 +68,16 @@ namespace MicroBenchmarks.Serializers
             dataContractJsonSerializer.WriteObject(memoryStream, value);
         }
 
+#if NETCOREAPP3_0 // API Available in .NET Core 3.0+
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark(Description = "System.Text.Json")]
+        public System.Threading.Tasks.Task SystemTextJson_()
+        {
+            memoryStream.Position = 0;
+            return System.Text.Json.JsonSerializer.SerializeAsync<T>(memoryStream, value);
+        }
+#endif
+
         [GlobalCleanup]
         public void Cleanup()
         {

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -31,5 +31,11 @@ namespace MicroBenchmarks.Serializers
 
         // DataContractJsonSerializer does not provide an API to serialize to string
         // so it's not included here (apples vs apples thing)
+
+#if NETCOREAPP3_0 // API Available in .NET Core 3.0+
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark(Description = "System.Text.Json")]
+        public string SystemTextJson_() => System.Text.Json.JsonSerializer.Serialize<T>(value);
+#endif
     }
 }


### PR DESCRIPTION
This is an attempt to add System.Text.Json's JSON serialization to the comparison microbenchmarks.  We're trying to get an apples to apples comparison of serializers we can use in .NET Core for ASP.NET Core and async streams. We figured adding them here for everyone is the best course of action.

Note: this test series fails with one of the generic type payloads. There is an exception in the serialization of `Dictionary<int, string>` isn't a valid thing for `System.Text.Json` to handle as of 3.0 preview 7. The rest seems to work well and...I hope I added these correctly

Here's an error trace from the failing tests on System.Text.Json with the `CollectionsOfPrimitives` type specifically:
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NotSupportedException: The collection type 'System.Collections.Generic.Dictionary`2[System.Int32,System.String]' on 'MicroBenchmarks.Serializers.CollectionsOfPrimitives.Dictionary' is not supported.
   at System.Text.Json.JsonClassInfo.GetElementType(Type propertyType, Type parentType, MemberInfo memberInfo, JsonSerializerOptions options)
   at System.Text.Json.JsonClassInfo.CreateProperty(Type declaredPropertyType, Type runtimePropertyType, PropertyInfo propertyInfo, Type parentClassType, JsonSerializerOptions options)
   at System.Text.Json.JsonClassInfo.AddProperty(Type propertyType, PropertyInfo propertyInfo, Type classType, JsonSerializerOptions options)
   at System.Text.Json.JsonClassInfo..ctor(Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializerOptions.GetOrAddClass(Type classType)
   at System.Text.Json.WriteStackFrame.Initialize(Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCore(Utf8JsonWriter writer, PooledByteBufferWriter output, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCore(PooledByteBufferWriter output, Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteCoreString(Object value, Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Serialize[TValue](TValue value, JsonSerializerOptions options)
   at MicroBenchmarks.Serializers.Json_ToString`1.SystemTextJson_() in C:\git\NickCraver\performance\src\benchmarks\micro\Serializers\Json_ToString.cs:line 38
   at BenchmarkDotNet.Autogenerated.Runnable_89.WorkloadActionNoUnroll(Int64 invokeCount) in C:\git\NickCraver\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\4645516e-6e5e-4e7e-8b18-05ede5ec7e66\4645516e-6e5e-4e7e-8b18-05ede5ec7e66.notcs:line 58161
   at BenchmarkDotNet.Engines.Engine.RunIteration(IterationData data)
   at BenchmarkDotNet.Engines.EngineFactory.Jit(Engine engine, Int32 jitIndex, Int32 invokeCount, Int32 unrollFactor)
   at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
   at BenchmarkDotNet.Autogenerated.Runnable_89.Run(IHost host, String benchmarkName) in C:\git\NickCraver\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\4645516e-6e5e-4e7e-8b18-05ede5ec7e66\4645516e-6e5e-4e7e-8b18-05ede5ec7e66.notcs:line 57838
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args) in C:\git\NickCraver\performance\artifacts\bin\MicroBenchmarks\Release\netcoreapp3.0\4645516e-6e5e-4e7e-8b18-05ede5ec7e66\4645516e-6e5e-4e7e-8b18-05ede5ec7e66.notcs:line 137
// AfterAll
```

Open questions:
- Is the usage right, or can it be more efficient?
- Is the `#if NETCOREAPP3_0` correct? (I used `Perf.Enumerable.cs` as a reference for closest-to-this)
- What do we want to do for the breaking `Dictionary<int, string>` runs?

cc @deanward81 @mgravell @benaadams @stevejgordon