### PR TITLE
Add benchmark and modify ConsoleMandel

### DIFF
--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -59,7 +59,7 @@ In order to build or run the benchmarks you will need the **.NET Core command-li
 
 ### Using .NET Cli
 
-To build the benchmarks you need to have the right `dotnet cli`. This repository allows to benchmark .NET Core 2.0, 2.1, 2.2 and 3.0 so you need to install all of them.
+To build the benchmarks you need to have the right `dotnet cli`. This repository allows to benchmark .NET Core 2.0, 2.1, 2.2, 3.0 and 5.0 so you need to install all of them.
 
 All you need to do is run the following command:
 

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -14,6 +14,8 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp2.2|netcoreapp3.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp3.0` as the target framework.
 
+The following commands are run from the `src/benchmarks/micro` directory.
+
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 
 ```cmd

--- a/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
+++ b/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
@@ -268,6 +268,10 @@ public class BilinearTest
     }
 #endif // !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
 
+    // This method is currently unused. It is useful, when generating a new vectorized version
+    // of the benchmark (e.g. with a different set of HW intrinsics), to ensure that it is
+    // correct (i.e. produces the same result as the scalar version).
+    //
     public static bool CheckResult(double[] output, double[] vectorOutput)
     {
         double eps = 1e-16;
@@ -282,17 +286,17 @@ public class BilinearTest
         return true;
     }
 
-    [Benchmark(Description = "BilinearInterpol_Scalar")]
+    [Benchmark]
     [BenchmarkCategory(Categories.CoreCLR)]
-    public double[] Test0()
+    public double[] Interpol_Scalar()
     {
         output = BilinearInterpol(input, A, minXA, maxXA, B, minXB, maxXB, weightB);
         return output;
     }
 
-    [Benchmark(Description = "BilinearInterpol_Vector")]
+    [Benchmark]
     [BenchmarkCategory(Categories.CoreCLR)]
-    public double[] Test1()
+    public double[] Interpol_Vector()
     {
         double[] vectorOutput = BilinearInterpol_Vector(input, A, minXA, maxXA, B, minXB, maxXB, weightB);
         return vectorOutput;
@@ -300,8 +304,8 @@ public class BilinearTest
 
 #if !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
     [BenchmarkCategory(Categories.CoreCLR)]
-    [Benchmark(Description = "BilinearInterpol_AVX")]
-    public double[] Test2()
+    [Benchmark]
+    public double[] Interpol_AVX()
     {
         if (Avx2.IsSupported)
         {

--- a/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
+++ b/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+
+// HW Intrinsic APIs are available only in .NET Core 3.0+
+#if !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+#endif
 
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
@@ -182,6 +186,7 @@ public class BilinearTest
         return z;
     }
 
+#if !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
     private static unsafe double[] BilinearInterpol_AVX(
                                             double[] x,
                                             double[] A,
@@ -261,6 +266,7 @@ public class BilinearTest
         }
         return z;
     }
+#endif // !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
 
     public static bool CheckResult(double[] output, double[] vectorOutput)
     {
@@ -292,6 +298,7 @@ public class BilinearTest
         return vectorOutput;
     }
 
+#if !NETCOREAPP2_1 && !NETCOREAPP2_2 && !NETFRAMEWORK
     [BenchmarkCategory(Categories.CoreCLR)]
     [Benchmark(Description = "BilinearInterpol_AVX")]
     public double[] Test2()
@@ -304,4 +311,5 @@ public class BilinearTest
         }
         return null;
     }
+#endif
 }

