### PR TITLE
fix ReadWrite() in System.IO.Pipes

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.PipeTest.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.PipeTest.cs
@@ -9,7 +9,6 @@ using MicroBenchmarks;
 
 namespace System.IO.Pipes.Tests
 {
-    [AllowedOperatingSystems("Hangs on non-Windows, dotnet/corefx#18290", OS.Windows)]
     [BenchmarkCategory(Categories.Libraries)]
     public abstract class Perf_PipeTest : PipeTestBase
     {
@@ -35,7 +34,13 @@ namespace System.IO.Pipes.Tests
         public async Task ReadWrite()
         {
             Task write = Task.Run(() => _serverClientPair.writeablePipe.Write(_sent, 0, _sent.Length));
-            _serverClientPair.readablePipe.Read(_received, 0, size);
+            int totalReadLength = 0;
+            while (totalReadLength < _sent.Length)
+            {
+                int readLength = _serverClientPair.readablePipe.Read(_received, totalReadLength, size - totalReadLength);
+                totalReadLength += readLength;
+            }
+
             await write;
         }
     }


### PR DESCRIPTION
The logic in ReadWrite() is not correct. It assumes that Write and Read are atomic and that they will always do what they are asked for e.g. read `size` at once. That is not true, at least on Unix. Large write will be partitioned based on socket buffer space and read will return as soon as it gets the first chunk, even that is less than asked for. Since there was only one read, write will fill up socket buffer again and it will get stuck since we don't read anymore. 

The fix is trivial. If we get less than we wanted, we need to keep reading. The test is passing now for NamePipes 


|    Method |    size |     Mean |   Error |   StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |-------- |---------:|--------:|---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| ReadWrite | 1000000 | 308.2 us | 9.41 us | 10.83 us | 310.7 us | 277.2 us | 319.5 us |     - |     - |     - |     128 B |

as well as Anonymous

|    Method |    size |     Mean |    Error |   StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |-------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| ReadWrite | 1000000 | 305.2 us | 11.87 us | 13.67 us | 305.2 us | 283.8 us | 330.8 us |     - |     - |     - |     128 B |

They seem to give similar performance. On Windows I get but it is a little bit different HW. It may be also impacted by underlying technology.

|    Method |    size |     Mean |   Error |  StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |-------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| ReadWrite | 1000000 | 197.7 us | 1.99 us | 1.77 us | 197.7 us | 194.9 us | 200.9 us |     - |     - |     - |     221 B |

cc: @stephentoub @adamsitnik 

fixes #56
