### PR TITLE
Remove parsing and make binding/emit benchmarks more reliable

### DIFF
--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -22,8 +22,8 @@ namespace CompilerBenchmarks
                 .Run(args, RecommendedConfig.Create(
                                artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location),
                                                                              "BenchmarkDotNet.Artifacts")),
-                               mandatoryCategories: ImmutableHashSet.Create("Roslyn"))
-                           .With(Job.Default.WithMaxRelativeError(0.01)))
+                               mandatoryCategories: ImmutableHashSet.Create("Roslyn"),
+                               job: Job.Default.WithMaxRelativeError(0.01)))
                 .ToExitCode();
         }
 

--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -4,8 +4,10 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Jobs;
 
 namespace CompilerBenchmarks
 {
@@ -18,8 +20,10 @@ namespace CompilerBenchmarks
             return BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
                 .Run(args, RecommendedConfig.Create(
-                    artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
-                    mandatoryCategories: ImmutableHashSet.Create("Roslyn")))
+                               artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location),
+                                                                             "BenchmarkDotNet.Artifacts")),
+                               mandatoryCategories: ImmutableHashSet.Create("Roslyn"))
+                           .With(Job.Default.WithMaxRelativeError(0.01)))
                 .ToExitCode();
         }
 

--- a/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
+++ b/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
@@ -19,12 +19,6 @@ namespace CompilerBenchmarks
         private EmitOptions _options;
         private MemoryStream _peStream;
 
-        [Benchmark]
-        public object Parsing()
-        {
-            return Helpers.CreateReproCompilation();
-        }
-
         [GlobalSetup(Target = nameof(CompileMethodsAndEmit))]
         public void LoadCompilation()
         {
@@ -39,7 +33,7 @@ namespace CompilerBenchmarks
         public object CompileMethodsAndEmit()
         {
             _peStream.Position = 0;
-            return _comp.Emit(_peStream);
+            return _comp.WithOptions(_comp.Options.WithConcurrentBuild(false)).Emit(_peStream);
         }
 
         [GlobalSetup(Target = nameof(SerializeMetadata))]

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -25,11 +25,11 @@ namespace BenchmarkDotNet.Extensions
                     .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slighlty too much for us
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
-                    .DontEnforcePowerPlan() // make sure BDN does not try to enforce High Performance power plan on Windows
-                    .AsDefault(); // tell BDN that this are our default settings
+                    .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
             }
+
             return DefaultConfig.Instance
-                .With(job)
+                .With(job.AsDefault()) // tell BDN that this are our default settings
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -26,10 +26,10 @@ namespace BenchmarkDotNet.Extensions
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
                     .DontEnforcePowerPlan() // make sure BDN does not try to enforce High Performance power plan on Windows
-                    .AsDefault();
+                    .AsDefault(); // tell BDN that this are our default settings
             }
             return DefaultConfig.Instance
-                .With(job) // tell BDN that this are our default settings
+                .With(job)
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -11,15 +11,25 @@ namespace BenchmarkDotNet.Extensions
 {
     public static class RecommendedConfig
     {
-        public static IConfig Create(DirectoryInfo artifactsPath, ImmutableHashSet<string> mandatoryCategories, int? partitionCount = null, int? partitionIndex = null)
-            => DefaultConfig.Instance
-                .With(Job.Default
+        public static IConfig Create(
+            DirectoryInfo artifactsPath,
+            ImmutableHashSet<string> mandatoryCategories,
+            int? partitionCount = null,
+            int? partitionIndex = null,
+            Job job = null)
+        {
+            if (job is null)
+            {
+                job = Job.Default
                     .WithWarmupCount(1) // 1 warmup is enough for our purpose
                     .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slighlty too much for us
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
                     .DontEnforcePowerPlan() // make sure BDN does not try to enforce High Performance power plan on Windows
-                    .AsDefault()) // tell BDN that this are our default settings
+                    .AsDefault();
+            }
+            return DefaultConfig.Instance
+                .With(job) // tell BDN that this are our default settings
                 .WithArtifactsPath(artifactsPath.FullName)
                 .With(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default
                 .With(new OperatingSystemFilter())
@@ -30,5 +40,6 @@ namespace BenchmarkDotNet.Extensions
                 .With(TooManyTestCasesValidator.FailOnError)
                 .With(new UniqueArgumentsValidator()) // don't allow for duplicated arguments #404
                 .With(new MandatoryCategoryValidator(mandatoryCategories));
+        }
     }
 }


### PR DESCRIPTION
I've been looking at the results that have built up from the first set of perf tests I uploaded and found a few things:

- The results are unfortunately pretty noisy.

- The noisiest results are the non-deterministic threading tests

- Even straight-line single threaded code (metadata serialization) has some noise

I've made some changes to try and help. First, I've removed the parsing tests. I think parsing is closer to a micro benchmark and I'm going to move it out of the e2e test suite. Second, I've turned off concurrent compilation. This increases test time, but seems to reduce variance. Lastly, I've stopped using the default RecommendedConfig. I think the Default Job parameters and a tighter standard error requirement is better for us. We may end up taking slightly longer to run the tests, but each test should only be a couple seconds at most.