### PR TITLE
Some minor .NET Core 5.0 fixes

### DIFF
--- a/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
+++ b/src/benchmarks/micro/coreclr/System.Reflection/Activator.cs
@@ -21,7 +21,7 @@ namespace System.Reflection
         [Benchmark]
         public object CreateInstanceType() => System.Activator.CreateInstance(typeof(T));
 
-#if NETFRAMEWORK || NETCOREAPP3_0 // API available in Full .NET Framework and .NET Core 3.0
+#if !NETCOREAPP2_1 && !NETCOREAPP2_2 // API available in Full .NET Framework and .NET Core 3.0+
         [Benchmark]
         public object CreateInstanceNames() => System.Activator.CreateInstance(_assemblyName, _typeName);
 #endif

--- a/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Buffers/ReadOnlySequenceTests.cs
@@ -29,7 +29,7 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstArray() => First(new ReadOnlySequence<T>(_array));
 
-#if NETCOREAPP3_0
+#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstSpanArray() => FirstSpan(new ReadOnlySequence<T>(_array));
 

--- a/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsFalse.cs
@@ -66,7 +66,7 @@ namespace System.Collections
             return result;
         }
 
-#if NETCOREAPP3_0
+#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2
         [BenchmarkCategory(Categories.Span)]
         [Benchmark]
         public bool Span()

--- a/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsTrue.cs
@@ -63,7 +63,7 @@ namespace System.Collections
             return result;
         }
 
-#if NETCOREAPP3_0
+#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2
         [BenchmarkCategory(Categories.Span)]
         [Benchmark]
         public bool Span()

--- a/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
+++ b/src/benchmarks/micro/corefx/System.Linq/Perf.Enumerable.cs
@@ -402,7 +402,7 @@ namespace System.Linq.Tests
         [Benchmark]
         public void EmptyTakeSelectToArray() => Enumerable.Empty<int>().Take(10).Select(i => i).ToArray();
 
-#if NETCOREAPP3_0 // API Available in .NET Core 3.0+
+#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2 // API Available in .NET Core 3.0+
         // Append() has two execution paths: AppendPrependIterator (a result of another Append or Prepend) and IEnumerable, this benchmark tests both
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/AppendPrepend.cs
         [Benchmark]

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0;netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0;netcoreapp5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I forgot that we have some `#if NETCOREAPP3_0` statements which would make given benchmarks run for .NET Core 3.0 but not 5.0 ;)

I've used `#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2` as a fix, it does not look perfect but as far as I know there is no way to express something like "#if newer than NETCOREAPP3_0`. 

I've also fixed .csprojs that VS was complaining about.