### PR TITLE
Add benchmark data for testing non-vectorised paths

### DIFF
--- a/src/benchmarks/micro/corefx/System.Collections/Perf.BitArray.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Perf.BitArray.cs
@@ -13,7 +13,8 @@ namespace System.Collections.Tests
     {
         private const int DefaultShiftCount = 17;
         private const bool BooleanValue = true;
-
+        // 4 - Small size to test non-vectorised paths
+        // DefaultCollectionSize - Big enough size to go through the vectorised paths
         [Params(4, Utils.DefaultCollectionSize)]
         public int Size { get; set; }
 

--- a/src/benchmarks/micro/corefx/System.Collections/Perf.BitArray.cs
+++ b/src/benchmarks/micro/corefx/System.Collections/Perf.BitArray.cs
@@ -14,7 +14,7 @@ namespace System.Collections.Tests
         private const int DefaultShiftCount = 17;
         private const bool BooleanValue = true;
 
-        [Params(Utils.DefaultCollectionSize)]
+        [Params(4, Utils.DefaultCollectionSize)]
         public int Size { get; set; }
 
         private BitArray _original;

--- a/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/corefx/System.Runtime/Perf.String.cs
@@ -135,6 +135,8 @@ namespace System.Tests
             => s.TrimEnd(c);
 
         [Benchmark]
+        [Arguments("Hello", 'l', '!')] // Contains two 'l'
+        [Arguments("Hello", 'a', 'b')] // Contains one 'a'
         [Arguments("This is a very nice sentence", 'z', 'y')] // 'z' does not exist in the string
         [Arguments("This is a very nice sentence", 'i', 'I')] // 'i' occuress 3 times in the string
         public string Replace_Char(string text, char oldChar, char newChar)


### PR DESCRIPTION
Related: https://github.com/dotnet/coreclr/pull/27798

The first commit is related to the PR mentioned above; I think it could be worth adding this even if the PR above doesn't make it in, in case there could be a similar change.

The second commit is per https://github.com/dotnet/corefx/pull/39173#issuecomment-516728961.