### PR TITLE
pass workitem name as scenario name

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -22,7 +22,7 @@
       <Command>$(Python) test.py startup --scenario-name %(Identity)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
-    <HelixWorkItem>
+    </HelixWorkItem>
   </ItemDefinitionGroup>
   
   <ItemGroup>

--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -19,7 +19,7 @@
   <ItemDefinitionGroup>
     <HelixWorkItem>
       <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup --scenario-name %(Identity)</Command>
+      <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>

--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -15,46 +15,31 @@
     <ScenariosDir>$(WorkItemDirectory)/src/scenarios/</ScenariosDir>
     <HelixPreCommands>$(HelixPreCommands);export PYTHONPATH=$HELIX_CORRELATION_PAYLOAD/scripts:$HELIX_CORRELATION_PAYLOAD</HelixPreCommands>
   </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <HelixWorkItem>
+      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
+      <Command>$(Python) test.py startup --scenario-name %(Identity)</Command>
+      <PostCommands>$(Python) post.py</PostCommands>
+      <Timeout>4:00</Timeout>
+    <HelixWorkItem>
+  </ItemDefinitionGroup>
   
   <ItemGroup>
     <HelixWorkItem Include="Static Console Template">
       <PayloadDirectory>$(ScenariosDir)staticconsoletemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-      <Timeout>4:00</Timeout>
     </HelixWorkItem>
-
     <HelixWorkItem Include="Static VB Console Template">
       <PayloadDirectory>$(ScenariosDir)staticvbconsoletemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-      <Timeout>4:00</Timeout>
     </HelixWorkItem>
-
     <HelixWorkItem Include="Static Winforms Template">
       <PayloadDirectory>$(ScenariosDir)staticwinformstemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-      <Timeout>4:00</Timeout>
     </HelixWorkItem>
-
     <HelixWorkItem Include="New Console Template">
       <PayloadDirectory>$(ScenariosDir)emptyconsoletemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-      <Timeout>4:00</Timeout>
     </HelixWorkItem>
-    
     <HelixWorkItem Include="New VB Console Template">
       <PayloadDirectory>$(ScenariosDir)emptyvbconsoletemplate</PayloadDirectory>
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-      <Timeout>4:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
 </Project>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -82,10 +82,10 @@
 
   <ItemGroup>
     <HelixWorkItem Include="@(SDKWorkItem -> '%(Identity) Clean Build')">
-      <Command>%(Command) clean_build --scenario-name %(Identity)</Command>
+      <Command>%(Command) clean_build --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(SDKWorkItem -> '%(Identity) Build(No Change)')">
-      <Command>%(Command) build_no_change --scenario-name %(Identity)</Command>
+      <Command>%(Command) build_no_change --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>
 </Project>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -82,10 +82,10 @@
 
   <ItemGroup>
     <HelixWorkItem Include="@(SDKWorkItem -> '%(Identity) Clean Build')">
-      <Command>%(Command) clean_build</Command>
+      <Command>%(Command) clean_build --scenario-name %(Identity)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(SDKWorkItem -> '%(Identity) Build(No Change)')">
-      <Command>%(Command) build_no_change</Command>
+      <Command>%(Command) build_no_change --scenario-name %(Identity)</Command>
     </HelixWorkItem>
   </ItemGroup>
 </Project>

--- a/src/scenarios/emptyconsoletemplate/test.py
+++ b/src/scenarios/emptyconsoletemplate/test.py
@@ -7,8 +7,7 @@ SCENARIONAME = 'Empty C# Console Template'
 EXENAME = 'emptycsconsoletemplate'
 
 if __name__ == "__main__":
