### PR TITLE
Adding benchmarks covering float.IsNaN and double.IsNaN

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Double.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Double.cs
@@ -27,6 +27,25 @@ namespace System.Tests
             => Values.OfType<double>().Select(value => value.ToString("r")).ToArray();
 
         [Benchmark]
+        [Arguments(0.0)]
+        [Arguments(double.NaN)]
+        public bool IsNaN(double value)
+        {
+            // double.IsNaN takes very little time to execute,
+            // so we need to boost the execution time a bit.
+
+            bool result = false;
+
+            for (int i = 0; i < 1000000; i++)
+            {
+                result &= double.IsNaN(value);
+                value += 1.0;
+            }
+
+            return result;
+        }
+
+        [Benchmark]
         [ArgumentsSource(nameof(Values))]
         public string ToString(double value) => value.ToString(); 
 

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Single.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Single.cs
@@ -25,6 +25,25 @@ namespace System.Tests
         public static IEnumerable<object> StringValues => Values.Select(value => value.ToString()).ToArray();
 
         [Benchmark]
+        [Arguments(0.0f)]
+        [Arguments(float.NaN)]
+        public bool IsNaN(float value)
+        {
+            // float.IsNaN takes very little time to execute,
+            // so we need to boost the execution time a bit.
+
+            bool result = false;
+
+            for (int i = 0; i < 1000000; i++)
+            {
+                result &= float.IsNaN(value);
+                value += 1.0f;
+            }
+
+            return result;
+        }
+
+        [Benchmark]
         [ArgumentsSource(nameof(Values))]
         public string ToString(float value) => value.ToString(); 
 


### PR DESCRIPTION
This just adds basic benchmarks for `float.IsNaN` and `double.IsNaN`.