### PR TITLE
warmup Jil benchmarks in the setup to make sure BDN calls them more than once per iteration

### DIFF
--- a/src/benchmarks/micro/Serializers/Json_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromStream.cs
@@ -44,6 +44,8 @@ namespace MicroBenchmarks.Serializers
                 Jil.JSON.Serialize<T>(value, writer, Jil.Options.ISO8601);
                 writer.Flush();
             }
+
+            Jil_(); // workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837
         }
 
         [GlobalSetup(Target = nameof(JsonNet_))]

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -19,7 +19,12 @@ namespace MicroBenchmarks.Serializers
         public Json_FromString() => value = DataGenerator.Generate<T>();
 
         [GlobalSetup(Target = nameof(Jil_))]
-        public void SerializeJil() => serialized = Jil.JSON.Serialize<T>(value, Jil.Options.ISO8601);
+        public void SerializeJil()
+        {
+            serialized = Jil.JSON.Serialize<T>(value, Jil.Options.ISO8601);
+
+            Jil_(); // workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837
+        }
 
         [GlobalSetup(Target = nameof(JsonNet_))]
         public void SerializeJsonNet() => serialized = Newtonsoft.Json.JsonConvert.SerializeObject(value);

--- a/src/benchmarks/micro/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.cs
@@ -36,6 +36,9 @@ namespace MicroBenchmarks.Serializers
             newtonSoftJsonSerializer = new Newtonsoft.Json.JsonSerializer();
         }
 
+        [GlobalSetup(Target = nameof(Jil_))]
+        public void WarmupJil() => Jil_(); // workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837
+
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public void Jil_()

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -17,6 +17,9 @@ namespace MicroBenchmarks.Serializers
 
         public Json_ToString() => value = DataGenerator.Generate<T>();
 
+        [GlobalSetup(Target = nameof(Jil_))]
+        public void WarmupJil() => Jil_(); // workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837
+
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
         public string Jil_() => Jil.JSON.Serialize<T>(value, Jil.Options.ISO8601);


### PR DESCRIPTION
@billwert as promissed yesterday this is the workaround for https://github.com/dotnet/BenchmarkDotNet/issues/837