### PR TITLE
Add release/3.1 and turn off 3.0 for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,8 @@ jobs:
       runCategories: 'coreclr corefx' 
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
 
@@ -108,7 +109,8 @@ jobs:
       runCategories: 'mldotnet'
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -123,7 +125,8 @@ jobs:
       runCategories: 'roslyn'
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
         
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -139,7 +142,8 @@ jobs:
       runCategories: 'coreclr corefx'
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
 
@@ -157,7 +161,8 @@ jobs:
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -173,7 +178,8 @@ jobs:
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
 ###########################################
 # Private Jobs
@@ -194,7 +200,8 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -210,7 +217,8 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -226,7 +234,8 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -242,7 +251,8 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -259,7 +269,8 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -276,7 +287,8 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
   
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -293,7 +305,8 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
 ################################################
 # Scheduled Private jobs
@@ -314,7 +327,8 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -329,7 +343,8 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -344,7 +359,8 @@ jobs:
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -359,7 +375,8 @@ jobs:
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1604 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -375,7 +392,8 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1604 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -391,7 +409,8 @@ jobs:
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
   
   # Ubuntu 1604 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -407,7 +426,8 @@ jobs:
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0
 
   # Ubuntu 1804 ARM64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -423,4 +443,5 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # currently ARM64 is supported only by .NET Core 3.0 https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md
-        - netcoreapp3.0
+        - netcoreapp3.1
+#       - netcoreapp3.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,7 @@ jobs:
       runCategories: 'coreclr corefx' 
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
 
@@ -109,8 +108,7 @@ jobs:
       runCategories: 'mldotnet'
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -125,8 +123,7 @@ jobs:
       runCategories: 'roslyn'
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
         
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -142,8 +139,7 @@ jobs:
       runCategories: 'coreclr corefx'
       frameworks: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
         - netcoreapp2.2
         - netcoreapp2.1
 
@@ -161,8 +157,7 @@ jobs:
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       frameworks: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -178,8 +173,7 @@ jobs:
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       frameworks: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
 ###########################################
 # Private Jobs
@@ -200,8 +194,7 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -217,8 +210,7 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -234,8 +226,7 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -251,8 +242,7 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -269,8 +259,7 @@ jobs:
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -287,8 +276,7 @@ jobs:
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
   
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -305,8 +293,7 @@ jobs:
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
         - netcoreapp5.0
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
 ################################################
 # Scheduled Private jobs
@@ -327,8 +314,7 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -343,8 +329,7 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -359,8 +344,7 @@ jobs:
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -375,8 +359,7 @@ jobs:
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1604 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -392,8 +375,7 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1604 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -409,8 +391,7 @@ jobs:
       runCategories: 'mldotnet'
       benchviewCategory: 'mldotnet'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
   
   # Ubuntu 1604 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -426,8 +407,7 @@ jobs:
       runCategories: 'roslyn'
       benchviewCategory: 'roslyn'
       frameworks: # for private jobs we want to benchmark .NET Core 3.0 only
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0
 
   # Ubuntu 1804 ARM64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -443,5 +423,4 @@ jobs:
       runCategories: 'coreclr corefx'
       benchviewCategory: 'coreclr'
       frameworks: # currently ARM64 is supported only by .NET Core 3.0 https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md
-        - netcoreapp3.1
-#       - netcoreapp3.0
+        - netcoreapp3.0

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -211,7 +211,7 @@ def __main(args: list) -> int:
 
     perfHash = decoded_output if args.get_perf_hash else args.perf_hash
 
-    remove_frameworks = ['netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0']
+    remove_frameworks = ['netcoreapp3.0', 'netcoreapp5.0']
 
     for framework in target_framework_monikers:
         if framework.startswith('netcoreapp'):

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -211,9 +211,11 @@ def __main(args: list) -> int:
 
     perfHash = decoded_output if args.get_perf_hash else args.perf_hash
 
+    remove_frameworks = ['netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0']
+
     for framework in target_framework_monikers:
         if framework.startswith('netcoreapp'):
-            if framework == 'netcoreapp3.0' or framework == 'netcoreapp5.0':
+            if framework in remove_frameworks:
                 remove_dotnet = True
             target_framework_moniker = micro_benchmarks.FrameworkAction.get_target_framework_moniker(framework)
             dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli)

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -439,7 +439,7 @@ def get_commit_date(
     if repository is None:
         # The origin of the repo where the commit belongs to has changed
         # between release. Here we attempt to naively guess the repo.
-        core_sdk_frameworks = ['netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0']
+        core_sdk_frameworks = ['netcoreapp3.0', 'netcoreapp5.0']
         repo = 'core-sdk' if framework  in core_sdk_frameworks else 'cli'
         url = urlformat % ('dotnet', repo, commit_sha)
     else:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -439,7 +439,8 @@ def get_commit_date(
     if repository is None:
         # The origin of the repo where the commit belongs to has changed
         # between release. Here we attempt to naively guess the repo.
-        repo = 'core-sdk' if framework == 'netcoreapp3.0' or framework == 'netcoreapp5.0' else 'cli'
+        core_sdk_frameworks = ['netcoreapp3.0', 'netcoreapp3.1', 'netcoreapp5.0']
+        repo = 'core-sdk' if framework  in core_sdk_frameworks else 'cli'
         url = urlformat % ('dotnet', repo, commit_sha)
     else:
         owner, repo = get_repository(repository)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -65,6 +65,7 @@ class FrameworkAction(Action):
         return {
             'netcoreapp5.0': 'master',
             'netcoreapp3.0': 'release/3.0.1xx',
+            'netcoreapp3.1': 'release/3.1.1xx',
             'netcoreapp2.2': '2.2',
             'netcoreapp2.1': '2.1',
             # For Full Framework download the LTS for dotnet cli.
@@ -85,12 +86,12 @@ class FrameworkAction(Action):
     @staticmethod
     def get_branch(target_framework_moniker: str) -> str:
         '''
-        Attemps to retrieve the channel that can be used to download the
-        DotNet Cli tools.
+        Attemps to retrieve the branch name for reporting purposes
         '''
         dct = {
             'netcoreapp5.0': 'master',
             'netcoreapp3.0': 'release/3.0.1xx',
+            'netcoreapp3.1': 'release/3.1.1xx',
             'netcoreapp2.2': 'release/2.2',
             'netcoreapp2.1': 'release/2.1',
             # For Full Framework download the LTS for dotnet cli.

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -64,8 +64,7 @@ class FrameworkAction(Action):
     def __get_target_framework_moniker_channel_map() -> dict:
         return {
             'netcoreapp5.0': 'master',
-            'netcoreapp3.0': 'release/3.0.1xx',
-            'netcoreapp3.1': 'release/3.1.1xx',
+            'netcoreapp3.0': 'release/3.1.1xx',
             'netcoreapp2.2': '2.2',
             'netcoreapp2.1': '2.1',
             # For Full Framework download the LTS for dotnet cli.
@@ -90,8 +89,7 @@ class FrameworkAction(Action):
         '''
         dct = {
             'netcoreapp5.0': 'master',
-            'netcoreapp3.0': 'release/3.0.1xx',
-            'netcoreapp3.1': 'release/3.1.1xx',
+            'netcoreapp3.0': 'release/3.1.1xx',
             'netcoreapp2.2': 'release/2.2',
             'netcoreapp2.1': 'release/2.1',
             # For Full Framework download the LTS for dotnet cli.


### PR DESCRIPTION
The 3.0 release branch isn't installing properly, which blocks our runs. We can turn it
back on after GA. Also adding tracking release/3.1.1xx.