### PR TITLE
make library projects target netstandard2.0

### DIFF
--- a/src/scenarios/weblarge3.0/src/ClassLib001/ClassLib001.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib001/ClassLib001.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup></ItemGroup>
 </Project>

--- a/src/scenarios/weblarge3.0/src/ClassLib002/ClassLib002.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib002/ClassLib002.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib003/ClassLib003.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib003/ClassLib003.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib004/ClassLib004.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib004/ClassLib004.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib005/ClassLib005.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib005/ClassLib005.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/scenarios/weblarge3.0/src/ClassLib006/ClassLib006.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib006/ClassLib006.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib007/ClassLib007.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib007/ClassLib007.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />

--- a/src/scenarios/weblarge3.0/src/ClassLib008/ClassLib008.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib008/ClassLib008.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup></ItemGroup>
 </Project>

--- a/src/scenarios/weblarge3.0/src/ClassLib009/ClassLib009.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib009/ClassLib009.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fluid.Core" Version="1.0.0-beta-9399" />

--- a/src/scenarios/weblarge3.0/src/ClassLib010/ClassLib010.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib010/ClassLib010.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.1" />

--- a/src/scenarios/weblarge3.0/src/ClassLib011/ClassLib011.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib011/ClassLib011.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00004" />

--- a/src/scenarios/weblarge3.0/src/ClassLib012/ClassLib012.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib012/ClassLib012.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.1" />

--- a/src/scenarios/weblarge3.0/src/ClassLib013/ClassLib013.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib013/ClassLib013.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib014/ClassLib014.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib014/ClassLib014.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/scenarios/weblarge3.0/src/ClassLib015/ClassLib015.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib015/ClassLib015.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib016/ClassLib016.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib016/ClassLib016.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.1" />

--- a/src/scenarios/weblarge3.0/src/ClassLib017/ClassLib017.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib017/ClassLib017.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/src/scenarios/weblarge3.0/src/ClassLib018/ClassLib018.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib018/ClassLib018.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.4" />

--- a/src/scenarios/weblarge3.0/src/ClassLib019/ClassLib019.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib019/ClassLib019.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup></ItemGroup>
 </Project>

--- a/src/scenarios/weblarge3.0/src/ClassLib020/ClassLib020.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib020/ClassLib020.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />

