### PR TITLE
publish startup as self-contained app

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -167,7 +167,6 @@ def __process_arguments(args: list):
     return parser.parse_args(args)
 
 def __main(args: list) -> int:
-    print(sys.version)
     validate_supported_runtime()
     args = __process_arguments(args)
     verbose = not args.quiet

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -30,7 +30,6 @@ def init_tools(
     This function writes a semaphore file when tools have been successfully
     installed in order to avoid reinstalling them on every rerun.
     '''
-    getLogger().info("Python version: %s" % sys.version)
     getLogger().info('Installing tools.')
     channels = [
         micro_benchmarks.FrameworkAction.get_channel(
@@ -168,6 +167,7 @@ def __process_arguments(args: list):
     return parser.parse_args(args)
 
 def __main(args: list) -> int:
+    print(sys.version)
     validate_supported_runtime()
     args = __process_arguments(args)
     verbose = not args.quiet

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -30,6 +30,7 @@ def init_tools(
     This function writes a semaphore file when tools have been successfully
     installed in order to avoid reinstalling them on every rerun.
     '''
+    getLogger.info(f"Python version: {sys.version}")
     getLogger().info('Installing tools.')
     channels = [
         micro_benchmarks.FrameworkAction.get_channel(

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -30,7 +30,7 @@ def init_tools(
     This function writes a semaphore file when tools have been successfully
     installed in order to avoid reinstalling them on every rerun.
     '''
-    getLogger.info(f"Python version: {sys.version}")
+    getLogger().info(f"Python version: {sys.version}")
     getLogger().info('Installing tools.')
     channels = [
         micro_benchmarks.FrameworkAction.get_channel(

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -30,7 +30,7 @@ def init_tools(
     This function writes a semaphore file when tools have been successfully
     installed in order to avoid reinstalling them on every rerun.
     '''
-    getLogger().info(f"Python version: {sys.version}")
+    getLogger().info("Python version: %s" % sys.version)
     getLogger().info('Installing tools.')
     channels = [
         micro_benchmarks.FrameworkAction.get_channel(

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -233,7 +233,10 @@ class CSharpProject:
         '''Gets the directory in which the built binaries will be placed.'''
         return self.__bin_directory
 
-    def restore(self, packages_path: str, verbose: bool) -> None:
+    def restore(self, 
+                packages_path: str, 
+                verbose: bool,
+                runtime_identifier: str = None) -> None:
         '''
         Calls dotnet to restore the dependencies and tools of the specified
         project.
@@ -248,6 +251,10 @@ class CSharpProject:
             self.csproj_file,
             '--packages', packages_path
         ]
+
+        if runtime_identifier:
+            cmdline += ['--runtime', runtime_identifier]
+            
         RunCommand(cmdline, verbose=verbose).run(
             self.working_directory)
 
@@ -257,6 +264,7 @@ class CSharpProject:
               packages_path: str,
               target_framework_monikers: list = None,
               output_to_bindir: bool = False,
+              runtime_identifier: str = None,
               *args) -> None:
         '''Calls dotnet to build the specified project.'''
         if not target_framework_monikers:  # Build all supported frameworks.
@@ -270,11 +278,16 @@ class CSharpProject:
 
             if output_to_bindir:
                 cmdline = cmdline + ['--output', self.__bin_directory]
-
+            
+            if runtime_identifier:
+                cmdline = cmdline + ['--runtime', runtime_identifier]
+            
             if args:
                 cmdline = cmdline + list(args)
+            
             RunCommand(cmdline, verbose=verbose).run(
                 self.working_directory)
+
         else:  # Only build specified frameworks
             for target_framework_moniker in target_framework_monikers:
                 cmdline = [
@@ -289,8 +302,12 @@ class CSharpProject:
                 if output_to_bindir:
                     cmdline = cmdline + ['--output', self.__bin_directory]
 
+                if runtime_identifier:
+                    cmdline = cmdline + ['--runtime', runtime_identifier]
+
                 if args:
                     cmdline = cmdline + list(args)
+                
                 RunCommand(cmdline, verbose=verbose).run(
                     self.working_directory)
     @staticmethod
@@ -340,6 +357,7 @@ class CSharpProject:
                 packages_path,
                 target_framework_moniker: str = None,
                 runtime_identifier: str = None,
+                *args,
                ) -> None:
         '''
         Invokes publish on the specified project
@@ -356,6 +374,9 @@ class CSharpProject:
 
         if target_framework_moniker:
             cmdline += ['--framework', target_framework_moniker]
+
+        if args:
+            cmdline = cmdline + list(args)
 
         RunCommand(cmdline, verbose=verbose).run(
             self.working_directory

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -357,8 +357,8 @@ class CSharpProject:
                 packages_path,
                 target_framework_moniker: str = None,
                 runtime_identifier: str = None,
-                *args,
-               ) -> None:
+                *args
+                ) -> None:
         '''
         Invokes publish on the specified project
         '''

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -3,12 +3,13 @@ Wrapper around startup tool.
 '''
 import sys
 import os
+import platform
 from shutil import copytree
 from performance.logger import setup_loggers
 from performance.common import get_artifacts_directory, get_packages_directory, RunCommand
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR
 from dotnet import CSharpProject, CSharpProjFile
-from shared.util import helixpayload, helixuploaddir, builtexe, publishedexe, runninginlab, uploadtokenpresent
+from shared.util import helixpayload, helixuploaddir, builtexe, publishedexe, runninginlab, uploadtokenpresent, getruntimeidentifier
 from shared.const import *
 class StartupWrapper(object):
     '''
@@ -29,11 +30,24 @@ class StartupWrapper(object):
                                                    sys.path[0]),
                                                    os.path.join(os.path.dirname(startupproj),
                                     os.path.join(get_artifacts_directory(), 'startup')))
-            startup.restore(get_packages_directory(), True)
-            startup.build(configuration='Release',
-                          verbose=True,
-                          packages_path=get_packages_directory(),
-                          output_to_bindir=True)
+
+            startup.restore(get_packages_directory(),
+                            True,
+                            getruntimeidentifier())
+            startup.build('Release',
+                          True,
+                          get_packages_directory(),
+                          None,
+                          False,
+                          getruntimeidentifier())
+            startup.publish('Release',
+                            os.path.join(get_artifacts_directory(), 'startup'),
+                            True,
+                            get_packages_directory(),
+                            None,
+                            getruntimeidentifier(),
+                            '--no-build'
+                            )
             self._setstartuppath(startup.bin_path)
 
     

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -34,19 +34,13 @@ class StartupWrapper(object):
             startup.restore(get_packages_directory(),
                             True,
                             getruntimeidentifier())
-            startup.build('Release',
-                          True,
-                          get_packages_directory(),
-                          None,
-                          False,
-                          getruntimeidentifier())
             startup.publish('Release',
                             os.path.join(get_artifacts_directory(), 'startup'),
                             True,
                             get_packages_directory(),
                             None,
                             getruntimeidentifier(),
-                            '--no-build'
+                            '--no-restore'
                             )
             self._setstartuppath(startup.bin_path)
 

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -39,9 +39,23 @@ def runninginlab():
     return environ.get('PERFLAB_INLAB') is not None
 
 def getruntimeidentifier():
-    rid = 'win-' if sys.platform == 'win32' else 'linux-'
+    rid = None
+    if sys.platform == 'win32':
+        rid = 'win-'
+    elif sys.platform == 'linux' or sys.platform == 'linux2':
+        rid = 'linux-'
+    else:
+        raise Exception('Platform %s not supported.' % sys.platform)
+
     if 'aarch64' in platform.machine() or os.environ.get('PERFLAB_BUILDARCH') == 'arm64':
         rid += 'arm64'
+    elif platform.machine().endswith('64'):
+        rid += 'x64'
+    elif platform.machine().endswith('86'):
+        rid += 'x86'
     else:
-        rid += 'x64' if platform.machine().endswith('64') else 'x86'
+        raise Exception('Machine %s not supported.' % platform.machine())
+
     return rid
+
+

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -3,6 +3,7 @@ Utility routines
 '''
 import sys
 import os
+import platform
 from os import environ
 from shared import const
 from performance.constants import UPLOAD_TOKEN_VAR
@@ -36,3 +37,8 @@ def uploadtokenpresent():
 
 def runninginlab():
     return environ.get('PERFLAB_INLAB') is not None
+
+def getruntimeidentifier():
+    rid = 'win-' if sys.platform == 'win32' else 'linux-'
+    rid += 'x64' if platform.machine().endswith('64') else 'x86'
+    return rid

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -40,5 +40,8 @@ def runninginlab():
 
 def getruntimeidentifier():
     rid = 'win-' if sys.platform == 'win32' else 'linux-'
-    rid += 'x64' if platform.machine().endswith('64') else 'x86'
+    if 'aarch64' in platform.machine() or os.environ.get('PERFLAB_BUILDARCH') == 'arm64':
+        rid += 'arm64'
+    else:
+        rid += 'x64' if platform.machine().endswith('64') else 'x86'
     return rid


### PR DESCRIPTION
Currently startup tool is built under >=netcoreapp3.0 and the generated executable is used. In order to support netcoreapp2.x, which doesn't generate an executable, the startup project needs to be published.