--- a/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
+++ b/src/benchmarks/micro/coreclr/BilinearInterpol/BilinearInterpol.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+public class BilinearTest
+{
+    // These must be a multiple of the largest available vector of doubles.
+    const int inputVectorSize = 1024;
+    const int outputVectorSize = 1024;
+    const double minXA = 0.0;
+    const double maxXA = Math.PI;
+    const int lengthA = 500;
+    const double deltaA = (maxXA - minXA) / (double)(lengthA - 1);
+
+    const double minXB = minXA + 2.0 * deltaA;
+    const double maxXB = maxXA - 2.0 * deltaA;
+    const double weightB = 0.15;
+    const int lengthB = 500;
+    const double deltaB = (maxXB - minXB) / (double)(lengthB - 1);
+
+    //ref values 
+    double[] A, B, input, output;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        A = new double[lengthA];
+        B = new double[lengthB];
+        for (int i = 0; i < lengthA; i++) A[i] = Math.Cos(i * deltaA + minXA);
+        for (int i = 0; i < lengthB; i++) B[i] = Math.Cos(i * deltaB + minXB);
+
+        //Init X values
+        input = new double[inputVectorSize];
+        double incr = (maxXA - minXA) / (double)(inputVectorSize - 3);
+        for (int i = 0; i < inputVectorSize; i++) input[i] = minXA + (i - 1) * incr;
+    }
+
+    private static double[] BilinearInterpol(double[] x,
+                                             double[] A,
+                                             double minXA,
+                                             double maxXA,
+                                             double[] B,
+                                             double minXB,
+                                             double maxXB,
+                                             double weightB)
+    {
+        double[] z = new double[outputVectorSize];
+
+        var weightA = 1.0 - weightB;
+
+        var deltaA = (maxXA - minXA) / (double)(A.Length - 1);
+        var deltaB = (maxXB - minXB) / (double)(B.Length - 1);
+
+        var invDeltaA = 1.0 / deltaA;
+        var invDeltaB = 1.0 / deltaB;
+
+        for (var i = 0; i < x.Length; i++)
+        {
+            var currentX = x[i];
+
+            // Determine the largest a, such that A[i] = f(xA) and xA <= x[i].
+            // This involves casting from double to int.
+            var a = (int)((currentX - minXA) * invDeltaA);
+            // We must ensure that it lies within our available range.
+            a = Math.Max(0, Math.Min(a, A.Length - 1));
+            var aPlusOne = Math.Min(a + 1, A.Length - 1);
+
+            // Now, get the reference input, xA, for our index a.
+            // This involves casting from  int to double.
+            var xA = (a * deltaA) + minXA;
+
+            // Now, compute the lambda for our A reference point.
+            var currentXNormA = Math.Max(minXA, Math.Min(currentX, maxXA));
+            var lambdaA = (currentXNormA - xA) * invDeltaA;
+
+            // Finally, get our A reference points.
+            var refALower = A[a];
+            var refAUpper = A[aPlusOne];
+
+            // Now, do the all of the above for our B reference point.
+            var b = (int)((currentX - minXB) * invDeltaB);
+            b = Math.Max(0, Math.Min(b, B.Length - 1));
+            var bPlusOne = Math.Min(b + 1, B.Length - 1);
+            var xB = (b * deltaB) + minXB;
+            var currentXNormB = Math.Max(minXB, Math.Min(currentX, maxXB));
+            var lambdaB = (currentXNormB - xB) * invDeltaB;
+            var refBLower = B[b];
+            var refBUpper = B[bPlusOne];
+
+            // Finally, compute our result.
+            z[i] = weightA * (refALower + lambdaA * (refAUpper - refALower)) +
+                    weightB * (refBLower + lambdaB * (refBUpper - refBLower));
+        }
+        return z;
+    }
+
+    private double[] BilinearInterpol_Vector(
+                                            double[] x,
+                                            double[] A,
+                                            double minXA,
+                                            double maxXA,
+                                            double[] B,
+                                            double minXB,
+                                            double maxXB,
+                                            double weightB)
+    {
+        double[] z = new double[outputVectorSize];
+
+        var vWeightB = new Vector<double>(weightB);
+        var vWeightA = new Vector<double>(1 - weightB);
+
+        var vMinXA = new Vector<double>(minXA);
+        var vMaxXA = new Vector<double>(maxXA);
+        var vMinXB = new Vector<double>(minXB);
+        var vMaxXB = new Vector<double>(maxXB);
+
+        var vDeltaA = new Vector<double>((maxXA - minXA) * (1.0 / (double)(A.Length - 1)));
+        var vDeltaB = new Vector<double>((maxXB - minXB) * (1.0 / (double)(B.Length - 1)));
+
+        var vInvDeltaA = Vector<double>.One / vDeltaA;
+        var vInvDeltaB = Vector<double>.One / vDeltaB;
+
+        var ALengthMinusOne = new Vector<int>(A.Length - 1);
+        var BLengthMinusOne = new Vector<int>(B.Length - 1);
+
+        double[] doubleTemp = new double[Vector<double>.Count];
+        for (var i = 0; i < x.Length; i += Vector<double>.Count)
+        {
+            var currentX = new Vector<double>(x, i);
+
+            // Determine the largest a, such that A[i] = f(xA) and xA <= x[i].
+            // This involves casting from double to int; here we use two Vector conversions.
+            Vector<int> a = Vector.ConvertToInt32(Vector.Narrow((currentX - vMinXA) * vInvDeltaA, Vector<double>.Zero));
+            a = Vector.Min(Vector.Max(a, Vector<int>.Zero), ALengthMinusOne);
+            Vector<int> aPlusOne = Vector.Min(a + Vector<int>.One, ALengthMinusOne);
+
+            // Now, get the reference input, xA, for our index a.
+            // This involves casting from  int to double.
+            Vector<double> tALeft;
+            Vector<double> tADummy;
+            Vector.Widen(Vector.ConvertToSingle(a), out tALeft, out tADummy);
+            Vector<double> xA = (tALeft * vDeltaA) + vMinXA;
+
+            // Now, compute the lambda for our A reference point.
+            Vector<double> currentXNormA = Vector.Max(vMinXA, Vector.Min(currentX, vMaxXA));
+            Vector<double> lambdaA = (currentXNormA - xA) * vInvDeltaA;
+
+            // Now, we need to load up our reference points.
+            // This is basically a "gather" operation, for which we use a temporary double array.
+            for (var j = 0; j < Vector<double>.Count; j++) doubleTemp[j] = A[a[j]];
+            Vector<double> AVector = new Vector<double>(doubleTemp);
+            for (var j = 0; j < Vector<double>.Count; j++) doubleTemp[j] = A[aPlusOne[j]];
+            Vector<double> AVectorPlusOne = new Vector<double>(doubleTemp);
+
+            // Now, do the all of the above for our B reference point.
+            Vector<int> b = Vector.ConvertToInt32(Vector.Narrow((currentX - vMinXB) * vInvDeltaB, Vector<double>.Zero));
+            b = Vector.Min(Vector.Max(b, Vector<int>.Zero), BLengthMinusOne);
+            Vector<int> bPlusOne = Vector.Min(b + Vector<int>.One, BLengthMinusOne);
+
+            Vector<double> tBLeft;
+            Vector<double> tBDummy;
+            Vector.Widen(Vector.ConvertToSingle(b), out tBLeft, out tBDummy);
+            Vector<double> xB = (tBLeft * vDeltaB) + vMinXB;
+
+            Vector<double> currentXNormB = Vector.Max(vMinXB, Vector.Min(currentX, vMaxXB));
+            Vector<double> lambdaB = (currentXNormB - xB) * vInvDeltaB;
+
+            for (var j = 0; j < Vector<double>.Count; j++) doubleTemp[j] = B[b[j]];
+            Vector<double> BVector = new Vector<double>(doubleTemp);
+            for (var j = 0; j < Vector<double>.Count; j++) doubleTemp[j] = B[bPlusOne[j]];
+            Vector<double> BVectorPlusOne = new Vector<double>(doubleTemp);
+
+            Vector<double> newZ = vWeightA * (AVector + lambdaA * (AVectorPlusOne - AVector)) +
+                        vWeightB * (BVector + lambdaB * (BVectorPlusOne - BVector));
+            newZ.CopyTo(z, i);
+        }
+        return z;
+    }
+
+    private static unsafe double[] BilinearInterpol_AVX(
+                                            double[] x,
+                                            double[] A,
+                                            double minXA,
+                                            double maxXA,
+                                            double[] B,
+                                            double minXB,
+                                            double maxXB,
+                                            double weightB)
+    {
+        double[] z = new double[outputVectorSize];
+
+        fixed (double* pX = &x[0], pA = &A[0], pB = &B[0], pZ = &z[0])
+        {
+            Vector256<double> vWeightB = Vector256.Create(weightB);
+            Vector256<double> vWeightA = Vector256.Create(1 - weightB);
+
+            Vector256<double> vMinXA = Vector256.Create(minXA);
+            Vector256<double> vMaxXA = Vector256.Create(maxXA);
+            Vector256<double> vMinXB = Vector256.Create(minXB);
+            Vector256<double> vMaxXB = Vector256.Create(maxXB);
+
+            double deltaA = (maxXA - minXA) / (double)(A.Length - 1);
+            double deltaB = (maxXB - minXB) / (double)(B.Length - 1);
+            Vector256<double> vDeltaA = Vector256.Create(deltaA);
+            Vector256<double> vDeltaB = Vector256.Create(deltaB);
+
+            double invDeltaA = 1.0 / deltaA;
+            double invDeltaB = 1.0 / deltaB;
+            Vector256<double> vInvDeltaA = Vector256.Create(invDeltaA);
+            Vector256<double> vInvDeltaB = Vector256.Create(invDeltaB);
+
+            Vector128<int> ALengthMinusOne = Vector128.Create(A.Length - 1);
+            Vector128<int> BLengthMinusOne = Vector128.Create(B.Length - 1);
+            Vector128<int> One = Vector128.Create(1);
+
+            for (var i = 0; i < x.Length; i += Vector256<double>.Count)
+            {
+                Vector256<double> currentX = Avx.LoadVector256(pX + i);
+
+                // Determine the largest a, such that A[i] = f(xA) and xA <= x[i].
+                // This involves casting from double to int; here we use a Vector conversion.
+                Vector256<double> aDouble = Avx.Multiply(Avx.Subtract(currentX, vMinXA), vInvDeltaA);
+                Vector128<int> a = Avx.ConvertToVector128Int32(aDouble);
+                a = Sse41.Min(Sse41.Max(a, Vector128<int>.Zero), ALengthMinusOne);
+                Vector128<int> aPlusOne = Sse41.Min(Sse2.Add(a, One), ALengthMinusOne);
+
+                // Now, get the reference input, xA, for our index a.
+                // This involves casting from  int to double.
+                Vector256<double> xA = Avx.Add(Avx.Multiply(Avx.ConvertToVector256Double(a), vDeltaA), vMinXA);
+
+                // Now, compute the lambda for our A reference point.
+                Vector256<double> currentXNormA = Avx.Max(vMinXA, Avx.Min(currentX, vMaxXA));
+                Vector256<double> lambdaA = Avx.Multiply(Avx.Subtract(currentXNormA, xA), vInvDeltaA);
+
+                // Now, we need to load up our reference points using Vector Gather operations.
+                Vector256<double> AVector = Avx2.GatherVector256(pA, a, 8);
+                Vector256<double> AVectorPlusOne = Avx2.GatherVector256(pA, aPlusOne, 8);
+
+                // Now, do the all of the above for our B reference point.
+                Vector256<double> bDouble = Avx.Multiply(Avx.Subtract(currentX, vMinXB), vInvDeltaB);
+                Vector128<int> b = Avx.ConvertToVector128Int32(bDouble);
+                b = Sse41.Min(Sse41.Max(b, Vector128<int>.Zero), BLengthMinusOne);
+                Vector128<int> bPlusOne = Sse41.Min(Sse2.Add(b, One), BLengthMinusOne);
+
+                Vector256<double> xB = Avx.Add(Avx.Multiply(Avx.ConvertToVector256Double(b), vDeltaB), vMinXB);
+                Vector256<double> currentXNormB = Avx.Max(vMinXB, Avx.Min(currentX, vMaxXB));
+                Vector256<double> lambdaB = Avx.Multiply(Avx.Subtract(currentXNormB, xB), vInvDeltaB);
+
+                Vector256<double> BVector = Avx2.GatherVector256(pB, b, 8);
+                Vector256<double> BVectorPlusOne = Avx2.GatherVector256(pB, bPlusOne, 8);
+
+                Vector256<double> newZ = Avx.Add(Avx.Multiply(vWeightA, Avx.Add(AVector, Avx.Multiply(lambdaA, Avx.Subtract(AVectorPlusOne, AVector)))),
+                                             Avx.Multiply(vWeightB, Avx.Add(BVector, Avx.Multiply(lambdaB, Avx.Subtract(BVectorPlusOne, BVector)))));
+                Avx.Store(pZ, newZ);
+            }
+        }
+        return z;
+    }
+
+    public static bool CheckResult(double[] output, double[] vectorOutput)
+    {
+        double eps = 1e-16;
+        for (int i = 0; i < output.Length; i++)
+        {
+            if (Math.Abs(output[i] - vectorOutput[i]) > eps)
+            {
+                Console.WriteLine("Failed at " + i + ": output is " + output[i] + ", vectorOutput is " + vectorOutput[i]);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [Benchmark(Description = "BilinearInterpol_Scalar")]
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public double[] Test0()
+    {
+        output = BilinearInterpol(input, A, minXA, maxXA, B, minXB, maxXB, weightB);
+        return output;
+    }
+
+    [Benchmark(Description = "BilinearInterpol_Vector")]
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public double[] Test1()
+    {
+        double[] vectorOutput = BilinearInterpol_Vector(input, A, minXA, maxXA, B, minXB, maxXB, weightB);
+        return vectorOutput;
+    }
+
+    [BenchmarkCategory(Categories.CoreCLR)]
+    [Benchmark(Description = "BilinearInterpol_AVX")]
+    public double[] Test2()
+    {
+        if (Avx2.IsSupported)
+        {
+            double[] vectorOutput;
+            vectorOutput = BilinearInterpol_AVX(input, A, minXA, maxXA, B, minXB, maxXB, weightB);
+            return vectorOutput;
+        }
+        return null;
+    }
+}

--- a/src/benchmarks/micro/coreclr/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/benchmarks/micro/coreclr/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -51,9 +51,15 @@ namespace SIMD
         }
 
         [Benchmark]
-        public void VectorFloatSinglethreadRawNoInt() => XBench(10, 8);
+        public void VectorFloatSinglethreadRaw() => XBench(10, 16);
 
         [Benchmark]
-        public void VectorFloatSinglethreadADTNoInt() => XBench(10, 9);
+        public void VectorFloatSinglethreadADT() => XBench(10, 17);
+
+        [Benchmark]
+        public void VectorDoubleSinglethreadRaw() => XBench(10, 20);
+
+        [Benchmark]
+        public void VectorDoubleSinglethreadADT() => XBench(10, 21);
     }
 }


### PR DESCRIPTION
Add a bilinear interpolation benchmark and modify the ConsoleMandel benchmark to include Double scenarios and change to use the versions that utilize `Vector<int>` and `Vector<long>` for comparisons.