-    traits = TestTraits(scenarioname=SCENARIONAME, 
-                        exename=EXENAME, 
+    traits = TestTraits(exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
                         sdk=True,

--- a/src/scenarios/emptyvbconsoletemplate/test.py
+++ b/src/scenarios/emptyvbconsoletemplate/test.py
@@ -7,8 +7,7 @@ SCENARIONAME = 'Empty VB Console Template'
 EXENAME = 'emptyvbconsoletemplate'
 
 if __name__ == "__main__":
-    traits = TestTraits(scenarioname=SCENARIONAME, 
-                        exename=EXENAME, 
+    traits = TestTraits(exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
                         guiapp='false',

--- a/src/scenarios/mvcapptemplate/test.py
+++ b/src/scenarios/mvcapptemplate/test.py
@@ -7,8 +7,7 @@ EXENAME = 'mvcapptemplate'
 
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         sdk=True,
                         )

--- a/src/scenarios/netstandard2.0/test.py
+++ b/src/scenarios/netstandard2.0/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = '.NET Core 2.0 Library Template'
 EXENAME = 'NetCoreApp(Library)'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         sdk=True,
                         )

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -60,10 +60,12 @@ class Runner:
         parser = ArgumentParser()
         subparsers = parser.add_subparsers(title='subcommands for sdk tests', required=True, dest='testtype')
         startupparser = subparsers.add_parser(const.STARTUP)
-        startupparser.add_argument('--scenario-name', dest='scenarioname')
+        self.add_common_arguments(startupparser)
+
         sdkparser = subparsers.add_parser(const.SDK)
         sdkparser.add_argument('sdktype', choices=[const.CLEAN_BUILD, const.BUILD_NO_CHANGE], type=str.lower)
-        sdkparser.add_argument('--scenario-name', dest='scenarioname')
+        self.add_common_arguments(sdkparser)
+
         args = parser.parse_args()
 
         if not getattr(self.traits, args.testtype):
@@ -75,6 +77,11 @@ class Runner:
             self.sdktype = args.sdktype
         if args.scenarioname:
             self.scenarioname = args.scenarioname
+    
+    def add_common_arguments(self, parser: ArgumentParser):
+        "Common arguments to add to subparsers"
+        parser.add_argument('--scenario-name',
+                            dest='scenarioname')
 
     def run(self):
         '''

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -61,8 +61,7 @@ class StartupWrapper(object):
             self.startupexe,
             '--app-exe', apptorun,
             '--metric-type', kwargs['startupmetric'], 
-            '--scenario-name', "%s - %s" % (kwargs['scenarioname'], kwargs['scenariotypename']),
-            '--trace-file-name', '%s_%s_startup.etl' % (kwargs['exename'], kwargs['scenariotypename']),
+            '--trace-file-name', '%s_startup.etl' % (kwargs['scenarioname'] or '%s_%s' % (kwargs['exename'],kwargs['scenariotypename'])),
             '--process-will-exit', (kwargs['processwillexit'] or 'true'),
             '--iterations', '%s' % (kwargs['iterations'] or defaultiterations),
             '--timeout', '%s' % (kwargs['timeout'] or '50'),
@@ -72,8 +71,9 @@ class StartupWrapper(object):
             '--report-json-path', reportjson,
             '--trace-directory', TRACEDIR
         ]
-
         # optional arguments
+        if kwargs['scenarioname']:
+            startup_args.extend(['--scenario-name', kwargs['scenarioname']])
         if kwargs['appargs']:
             startup_args.extend(['--app-args', kwargs['appargs']])
         if kwargs['environmentvariables']:

--- a/src/scenarios/staticconsoletemplate/test.py
+++ b/src/scenarios/staticconsoletemplate/test.py
@@ -7,8 +7,7 @@ SCENARIONAME = 'Static Console Template'
 EXENAME = 'staticconsoletemplate'
 
 if __name__ == "__main__":
-    traits = TestTraits(scenarioname=SCENARIONAME, 
-                        exename=EXENAME, 
+    traits = TestTraits(exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
                         guiapp='false',

--- a/src/scenarios/staticvbconsoletemplate/test.py
+++ b/src/scenarios/staticvbconsoletemplate/test.py
@@ -7,8 +7,7 @@ SCENARIONAME = 'Static VB Console Template'
 EXENAME = 'staticvbconsoletemplate'
 
 if __name__ == "__main__":
-    traits = TestTraits(scenarioname=SCENARIONAME, 
-                        exename=EXENAME, 
+    traits = TestTraits(exename=EXENAME, 
                         startupmetric='TimeToMain',
                         startup=True,
                         guiapp='false',

--- a/src/scenarios/staticwinformstemplate/test.py
+++ b/src/scenarios/staticwinformstemplate/test.py
@@ -7,8 +7,7 @@ SCENARIONAME = 'Winforms Template'
 EXENAME = 'staticwinformstemplate'
 
 if __name__ == "__main__":
-    traits = TestTraits(scenarioname=SCENARIONAME, 
-                        exename=EXENAME, 
+    traits = TestTraits(exename=EXENAME, 
                         startupmetric='GenericStartup',
                         startup=True,
                         guiapp='true',

--- a/src/scenarios/weblarge2.0/test.py
+++ b/src/scenarios/weblarge2.0/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'Web Large 2.0'
 EXENAME = 'weblarge20'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false',
                         workingdir='mvc',
                         timeout= f'{const.MINUTE*30}',  # increase timeout for the large project

--- a/src/scenarios/weblarge3.0/test.py
+++ b/src/scenarios/weblarge3.0/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'Web Large 3.0'
 EXENAME = 'weblarge30'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false',
                         workingdir='mvc',
                         timeout= f'{const.MINUTE*30}',   # increase timeout for the large project

--- a/src/scenarios/windowsforms/test.py
+++ b/src/scenarios/windowsforms/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'Windows Forms Template'
 EXENAME = 'windowsforms'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         sdk=True,
                         )

--- a/src/scenarios/windowsformslarge/test.py
+++ b/src/scenarios/windowsformslarge/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'Windows Forms Large'
 EXENAME = 'windowsformslarge'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         sdk=True,
                         )

--- a/src/scenarios/wpf/test.py
+++ b/src/scenarios/wpf/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'WPF Template'
 EXENAME = 'wpf'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         sdk=True,
                         )

--- a/src/scenarios/wpflarge/test.py
+++ b/src/scenarios/wpflarge/test.py
@@ -6,8 +6,7 @@ SCENARIONAME = 'WPF Large'
 EXENAME = 'wpflarge'
 
 def main():
-    traits = TestTraits(scenarioname=SCENARIONAME,
-                        exename=EXENAME,
+    traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
                         timeout= f'{const.MINUTE*15}',
                         sdk=True,

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -72,7 +72,6 @@ namespace ScenarioMeasurement
                 if (String.IsNullOrEmpty(arg))
                     throw new ArgumentException(name);
             };
-            checkArg(scenarioName, nameof(scenarioName));
             checkArg(appExe, nameof(appExe));
             checkArg(traceFileName, nameof(traceFileName));
 


### PR DESCRIPTION
- make scenario name a parameter to ```test.py``` so it can be set equal to workitem name, which includes framework and is enough to distinguish tests
- set trace file name to ```exename+scenariotype``` for customer runs and ```scenarioname``` for CI runs
- refactor ```scenarios.proj```