### PR TITLE
Add netcoreapp5.0 as a legal target framework for the real world benchs.

### DIFF
--- a/src/benchmarks/real-world/JitBench/RealWorld.csproj
+++ b/src/benchmarks/real-world/JitBench/RealWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0;netcoreapp3.0;netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
     <IsShipping>false</IsShipping>
     <!-- this app is using internal Roslyn API and needs to be signed -->
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
That makes it easier to run them locally with the current coreclr master.

PTAL @adamsitnik 