### PR TITLE
add nuget feeds to temporarily resolve package issue

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -139,7 +139,7 @@
     </HelixWorkItem>
   </ItemGroup>
 
-  <!-- <ItemGroup>
+  <ItemGroup>
     <HelixWorkItem Include="SDK Web Large 3.0 Clean Build">
       <PayloadDirectory>$(ScenariosDir)weblarge3.0</PayloadDirectory>
       <PreCommands>$(Python) pre.py default</PreCommands>
@@ -157,9 +157,9 @@
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>20:00</Timeout>
     </HelixWorkItem>
-  </ItemGroup> -->
+  </ItemGroup>
 
-  <!-- <ItemGroup>
+  <ItemGroup>
     <HelixWorkItem Include="SDK Windows Forms Large Clean Build">
       <PayloadDirectory>$(ScenariosDir)windowsformslarge</PayloadDirectory>
       <PreCommands>$(Python) pre.py default</PreCommands>
@@ -177,9 +177,9 @@
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
-  </ItemGroup> -->
+  </ItemGroup>
 
-  <!-- <ItemGroup>
+  <ItemGroup>
     <HelixWorkItem Include="SDK WPF Large Clean Build">
       <PayloadDirectory>$(ScenariosDir)wpflarge</PayloadDirectory>
       <PreCommands>$(Python) pre.py default</PreCommands>
@@ -197,7 +197,7 @@
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
-  </ItemGroup> -->
+  </ItemGroup>
 
   <ItemGroup>
     <HelixWorkItem Include="SDK Windows Forms Template Clean Build">

--- a/src/scenarios/NuGet.config
+++ b/src/scenarios/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<packageSources>
+    <add key="tmp" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/3.0.101-servicing-014347/nuget/v3/index.json" />
+</packageSources>
+</configuration>


### PR DESCRIPTION
Following the [build failure](https://dev.azure.com/dnceng/public/_build/results?buildId=430718) of netcoreapp3.1 workitems: 
SDK 3.1.100-rtm-014727 requires 3.0.1/3.0.101 packages that aren't available on nuget.org yet. Add a nuget feed here to unblock the builds.