### PR TITLE
change condition of IndividualCI runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,7 @@ jobs:
 # Private Jobs
 ###########################################
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI')) }}:
 
   # Windows x64 scenario benchmarks
   - template: /eng/performance/scenarios.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,7 @@ jobs:
 # Private Jobs
 ###########################################
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'IndividualCI')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')) }}:
 
   # Windows x64 scenario benchmarks
   - template: /eng/performance/scenarios.yml


### PR DESCRIPTION
Currently manual runs will trigger private jobs, too. This change will exclude private jobs from manual runs. 