### PR TITLE
add two tests for NetworkInterface

### DIFF
--- a/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -12,7 +12,7 @@ namespace System.Net.NetworkInformation.Tests
     public class NetworkInterfaceTests
     {
         [Benchmark]
-        public void GetAllNetworkInterfaces() => NetworkInterface.GetAllNetworkInterfaces();
+        public NetworkInterface[] GetAllNetworkInterfaces() => NetworkInterface.GetAllNetworkInterfaces();
 
         [Benchmark]
         public void GetAllNetworkInterfacesProperties()

--- a/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class NetworkInterfaceTests
+    {
+        private PropertyInfo[] NetworkInterfaceInfo = typeof(System.Net.NetworkInformation.NetworkInterface).GetProperties(BindingFlags.Instance | BindingFlags.Public);
+        private PropertyInfo[] IPInterfaceStatisticsInfo = typeof(System.Net.NetworkInformation.IPInterfaceStatistics).GetProperties(BindingFlags.Instance | BindingFlags.Public);
+        private PropertyInfo[] IPInterfacePropertiesInfo = typeof(System.Net.NetworkInformation.IPInterfaceProperties).GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+        [Benchmark]
+        public void GetAllNetworkInterfaces() => NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+
+        [Benchmark]
+        public void GetAllNetworkInterfacesProperties()
+        {
+            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                IPInterfaceStatistics ips = ni.GetIPStatistics();
+                IPInterfaceProperties ipp = ni.GetIPProperties();
+
+                foreach(var pi in NetworkInterfaceInfo)
+                {
+                    try
+                    {
+                        _ = pi.GetValue(ni);
+                    }
+                    catch (Exception) { };
+                }
+
+                foreach(var pi in IPInterfaceStatisticsInfo)
+                {
+                    try
+                    {
+                        _ = pi.GetValue(ips);
+                    }
+                    catch (Exception) { };
+                }
+
+                foreach(var pi in IPInterfacePropertiesInfo)
+                {
+                    try
+                    {
+                        _ = pi.GetValue(ipp);
+                    }
+                    catch (Exception) { };
+                }
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/corefx/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.NetworkInformation;
-using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
@@ -14,12 +11,8 @@ namespace System.Net.NetworkInformation.Tests
     [BenchmarkCategory(Categories.CoreFX)]
     public class NetworkInterfaceTests
     {
-        private PropertyInfo[] NetworkInterfaceInfo = typeof(System.Net.NetworkInformation.NetworkInterface).GetProperties(BindingFlags.Instance | BindingFlags.Public);
-        private PropertyInfo[] IPInterfaceStatisticsInfo = typeof(System.Net.NetworkInformation.IPInterfaceStatistics).GetProperties(BindingFlags.Instance | BindingFlags.Public);
-        private PropertyInfo[] IPInterfacePropertiesInfo = typeof(System.Net.NetworkInformation.IPInterfaceProperties).GetProperties(BindingFlags.Instance | BindingFlags.Public);
-
         [Benchmark]
-        public void GetAllNetworkInterfaces() => NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+        public void GetAllNetworkInterfaces() => NetworkInterface.GetAllNetworkInterfaces();
 
         [Benchmark]
         public void GetAllNetworkInterfacesProperties()
@@ -29,32 +22,40 @@ namespace System.Net.NetworkInformation.Tests
                 IPInterfaceStatistics ips = ni.GetIPStatistics();
                 IPInterfaceProperties ipp = ni.GetIPProperties();
 
-                foreach(var pi in NetworkInterfaceInfo)
-                {
-                    try
-                    {
-                        _ = pi.GetValue(ni);
-                    }
-                    catch (Exception) { };
-                }
+                _ = ni.Id;
+                _ = ni.Name;
+                _ = ni.Description;
+                _ = ni.NetworkInterfaceType;
+                try { _ = ni.OperationalStatus; } catch { }
+                try { _ = ni.Speed; } catch { }
+                try { _ = ni.IsReceiveOnly; } catch { }
+                try { _ = ni.SupportsMulticast; } catch { }
 
-                foreach(var pi in IPInterfaceStatisticsInfo)
-                {
-                    try
-                    {
-                        _ = pi.GetValue(ips);
-                    }
-                    catch (Exception) { };
-                }
+                // IP Statistics
+                try { _ = ips.BytesReceived; } catch { }
+                try { _ = ips.BytesSent; } catch { }
+                try { _ = ips.IncomingPacketsDiscarded;} catch { }
+                try { _ = ips.IncomingPacketsWithErrors;} catch { }
+                try { _ = ips.IncomingUnknownProtocolPackets;} catch { }
+                try { _ = ips.NonUnicastPacketsReceived; } catch { }
+                try { _ = ips.NonUnicastPacketsSent; } catch { }
+                try { _ = ips.OutgoingPacketsDiscarded; } catch { }
+                try { _ = ips.OutgoingPacketsWithErrors; } catch { }
+                try { _ = ips.OutputQueueLength; } catch { }
+                try { _ = ips.UnicastPacketsReceived; } catch { }
+                try { _ = ips.UnicastPacketsSent; } catch { }
 
-                foreach(var pi in IPInterfacePropertiesInfo)
-                {
-                    try
-                    {
-                        _ = pi.GetValue(ipp);
-                    }
-                    catch (Exception) { };
-                }
+                // IP Properties
+                try { _ = ipp.IsDnsEnabled; } catch { };
+                try { _ = ipp.DnsSuffix; } catch { };
+                try { _ = ipp.IsDynamicDnsEnabled; } catch { };
+                try { _ = ipp.UnicastAddresses; } catch { };
+                try { _ = ipp.MulticastAddresses; } catch { };
+                try { _ = ipp.AnycastAddresses; } catch { };
+                try { _ = ipp.DnsAddresses; } catch { };
+                try { _ = ipp.GatewayAddresses; } catch { };
+                try { _ = ipp.DhcpServerAddresses; } catch { };
+                try { _ = ipp.DnsAddresses; } catch { };
             }
         }
     }


### PR DESCRIPTION
GetAllNetworkInterfaces simply get list of all network interfaces. 
GetAllNetworkInterfacesProperties iterates through most of interesting properties to cover any cases where we throw or possibly use lazy initialization.

|                            Method |     Mean |     Error |    StdDev |   Median |      Min |      Max |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|---------------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|--------:|------:|----------:|
|           GetAllNetworkInterfaces | 3.539 ms | 0.0284 ms | 0.0237 ms | 3.528 ms | 3.515 ms | 3.589 ms | 450.0000 | 12.5000 |     - |   1.81 MB |
| GetAllNetworkInterfacesProperties | 7.388 ms | 0.0261 ms | 0.0232 ms | 7.385 ms | 7.355 ms | 7.436 ms | 515.1515 | 30.3030 |     - |   2.12 MB |
