### PR TITLE
fix bug: remove space at the end of commandline when no args

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -202,7 +202,7 @@ namespace ScenarioMeasurement
                 }
                 TraceEventSession.Merge(files.ToArray(), traceFileName);
 
-                string commandLine = $"\"{appExe}\" {appArgs}";
+                string commandLine = $"\"{appExe}\" {appArgs}".TrimEnd();
                 var counters = parser.Parse(traceFileName, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
 
                 WriteResultTable(counters, logger);


### PR DESCRIPTION
Trim the commandline string so it leaves no space at the end when there's no args for the commandline