### PR TITLE
Add test for AnalyzerConfigSet

### DIFF
--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0-beta1-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/Helpers.cs
+++ b/src/benchmarks/real-world/Roslyn/Helpers.cs
@@ -13,13 +13,19 @@ namespace CompilerBenchmarks
     {
         public const string TestProjectEnvVarName = "ROSLYN_TEST_PROJECT_DIR";
 
-        public static CSharpCompilation CreateReproCompilation()
+        public static CSharpCommandLineArguments GetReproCommandLineArgs()
         {
             var projectDir = Environment.GetEnvironmentVariable(TestProjectEnvVarName);
-            var cmdLineArgs = CSharpCommandLineParser.Default.Parse(
+            return CSharpCommandLineParser.Default.Parse(
                 new[] { "@repro.rsp"},
                 projectDir,
                 sdkDirectory: null);
+        }
+
+        public static CSharpCompilation CreateReproCompilation()
+        {
+            var projectDir = Environment.GetEnvironmentVariable(TestProjectEnvVarName);
+            var cmdLineArgs = GetReproCommandLineArgs();
             var sourceFiles = cmdLineArgs.SourceFiles;
             var trees = new SyntaxTree[sourceFiles.Length];
             Parallel.For(0, sourceFiles.Length, i =>

--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -29,9 +29,9 @@ namespace CompilerBenchmarks
 
         private static async Task Setup()
         {
-            string cscSourceDownloadLink = "https://roslyninfra.blob.core.windows.net/perf-artifacts/CodeAnalysisRepro.zip";
+            string cscSourceDownloadLink = "https://roslyninfra.blob.core.windows.net/perf-artifacts/CodeAnalysisReproWithAnalyzers.zip";
             string sourceDownloadDir = Path.Combine(AppContext.BaseDirectory, "roslynSource");
-            var sourceDir = Path.Combine(sourceDownloadDir, "CodeAnalysisRepro");
+            var sourceDir = Path.Combine(sourceDownloadDir, "CodeAnalysisReproWithAnalyzers");
             if (!Directory.Exists(sourceDir))
             {
                 await FileTasks.DownloadAndUnzip(cscSourceDownloadLink, sourceDownloadDir);

--- a/src/benchmarks/real-world/Roslyn/RoslynApis.cs
+++ b/src/benchmarks/real-world/Roslyn/RoslynApis.cs
@@ -1,4 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.IO;
 using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis;

--- a/src/benchmarks/real-world/Roslyn/RoslynApis.cs
+++ b/src/benchmarks/real-world/Roslyn/RoslynApis.cs
@@ -12,7 +12,7 @@ namespace CompilerBenchmarks
     public class RoslynApis
     {
         [Benchmark]
-        public object BuildAnalyzerConfigs()
+        public ImmutableArray<AnalyzerConfigOptionsResult> BuildAnalyzerConfigs()
         {
             var cmdLineArgs = Helpers.GetReproCommandLineArgs();
             var analyzerConfigs = cmdLineArgs.AnalyzerConfigPaths

--- a/src/benchmarks/real-world/Roslyn/RoslynApis.cs
+++ b/src/benchmarks/real-world/Roslyn/RoslynApis.cs
@@ -1,0 +1,26 @@
+
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis;
+
+namespace CompilerBenchmarks
+{
+    /// <summary>
+    /// A collection of benchmarks for Roslyn APIs
+    /// </summary>
+    [BenchmarkCategory("Roslyn")]
+    public class RoslynApis
+    {
+        [Benchmark]
+        public object BuildAnalyzerConfigs()
+        {
+            var cmdLineArgs = Helpers.GetReproCommandLineArgs();
+            var analyzerConfigs = cmdLineArgs.AnalyzerConfigPaths
+               .SelectAsArray(p => AnalyzerConfig.Parse(File.ReadAllText(p), p));
+            var set = AnalyzerConfigSet.Create(analyzerConfigs);
+
+            return cmdLineArgs.SourceFiles
+                .SelectAsArray(s => set.GetOptionsForSourcePath(s.Path));
+        }
+    }
+}


### PR DESCRIPTION
This is the first test for some Roslyn APIs. We may want to add some more, like measuring GetTypeByMetadata, in the future.