### PR TITLE
recursively change framework version for weblarge3.0 project

### DIFF
--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -91,12 +91,16 @@ class PreCommands:
                             metavar='/p:Foo=Bar;/p:Baz=Blee;...')
         parser.set_defaults(configuration=RELEASE)
 
-    def existing(self, projectdir: str, projectfile: str):
-        'create a project from existing project file'
+    def existing(self, projectdir: str, projectfiles):
+        'create a project for each existing project file'
         self._backup(projectdir)
-        csproj = CSharpProjFile(os.path.join(const.APPDIR, projectfile), sys.path[0])
-        self.project = CSharpProject(csproj, const.BINDIR)
-        self._updateframework(csproj.file_name)
+        if type(projectfiles) is str:
+            projectfiles = [projectfiles]
+        for projectfile in projectfiles:
+            csproj = CSharpProjFile(os.path.join(const.APPDIR, projectfile), sys.path[0])
+            self.project = CSharpProject(csproj, const.BINDIR)
+            self._updateframework(csproj.file_name)
+
 
     def execute(self):
         'Parses args and runs precommands'
@@ -130,14 +134,7 @@ class PreCommands:
 
     def _updateframework(self, projectfile: str):
         if self.framework:
-            if projectfile.endswith('mvc\\mvc.csproj'): # for the weblarge3.0 project, replace frameworks of all project files 
-                for (path, dirnames, filenames) in os.walk(os.path.dirname(os.path.dirname(projectfile))):
-                    for filename in filenames:
-                        if filename.endswith('.csproj'):
-                            absfilename = os.path.join(path,filename)
-                            replace_line(absfilename, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
-            else:
-                replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
+            replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
 
     def _publish(self, configuration: str, framework: str = None):
         self.project.publish(configuration=configuration,

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -130,7 +130,14 @@ class PreCommands:
 
     def _updateframework(self, projectfile: str):
         if self.framework:
-            replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
+            if projectfile.endswith('mvc\\mvc.csproj'): # for the weblarge3.0 project, replace frameworks of all project files 
+                for (path, dirnames, filenames) in os.walk(os.path.dirname(os.path.dirname(projectfile))):
+                    for filename in filenames:
+                        if filename.endswith('.csproj'):
+                            absfilename = os.path.join(path,filename)
+                            replace_line(absfilename, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
+            else:
+                replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
 
     def _publish(self, configuration: str, framework: str = None):
         self.project.publish(configuration=configuration,

--- a/src/scenarios/weblarge3.0/pre.py
+++ b/src/scenarios/weblarge3.0/pre.py
@@ -7,7 +7,15 @@ from performance.logger import setup_loggers
 from shared.precommands import PreCommands
 from shared import const
 
+def findallprojectfiles():
+    projectfiles = [] 
+    for (path, dirnames, filenames) in os.walk(const.SRCDIR):
+        for filename in filenames:
+            if filename.endswith('.csproj'):
+                projectfiles.append(os.path.relpath(os.path.join(path,filename), const.SRCDIR))
+    return projectfiles # main project file \mvc\mvc.csproj is the last element  
+
 setup_loggers(True)
 precommands = PreCommands()
-precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc\\mvc.csproj')
+precommands.existing(os.path.join(sys.path[0], const.SRCDIR), findallprojectfiles())
 precommands.execute()


### PR DESCRIPTION
Weblarge3.0 project has more than one .csproj files that need to change, so we need to replace the frameworks recursively. 