### PR TITLE
Fix startup publish; reduce scenario iterations in PR runs

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -84,14 +84,14 @@ jobs:
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries
-          - script: $(CorrelationStaging)dotnet\dotnet publish -o $(CorrelationStaging)startup -f $(_Framework) $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj
+          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r win-${{parameters.architecture}} $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj
             displayName: Build startup tool
             env:
               PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
         - ${{ if ne(parameters.osName, 'windows') }}:
           - script: cp -r ./scripts $(CorrelationStaging)scripts;cp -r ./src/scenarios/shared $(CorrelationStaging)shared;cp -r ./src/scenarios/staticdeps $(CorrelationStaging)staticdeps
             displayName: Copy python libraries
-          - script: $(CorrelationStaging)dotnet/dotnet publish -o $(CorrelationStaging)startup -f $(_Framework) $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
             displayName: Build startup tool
             env:
               PERFLAB_TARGET_FRAMEWORKS: $(_Framework)

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -57,6 +57,9 @@ class StartupWrapper(object):
                 raise Exception('startup tests require %s' % key)
         reportjson = os.path.join(TRACEDIR, 'perf-lab-report.json')
         defaultiterations = '1' if not runninginlab() and helixpayload() else '5'
+        print('runninginlab: %s' % runninginlab())
+        print('helixpayload: %s' % helixpayload())
+        print('uploadtoken: %s' % uploadtokenpresent())
         startup_args = [
             self.startupexe,
             '--app-exe', apptorun,

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -56,6 +56,7 @@ class StartupWrapper(object):
             if not kwargs[key]:
                 raise Exception('startup tests require %s' % key)
         reportjson = os.path.join(TRACEDIR, 'perf-lab-report.json')
+        defaultiterations = '1' if not runninginlab() and helixpayload() else '5'
         startup_args = [
             self.startupexe,
             '--app-exe', apptorun,
@@ -63,7 +64,7 @@ class StartupWrapper(object):
             '--scenario-name', "%s - %s" % (kwargs['scenarioname'], kwargs['scenariotypename']),
             '--trace-file-name', '%s_%s_startup.etl' % (kwargs['exename'], kwargs['scenariotypename']),
             '--process-will-exit', (kwargs['processwillexit'] or 'true'),
-            '--iterations', '%s' % (kwargs['iterations'] or '5'),
+            '--iterations', '%s' % (kwargs['iterations'] or defaultiterations),
             '--timeout', '%s' % (kwargs['timeout'] or '50'),
             '--warmup', '%s' % (kwargs['warmup'] or 'true'),
             '--gui-app', kwargs['guiapp'],

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -56,10 +56,7 @@ class StartupWrapper(object):
             if not kwargs[key]:
                 raise Exception('startup tests require %s' % key)
         reportjson = os.path.join(TRACEDIR, 'perf-lab-report.json')
-        defaultiterations = '1' if not runninginlab() and helixpayload() else '5'
-        print('runninginlab: %s' % runninginlab())
-        print('helixpayload: %s' % helixpayload())
-        print('uploadtoken: %s' % uploadtokenpresent())
+        defaultiterations = '1' if runninginlab() and not uploadtokenpresent() else '5' # only run 1 iteration for PR-triggered build
         startup_args = [
             self.startupexe,
             '--app-exe', apptorun,


### PR DESCRIPTION
- specify runtime when publishing startup in CI so it can generate exe for netcoreapp2.x
- reduce iterations of scenario tests to 1 for PR runs; customer and private runs will remain having the default 5 iterations