### PR TITLE
fix the high char benchmark for en-US culture

### DIFF
--- a/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
@@ -69,10 +69,10 @@ namespace System.Globalization.Tests
             char[] copy = characters.ToArray();
             // to get a different char we can not just increment the first|last char because for the HighChars=true
             // CultureInfo.GetCultureInfo("en-US").CompareInfo.IsSuffix(new string((char)0x81, 1), new string((char)0x82, 1)) returns true
-            copy[0] = (char)(copy[0] * 2);
+            copy[0] = (char)(Options.highChars ? copy[0] * 2 : copy[0] + 1);
             _diffAtFirstChar = new string(copy);
             copy = characters.ToArray();
-            copy[characters.Length - 1] = (char)(copy[characters.Length - 1] * 2);
+            copy[characters.Length - 1] = (char)(Options.highChars ? copy[characters.Length - 1] * 2 : copy[characters.Length - 1] + 1);
             _diffAtLastChar = new string(copy);
 
             // now we need to ensure that the test data is correct to avoid issues like https://github.com/dotnet/performance/pull/909

--- a/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
@@ -6,7 +6,6 @@ using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace System.Globalization.Tests
 {
@@ -56,6 +55,9 @@ namespace System.Globalization.Tests
             // we are using simple input to mimic "real world test case"
             char[] characters = "NET Conf provides a wide selection of live sessions streaming here that feature speakers from the community and .NET product teams. It is a chance to learn, ask questions live, and get inspired for your next software project".ToArray();
 
+            if (!ContainsSimpleCharactersOnly(characters))
+                throw new Exception("The sentence must contain only simple characters to ensure that it contains high chars only when Options.highChars is set to true");
+
             // we ensure that high chars are present by inserting one
             if (Options.highChars)
             {
@@ -76,12 +78,6 @@ namespace System.Globalization.Tests
             _diffAtLastChar = new string(copy);
 
             // now we need to ensure that the test data is correct to avoid issues like https://github.com/dotnet/performance/pull/909
-            if (ContainsHighChar(_value) != Options.highChars)
-                throw new Exception(nameof(_value));
-            if (ContainsHighChar(_diffAtFirstChar) != Options.highChars)
-                throw new Exception(nameof(_diffAtFirstChar));
-            if (ContainsHighChar(_diffAtLastChar) != Options.highChars)
-                throw new Exception(nameof(_diffAtLastChar));
             if (Options.CultureInfo.CompareInfo.IsPrefix(new string(_value.First(), 1), new string(_diffAtFirstChar.First(), 1), Options.CompareOptions))
                 throw new Exception(nameof(_diffAtFirstChar));
             if (Options.CultureInfo.CompareInfo.IsSuffix(new string(_value.Last(), 1), new string(_diffAtLastChar.Last(), 1), Options.CompareOptions))
@@ -106,138 +102,6 @@ namespace System.Globalization.Tests
         [Benchmark]
         public int LastIndexOf_Word_NotFound() => Options.CultureInfo.CompareInfo.LastIndexOf(_value, "word", Options.CompareOptions);
 
-        private static bool ContainsHighChar(string text) => text.Any(c => c > 0x80 || HighChars[c]);
-
-        // source: https://github.com/dotnet/coreclr/blob/68ff240063fc2ddb9b03275ae5d5063a09d38ace/src/utilcode/util_nodependencies.cpp#L856-L993
-        private static readonly bool[] HighChars = new bool[] {
-            true, /* 0x0, 0x0 */
-            true, /* 0x1, .*/
-            true, /* 0x2, .*/
-            true, /* 0x3, .*/
-            true, /* 0x4, .*/
-            true, /* 0x5, .*/
-            true, /* 0x6, .*/
-            true, /* 0x7, .*/
-            true, /* 0x8, .*/
-            false, /* 0x9,   */
-            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows), /* 0xA,  */
-            false, /* 0xB, .*/
-            false, /* 0xC, .*/
-            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows), /* 0xD,  */
-            true, /* 0xE, .*/
-            true, /* 0xF, .*/
-            true, /* 0x10, .*/
-            true, /* 0x11, .*/
-            true, /* 0x12, .*/
-            true, /* 0x13, .*/
-            true, /* 0x14, .*/
-            true, /* 0x15, .*/
-            true, /* 0x16, .*/
-            true, /* 0x17, .*/
-            true, /* 0x18, .*/
-            true, /* 0x19, .*/
-            true, /* 0x1A, */
-            true, /* 0x1B, .*/
-            true, /* 0x1C, .*/
-            true, /* 0x1D, .*/
-            true, /* 0x1E, .*/
-            true, /* 0x1F, .*/
-            false, /*0x20,  */
-            false, /*0x21, !*/
-            false, /*0x22, "*/
-            false, /*0x23,  #*/
-            false, /*0x24,  $*/
-            false, /*0x25,  %*/
-            false, /*0x26,  &*/
-            true,  /*0x27, '*/
-            false, /*0x28, (*/
-            false, /*0x29, )*/
-            false, /*0x2A **/
-            false, /*0x2B, +*/
-            false, /*0x2C, ,*/
-            true,  /*0x2D, -*/
-            false, /*0x2E, .*/
-            false, /*0x2F, /*/
-            false, /*0x30, 0*/
-            false, /*0x31, 1*/
-            false, /*0x32, 2*/
-            false, /*0x33, 3*/
-            false, /*0x34, 4*/
-            false, /*0x35, 5*/
-            false, /*0x36, 6*/
-            false, /*0x37, 7*/
-            false, /*0x38, 8*/
-            false, /*0x39, 9*/
-            false, /*0x3A, :*/
-            false, /*0x3B, ;*/
-            false, /*0x3C, <*/
-            false, /*0x3D, =*/
-            false, /*0x3E, >*/
-            false, /*0x3F, ?*/
-            false, /*0x40, @*/
-            false, /*0x41, A*/
-            false, /*0x42, B*/
-            false, /*0x43, C*/
-            false, /*0x44, D*/
-            false, /*0x45, E*/
-            false, /*0x46, F*/
-            false, /*0x47, G*/
-            false, /*0x48, H*/
-            false, /*0x49, I*/
-            false, /*0x4A, J*/
-            false, /*0x4B, K*/
-            false, /*0x4C, L*/
-            false, /*0x4D, M*/
-            false, /*0x4E, N*/
-            false, /*0x4F, O*/
-            false, /*0x50, P*/
-            false, /*0x51, Q*/
-            false, /*0x52, R*/
-            false, /*0x53, S*/
-            false, /*0x54, T*/
-            false, /*0x55, U*/
-            false, /*0x56, V*/
-            false, /*0x57, W*/
-            false, /*0x58, X*/
-            false, /*0x59, Y*/
-            false, /*0x5A, Z*/
-            false, /*0x5B, [*/
-            false, /*0x5C, \*/
-            false, /*0x5D, ]*/
-            false, /*0x5E, ^*/
-            false, /*0x5F, _*/
-            false, /*0x60, `*/
-            false, /*0x61, a*/
-            false, /*0x62, b*/
-            false, /*0x63, c*/
-            false, /*0x64, d*/
-            false, /*0x65, e*/
-            false, /*0x66, f*/
-            false, /*0x67, g*/
-            false, /*0x68, h*/
-            false, /*0x69, i*/
-            false, /*0x6A, j*/
-            false, /*0x6B, k*/
-            false, /*0x6C, l*/
-            false, /*0x6D, m*/
-            false, /*0x6E, n*/
-            false, /*0x6F, o*/
-            false, /*0x70, p*/
-            false, /*0x71, q*/
-            false, /*0x72, r*/
-            false, /*0x73, s*/
-            false, /*0x74, t*/
-            false, /*0x75, u*/
-            false, /*0x76, v*/
-            false, /*0x77, w*/
-            false, /*0x78, x*/
-            false, /*0x79, y*/
-            false, /*0x7A, z*/
-            false, /*0x7B, {*/
-            false, /*0x7C, |*/
-            false, /*0x7D, }*/
-            false, /*0x7E, ~*/
-            true, /*0x7F, */
-        };
+        private static bool ContainsSimpleCharactersOnly(char[] text) => text.All(c => c == ' ' || c == '.' || c == ',' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
     }
 }

