### PR TITLE
increase timeout for weblarge projects

### DIFF
--- a/src/scenarios/weblarge2.0/test.py
+++ b/src/scenarios/weblarge2.0/test.py
@@ -10,7 +10,7 @@ def main():
                         exename=EXENAME,
                         guiapp='false',
                         workingdir='mvc',
-                        timeout= f'{const.MINUTE*15}',  # increase timeout for the large project
+                        timeout= f'{const.MINUTE*30}',  # increase timeout for the large project
                         sdk=True,
                         )
     runner = Runner(traits)

--- a/src/scenarios/weblarge3.0/test.py
+++ b/src/scenarios/weblarge3.0/test.py
@@ -10,7 +10,7 @@ def main():
                         exename=EXENAME,
                         guiapp='false',
                         workingdir='mvc',
-                        timeout= f'{const.MINUTE*15}',   # increase timeout for the large project
+                        timeout= f'{const.MINUTE*30}',   # increase timeout for the large project
                         sdk=True,
                         )
     runner = Runner(traits)


### PR DESCRIPTION
Occasionally Web Large projects still exceed timeout value (15min) in profile iteration. Extend it to 30min. Will merge if no opposition.