### PR TITLE
Add missing Benchmark attribute and simplify the benchmark name

### DIFF
--- a/src/benchmarks/micro/corefx/System.Threading/Perf.Thread.cs
+++ b/src/benchmarks/micro/corefx/System.Threading/Perf.Thread.cs
@@ -14,10 +14,8 @@ namespace System.Threading.Tests
         public Thread CurrentThread() => Thread.CurrentThread;
 
 #if !NETFRAMEWORK
-        public int ThreadGetCurrentProcessorId()
-        {
-            return System.Threading.Thread.GetCurrentProcessorId();
-        }
+        [Benchmark]
+        public int GetCurrentProcessorId() => Thread.GetCurrentProcessorId();
 #endif
     }
 }


### PR DESCRIPTION
Despite 3 reviewers we have forgot about... `[Benchmark]` attribute in #1016

I've also simplified the name and benchmark code itself.

/cc @VSadov