### PR TITLE
Rewrite StringBuilder benchmarks

### DIFF
--- a/src/benchmarks/micro/corefx/System.Text/Perf.StringBuilder.cs
+++ b/src/benchmarks/micro/corefx/System.Text/Perf.StringBuilder.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
-namespace System.Tests
+namespace System.Text.Tests
 {
     [BenchmarkCategory(Categories.CoreFX, Categories.CoreCLR)]
     public class Perf_StringBuilder


### PR DESCRIPTION
I've improved|rewritten the `StringBuilder` benchmarks.

The old benchmarks did not cover `StringBuilder.Append(char)` and hence https://github.com/dotnet/coreclr/issues/26825 got unnoticed in 3.0 release. I've also added a few other missing benchmarks.

/cc @jkotas 