### PR TITLE
Support for process flag and updated documentation for GC Infra

### DIFF
--- a/src/benchmarks/gc/jupyter_notebook.py
+++ b/src/benchmarks/gc/jupyter_notebook.py
@@ -52,9 +52,9 @@ from src.analysis.report import diff_for_jupyter, report_reasons_for_jupyter
 from src.analysis.single_gc_metrics import get_bytes_allocated_since_last_gc
 from src.analysis.single_heap_metrics import ALL_GC_GENS
 from src.analysis.trace_commands import print_events_for_jupyter
-from src.analysis.types import GCKind, get_gc_kind, ProcessedTrace, ProcessQuery, SpecialSampleKind
+from src.analysis.types import GCKind, get_gc_kind, ProcessedTrace, SpecialSampleKind
 
-from src.commonlib.bench_file import Vary
+from src.commonlib.bench_file import ProcessQuery, Vary
 from src.commonlib.collection_util import repeat
 from src.commonlib.document import Cell, handle_doc, Row, single_table_document, Table
 from src.commonlib.option import non_null
@@ -71,8 +71,7 @@ def get_trace_with_everything(
 ) -> ProcessedTrace:
     return unwrap(
         ALL_TRACES.get(
-            test_result=test_result_from_path(path),
-            process=process,
+            test_result=test_result_from_path(path, process),
             # TODO: disabling mechanisms and join info for now
             # as it doesn't work without updating TraceEvent
             need_mechanisms_and_reasons=False,
@@ -225,6 +224,7 @@ handle_doc(
         # Only for metrics_as_columns
         sort_by_metric=None,
         min_difference_pct=5,
+        process=("name:corerun",),
     )
 )
 
@@ -233,10 +233,7 @@ handle_doc(
 
 handle_doc(
     report_reasons_for_jupyter(
-        traces=ALL_TRACES,
-        bench_file_path=_LOW_MEMORY_CONTAINER,
-        process=("name:corerun",),
-        max_iterations=None,
+        traces=ALL_TRACES, bench_file_path=_LOW_MEMORY_CONTAINER, max_iterations=None
     )
 )
 

--- a/src/benchmarks/gc/src/__init__.py
+++ b/src/benchmarks/gc/src/__init__.py
@@ -1,6 +1,0 @@
-# Licensed to the .NET Foundation under one or more agreements.
-# The .NET Foundation licenses this file to you under the MIT license.
-# See the LICENSE file in the project root for more information.
-
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.

--- a/src/benchmarks/gc/src/analysis/analyze_joins.py
+++ b/src/benchmarks/gc/src/analysis/analyze_joins.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional, Sequence
 
 from result import Result
 
+from ..commonlib.bench_file import ProcessQuery
 from ..commonlib.collection_util import indices, is_empty, min_max_float
 from ..commonlib.command import Command, CommandKind, CommandsMapping
 from ..commonlib.document import (
@@ -40,7 +41,7 @@ from .core_analysis import GC_NUMBER_DOC, PROCESS_DOC, TRACE_PATH_DOC
 from .enums import GcJoinPhase, GcJoinStage, Gens, ServerGCState
 from .process_trace import get_processed_trace, test_result_from_path
 from .single_gc_metrics import get_gc_index_with_number
-from .types import ProcessedTrace, ThreadToProcessToName, ProcessQuery
+from .types import ProcessedTrace, ThreadToProcessToName
 
 
 class StagesOrPhases(Enum):
@@ -151,8 +152,7 @@ def _get_processed_trace_with_just_join_info(
 ) -> Result[str, ProcessedTrace]:
     return get_processed_trace(
         clr=clr,
-        test_result=test_result_from_path(path),
-        process=process,
+        test_result=test_result_from_path(path, process),
         need_mechanisms_and_reasons=False,
         need_join_info=True,
     )

--- a/src/benchmarks/gc/src/analysis/analyze_single.py
+++ b/src/benchmarks/gc/src/analysis/analyze_single.py
@@ -8,7 +8,7 @@ from math import inf
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence
 
-from ..commonlib.bench_file import try_find_benchfile_from_trace_file_path
+from ..commonlib.bench_file import ProcessQuery, try_find_benchfile_from_trace_file_path
 from ..commonlib.collection_util import cat_unique, identity, is_empty, items_sorted_by_key
 from ..commonlib.command import Command, CommandKind, CommandsMapping
 from ..commonlib.document import (
@@ -40,7 +40,6 @@ from .types import (
     EventNames,
     MetricBase,
     ProcessedGC,
-    ProcessQuery,
     ProcessedTrace,
     RunMetrics,
     RUN_METRICS_DOC,
@@ -122,8 +121,7 @@ def _analyze_single_gc(args: _AnalyzeSingleGcArgs) -> None:
 
     trace = get_processed_trace(
         clr=get_clr(),
-        test_result=test_result_from_path(args.trace_path),
-        process=args.process,
+        test_result=test_result_from_path(args.trace_path, args.process),
         need_mechanisms_and_reasons=False,
         need_join_info=False,
     ).unwrap()
@@ -184,8 +182,7 @@ def _get_analyze_single_document(args: _AnalyzeSingleArgs) -> Document:
 
     trace = get_processed_trace(
         clr=get_clr(),
-        test_result=test_result_from_path(args.path),
-        process=args.process,
+        test_result=test_result_from_path(args.path, args.process),
         need_mechanisms_and_reasons=False,
         need_join_info=False,
     ).unwrap()

--- a/src/benchmarks/gc/src/analysis/chart_individual_gcs.py
+++ b/src/benchmarks/gc/src/analysis/chart_individual_gcs.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Mapping, Optional, Sequence
 from matplotlib.axes._subplots import SubplotBase
 from matplotlib.lines import Line2D
 
+from ..commonlib.bench_file import ProcessQuery
 from ..commonlib.collection_util import is_empty, map_non_null_together, zip_check
 from ..commonlib.command import Command, CommandKind, CommandsMapping
 from ..commonlib.option import non_null
@@ -28,7 +29,6 @@ from .process_trace import get_processed_trace, test_result_from_path
 from .types import (
     ProcessedGC,
     ProcessedTrace,
-    ProcessQuery,
     SingleGCMetric,
     SingleGCMetrics,
     SINGLE_GC_METRICS_DOC,
@@ -112,8 +112,7 @@ def chart_individual_gcs(args: ChartIndividualGcsArgs) -> None:
         [
             get_processed_trace(
                 clr=clr,
-                test_result=test_result_from_path(trace_path),
-                process=args.process,
+                test_result=test_result_from_path(trace_path, args.process),
                 need_mechanisms_and_reasons=False,
                 need_join_info=False,
             )
@@ -300,8 +299,7 @@ def chart_individual_gcs_histogram(args: ChartIndividualGcsHistogramArgs) -> Non
 
     trace = get_processed_trace(
         clr=get_clr(),
-        test_result=test_result_from_path(args.trace_path),
-        process=args.process,
+        test_result=test_result_from_path(args.trace_path, args.process),
         need_mechanisms_and_reasons=False,
         need_join_info=False,
     ).unwrap()

--- a/src/benchmarks/gc/src/analysis/condemned_reasons.py
+++ b/src/benchmarks/gc/src/analysis/condemned_reasons.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import FrozenSet, Mapping, Optional, Sequence
 
+from ..commonlib.bench_file import ProcessQuery
 from ..commonlib.collection_util import indices, is_empty, map_to_mapping_optional
 from ..commonlib.command import Command, CommandKind, CommandsMapping
 from ..commonlib.document import (
@@ -29,7 +30,7 @@ from .core_analysis import GC_NUMBER_DOC, PROCESS_DOC, SINGLE_PATH_DOC
 from .enums import Gens, gen_short_name
 from .process_trace import get_processed_trace, test_result_from_path
 from .single_gc_metrics import get_gc_with_number
-from .types import ProcessedGC, ProcessedTrace, ProcessQuery
+from .types import ProcessedGC, ProcessedTrace
 
 # From TraceManagedProcess.cs in PerfView
 class _CondemnedReasonGroup(Enum):
@@ -245,8 +246,7 @@ class _ShowCondemnedReasonsArgs:
 def _show_condemned_reasons(args: _ShowCondemnedReasonsArgs) -> None:
     trace = get_processed_trace(
         clr=get_clr(),
-        test_result=test_result_from_path(args.path),
-        process=args.process,
+        test_result=test_result_from_path(args.path, args.process),
         need_mechanisms_and_reasons=False,
         need_join_info=False,
     ).unwrap()
@@ -264,8 +264,7 @@ class _ShowCondemnedReasonsForGCArgs(DocOutputArgs):
 def _show_condemned_reasons_for_gc(args: _ShowCondemnedReasonsForGCArgs) -> None:
     trace = get_processed_trace(
         clr=get_clr(),
-        test_result=test_result_from_path(args.path),
-        process=args.process,
+        test_result=test_result_from_path(args.path, args.process),
         need_mechanisms_and_reasons=False,
         need_join_info=False,
     ).unwrap()

--- a/src/benchmarks/gc/src/analysis/core_analysis.py
+++ b/src/benchmarks/gc/src/analysis/core_analysis.py
@@ -11,7 +11,7 @@ from typing import Any, cast, Dict, Iterable, Mapping, Optional, Pattern, Sequen
 
 from overrides import overrides
 
-from ..commonlib.bench_file import get_trace_kind, TraceKind
+from ..commonlib.bench_file import get_trace_kind, ProcessQuery, TraceKind
 from ..commonlib.collection_util import find_only, is_empty, try_find_only, TryFindOnlyFailure
 from ..commonlib.option import map_option, non_null, optional_to_iter
 from ..commonlib.type_utils import check_cast, with_slots
@@ -28,7 +28,7 @@ from .clr_types import (
     AbstractTraceLoadedDotNetRuntime,
 )
 from .enums import GCType
-from .types import ProcessInfo, ThreadToProcessToName, ProcessQuery
+from .types import ProcessInfo, ThreadToProcessToName
 
 
 def get_etl_trace(clr: Clr, etl_path: Path) -> AbstractEtlTrace:

--- a/src/benchmarks/gc/src/analysis/core_analysis.py
+++ b/src/benchmarks/gc/src/analysis/core_analysis.py
@@ -147,6 +147,8 @@ This may be:
 * `id:123` to specify a process ID
 * `name:abc` to specify a regular expression to match a process name.
 * `args:abc` to specify a regular expression to match process arguments.
+
+This will only work when analyzing trace files (`.etl` extension).
 """
 
 

--- a/src/benchmarks/gc/src/analysis/diffable.py
+++ b/src/benchmarks/gc/src/analysis/diffable.py
@@ -17,6 +17,7 @@ from ..commonlib.bench_file import (
     parse_machines_arg,
     PartialConfigAndName,
     PartialTestCombination,
+    ProcessQuery,
     SingleTestCombination,
     Vary,
 )
@@ -34,10 +35,10 @@ from ..commonlib.type_utils import with_slots
 from .parse_metrics import get_score_metrics
 from .process_trace import ProcessedTraces, test_result_from_path
 from .types import (
+    FailableMetricValue,
     MaybeMetricStatisticsFromAllIterations,
     MaybeMetricValuesForSingleIteration,
     MetricStatisticsFromAllIterations,
-    FailableMetricValue,
     MetricValuesForSingleIteration,
     metric_value_of,
     RunMetric,
@@ -150,8 +151,10 @@ def get_diffables(
     test_where: Optional[Sequence[str]],
     sample_kind: SampleKind,
     max_iterations: Optional[int],
+    process: ProcessQuery,
 ) -> Diffables:
     if len(paths) == 1:
+        assert process is None, "If giving a bench file (yaml), then --process is not needed."
         return get_diffables_from_bench_file(
             traces=traces,
             bench_file_path=paths[0],
@@ -172,7 +175,7 @@ def get_diffables(
                 name=str(path),
                 test=None,
                 stats=iterations_to_statistics(
-                    (traces.get_run_metrics(test_result_from_path(path), run_metrics),),
+                    (traces.get_run_metrics(test_result_from_path(path, process), run_metrics),),
                     run_metrics,
                     sample_kind,
                 ),

--- a/src/benchmarks/gc/src/analysis/process_trace.py
+++ b/src/benchmarks/gc/src/analysis/process_trace.py
@@ -8,11 +8,17 @@ from typing import cast, Dict, Iterable, Sequence
 
 from result import Err, Ok, Result
 
-from ..commonlib.bench_file import is_trace_path, load_test_status, TestResult, TestRunStatus
+from ..commonlib.bench_file import (
+    is_trace_path,
+    load_test_status,
+    ProcessQuery,
+    TestResult,
+    TestRunStatus,
+)
 from ..commonlib.collection_util import indices, map_to_mapping, repeat, zip_check, zip_check_3
 from ..commonlib.option import map_option, non_null
 from ..commonlib.result_utils import map_err, map_ok, match, option_to_result, unwrap
-from ..commonlib.util import change_extension, show_size_bytes
+from ..commonlib.util import show_size_bytes
 
 from .clr import Clr, get_clr
 from .clr_types import (
@@ -43,34 +49,30 @@ from .types import (
     ProcessedHeap,
     ProcessInfo,
     ProcessedTrace,
-    ProcessQuery,
     RunMetrics,
     ThreadToProcessToName,
 )
 
 
-def test_result_from_path(path: Path) -> TestResult:
+def test_result_from_path(path: Path, process: ProcessQuery) -> TestResult:
     if path.name.endswith(".yaml"):
         # Try to find trace path
+        assert (
+            process is None
+        ), f"When working with .yaml files, --process is not needed. Check {path}."
         trace_file_name = load_test_status(path).trace_file_name
         return TestResult(
             test_status_path=path, trace_path=map_option(trace_file_name, lambda n: path.parent / n)
         )
     else:
         assert is_trace_path(path), f"{path} should be a '.yaml' test output file or a trace file."
-        # User might have specified the tracefile when a status file still exists
-        test_status = change_extension(path, ".yaml")
-        status_exists = test_status.exists()
-        assert (not status_exists) or load_test_status(test_status).trace_file_name == path.name
-        return TestResult(test_status_path=test_status if status_exists else None, trace_path=path)
+        return TestResult(
+            test_status_path=None, trace_path=path, process=_convert_to_tuple(process)
+        )
 
 
 def get_processed_trace(
-    clr: Clr,
-    test_result: TestResult,
-    process: ProcessQuery,
-    need_mechanisms_and_reasons: bool,
-    need_join_info: bool,
+    clr: Clr, test_result: TestResult, need_mechanisms_and_reasons: bool, need_join_info: bool
 ) -> Result[str, ProcessedTrace]:
     test_status = option_to_result(
         test_result.load_test_status(), lambda: "Need a test status file"
@@ -79,8 +81,6 @@ def get_processed_trace(
     if test_result.trace_path is None:
         if need_join_info:
             return Err("Can't get join info without a trace.")
-        elif process is not None:
-            return Err("Can't get process without a trace.")
         else:
             return Ok(
                 ProcessedTrace(
@@ -101,8 +101,6 @@ def get_processed_trace(
                 clr,
                 test_status,
                 test_result,
-                test_result.trace_path,
-                process,
                 need_join_info=need_join_info,
                 need_mechanisms_and_reasons=need_mechanisms_and_reasons,
             )
@@ -137,12 +135,10 @@ def _get_processed_trace_from_process(
     clr: Clr,
     test_status: Failable[TestRunStatus],
     test_result: TestResult,
-    trace_path: Path,
-    process: ProcessQuery,
     need_join_info: bool,
     need_mechanisms_and_reasons: bool,
 ) -> ProcessedTrace:
-    if process is None:
+    if test_result.process is None:
         ts = unwrap(
             map_err(
                 test_status,
@@ -157,10 +153,10 @@ def _get_processed_trace_from_process(
         assert (
             test_status.is_err()
         ), "'--process' is unnecessary as the test result specifies the PID"
-        process_predicate = process_predicate_from_parts(process)
+        process_predicate = process_predicate_from_parts(test_result.process)
     process_names, proc = get_process_names_and_process_info(
         clr,
-        trace_path,
+        non_null(test_result.trace_path),
         str(test_result),
         process_predicate,
         # TODO: make this optional; though the metric FirstEventToFirstGCSeconds needs this too.
@@ -177,7 +173,7 @@ def _get_processed_trace_from_process(
         test_status=test_status,
         process_info=proc,
         process_names=process_names,
-        process_query=process,
+        process_query=test_result.process,
         join_info=join_info,
         # TODO: just do this lazily
         mechanisms_and_reasons=get_mechanisms_and_reasons_for_process_info(proc)
@@ -290,7 +286,6 @@ class ProcessedTraces:
     def get(
         self,
         test_result: TestResult,
-        process: ProcessQuery,
         need_mechanisms_and_reasons: bool,
         need_join_info: bool,
         dont_cache: bool = False,
@@ -301,7 +296,7 @@ class ProcessedTraces:
             and current.is_ok()
             and _processed_trace_file_has_enough_info(
                 current.unwrap(),
-                process,
+                test_result.process,
                 need_mechanisms_and_reasons=need_mechanisms_and_reasons,
                 need_join_info=need_join_info,
             )
@@ -314,14 +309,13 @@ class ProcessedTraces:
             updated = get_processed_trace(
                 clr=self.clr,
                 test_result=test_result,
-                process=process,
                 need_mechanisms_and_reasons=need_mechanisms_and_reasons,
                 need_join_info=need_join_info,
             )
             if updated.is_ok():
                 assert _processed_trace_file_has_enough_info(
                     updated.unwrap(),
-                    process,
+                    test_result.process,
                     need_mechanisms_and_reasons=need_mechanisms_and_reasons,
                     need_join_info=need_join_info,
                 )
@@ -336,9 +330,7 @@ class ProcessedTraces:
         already_had = test_result in self.path_to_file
         # TODO: may need join info
         res = map_ok(
-            self.get(
-                test_result, process=None, need_mechanisms_and_reasons=False, need_join_info=False
-            ),
+            self.get(test_result, need_mechanisms_and_reasons=False, need_join_info=False),
             lambda trace: map_to_mapping(run_metrics, trace.metric),
         )
 
@@ -351,6 +343,13 @@ class ProcessedTraces:
         return res
 
 
+def _convert_to_tuple(process: ProcessQuery) -> ProcessQuery:
+    if process is None:
+        return None
+    else:
+        return tuple(process)
+
+
 def _processed_trace_file_has_enough_info(
     current: ProcessedTrace,
     process: ProcessQuery,
@@ -358,7 +357,7 @@ def _processed_trace_file_has_enough_info(
     need_join_info: bool,
 ) -> bool:
     return (
-        current.process_query == process
+        _convert_to_tuple(current.process_query) == _convert_to_tuple(process)
         and current.has_mechanisms_and_reasons >= need_mechanisms_and_reasons
         and current.has_join_info >= need_join_info
     )

--- a/src/benchmarks/gc/src/analysis/types.py
+++ b/src/benchmarks/gc/src/analysis/types.py
@@ -26,7 +26,7 @@ from typing import (
 
 from result import Err, Ok, Result
 
-from ..commonlib.bench_file import GCPerfSimResult, TestResult, TestRunStatus
+from ..commonlib.bench_file import GCPerfSimResult, ProcessQuery, TestResult, TestRunStatus
 from ..commonlib.collection_util import count, empty_mapping, is_empty, map_to_mapping
 from ..commonlib.document import Cell
 from ..commonlib.frozen_dict import FrozenDict
@@ -1218,9 +1218,6 @@ def union_mechanisms(a: MechanismsAndReasons, b: MechanismsAndReasons) -> Mechan
         heap_expand=a.heap_expand | b.heap_expand,
         heap_compact=a.heap_compact | b.heap_compact,
     )
-
-
-ProcessQuery = Optional[Sequence[str]]
 
 
 @with_slots

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1131,7 +1131,7 @@ class TestResult:
 
     def __post_init__(self) -> None:
         # Making sure this is a tuple because Python requires it to be hashable.
-        assert isinstance(self.process, tuple)
+        # assert isinstance(self.process, tuple)
         assert self.test_status_path is not None or self.trace_path is not None
         assert self.test_status_path is None or self.test_status_path.name.endswith(".yaml")
         assert self.trace_path is None or is_trace_path(self.trace_path)
@@ -1151,14 +1151,6 @@ class TestResult:
 
     def __str__(self) -> str:
         return str(self.test_status_or_trace_path)
-
-
-# @with_slots
-# @dataclass(frozen=True)
-# class TestResultWithTuples:
-#     test_status_path: Optional[Path] = None
-#     trace_path: Optional[Path] = None
-#     process: ProcessQuery = None
 
 
 class TraceKind(Enum):

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1119,16 +1119,24 @@ def parse_bench_file(path: Path) -> BenchFileAndPath:
     return BenchFileAndPath(load_yaml(BenchFile, path), path)
 
 
+ProcessQuery = Optional[Sequence[str]]
+
+
 @with_slots
 @dataclass(frozen=True)
 class TestResult:
     test_status_path: Optional[Path] = None
     trace_path: Optional[Path] = None
+    process: ProcessQuery = None
 
     def __post_init__(self) -> None:
+        # Making sure this is a tuple because Python requires it to be hashable.
+        assert isinstance(self.process, tuple)
         assert self.test_status_path is not None or self.trace_path is not None
         assert self.test_status_path is None or self.test_status_path.name.endswith(".yaml")
         assert self.trace_path is None or is_trace_path(self.trace_path)
+        if self.trace_path is None:
+            assert self.process is None
 
     def load_test_status(self) -> Optional[TestRunStatus]:
         return map_option(self.test_status_path, load_test_status)
@@ -1143,6 +1151,14 @@ class TestResult:
 
     def __str__(self) -> str:
         return str(self.test_status_or_trace_path)
+
+
+# @with_slots
+# @dataclass(frozen=True)
+# class TestResultWithTuples:
+#     test_status_path: Optional[Path] = None
+#     trace_path: Optional[Path] = None
+#     process: ProcessQuery = None
 
 
 class TraceKind(Enum):

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1130,13 +1130,16 @@ class TestResult:
     process: ProcessQuery = None
 
     def __post_init__(self) -> None:
+        if self.trace_path is None:
+            assert self.process is None
+
         # Making sure this is a tuple because Python requires it to be hashable.
-        # assert isinstance(self.process, tuple)
+        if (self.process is not None):
+            assert isinstance(self.process, tuple)
+
         assert self.test_status_path is not None or self.trace_path is not None
         assert self.test_status_path is None or self.test_status_path.name.endswith(".yaml")
         assert self.trace_path is None or is_trace_path(self.trace_path)
-        if self.trace_path is None:
-            assert self.process is None
 
     def load_test_status(self) -> Optional[TestRunStatus]:
         return map_option(self.test_status_path, load_test_status)

--- a/src/benchmarks/gc/src/commonlib/document.py
+++ b/src/benchmarks/gc/src/commonlib/document.py
@@ -139,6 +139,9 @@ def _pad(width: int, s: str, align: Align) -> str:
     return switch[align]()
 
 
+_SUPPORTED_TERMINALS = {"ConEmuC64.exe", "WindowsTerminal.exe"}
+
+
 def _shell_supports_color() -> bool:
     if os_is_windows():
         py = _get_py_process()
@@ -148,7 +151,7 @@ def _shell_supports_color() -> bool:
         else:
             assert parent.name() in ("powershell.exe", "cmd.exe")
             shell = parent.parent()
-            return {"ConEmuC64.exe": True, "explorer.exe": False}[shell.name()]
+            return shell.name() in _SUPPORTED_TERMINALS
     else:
         return True
 

--- a/src/benchmarks/gc/src/suite.py
+++ b/src/benchmarks/gc/src/suite.py
@@ -345,6 +345,7 @@ def suite_diff(args: SuiteDiffArgs) -> None:
             test_where=None,
             sample_kind=args.sample_kind,
             max_iterations=args.max_iterations,
+            process=None,
         )
         # Print a summary -- write detailed diff to a file
         print_diff_score_summary(diffables)


### PR DESCRIPTION
When analyzing and comparing trace files, one requires to be able to select which process to work with. This PR adds this functionality via a `--process` flag, which works with either the name or the id of the process. Some refactoring was also made.

Additionally, the documentation received a significant overhaul, giving _Pythonnet_ its own doc, adding more detailed explanations on scenarios and working with trace files, and some metrics were updated as well.