--- a/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace System.Globalization.Tests
 {
@@ -67,12 +68,24 @@ namespace System.Globalization.Tests
             _secondHalf = new string(characters.Skip(characters.Length / 2).ToArray());
             char[] copy = characters.ToArray();
             // to get a different char we can not just increment the first|last char because for the HighChars=true
-            // CultureInfo.GetCultureInfo("en-US").CompareInfo.IsSuffix(new string((char)0x81, 1), new string((char)0x82, 1)) returns TRUE
+            // CultureInfo.GetCultureInfo("en-US").CompareInfo.IsSuffix(new string((char)0x81, 1), new string((char)0x82, 1)) returns true
             copy[0] = (char)(copy[0] * 2);
             _diffAtFirstChar = new string(copy);
             copy = characters.ToArray();
             copy[characters.Length - 1] = (char)(copy[characters.Length - 1] * 2);
             _diffAtLastChar = new string(copy);
+
+            // now we need to ensure that the test data is correct to avoid issues like https://github.com/dotnet/performance/pull/909
+            if (ContainsHighChar(_value) != Options.highChars)
+                throw new Exception(nameof(_value));
+            if (ContainsHighChar(_diffAtFirstChar) != Options.highChars)
+                throw new Exception(nameof(_diffAtFirstChar));
+            if (ContainsHighChar(_diffAtLastChar) != Options.highChars)
+                throw new Exception(nameof(_diffAtLastChar));
+            if (Options.CultureInfo.CompareInfo.IsPrefix(new string(_value.First(), 1), new string(_diffAtFirstChar.First(), 1), Options.CompareOptions))
+                throw new Exception(nameof(_diffAtFirstChar));
+            if (Options.CultureInfo.CompareInfo.IsSuffix(new string(_value.Last(), 1), new string(_diffAtLastChar.Last(), 1), Options.CompareOptions))
+                throw new Exception(nameof(_diffAtLastChar));
         }
 
         [Benchmark]
