### PR TITLE
Add XUnit-style xml output for ResultsComparer

### DIFF
--- a/src/tools/ResultsComparer/CommandLineOptions.cs
+++ b/src/tools/ResultsComparer/CommandLineOptions.cs
@@ -29,6 +29,9 @@ namespace ResultsComparer
         [Option("csv", HelpText = "Path to exported CSV results. Optional.")]
         public FileInfo CsvPath { get; set; }
 
+        [Option("xml", HelpText = "Path to exported XML results. Optional.")]
+        public FileInfo XmlPath { get; set; }
+
         [Option('f', "filter", HelpText = "Filter the benchmarks by name using glob pattern(s). Optional.")]
         public IEnumerable<string> Filters { get; set; }
 

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Xml;
 using BenchmarkDotNet.Mathematics;
 using BenchmarkDotNet.Mathematics.StatisticalTesting;
 using CommandLine;
@@ -57,6 +58,7 @@ namespace ResultsComparer
             PrintTable(notSame, EquivalenceTestConclusion.Faster, args);
 
             ExportToCsv(notSame, args.CsvPath);
+            ExportToXml(notSame, args.XmlPath);
         }
 
         private static IEnumerable<(string id, Benchmark baseResult, Benchmark diffResult, EquivalenceTestConclusion conclusion)> GetNotSameResults(CommandLineOptions args, Threshold testThreshold, Threshold noiseThreshold)
@@ -183,6 +185,54 @@ namespace ResultsComparer
             }
 
             Console.WriteLine($"CSV results exported to {csvPath.FullName}");
+        }
+
+        private static void ExportToXml((string id, Benchmark baseResult, Benchmark diffResult, EquivalenceTestConclusion conclusion)[] notSame, FileInfo xmlPath)
+        {
+            if (xmlPath == null)
+            {  
+                Console.WriteLine("No file given");
+                return;
+            }
+
+             if (xmlPath.Exists)
+                xmlPath.Delete();
+
+            using (XmlWriter writer = XmlWriter.Create(xmlPath.Open(FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write)))
+            {
+                writer.WriteStartElement("performance-tests");
+                foreach (var slower in notSame.Where(x => x.conclusion == EquivalenceTestConclusion.Slower))
+                {
+                    writer.WriteStartElement("test");
+                    writer.WriteAttributeString("name", slower.id);
+                    writer.WriteAttributeString("type", slower.baseResult.Type);
+                    writer.WriteAttributeString("method", slower.baseResult.Method);
+                    writer.WriteAttributeString("time", "0");
+                    writer.WriteAttributeString("result", "Fail");
+                    writer.WriteStartElement("failure");
+                    writer.WriteAttributeString("exception-type", "Regression");
+                    writer.WriteElementString("message", $"{slower.id} has regressed, was {slower.baseResult.Statistics.Median} is {slower.diffResult.Statistics.Median}.");
+                    writer.WriteEndElement();
+                }
+
+                foreach (var faster in notSame.Where(x => x.conclusion == EquivalenceTestConclusion.Faster))
+                {
+                    writer.WriteStartElement("test");
+                    writer.WriteAttributeString("name", faster.id);
+                    writer.WriteAttributeString("type", faster.baseResult.Type);
+                    writer.WriteAttributeString("method", faster.baseResult.Method);
+                    writer.WriteAttributeString("time", "0");
+                    writer.WriteAttributeString("result", "Skip");
+                    writer.WriteElementString("reason", $"{faster.id} has improved, was {faster.baseResult.Statistics.Median} is {faster.diffResult.Statistics.Median}.");
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+                writer.Flush();
+            }
+
+            Console.WriteLine($"XML results exported to {xmlPath.FullName}");
+            return;
         }
 
         private static string[] GetFilesToParse(string path)

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -232,7 +232,6 @@ namespace ResultsComparer
             }
 
             Console.WriteLine($"XML results exported to {xmlPath.FullName}");
-            return;
         }
 
         private static string[] GetFilesToParse(string path)


### PR DESCRIPTION
Running in AzDO, helix has support for parsing xml output from test legs
if the xml is in a particular format. This change adds the --xml option
which enables us to output these xunit-style xml output files that we
can use when running ResultsComparer in the lab to compare two
performance runs.