### PR TITLE
Add benchmarks for special cased LINQ methods

### DIFF
--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
@@ -69,10 +69,13 @@ namespace System.Linq.Tests
 
         public IEnumerable<object> FirstPredicateArguments()
         {
-            // First(predicate) has 2 code paths: OrderedEnumerable and IEnumerable
+            // First(predicate) has 4 code paths: OrderedEnumerable, Array, List, and IEnumerable
+            // TODO: Update link to GitHub.
             // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/First.cs
 
             yield return LinqTestData.IOrderedEnumerable;
+            yield return LinqTestData.Array;
+            yield return LinqTestData.List;
             yield return LinqTestData.IEnumerable;
         }
 
@@ -105,10 +108,12 @@ namespace System.Linq.Tests
         [ArgumentsSource(nameof(WhereArguments))]
         public bool WhereAny_LastElementMatches(LinqTestData input) => input.Collection.Where(i => i >= LinqTestData.Size - 1).Any();
 
-        // Any() has no special treatment and it has a single execution path
-        // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/AnyAll.cs
+
+        // Any uses TryGetFirst internally.
+        // TODO: Link to GitHub ?
+        // TODO: Maybe remove this with a comment why Any() is not benchmarked? Same as FirstOrDefault / LastOrDefault.
         [Benchmark]
-        [ArgumentsSource(nameof(IEnumerableArgument))]
+        [ArgumentsSource(nameof(FirstPredicateArguments))]
         public bool AnyWithPredicate_LastElementMatches(LinqTestData input) => input.Collection.Any(i => i >= LinqTestData.Size - 1);
 
         // All() has no special treatment and it has a single execution path
@@ -129,23 +134,30 @@ namespace System.Linq.Tests
         [ArgumentsSource(nameof(WhereArguments))]
         public int WhereSingleOrDefault_LastElementMatches(LinqTestData input) => input.Collection.Where(i => i >= LinqTestData.Size - 1).SingleOrDefault();
 
+        public IEnumerable<object> SinglePredicateArguments()
+        {
+            // Single(predicate) has 3 code paths: Array, List, and IEnumerable
+            // TODO: Link to GitHub?
+
+            yield return LinqTestData.Array;
+            yield return LinqTestData.List;
+            yield return LinqTestData.IEnumerable;
+        }
+
         // Single() has no special treatment and it has a single execution path
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Single.cs
         [Benchmark]
-        [ArgumentsSource(nameof(IEnumerableArgument))]
+        [ArgumentsSource(nameof(SinglePredicateArguments))]
         public int SingleWithPredicate_LastElementMatches(LinqTestData input) => input.Collection.Single(i => i >= LinqTestData.Size - 1);
 
         // Single() has no special treatment and it has a single execution path
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Single.cs
         [Benchmark]
-        [ArgumentsSource(nameof(IEnumerableArgument))]
-        public int SingleOrDefaultWithPredicate_LastElementMatches(LinqTestData input) => input.Collection.SingleOrDefault(i => i >= LinqTestData.Size - 1);
+        [ArgumentsSource(nameof(SinglePredicateArguments))]
+        public int SingleWithPredicate_FirstElementMatches(LinqTestData input) => input.Collection.Single(i => i <= 0);
 
-        // Single() has no special treatment and it has a single execution path
-        // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Single.cs
-        [Benchmark]
-        [ArgumentsSource(nameof(IEnumerableArgument))]
-        public int SingleOrDefaultWithPredicate_FirstElementMatches(LinqTestData input) => input.Collection.SingleOrDefault(i => i <= 0);
+        // SingleOrDefault() runs the same code as Single, except that it does not throw. Benchmarking it does not add any value so it go removed.
+        // TODO: Link to GitHub?
 
         // Cast has no special treatment and it has a single execution path
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Cast.cs

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
@@ -70,8 +70,7 @@ namespace System.Linq.Tests
         public IEnumerable<object> FirstPredicateArguments()
         {
             // First(predicate) has 4 code paths: OrderedEnumerable, Array, List, and IEnumerable
-            // TODO: Update link to GitHub.
-            // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/First.cs
+            // https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/First.cs
 
             yield return LinqTestData.IOrderedEnumerable;
             yield return LinqTestData.Array;
@@ -108,10 +107,8 @@ namespace System.Linq.Tests
         [ArgumentsSource(nameof(WhereArguments))]
         public bool WhereAny_LastElementMatches(LinqTestData input) => input.Collection.Where(i => i >= LinqTestData.Size - 1).Any();
 
-
         // Any uses TryGetFirst internally.
-        // TODO: Link to GitHub ?
-        // TODO: Maybe remove this with a comment why Any() is not benchmarked? Same as FirstOrDefault / LastOrDefault.
+        // https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/First.cs
         [Benchmark]
         [ArgumentsSource(nameof(FirstPredicateArguments))]
         public bool AnyWithPredicate_LastElementMatches(LinqTestData input) => input.Collection.Any(i => i >= LinqTestData.Size - 1);
@@ -137,27 +134,23 @@ namespace System.Linq.Tests
         public IEnumerable<object> SinglePredicateArguments()
         {
             // Single(predicate) has 3 code paths: Array, List, and IEnumerable
-            // TODO: Link to GitHub?
+            // https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/First.cs
 
             yield return LinqTestData.Array;
             yield return LinqTestData.List;
             yield return LinqTestData.IEnumerable;
         }
 
-        // Single() has no special treatment and it has a single execution path
-        // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Single.cs
         [Benchmark]
         [ArgumentsSource(nameof(SinglePredicateArguments))]
         public int SingleWithPredicate_LastElementMatches(LinqTestData input) => input.Collection.Single(i => i >= LinqTestData.Size - 1);
 
-        // Single() has no special treatment and it has a single execution path
-        // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Single.cs
         [Benchmark]
         [ArgumentsSource(nameof(SinglePredicateArguments))]
         public int SingleWithPredicate_FirstElementMatches(LinqTestData input) => input.Collection.Single(i => i <= 0);
 
         // SingleOrDefault() runs the same code as Single, except that it does not throw. Benchmarking it does not add any value so it go removed.
-        // TODO: Link to GitHub?
+        // https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/First.cs
 
         // Cast has no special treatment and it has a single execution path
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/Cast.cs


### PR DESCRIPTION
This pull request adds benchmarks for LINQ methods that have special cased implementations for `List<T>` and `T[]` as implemented in https://github.com/dotnet/corefx/pull/39200.

Since `Single` and `SingleOrDefault` use the same code path internally, the benchmarks for `SingleOrDefault` have been removed (in line with `First` and `FirstOrDefault`).

This pull request is not completely finished yet, links to GitHub still have to be added.
Should I update those after the PR is merged, or how can I make sure the link stays valid while the PR is open?.

`Any(predicate)` does not have a really interesting code path, it delegates to `TryGetFirst()` internally, remove the benchmarks for `Any(pred)`? 

/cc @adamsitnik 