### PR TITLE
Allow ResultsComparer to run without specifying target framework

### DIFF
--- a/src/tools/ResultsComparer/ResultsComparer.csproj
+++ b/src/tools/ResultsComparer/ResultsComparer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1</TargetFrameworks>
+    <TargetFramework Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This allows running ResultsComparer [as documented](https://github.com/dotnet/performance/blob/master/docs/benchmarking-workflow-corefx.md#preventing-regressions) with just `dotnet run`. Without this change, doing that produces the following error:

> Unable to run your project
> Your project targets multiple frameworks. Specify which framework to run using '--framework'.

And to fix that without changing the csproj, it's required to use `dotnet run -f netcoreapp2.1`.