### PR TITLE
remove nuget.config

### DIFF
--- a/src/scenarios/NuGet.config
+++ b/src/scenarios/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-<packageSources>
-    <add key="tmp" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/3.0.101-servicing-014347/nuget/v3/index.json" />
-</packageSources>
-</configuration>


### PR DESCRIPTION
This temporary fix could be removed since ```Microsoft.AspNetCore.App.Ref``` with version 3.0.1 and ```Microsoft.NETCore.App.Host.win-x64``` with version 3.0.1 are available on Nuget.org now. 