### PR TITLE
benchmark for Thread.GetCurrentProcessorId

### DIFF
--- a/src/benchmarks/micro/corefx/System.Threading/Perf.Thread.cs
+++ b/src/benchmarks/micro/corefx/System.Threading/Perf.Thread.cs
@@ -12,5 +12,12 @@ namespace System.Threading.Tests
     {
         [Benchmark]
         public Thread CurrentThread() => Thread.CurrentThread;
+
+#if !NETFRAMEWORK
+        public int ThreadGetCurrentProcessorId()
+        {
+            return System.Threading.Thread.GetCurrentProcessorId();
+        }
+#endif
     }
 }


### PR DESCRIPTION
`Thread.GetCurrentProcessorId` has nontrivial implementation. 
There are tradeoffs between precision and performance, which may be worth revisiting and tuning. It would be nice to have perf history for this API.