### PR TITLE
Adding Scalar versions of the ConsoleMandel SIMD benchmarks

### DIFF
--- a/src/benchmarks/micro/coreclr/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/benchmarks/micro/coreclr/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -51,6 +51,18 @@ namespace SIMD
         }
 
         [Benchmark]
+        public void ScalarFloatSinglethreadRaw() => XBench(10, 0);
+
+        [Benchmark]
+        public void ScalarFloatSinglethreadADT() => XBench(10, 1);
+
+        [Benchmark]
+        public void ScalarDoubleSinglethreadRaw() => XBench(10, 4);
+
+        [Benchmark]
+        public void ScalarDoubleSinglethreadADT() => XBench(10, 5);
+
+        [Benchmark]
         public void VectorFloatSinglethreadRaw() => XBench(10, 16);
 
         [Benchmark]


### PR DESCRIPTION
This exposes the scalar equivalents to the existing vector versions of the ConsoleMandel SIMD benchmarks.