### PR TITLE
Minor fixes in the StageBenchmarks

### DIFF
--- a/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
+++ b/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -54,16 +55,11 @@ namespace CompilerBenchmarks
         }
 
         [Benchmark]
-        public object GetDiagnostics()
-        {
-            return _comp.GetDiagnostics();
-        }
+        public ImmutableArray<Diagnostic> GetDiagnostics() => _comp.GetDiagnostics();
 
         [Benchmark]
-        public async Task<object> GetDiagnosticsWithAnalyzers()
-        {
-            return await _compWithAnalyzers.GetAllDiagnosticsAsync();
-        }
+        public Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithAnalyzers()
+            => _compWithAnalyzers.GetAllDiagnosticsAsync();
 
         [GlobalSetup(Target = nameof(CompileMethodsAndEmit))]
         public void LoadCompilationAndGetDiagnostics()
@@ -75,7 +71,7 @@ namespace CompilerBenchmarks
         }
 
         [Benchmark]
-        public object CompileMethodsAndEmit()
+        public EmitResult CompileMethodsAndEmit()
         {
             _peStream.Position = 0;
             return _comp.WithOptions(_comp.Options.WithConcurrentBuild(false)).Emit(_peStream);
@@ -128,7 +124,7 @@ namespace CompilerBenchmarks
         }
 
         [Benchmark]
-        public object SerializeMetadata()
+        public Stream SerializeMetadata()
         {
             _peStream.Position = 0;
             var diagnostics = DiagnosticBag.GetInstance();

--- a/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
+++ b/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
@@ -45,6 +45,9 @@ namespace CompilerBenchmarks
                 options);
         }
 
+        [Benchmark]
+        public ImmutableArray<Diagnostic> GetDiagnostics() => _comp.GetDiagnostics();
+
         [IterationSetup(Target = nameof(GetDiagnosticsWithAnalyzers))]
         public void LoadFreshCompilationWithAnalyzers()
         {
@@ -53,9 +56,6 @@ namespace CompilerBenchmarks
                 _comp,
                 Helpers.GetReproCommandLineArgs());
         }
-
-        [Benchmark]
-        public ImmutableArray<Diagnostic> GetDiagnostics() => _comp.GetDiagnostics();
 
         [Benchmark]
         public Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithAnalyzers()


### PR DESCRIPTION
I've missed #893 review and this PR are just some minor fixes:

* remove boxing (to not include extra allocations in the results)
* remove "double await" - if given benchmark just calls one async method there is no need to await it, we can just return it and BDN will await it. This avoids creating an async state machine twice. Minor detail, but adds some overhead ;)