### PR TITLE
Create benchmarks for System.Threading.Tasks.Dataflow

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />

--- a/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
@@ -24,12 +24,93 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
     public class ParallelActionBlockPerfTests : DefaultTargetPerfTests
     {
-        public override ITargetBlock<int> CreateBlock() => new ActionBlock<int>(i => { }, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+        public override ITargetBlock<int> CreateBlock() =>
+            new ActionBlock<int>(
+                i => { },
+                new ExecutionDataflowBlockOptions
+                {
+                    MaxDegreeOfParallelism = Environment.ProcessorCount
+                }
+            );
     }
 
     public class UnorderedParallelActionBlockPerfTests : DefaultTargetPerfTests
     {
-        public override ITargetBlock<int> CreateBlock() => new ActionBlock<int>(i => { }, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, EnsureOrdered = false });
+        public override ITargetBlock<int> CreateBlock() =>
+            new ActionBlock<int>(
+                i => { },
+                new ExecutionDataflowBlockOptions
+                {
+                    MaxDegreeOfParallelism = Environment.ProcessorCount,
+                    EnsureOrdered = false
+                }
+            );
+    }
+
+    public class SPCActionBlockPerfTests : DefaultTargetPerfTests
+    {
+        public override ITargetBlock<int> CreateBlock() =>
+            new ActionBlock<int>(
+                i => { },
+                new ExecutionDataflowBlockOptions
+                {
+                    SingleProducerConstrained = true
+                }
+            );
+    }
+
+
+    // public class BufferedActionBlockPerfTests : DefaultTargetPerfTests
+    // {
+    //     public override ITargetBlock<int> CreateBlock()
+    //     {
+    //         var buffer = new BufferBlock<int>();
+    //         var action = new ActionBlock<int>(i => { });
+    //         buffer.LinkTo(action, new DataflowLinkOptions { PropagateCompletion = true });
+    //         return DataflowBlock.Encapsulate(action, buffer);
+    //     }
+    // }
+
+    public class TransformBlockPerfTests : DefaultPropagatorPerfTests
+    {
+        public override IPropagatorBlock<int, int> CreateBlock() =>
+            new TransformBlock<int, int>(i => i);
+    }
+
+    public class ParallelTransformBlockPerfTests : DefaultPropagatorPerfTests
+    {
+        public override IPropagatorBlock<int, int> CreateBlock() =>
+            new TransformBlock<int, int>(
+                i => i,
+                new ExecutionDataflowBlockOptions
+                {
+                    MaxDegreeOfParallelism = Environment.ProcessorCount
+                }
+            );
+    }
+
+    public class UnorderedParallelTransformBlockPerfTests : DefaultPropagatorPerfTests
+    {
+        public override IPropagatorBlock<int, int> CreateBlock() =>
+            new TransformBlock<int, int>(
+                i => i,
+                new ExecutionDataflowBlockOptions
+                {
+                    MaxDegreeOfParallelism = Environment.ProcessorCount,
+                    EnsureOrdered = false
+                }
+            );
+    }
+
+    public class EncapsulateBlockPerfTests : DefaultPropagatorPerfTests
+    {
+        public override IPropagatorBlock<int, int> CreateBlock()
+        {
+            var block1 = new TransformBlock<int, int>(i => ++i, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+            var block2 = new TransformBlock<int, int>(i => --i, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+            block1.LinkTo(block2, new DataflowLinkOptions { PropagateCompletion = true });
+            return DataflowBlock.Encapsulate(block1, block2);
+        }
     }
 
     [BenchmarkCategory(Categories.CoreFX)]

--- a/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+//#pragma warning disable CS1998 // async methods without awaits
+
+namespace System.Threading.Tasks.Dataflow.Tests
+{
+    [BenchmarkCategory(Categories.CoreFX)]
+    public class Perf_Dataflow
+    {
+        [Benchmark]
+        public async Task BufferBlock_Completion()
+        {
+            var block = new BufferBlock<int>();
+            block.Complete();
+            await block.Completion;
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public void BufferBlock_Post()
+        {
+            var block = new BufferBlock<int>();
+            for (int i = 0; i < 100_000; i++)
+            {
+                block.Post(i);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public async Task BufferBlock_SendAsync()
+        {
+            var block = new BufferBlock<int>();
+            for (int i = 0; i < 100_000; i++)
+            {
+                await block.SendAsync(i);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public void BufferBlock_PostReceiveSequential()
+        {
+            var block = new BufferBlock<int>();
+            for (int i = 0; i < 100_000; i++)
+            {
+                block.Post(i);
+            }
+
+            for (int i = 0; i < 100_000; i++)
+            {
+                block.Receive();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public async Task BufferBlock_SendReceiveAsyncSequential()
+        {
+            var block = new BufferBlock<int>();
+            for (int i = 0; i < 100_000; i++)
+            {
+                await block.SendAsync(i);
+            }
+
+            for (int i = 0; i < 100_000; i++)
+            {
+                await block.ReceiveAsync();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public async Task BufferBlock_PostReceiveParallel()
+        {
+            var block = new BufferBlock<int>();
+            await Task.WhenAll(Post(), Receive());
+            
+            Task Post() => Task.Run(()=>
+            {
+                for (int i = 0; i < 100_000; i++)
+                {
+                    block.Post(i);
+                }
+            });
+
+            Task Receive() => Task.Run(()=>
+            {
+                for (int i = 0; i < 100_000; i++)
+                {
+                    block.Receive();
+                }
+            });
+        }
+
+        [Benchmark(OperationsPerInvoke = 100_000)]
+        public async Task BufferBlock_SendReceiveAsyncParallel()
+        {
+            var block = new BufferBlock<int>();
+            await Task.WhenAll(SendAsync(), ReceiveAsync());
+            
+            async Task SendAsync()
+            {
+                for (int i = 0; i < 100_000; i++)
+                {
+                    await block.SendAsync(i);
+                }
+            }
+
+            async Task ReceiveAsync()
+            {
+                for (int i = 0; i < 100_000; i++)
+                {
+                    await block.ReceiveAsync();
+                }
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
+++ b/src/benchmarks/micro/corefx/System.Threading.Tasks.Dataflow/Perf.Dataflow.cs
@@ -22,6 +22,16 @@ namespace System.Threading.Tasks.Dataflow.Tests
         public override ITargetBlock<int> CreateBlock() => new ActionBlock<int>(i => { });
     }
 
+    public class ParallelActionBlockPerfTests : DefaultTargetPerfTests
+    {
+        public override ITargetBlock<int> CreateBlock() => new ActionBlock<int>(i => { }, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount });
+    }
+
+    public class UnorderedParallelActionBlockPerfTests : DefaultTargetPerfTests
+    {
+        public override ITargetBlock<int> CreateBlock() => new ActionBlock<int>(i => { }, new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, EnsureOrdered = false });
+    }
+
     [BenchmarkCategory(Categories.CoreFX)]
     public abstract class PerfTests<T> where T : IDataflowBlock
     {
@@ -44,7 +54,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
     }
 
     [BenchmarkCategory(Categories.CoreFX)]
-    public abstract class DefaultTargetPerfTests : PerfTests<ITargetBlock<int>> { }
+    public abstract class DefaultTargetPerfTests : TargetPerfTests<ITargetBlock<int>> { }
 
     [BenchmarkCategory(Categories.CoreFX)]
     public abstract class TargetPerfTests<T> : PerfTests<T> where T : ITargetBlock<int>
@@ -75,7 +85,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
     public abstract class DefaultPropagatorPerfTests : PropagatorPerfTests<IPropagatorBlock<int, int>> { }
 
     [BenchmarkCategory(Categories.CoreFX)]
-    public abstract class PropagatorPerfTests<T> : BoundedPropagatorPerfTests<T> where T : IPropagatorBlock<int, int> 
+    public abstract class PropagatorPerfTests<T> : BoundedPropagatorPerfTests<T> where T : IPropagatorBlock<int, int>
     {
         [Benchmark(OperationsPerInvoke = 100_000)]
         public void PostReceiveSequential()
@@ -118,7 +128,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             {
                 for (int i = 0; i < 100_000; i++)
                 {
-                    while (!block.Post(i));
+                    while (!block.Post(i)) ;
                 }
             });
 


### PR DESCRIPTION
I propose multiple benchmarks for the `System.Threading.Tasks.Dataflow` library.
They cover some main performance-related use cases for each type of Dataflow block (BufferBlock, ActionBlock, TransformBlock…)

Fixes #950 