### PR TITLE
Change logging of Startup Tool

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -18,7 +18,7 @@ namespace ScenarioMeasurement
     class Startup
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="appExe">Full path to test executable</param>
         /// <param name="metricType">Type of interval measurement</param>
@@ -255,14 +255,14 @@ namespace ScenarioMeasurement
 
         private static void WriteResultTable(IEnumerable<Counter> counters, Logger logger)
         {
-            logger.Log($"{"Metric",-15}|{"Average",-15}|{"Max",-15}|{"Min",-15}");
+            logger.Log($"{"Metric",-15}|{"Average",-15}|{"Min",-15}|{"Max",-15}");
             logger.Log($"---------------|---------------|---------------|---------------");
             foreach (var counter in counters)
             {
                 string average = $"{counter.Results.Average():F3} {counter.MetricName}";
                 string max = $"{counter.Results.Max():F3} {counter.MetricName}";
                 string min = $"{counter.Results.Min():F3} {counter.MetricName}";
-                logger.Log($"{counter.Name,-15}|{average,-15}|{max,-15}|{min,-15}");
+                logger.Log($"{counter.Name,-15}|{average,-15}|{min,-15}|{max,-15}");
             }
         }
     }

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -103,6 +103,7 @@ namespace ScenarioMeasurement
 
             if (warmup)
             {
+                logger.Log("=============== Warm up ================");
                 procHelper.Run();
             }
 
@@ -134,6 +135,7 @@ namespace ScenarioMeasurement
                     parser.EnableUserProviders(user);
                     for (int i = 0; i < iterations; i++)
                     {
+                        logger.Log($"=============== Iteration {i} ================ ");
                         // set up iteration
                         if (setupProcHelper != null)
                         {
@@ -184,9 +186,13 @@ namespace ScenarioMeasurement
                 }
                 TraceEventSession.Merge(files.ToArray(), traceFileName);
                 var counters = parser.Parse(traceFileName, Path.GetFileNameWithoutExtension(appExe), pids);
+
                 foreach (var counter in counters)
                 {
-                    logger.Log($"{counter.Name,-15}: {counter.Results.Average():F3} {counter.MetricName}");
+                    string average = $"Average {counter.Results.Average():F3} {counter.MetricName}";
+                    string max = $"Max {counter.Results.Max():F3} {counter.MetricName}";
+                    string min = $"Min {counter.Results.Min():F3} {counter.MetricName}";
+                    logger.Log($"{counter.Name,-15}: {average,-25}|{max,-25}|{min,-25}");
                 }
 
                 var reporter = Reporter.CreateReporter();

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.IO;
-using System.Linq;
-using Microsoft.Diagnostics.Tracing.Parsers;
+﻿using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Session;
 using Reporting;
-
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace ScenarioMeasurement
 {
@@ -257,7 +255,6 @@ namespace ScenarioMeasurement
 
         private static void WriteResultTable(IEnumerable<Counter> counters, Logger logger)
         {
-
             logger.Log($"{"Metric",-15}|{"Average",-15}|{"Max",-15}|{"Min",-15}");
             logger.Log($"---------------|---------------|---------------|---------------");
             foreach (var counter in counters)

--- a/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
+++ b/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
@@ -31,6 +31,13 @@ namespace ScenarioMeasurement
 
         public bool GuiApp { get; set; } = false;
 
+        public Logger logger;
+
+        public ProcessHelper(Logger logger)
+        {
+            this.logger = logger;
+        }
+
         /// <summary>
         /// Runs the specified process and waits for it to exit.
         /// </summary>
@@ -103,8 +110,8 @@ namespace ScenarioMeasurement
                     }
                 }
 
-                Console.WriteLine(output.ToString());
-                Console.WriteLine(error.ToString());
+                logger.Log(output.ToString());
+                logger.Log(error.ToString());
 
                 // Be aware a successful exit could be non-zero
                 if (process.ExitCode != 0)

--- a/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
+++ b/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
@@ -102,13 +102,10 @@ namespace ScenarioMeasurement
                         return (Result.CloseFailed, pid);
                     }
                 }
-                using (var sw = new StreamWriter($"testlog_{Path.GetFileName(Executable)}_{process.Id}.log"))
-                {
-                    sw.WriteLine("Standard output:");
-                    sw.WriteLine(output.ToString());
-                    sw.WriteLine("Standard error:");
-                    sw.WriteLine(error.ToString());
-                }
+
+                Console.WriteLine(output.ToString());
+                Console.WriteLine(error.ToString());
+
                 // Be aware a successful exit could be non-zero
                 if (process.ExitCode != 0)
                 {


### PR DESCRIPTION
1)	Log the output of subprocesses in the main window, instead of creating a .log file for each iteration (it’s hard to find which file contains the error when there are many iterations) 
2)	Give more statistics like max and min
