### PR TITLE
Improve collection benchmarks

### DIFF
--- a/src/benchmarks/micro/corefx/System.Collections/Add/AddGivenSize.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Add/AddGivenSize.cs
@@ -14,6 +14,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class AddGivenSize<T>
     {
         private T[] _uniqueValues;

--- a/src/benchmarks/micro/corefx/System.Collections/Add/TryAddDefaultSize.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Add/TryAddDefaultSize.cs
@@ -13,6 +13,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class TryAddDefaultSize<T>
     {
         private T[] _uniqueValues;

--- a/src/benchmarks/micro/corefx/System.Collections/Add/TryAddGivenSize.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Add/TryAddGivenSize.cs
@@ -13,6 +13,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class TryAddGiventSize<T>
     {
         private T[] _uniqueValues;

--- a/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsKeyFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsKeyFalse.cs
@@ -16,6 +16,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int), typeof(int))] // value type
     [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue), typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject), typeof(CustomObject))] // custom reference type (less overhead)
     public class ContainsKeyFalse<TKey, TValue>
     {
         private TKey[] _notFound;

--- a/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsKeyTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsKeyTrue.cs
@@ -16,6 +16,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int), typeof(int))] // value type
     [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue), typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject), typeof(CustomObject))] // custom reference type (less overhead)
     public class ContainsKeyTrue<TKey, TValue>
     {
         private TKey[] _found;

--- a/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Contains/ContainsTrue.cs
@@ -15,6 +15,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class ContainsTrue<T>
         where T : IEquatable<T>
     {

--- a/src/benchmarks/micro/corefx/System.Collections/CopyAndRemove.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/CopyAndRemove.cs
@@ -15,6 +15,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class CopyAndRemove<T>
     {
         private T[] _items;

--- a/src/benchmarks/micro/corefx/System.Collections/CopyAndRemove.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/CopyAndRemove.cs
@@ -1,0 +1,171 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Collections
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    [GenericTypeArguments(typeof(int))] // value type
+    [GenericTypeArguments(typeof(string))] // reference type
+    public class CopyAndRemove<T>
+    {
+        private T[] _items;
+        
+        private List<T> _list;
+        private LinkedList<T> _linkedList;
+        private HashSet<T> _hashSet;
+        private SortedSet<T> _sortedSet;
+        private Dictionary<T, T> _dictionary;
+        private SortedList<T, T> _sortedList;
+        private SortedDictionary<T, T> _sortedDictionary;
+
+        [Params(Utils.DefaultCollectionSize)]
+        public int Size;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            T[] twoParts = ValuesGenerator.ArrayOfUniqueValues<T>(Size * 2);
+            T[] part1 = twoParts.Take(Size).ToArray();
+            T[] part2 = twoParts.Skip(Size).ToArray();
+
+            _items = part1;
+            _list = new List<T>(_items);
+            _linkedList = new LinkedList<T>(_items);
+            _hashSet = new HashSet<T>(_items);
+            _sortedSet = new SortedSet<T>(_items);
+            _dictionary = new Dictionary<T, T>();
+            _sortedList = new SortedList<T, T>();
+            _sortedDictionary = new SortedDictionary<T, T>();
+
+            foreach (var value in _items)
+            {
+                _dictionary.Add(value, value);
+                _sortedList.Add(value, value);
+                _sortedDictionary.Add(value, value);
+            }
+
+            Array.Sort(part2, _items);
+        }
+
+        [Benchmark]
+        public bool List()
+        {
+            bool result = true;
+            T[] items = _items;
+            List<T> copy = new List<T>(_list);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool LinkedList()
+        {
+            bool result = true;
+            T[] items = _items;
+            LinkedList<T> copy = new LinkedList<T>(_linkedList);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool HashSet()
+        {
+            bool result = true;
+            T[] items = _items;
+            HashSet<T> copy = new HashSet<T>(_hashSet);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedSet()
+        {
+            bool result = true;
+            T[] items = _items;
+            SortedSet<T> copy = new SortedSet<T>(_sortedSet);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool Dictionary()
+        {
+            bool result = true;
+            T[] items = _items;
+            Dictionary<T, T> copy = new Dictionary<T, T>(_dictionary);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedList()
+        {
+            bool result = true;
+            T[] items = _items;
+            SortedList<T, T> copy = new SortedList<T, T>(_sortedList);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedDictionary()
+        {
+            bool result = true;
+            T[] items = _items;
+            SortedDictionary<T, T> copy = new SortedDictionary<T, T>(_sortedDictionary);
+
+            for (int i = 0; i < items.Length; i++)
+                result &= copy.Remove(items[i]);
+
+            if (!result)
+                throw new InvalidOperationException("All items must be in the collection.");
+
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/Create/CtorFromCollection.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Create/CtorFromCollection.cs
@@ -14,6 +14,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class CtorFromCollection<T>
     {
         private ICollection<T> _collection;

--- a/src/benchmarks/micro/corefx/System.Collections/CreateAddAndClear.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/CreateAddAndClear.cs
@@ -14,6 +14,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class CreateAddAndClear<T>
     {
         [Params(Utils.DefaultCollectionSize)]

--- a/src/benchmarks/micro/corefx/System.Collections/CreateAddAndRemove.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/CreateAddAndRemove.cs
@@ -13,6 +13,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class CreateAddAndRemove<T>
     {
         [Params(Utils.DefaultCollectionSize)]

--- a/src/benchmarks/micro/corefx/System.Collections/Indexer/IndexerSet.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Indexer/IndexerSet.cs
@@ -15,6 +15,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreCLR, Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class IndexerSet<T>
     {
         [Params(Utils.DefaultCollectionSize)] 

--- a/src/benchmarks/micro/corefx/System.Collections/Indexer/IndexerSetReverse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Indexer/IndexerSetReverse.cs
@@ -13,6 +13,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreCLR, Categories.Collections, Categories.GenericCollections)] // this benchmark does not belong to CoreFX because it's more a codegen benchmark
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class IndexerSetReverse<T>
     {
         [Params(Utils.DefaultCollectionSize)] 

--- a/src/benchmarks/micro/corefx/System.Collections/Remove/RemoveFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Remove/RemoveFalse.cs
@@ -15,6 +15,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject))] // custom reference type (less overhead)
     public class RemoveFalse<T>
     {
         private T[] _notFound;

--- a/src/benchmarks/micro/corefx/System.Collections/Remove/RemoveFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Remove/RemoveFalse.cs
@@ -1,0 +1,163 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Collections
+{
+    [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
+    [GenericTypeArguments(typeof(int))] // value type
+    [GenericTypeArguments(typeof(string))] // reference type
+    public class RemoveFalse<T>
+    {
+        private T[] _notFound;
+        
+        private List<T> _list;
+        private LinkedList<T> _linkedList;
+        private HashSet<T> _hashSet;
+        private SortedSet<T> _sortedSet;
+        private Dictionary<T, T> _dictionary;
+        private SortedList<T, T> _sortedList;
+        private SortedDictionary<T, T> _sortedDictionary;
+
+        [Params(Utils.DefaultCollectionSize)]
+        public int Size;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            T[] twoParts = ValuesGenerator.ArrayOfUniqueValues<T>(Size * 2);
+            T[] part1 = twoParts.Take(Size).ToArray();
+            T[] part2 = twoParts.Skip(Size).ToArray();
+
+            _list = new List<T>(part1);
+            _linkedList = new LinkedList<T>(part1);
+            _hashSet = new HashSet<T>(part1);
+            _sortedSet = new SortedSet<T>(part1);
+            _dictionary = new Dictionary<T, T>();
+            _sortedList = new SortedList<T, T>();
+            _sortedDictionary = new SortedDictionary<T, T>();
+
+            foreach (var value in part1)
+            {
+                _dictionary.Add(value, value);
+                _sortedList.Add(value, value);
+                _sortedDictionary.Add(value, value);
+            }
+
+            _notFound = part2;
+        }
+
+        [Benchmark]
+        public bool List()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _list.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool LinkedList()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _linkedList.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool HashSet()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _hashSet.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedSet()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _sortedSet.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool Dictionary()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _dictionary.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedList()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _sortedList.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool SortedDictionary()
+        {
+            bool result = false;
+            T[] notFound = _notFound;
+
+            for (int i = 0; i < notFound.Length; i++)
+                result |= _sortedDictionary.Remove(notFound[i]);
+
+            if (result)
+                throw new InvalidOperationException("None of the notFound should be in the collection.");
+
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -21,6 +21,7 @@ namespace System.Collections
         private TKey[] _notFound;
         private Dictionary<TKey, TValue> _source;
 
+        private HashSet<TKey> _hashSet;
         private Dictionary<TKey, TValue> _dictionary;
         private SortedList<TKey, TValue> _sortedList;
         private SortedDictionary<TKey, TValue> _sortedDictionary;
@@ -39,11 +40,23 @@ namespace System.Collections
 
             _source = values.Skip(Size).Take(Size).ToDictionary(item => item, item => (TValue)(object)item);
             _dictionary = new Dictionary<TKey, TValue>(_source);
+            _hashSet = new HashSet<TKey>(_dictionary.Keys);
             _sortedList = new SortedList<TKey, TValue>(_source);
             _sortedDictionary = new SortedDictionary<TKey, TValue>(_source);
             _concurrentDictionary = new ConcurrentDictionary<TKey, TValue>(_source);
             _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
             _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
+        }
+
+        [Benchmark]
+        public bool HashSet()
+        {
+            bool result = default;
+            HashSet<TKey> collection = _hashSet;
+            TKey[] notFound = _notFound;
+            for (int i = 0; i < notFound.Length; i++)
+                result ^= collection.TryGetValue(notFound[i], out _);
+            return result;
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -16,6 +16,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int), typeof(int))] // value type
     [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue), typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject), typeof(CustomObject))] // custom reference type (less overhead)
     public class TryGetValueFalse<TKey, TValue>
     {
         private TKey[] _notFound;

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -21,6 +21,7 @@ namespace System.Collections
         private TKey[] _found;
         private Dictionary<TKey, TValue> _source;
         
+        private HashSet<TKey> _hashSet;
         private Dictionary<TKey, TValue> _dictionary;
         private SortedList<TKey, TValue> _sortedList;
         private SortedDictionary<TKey, TValue> _sortedDictionary;
@@ -36,12 +37,24 @@ namespace System.Collections
         {
             _found = ValuesGenerator.ArrayOfUniqueValues<TKey>(Size);
             _source = _found.ToDictionary(item => item, item => (TValue)(object)item);
+            _hashSet = new HashSet<TKey>(_found);
             _dictionary = new Dictionary<TKey, TValue>(_source);
             _sortedList = new SortedList<TKey, TValue>(_source);
             _sortedDictionary = new SortedDictionary<TKey, TValue>(_source);
             _concurrentDictionary = new ConcurrentDictionary<TKey, TValue>(_source);
             _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
             _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
+        }
+
+        [Benchmark]
+        public bool HashSet()
+        {
+            bool result = default;
+            var collection = _hashSet;
+            TKey[] found = _found;
+            for (var i = 0; i < found.Length; i++)
+                result ^= collection.TryGetValue(found[i], out _);
+            return result;
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -16,6 +16,8 @@ namespace System.Collections
     [BenchmarkCategory(Categories.CoreFX, Categories.Collections, Categories.GenericCollections)]
     [GenericTypeArguments(typeof(int), typeof(int))] // value type
     [GenericTypeArguments(typeof(string), typeof(string))] // reference type
+    [GenericTypeArguments(typeof(CustomValue), typeof(CustomValue))] // custom value type (more overhead)
+    [GenericTypeArguments(typeof(CustomObject), typeof(CustomObject))] // custom reference type (less overhead)
     public class TryGetValueTrue<TKey, TValue>
     {
         private TKey[] _found;

--- a/src/harness/BenchmarkDotNet.Extensions/CustomObject.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/CustomObject.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BenchmarkDotNet.Extensions
+{
+    public class CustomObject : IEquatable<CustomObject>, IComparable<CustomObject>
+    {
+        private readonly int _value;
+
+        public CustomObject(int value)
+        {
+            _value = value;
+        }
+
+        public bool Equals(CustomObject other)
+        {
+            return _value == other._value;
+        }
+        
+        public int CompareTo(CustomObject other)
+        {
+            return _value - other._value;
+        }
+
+        public override int GetHashCode()
+        {
+            return _value;
+        }
+    }
+}

--- a/src/harness/BenchmarkDotNet.Extensions/CustomValue.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/CustomValue.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BenchmarkDotNet.Extensions
+{
+    public struct CustomValue : IEquatable<CustomValue>, IComparable<CustomValue>
+    {
+        private readonly int _value;
+
+        public CustomValue(int value)
+        {
+            _value = value;
+        }
+
+        public bool Equals(CustomValue other)
+        {
+            return _value == other._value;
+        }
+        
+        public int CompareTo(CustomValue other)
+        {
+            return _value - other._value;
+        }
+
+        public override int GetHashCode()
+        {
+            return _value;
+        }
+    }
+}

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -91,6 +91,10 @@ namespace BenchmarkDotNet.Extensions
                 return (T)(object)(random.NextDouble() > 0.5);
             if (typeof(T) == typeof(string))
                 return (T) (object) GenerateRandomString(random, 1, 50);
+            if (typeof(T) == typeof(CustomObject))
+                return (T)(object)(new CustomObject(random.Next()));
+            if (typeof(T) == typeof(CustomValue))
+                return (T)(object)(new CustomValue(random.Next()));
             
             throw new NotImplementedException($"{typeof(T).Name} is not implemented");
         }


### PR DESCRIPTION
I've made some changes to the collection benchmarks when I was working on `HashSet` improvement (dotnet/corefx#40106).

Currently there's only one benchmark `CreateAddAndRemove` for `HashSet.Remove`. The problem of `CreateAddAndRemove` is that it has the “Create" and "Add" part which usually take more time than the "Remove" part so it doesn't like a proper benchmark for removal operations to me.

I've created two additional benchmarks `RemoveFalse` and `CopyAndRemove`. `RemoveFalse` has no side-affect cause nothing's been removed. `CopyAndRemove` would create a copy of collection from constructor and remove all the items from it one by one. Making a self-copy from constructor is much faster than through `Add` method (for most collections) so the benchmark is more focusing on removal operations.

I also introduced two new types `CustomValue` (a struct) and `CustomObject` (a class). I want to make sure the optimizations applied to custom structs (by using `CustomValue`) and the current reference generic argument `String` for collection benchmarks doesn't seem like a good target to me as it has a relatively complex/slow implementation. Those new types have the simplest implementations that meet the minimum requirement of benchmark so the benchmark result would be sorely affected by collection implementation.

Those two new types have been applied to collection benchmarks (not limit to new ones mentioned above) as generic arguments.