--- a/src/scenarios/weblarge3.0/src/ClassLib021/ClassLib021.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib021/ClassLib021.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib007\ClassLib007.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib022/ClassLib022.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib022/ClassLib022.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib007\ClassLib007.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib023/ClassLib023.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib023/ClassLib023.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib008\ClassLib008.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib024/ClassLib024.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib024/ClassLib024.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib008\ClassLib008.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib025/ClassLib025.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib025/ClassLib025.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib010\ClassLib010.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib026/ClassLib026.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib026/ClassLib026.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib011\ClassLib011.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib027/ClassLib027.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib027/ClassLib027.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib012\ClassLib012.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib028/ClassLib028.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib028/ClassLib028.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib005\ClassLib005.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib029/ClassLib029.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib029/ClassLib029.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib016\ClassLib016.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib030/ClassLib030.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib030/ClassLib030.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib017\ClassLib017.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib031/ClassLib031.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib031/ClassLib031.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib017\ClassLib017.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib032/ClassLib032.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib032/ClassLib032.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib018\ClassLib018.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib033/ClassLib033.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib033/ClassLib033.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib002\ClassLib002.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib034/ClassLib034.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib034/ClassLib034.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib004\ClassLib004.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib035/ClassLib035.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib035/ClassLib035.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib036/ClassLib036.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib036/ClassLib036.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib022\ClassLib022.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib037/ClassLib037.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib037/ClassLib037.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib006\ClassLib006.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib038/ClassLib038.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib038/ClassLib038.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib004\ClassLib004.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib039/ClassLib039.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib039/ClassLib039.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib028\ClassLib028.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib040/ClassLib040.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib040/ClassLib040.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib041/ClassLib041.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib041/ClassLib041.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib022\ClassLib022.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib042/ClassLib042.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib042/ClassLib042.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib007\ClassLib007.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib043/ClassLib043.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib043/ClassLib043.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib004\ClassLib004.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib044/ClassLib044.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib044/ClassLib044.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib045/ClassLib045.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib045/ClassLib045.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib028\ClassLib028.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib046/ClassLib046.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib046/ClassLib046.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib047/ClassLib047.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib047/ClassLib047.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib005\ClassLib005.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib048/ClassLib048.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib048/ClassLib048.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib007\ClassLib007.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib049/ClassLib049.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib049/ClassLib049.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib042\ClassLib042.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib050/ClassLib050.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib050/ClassLib050.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib051/ClassLib051.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib051/ClassLib051.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib006\ClassLib006.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib052/ClassLib052.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib052/ClassLib052.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib038\ClassLib038.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib053/ClassLib053.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib053/ClassLib053.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib054/ClassLib054.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib054/ClassLib054.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib039\ClassLib039.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib055/ClassLib055.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib055/ClassLib055.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib036\ClassLib036.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib056/ClassLib056.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib056/ClassLib056.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib037\ClassLib037.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib057/ClassLib057.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib057/ClassLib057.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib058/ClassLib058.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib058/ClassLib058.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib059/ClassLib059.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib059/ClassLib059.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib060/ClassLib060.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib060/ClassLib060.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib061/ClassLib061.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib061/ClassLib061.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib062/ClassLib062.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib062/ClassLib062.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib063/ClassLib063.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib063/ClassLib063.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib064/ClassLib064.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib064/ClassLib064.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib065/ClassLib065.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib065/ClassLib065.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib006\ClassLib006.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib066/ClassLib066.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib066/ClassLib066.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib054\ClassLib054.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib067/ClassLib067.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib067/ClassLib067.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib068/ClassLib068.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib068/ClassLib068.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib069/ClassLib069.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib069/ClassLib069.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib070/ClassLib070.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib070/ClassLib070.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib071/ClassLib071.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib071/ClassLib071.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib072/ClassLib072.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib072/ClassLib072.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib056\ClassLib056.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib073/ClassLib073.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib073/ClassLib073.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib074/ClassLib074.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib074/ClassLib074.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib075/ClassLib075.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib075/ClassLib075.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib076/ClassLib076.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib076/ClassLib076.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib050\ClassLib050.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib077/ClassLib077.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib077/ClassLib077.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib078/ClassLib078.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib078/ClassLib078.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib079/ClassLib079.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib079/ClassLib079.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib080/ClassLib080.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib080/ClassLib080.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib051\ClassLib051.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib081/ClassLib081.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib081/ClassLib081.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib082/ClassLib082.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib082/ClassLib082.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib001\ClassLib001.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib083/ClassLib083.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib083/ClassLib083.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib033\ClassLib033.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib084/ClassLib084.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib084/ClassLib084.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib085/ClassLib085.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib085/ClassLib085.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib086/ClassLib086.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib086/ClassLib086.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib061\ClassLib061.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib087/ClassLib087.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib087/ClassLib087.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib088/ClassLib088.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib088/ClassLib088.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib089/ClassLib089.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib089/ClassLib089.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib090/ClassLib090.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib090/ClassLib090.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib091/ClassLib091.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib091/ClassLib091.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib092/ClassLib092.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib092/ClassLib092.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib093/ClassLib093.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib093/ClassLib093.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib027\ClassLib027.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib094/ClassLib094.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib094/ClassLib094.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib095/ClassLib095.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib095/ClassLib095.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib096/ClassLib096.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib096/ClassLib096.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib097/ClassLib097.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib097/ClassLib097.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib060\ClassLib060.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib098/ClassLib098.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib098/ClassLib098.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib099/ClassLib099.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib099/ClassLib099.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib100/ClassLib100.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib100/ClassLib100.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib101/ClassLib101.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib101/ClassLib101.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib001\ClassLib001.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib102/ClassLib102.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib102/ClassLib102.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib103/ClassLib103.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib103/ClassLib103.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib104/ClassLib104.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib104/ClassLib104.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib105/ClassLib105.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib105/ClassLib105.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib106/ClassLib106.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib106/ClassLib106.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib107/ClassLib107.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib107/ClassLib107.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib108/ClassLib108.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib108/ClassLib108.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib109/ClassLib109.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib109/ClassLib109.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib110/ClassLib110.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib110/ClassLib110.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib111/ClassLib111.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib111/ClassLib111.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib085\ClassLib085.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib112/ClassLib112.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib112/ClassLib112.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib113/ClassLib113.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib113/ClassLib113.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib038\ClassLib038.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib114/ClassLib114.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib114/ClassLib114.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib115/ClassLib115.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib115/ClassLib115.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib116/ClassLib116.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib116/ClassLib116.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib117/ClassLib117.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib117/ClassLib117.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib082\ClassLib082.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib118/ClassLib118.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib118/ClassLib118.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib119/ClassLib119.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib119/ClassLib119.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib003\ClassLib003.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib120/ClassLib120.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib120/ClassLib120.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib121/ClassLib121.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib121/ClassLib121.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib122/ClassLib122.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib122/ClassLib122.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib021\ClassLib021.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib123/ClassLib123.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib123/ClassLib123.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib124/ClassLib124.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib124/ClassLib124.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib081\ClassLib081.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib125/ClassLib125.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib125/ClassLib125.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib101\ClassLib101.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib126/ClassLib126.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib126/ClassLib126.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib049\ClassLib049.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib127/ClassLib127.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib127/ClassLib127.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib081\ClassLib081.csproj" />

--- a/src/scenarios/weblarge3.0/src/ClassLib128/ClassLib128.csproj
+++ b/src/scenarios/weblarge3.0/src/ClassLib128/ClassLib128.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ClassLib059\ClassLib059.csproj" />


### PR DESCRIPTION
Since library projects targeting netstandard2.0 should be a scenario, we will make the changes for easier framework update. 