### PR TITLE
Skip CI on commit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
 # Public correctness jobs
 ######################################################
 
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   # Windows x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
     parameters:


### PR DESCRIPTION
Merging to internal isn't gated on the CI job after a commit. The internal
run and the CI happen at the same time. As we require PRs to be clean before they are
checked in this is wasted effort.