### PR TITLE
fix System.Memory.ReadOnlySpan.IndexOfString benchmark logical bug

### DIFF
--- a/src/benchmarks/micro/corefx/System.Memory/ReadOnlySpan.cs
+++ b/src/benchmarks/micro/corefx/System.Memory/ReadOnlySpan.cs
@@ -90,7 +90,7 @@ namespace System.Memory
             char[] str = new char[count];
             for (int i = 0; i < count; i++)
             {
-                str[i] = replaceChar;
+                str[i] = source;
             }
             str[replacePos] = replaceChar;
 


### PR DESCRIPTION
The setup method was supposed to use `source` char `count`-many times and put `replaceChar` at the `replacePos` index.

I found this bug when looking for Windows vs Linux performance comparison