### PR TITLE
GC.AllocateUninitializedArray microbenchmark

### DIFF
--- a/src/benchmarks/micro/coreclr/GC/Perf_GC.cs
+++ b/src/benchmarks/micro/coreclr/GC/Perf_GC.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Reflection;
+
+namespace System.Tests
+{
+    [GenericTypeArguments(typeof(byte))]
+    [GenericTypeArguments(typeof(char))]
+    [BenchmarkCategory(Categories.CoreCLR)]
+    public class Perf_GC<T>
+    {
+        [Benchmark]
+        [Arguments(512)]
+        [Arguments(512 * 8)]
+        public T[] NewOperator_Array(int length) => new T[length];
+
+#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP2_2// API added in .NET Core 3.0 (internal)
+        private readonly Func<int, T[]> _allocateUninitializedArrayDelegate = CreateDelegate(typeof(GC), "AllocateUninitializedArray");
+
+        [Benchmark]
+        [Arguments(512)] // less than GC.AllocateUninitializedArray threshold
+        [Arguments(512 * 8)] // more than GC.AllocateUninitializedArray threshold
+        public T[] AllocateUninitializedArray(int length) => _allocateUninitializedArrayDelegate(length);
+
+        private static Func<int, T[]> CreateDelegate(Type type, string methodName)
+        {
+            // this method is not a part of .NET Standard so we need to use reflection
+            var method = type
+                .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod(typeof(T));
+
+            return method != null ? (Func<int, T[]>)method.CreateDelegate(typeof(Func<int, T[]>)) : null;
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Sample results:

|          Type |                     Method | length |      Mean |     Error |    StdDev |    Median |       Min |       Max |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------- |--------------------------- |------- |----------:|----------:|----------:|----------:|----------:|----------:|-------:|-------:|------:|----------:|
| **Perf_GC&lt;Byte&gt;** |          **NewOperator_Array** |    **512** |  **32.57 ns** |  **0.750 ns** |  **0.770 ns** |  **32.38 ns** |  **31.50 ns** |  **34.39 ns** | **0.0683** |      **-** |     **-** |     **536 B** |
| Perf_GC&lt;Char&gt; |          NewOperator_Array |    512 |  60.62 ns |  0.366 ns |  0.325 ns |  60.66 ns |  60.17 ns |  61.15 ns | 0.1335 | 0.0005 |     - |    1048 B |
| Perf_GC&lt;Byte&gt; | AllocateUninitializedArray |    512 |  84.64 ns |  1.759 ns |  1.727 ns |  84.77 ns |  82.57 ns |  87.47 ns | 0.0712 |      - |     - |     536 B |
| Perf_GC&lt;Char&gt; | AllocateUninitializedArray |    512 |  92.23 ns |  1.099 ns |  1.028 ns |  92.08 ns |  91.10 ns |  94.09 ns | 0.1359 | 0.0004 |     - |    1048 B |
| **Perf_GC&lt;Byte&gt;** |          **NewOperator_Array** |   **4096** | **255.53 ns** | **11.482 ns** | **12.762 ns** | **248.36 ns** | **243.14 ns** | **282.16 ns** | **0.5242** | **0.0079** |     **-** |    **4120 B** |
| Perf_GC&lt;Char&gt; |          NewOperator_Array |   4096 | 484.82 ns |  3.862 ns |  3.612 ns | 483.42 ns | 478.87 ns | 490.99 ns | 1.0456 | 0.0310 |     - |    8216 B |
| Perf_GC&lt;Byte&gt; | AllocateUninitializedArray |   4096 | 140.37 ns |  2.421 ns |  2.146 ns | 140.18 ns | 136.98 ns | 145.10 ns | 0.5267 | 0.0076 |     - |    4120 B |
| Perf_GC&lt;Char&gt; | AllocateUninitializedArray |   4096 | 197.96 ns |  1.710 ns |  1.599 ns | 198.24 ns | 194.87 ns | 200.12 ns | 1.0466 | 0.0316 |     - |    8216 B |