@@ -92,5 +105,139 @@ namespace System.Globalization.Tests
 
         [Benchmark]
         public int LastIndexOf_Word_NotFound() => Options.CultureInfo.CompareInfo.LastIndexOf(_value, "word", Options.CompareOptions);
+
+        private static bool ContainsHighChar(string text) => text.Any(c => c > 0x80 || HighChars[c]);
+
+        // source: https://github.com/dotnet/coreclr/blob/68ff240063fc2ddb9b03275ae5d5063a09d38ace/src/utilcode/util_nodependencies.cpp#L856-L993
+        private static readonly bool[] HighChars = new bool[] {
+            true, /* 0x0, 0x0 */
+            true, /* 0x1, .*/
+            true, /* 0x2, .*/
+            true, /* 0x3, .*/
+            true, /* 0x4, .*/
+            true, /* 0x5, .*/
+            true, /* 0x6, .*/
+            true, /* 0x7, .*/
+            true, /* 0x8, .*/
+            false, /* 0x9,   */
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows), /* 0xA,  */
+            false, /* 0xB, .*/
+            false, /* 0xC, .*/
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows), /* 0xD,  */
+            true, /* 0xE, .*/
+            true, /* 0xF, .*/
+            true, /* 0x10, .*/
+            true, /* 0x11, .*/
+            true, /* 0x12, .*/
+            true, /* 0x13, .*/
+            true, /* 0x14, .*/
+            true, /* 0x15, .*/
+            true, /* 0x16, .*/
+            true, /* 0x17, .*/
+            true, /* 0x18, .*/
+            true, /* 0x19, .*/
+            true, /* 0x1A, */
+            true, /* 0x1B, .*/
+            true, /* 0x1C, .*/
+            true, /* 0x1D, .*/
+            true, /* 0x1E, .*/
+            true, /* 0x1F, .*/
+            false, /*0x20,  */
+            false, /*0x21, !*/
+            false, /*0x22, "*/
+            false, /*0x23,  #*/
+            false, /*0x24,  $*/
+            false, /*0x25,  %*/
+            false, /*0x26,  &*/
+            true,  /*0x27, '*/
+            false, /*0x28, (*/
+            false, /*0x29, )*/
+            false, /*0x2A **/
+            false, /*0x2B, +*/
+            false, /*0x2C, ,*/
+            true,  /*0x2D, -*/
+            false, /*0x2E, .*/
+            false, /*0x2F, /*/
+            false, /*0x30, 0*/
+            false, /*0x31, 1*/
+            false, /*0x32, 2*/
+            false, /*0x33, 3*/
+            false, /*0x34, 4*/
+            false, /*0x35, 5*/
+            false, /*0x36, 6*/
+            false, /*0x37, 7*/
+            false, /*0x38, 8*/
+            false, /*0x39, 9*/
+            false, /*0x3A, :*/
+            false, /*0x3B, ;*/
+            false, /*0x3C, <*/
+            false, /*0x3D, =*/
+            false, /*0x3E, >*/
+            false, /*0x3F, ?*/
+            false, /*0x40, @*/
+            false, /*0x41, A*/
+            false, /*0x42, B*/
+            false, /*0x43, C*/
+            false, /*0x44, D*/
+            false, /*0x45, E*/
+            false, /*0x46, F*/
+            false, /*0x47, G*/
+            false, /*0x48, H*/
+            false, /*0x49, I*/
+            false, /*0x4A, J*/
+            false, /*0x4B, K*/
+            false, /*0x4C, L*/
+            false, /*0x4D, M*/
+            false, /*0x4E, N*/
+            false, /*0x4F, O*/
+            false, /*0x50, P*/
+            false, /*0x51, Q*/
+            false, /*0x52, R*/
+            false, /*0x53, S*/
+            false, /*0x54, T*/
+            false, /*0x55, U*/
+            false, /*0x56, V*/
+            false, /*0x57, W*/
+            false, /*0x58, X*/
+            false, /*0x59, Y*/
+            false, /*0x5A, Z*/
+            false, /*0x5B, [*/
+            false, /*0x5C, \*/
+            false, /*0x5D, ]*/
+            false, /*0x5E, ^*/
+            false, /*0x5F, _*/
+            false, /*0x60, `*/
+            false, /*0x61, a*/
+            false, /*0x62, b*/
+            false, /*0x63, c*/
+            false, /*0x64, d*/
+            false, /*0x65, e*/
+            false, /*0x66, f*/
+            false, /*0x67, g*/
+            false, /*0x68, h*/
+            false, /*0x69, i*/
+            false, /*0x6A, j*/
+            false, /*0x6B, k*/
+            false, /*0x6C, l*/
+            false, /*0x6D, m*/
+            false, /*0x6E, n*/
+            false, /*0x6F, o*/
+            false, /*0x70, p*/
+            false, /*0x71, q*/
+            false, /*0x72, r*/
+            false, /*0x73, s*/
+            false, /*0x74, t*/
+            false, /*0x75, u*/
+            false, /*0x76, v*/
+            false, /*0x77, w*/
+            false, /*0x78, x*/
+            false, /*0x79, y*/
+            false, /*0x7A, z*/
+            false, /*0x7B, {*/
+            false, /*0x7C, |*/
+            false, /*0x7D, }*/
+            false, /*0x7E, ~*/
+            true, /*0x7F, */
+        };
     }
 }

