### PR TITLE
Added serializing object property to JSON

### DIFF
--- a/src/benchmarks/micro/corefx/System.Text.Json/Serializer/WriteJson.cs
+++ b/src/benchmarks/micro/corefx/System.Text.Json/Serializer/WriteJson.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.Serialization.Tests
     {
         private T _value;
         private MemoryStream _memoryStream;
+        private object _objectWithObjectProperty;
 
         [GlobalSetup]
         public async Task Setup()
@@ -36,6 +37,8 @@ namespace System.Text.Json.Serialization.Tests
 
             _memoryStream = new MemoryStream(capacity: short.MaxValue);
             await JsonSerializer.SerializeAsync(_memoryStream, _value);
+
+            _objectWithObjectProperty = new { Prop = (object)_value };
         }
 
         [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
@@ -56,7 +59,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
         [Benchmark]
-        public string SerializeObjectProperty() => JsonSerializer.Serialize(new { Prop = (object)_value });
+        public string SerializeObjectProperty() => JsonSerializer.Serialize(_objectWithObjectProperty);
 
         [GlobalCleanup]
         public void Cleanup() => _memoryStream.Dispose();

--- a/src/benchmarks/micro/corefx/System.Text.Json/Serializer/WriteJson.cs
+++ b/src/benchmarks/micro/corefx/System.Text.Json/Serializer/WriteJson.cs
@@ -54,6 +54,10 @@ namespace System.Text.Json.Serialization.Tests
             await JsonSerializer.SerializeAsync(_memoryStream, _value);
         }
 
+        [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
+        [Benchmark]
+        public string SerializeObjectProperty() => JsonSerializer.Serialize(new { Prop = (object)_value });
+
         [GlobalCleanup]
         public void Cleanup() => _memoryStream.Dispose();
     }


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/pull/41753 and https://github.com/dotnet/corefx/issues/41638.

This is a case where System.Text.Json currently has a performance issue, so I think it makes sense to add a benchmark for it, independently of whether the PR https://github.com/dotnet/corefx/pull/41753 is accepted into corefx.