### PR TITLE
Fix artifact directory for windows PerfSnakes and arm64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,7 +297,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS1
       kind: micro
       architecture: x64
       pool: Hosted VS2017
@@ -312,7 +312,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS1
       kind: micro
       architecture: x86
       pool: Hosted VS2017
@@ -327,7 +327,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS1
       kind: mlnet
       architecture: x64
       pool: Hosted VS2017
@@ -342,7 +342,7 @@ jobs:
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
-      osVersion: 10
+      osVersion: RS1
       kind: roslyn
       architecture: x64
       pool: Hosted VS2017

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -45,7 +45,7 @@ jobs:
           - ${{ if eq(parameters.osVersion, '1804')}}:
             - name: ArtifactsDirectory
               value: '$HELIX_WORKITEM_UPLOAD_ROOT/BenchmarkDotNet.Artifacts'
-          - ${{ if eq(parameters.osVersion, '1604')}}:
+          - ${{ if or(eq(parameters.osVersion, '1604'), eq(parameters.architecture, 'arm64'))}}:
             - name: ArtifactsDirectory
               value: '$HELIX_WORKITEM_PAYLOAD/artifacts/BenchmarkDotNet.Artifacts'
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
We added conditionals to only use the upload directory for new hardware, but forgot about arm64, and didn't update the osVersion for the windows perfsnakes correctly.