--- a/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
@@ -66,10 +66,12 @@ namespace System.Globalization.Tests
             _firstHalf = new string(characters.Take(characters.Length / 2).ToArray());
             _secondHalf = new string(characters.Skip(characters.Length / 2).ToArray());
             char[] copy = characters.ToArray();
-            copy[0] = (char)(copy[0] + 1);
+            // to get a different char we can not just increment the first|last char because for the HighChars=true
+            // CultureInfo.GetCultureInfo("en-US").CompareInfo.IsSuffix(new string((char)0x81, 1), new string((char)0x82, 1)) returns TRUE
+            copy[0] = (char)(copy[0] * 2);
             _diffAtFirstChar = new string(copy);
             copy = characters.ToArray();
-            copy[characters.Length - 1] = (char)(copy[characters.Length - 1] + 1);
+            copy[characters.Length - 1] = (char)(copy[characters.Length - 1] * 2);
             _diffAtLastChar = new string(copy);
         }
 

--- a/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
+++ b/src/benchmarks/micro/corefx/System.Globalization/StringSearch.cs
@@ -54,7 +54,7 @@ namespace System.Globalization.Tests
         public void Setup()
         {
             // we are using simple input to mimic "real world test case"
-            char[] characters = ".NET Conf provides a wide selection of live sessions streaming here that feature speakers from the community and .NET product teams. It is a chance to learn, ask questions live, and get inspired for your next software project.".ToArray();
+            char[] characters = "NET Conf provides a wide selection of live sessions streaming here that feature speakers from the community and .NET product teams. It is a chance to learn, ask questions live, and get inspired for your next software project".ToArray();
 
             // we ensure that high chars are present by inserting one
             if (Options.highChars)


### PR DESCRIPTION
While working on https://github.com/dotnet/coreclr/pull/26962 I've used the `IsSuffix_DifferentLastChar` benchmark and I got an x100 improvement for non `en-US` culture and a very small one for `en-US`. Which got me thinking that sth must be wrong.

It turns out that on Linux where we use ICU the following code prints true:

```cs
string a = new string((char)0x81, 1);
string b = new string((char)0x82, 1);

Console.WriteLine(CultureInfo.GetCultureInfo("en-US").CompareInfo.IsSuffix(a, b));
```

So to get a real difference for given string that starts|ends with `(char)0x81` we should not just increment the char. I decided to double it.

The change is safe for non-high char code path because the sentence starts and ends with `.` which values is `46` and even doubled it's still not a high char.