### PR TITLE
add benchmark for Environment.SetEnvironmentVariable

### DIFF
--- a/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.Environment.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime.Extensions/Perf.Environment.cs
@@ -36,5 +36,12 @@ namespace System.Tests
 
         [Benchmark]
         public string[] GetLogicalDrives() => Environment.GetLogicalDrives();
+
+        [Benchmark(OperationsPerInvoke = 2)]
+        public void SetEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(Key, "some value 1");
+            Environment.SetEnvironmentVariable(Key, "some value 2");
+        }
     }
 }


### PR DESCRIPTION
I was looking at perf of Env Vars API on Linux (https://github.com/dotnet/corefx/issues/42216) and realized that we don't have a benchmark for setting the variables (only for getting)