### PR TITLE
Gracefully shutdown the dotnet build-server after run

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -251,6 +251,8 @@ def __main(args: list) -> int:
                 verbose,
                 args
             )
+            
+        dotnet.shutdown_server(verbose)
 
         benchview.run_scripts(args, verbose, BENCHMARKS_CSPROJ)
 

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -513,7 +513,7 @@ def remove_dotnet(architecture: str) -> str:
 
 def shutdown_server(verbose:bool) -> None:
     '''
-    Shutsdown the dotnet server
+    Shuts down the dotnet server
     '''
     cmdline = [
         'dotnet', 'build-server', 'shutdown'

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -511,6 +511,16 @@ def remove_dotnet(architecture: str) -> str:
     '''
     rmtree(__get_directory(architecture))
 
+def shutdown_server(verbose:bool) -> None:
+    '''
+    Shutsdown the dotnet server
+    '''
+    cmdline = [
+        'dotnet', 'build-server', 'shutdown'
+    ]
+    RunCommand(cmdline, verbose=verbose).run(
+        get_repo_root_path())
+
 
 def install(
         architecture: str,


### PR DESCRIPTION
The dotnet process keeps running, even after a build or run has
completed. Before exiting the pyhton script, call dotnet build-server
shutdown to gracefully shutdown dotnet so we do not have zombie
processes still running.