### PR TITLE
CryptoConfig.CreateFromName benchmarks

### DIFF
--- a/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.CryptoConfig.cs
+++ b/src/benchmarks/micro/corefx/System.Security.Cryptography/Perf.CryptoConfig.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Security.Cryptography.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_CryptoConfig
+    {
+        [Benchmark]
+        [Arguments("SHA512")]
+        [Arguments("RSA")]
+        [Arguments("X509Chain")]
+        public object CreateFromName(string name) => CryptoConfig.CreateFromName(name);
+    }
+}


### PR DESCRIPTION
I was looking at https://github.com/dotnet/corefx/pull/39600 and realized that we don't have any benchmarks for `CryptoConfig.CreateFromName`

Sample results:

|         Method |      name |     Mean | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------- |---------:|------------:|------------:|------------:|--------------------:|
| CreateFromName |       RSA | 3.457 us |      0.0791 |           - |           - |               688 B |
| CreateFromName |    SHA512 | 1.284 us |      0.0539 |      0.0135 |      0.0045 |               424 B |
| CreateFromName | X509Chain | 3.256 us |      0.0534 |           - |           - |               464 B |