### PR TITLE
enable framework change for dynamically generated templates

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -61,7 +61,7 @@
 
   <ItemGroup>
     <HelixWorkItem Include="SDK Console Template Clean Build">
-      <PayloadDirectory>$(ScenariosDir)staticconsoletemplate</PayloadDirectory>
+      <PayloadDirectory>$(ScenariosDir)emptyconsoletemplate</PayloadDirectory>
       <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk clean_build</Command>
       <PostCommands>$(Python) post.py</PostCommands>
@@ -71,7 +71,7 @@
 
   <ItemGroup>
     <HelixWorkItem Include="SDK Console Template Build(No Change)">
-      <PayloadDirectory>$(ScenariosDir)staticconsoletemplate</PayloadDirectory>
+      <PayloadDirectory>$(ScenariosDir)emptyconsoletemplate</PayloadDirectory>
       <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk build_no_change</Command>
       <PostCommands>$(Python) post.py</PostCommands>
@@ -102,7 +102,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK ASP.NET MVC App Template Clean Build">
       <PayloadDirectory>$(ScenariosDir)mvcapptemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk clean_build</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
@@ -112,7 +112,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK ASP.NET MVC App Template Build(No Change)">
       <PayloadDirectory>$(ScenariosDir)mvcapptemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk build_no_change</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
@@ -202,7 +202,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK Windows Forms Template Clean Build">
       <PayloadDirectory>$(ScenariosDir)windowsforms</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk clean_build</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
@@ -212,7 +212,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK Windows Forms Template Build(No Change)">
       <PayloadDirectory>$(ScenariosDir)windowsforms</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk build_no_change</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
@@ -222,7 +222,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK WPF Template Clean Build">
       <PayloadDirectory>$(ScenariosDir)wpf</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk clean_build</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
@@ -232,7 +232,7 @@
   <ItemGroup>
     <HelixWorkItem Include="SDK WPF Template Build(No Change)">
       <PayloadDirectory>$(ScenariosDir)wpf</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(_Framework)</PreCommands>
       <Command>$(Python) test.py sdk build_no_change</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -301,7 +301,6 @@ class CSharpProject:
             working_directory: str,
             force: bool = False,
             exename: str = None,
-            target_framework_moniker: str = None,
             language: str = None
             ):
         '''
@@ -319,12 +318,8 @@ class CSharpProject:
         if exename:
             cmdline += ['--name', exename]
 
-        if target_framework_moniker:
-            cmdline += ['--framework', target_framework_moniker]
-
         if language:
             cmdline += ['--language', language]
-
 
         RunCommand(cmdline, verbose=verbose).run(
             working_directory

--- a/src/scenarios/emptyconsoletemplate/test.py
+++ b/src/scenarios/emptyconsoletemplate/test.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
                         exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
+                        sdk=True,
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/shared/codefixes.py
+++ b/src/scenarios/shared/codefixes.py
@@ -6,6 +6,8 @@
 routines for fixing up code in templates
 '''
 
+from re import sub
+
 def readfile(file: str) -> []:
     ret = []
     with open(file, "r") as opened:
@@ -27,5 +29,5 @@ def insert_after(file: str, search: str, insert: str):
 def replace_line(file: str, search: str, replace: str):
     lines = []
     for line in readfile(file):
-        lines.append(line.replace(search, replace))
+        lines.append(sub(search, replace, line))
     writefile(file, lines)

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -70,8 +70,8 @@ class PreCommands:
                                  working_directory=working_directory,
                                  force=True,
                                  verbose=True,
-                                 target_framework_moniker=self.framework,
                                  language=language)
+        self._updateframework(self.project.csproj_file)
 
     def add_common_arguments(self, parser: ArgumentParser):
         "Options that are common across many 'dotnet' commands"
@@ -130,7 +130,7 @@ class PreCommands:
 
     def _updateframework(self, projectfile: str):
         if self.framework:
-            replace_line(projectfile, "$FRAMEWORK", self.framework)
+            replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
 
     def _publish(self, configuration: str, framework: str = None):
         self.project.publish(configuration=configuration,

--- a/src/scenarios/staticconsoletemplate/test.py
+++ b/src/scenarios/staticconsoletemplate/test.py
@@ -11,7 +11,6 @@ if __name__ == "__main__":
                         exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
-                        sdk=True,
                         guiapp='false',
                         )
     Runner(traits).run()


### PR DESCRIPTION
Currently the target frameworks of dynamically generated templates (```emptyconsoletemplate```, ```mvcapptemplate```, ```wpf```) can only be set to a static version corresponding to the SDK in use. In order to implement the matrix of different frameworks vs. different SDKs, we need to enable changing the target frameworks of dynamically generated templates, in addition to the static templates.