### PR TITLE
Add iteration set up to Startup Tool

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
@@ -27,7 +27,7 @@ namespace ScenarioMeasurement
             user.EnableProvider("PerfLabGenericEventSource");
         }
 
-        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids)
         {
             var results = new List<double>();
             var threadTimes = new List<double>();
@@ -40,7 +40,7 @@ namespace ScenarioMeasurement
 
                 source.Kernel.ProcessStart += evt =>
                 {
-                    if (evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    if (evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase) && pids.Contains(evt.ProcessID))
                     {
                         if (pid.HasValue)
                         {

--- a/src/tools/ScenarioMeasurement/Startup/IParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/IParser.cs
@@ -8,6 +8,6 @@ namespace ScenarioMeasurement
     {
         void EnableUserProviders(TraceEventSession user);
         void EnableKernelProvider(TraceEventSession kernel);
-        IList<Counter> Parse(string mergeTraceFile, string processName);
+        IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids);
     }
 }

--- a/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
@@ -53,7 +53,7 @@ namespace ScenarioMeasurement
 
         }
 
-        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids)
         {
             throw new NotImplementedException("Parsing is not supported on ProfileParser");
         }

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -19,7 +19,7 @@ namespace ScenarioMeasurement
             user.EnableProvider(ClrPrivateTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)ClrPrivateTraceEventParser.Keywords.Startup);
         }
 
-        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids)
         {
             var results = new List<double>();
             double threadTime = 0;
@@ -32,7 +32,7 @@ namespace ScenarioMeasurement
                 
                 source.Kernel.ProcessStart += evt =>
                 {
-                    if(evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    if(evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase) && pids.Contains(evt.ProcessID))
                     {
                         if(pid.HasValue)
                         {

--- a/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
@@ -16,7 +16,7 @@ namespace ScenarioMeasurement
             throw new System.NotImplementedException();
         }
 
-        public IList<Counter> Parse(string mergeTraceFile, string processName)
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids)
         {
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
- Startup.cs: Added iteration set up option before each iteration 
- ProcessTimeParser.cs: 
1) Changed it to matching event's commandLine instead, which is more accurate when events associated with setup/cleanup share the same process name with those of the actual test (ex: dotnet.exe)
2) Todo: This means we need to change the same thing for other metric types as well
- Util\ProcessHelper.cs: handle the case when the exit code is not 0 and give a ExitedWithError, instead of Success
- Todo: 
1) add iteration clean up
2) fix test log issue

