### PR TITLE
Fixing Perf_Single.IsNaN and Perf_Double.IsNaN to do `result |=` rather than `result &=`

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Double.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Double.cs
@@ -38,7 +38,7 @@ namespace System.Tests
 
             for (int i = 0; i < 1000000; i++)
             {
-                result &= double.IsNaN(value);
+                result |= double.IsNaN(value);
                 value += 1.0;
             }
 

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.Single.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.Single.cs
@@ -36,7 +36,7 @@ namespace System.Tests
 
             for (int i = 0; i < 1000000; i++)
             {
-                result &= float.IsNaN(value);
+                result |= float.IsNaN(value);
                 value += 1.0f;
             }
 


### PR DESCRIPTION
This resolves an issue where LLVM was optimizing the code to just `xor eax, eax`: https://github.com/dotnet/performance/pull/952#issuecomment-544185927

CC. @EgorBo, @adamsitnik 