### PR TITLE
Fix Brotli benchmark bugs

### DIFF
--- a/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
@@ -20,8 +20,8 @@ namespace System.IO.Compression
         {
             using (BrotliEncoder encoder = new BrotliEncoder(GetQuality(level), Window))
             {
-                Span<byte> output = new Span<byte>(CompressedFile.UncompressedData);
-                ReadOnlySpan<byte> input = CompressedFile.CompressedData;
+                Span<byte> output = new Span<byte>(CompressedFile.CompressedData);
+                ReadOnlySpan<byte> input = CompressedFile.UncompressedData;
                 while (!input.IsEmpty && !output.IsEmpty)
                 {
                     encoder.Compress(input, output, out int bytesConsumed, out int written, isFinalBlock:false);

--- a/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
+++ b/src/benchmarks/micro/corefx/System.IO.Compression/Brotli.cs
@@ -54,7 +54,7 @@ namespace System.IO.Compression
 
         [Benchmark]
         public bool Compress_WithoutState()
-            => BrotliEncoder.TryCompress(CompressedFile.UncompressedData, CompressedFile.UncompressedData, out int bytesWritten, GetQuality(level), Window);
+            => BrotliEncoder.TryCompress(CompressedFile.UncompressedData, CompressedFile.CompressedData, out int bytesWritten, GetQuality(level), Window);
 
         /// <summary>
         /// The perf tests for the instant decompression aren't exactly indicative of real-world scenarios since they require you to know 


### PR DESCRIPTION
Fixes #705 for more details see https://github.com/dotnet/performance/issues/705#issuecomment-515180955

BTW @ericstj I found that the Brotli benchmark had another bug (please see my changes). 

I've also checked that I am the person who introduced these bugs while porting in #105. The original benchmark was fine: https://github.com/dotnet/corefx/blob/4806397c9e0d553511094345a3e4face1dca13a5/src/System.IO.Compression.Brotli/tests/Performance/BrotliPerfTests.cs I apology for that.