### PR TITLE
Add client env setup for scenario tests

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -25,6 +25,7 @@ from performance.common import push_dir
 from performance.common import RunCommand
 from performance.common import validate_supported_runtime
 from performance.logger import setup_loggers
+from channel_map import ChannelMap
 
 
 def info(verbose: bool) -> None:
@@ -810,19 +811,13 @@ def __process_arguments(args: list):
         help='Installs dotnet cli',
     )
 
-    # TODO: Could pull this information from repository.
-    SUPPORTED_CHANNELS = [
-        'master',  # Default channel
-        '2.1',
-        'LTS',
-    ]
     install_parser.add_argument(
         '--channels',
         dest='channels',
         required=False,
         nargs='+',
-        default=[SUPPORTED_CHANNELS[0]],
-        choices=SUPPORTED_CHANNELS,
+        default=['master'],
+        choices= ChannelMap.get_supported_channels(),
         help='Download DotNet Cli from the Channel specified.'
     )
 

--- a/src/scenarios/init.ps1
+++ b/src/scenarios/init.ps1
@@ -1,2 +1,31 @@
+Param(
+    $Channel = 'master' # default is master
+)
+
 $scripts = Join-Path $PSScriptRoot '..\..\scripts' -Resolve
 $env:PYTHONPATH="$scripts;$PSScriptRoot"
+$dotnetScript= Join-Path "$scripts" 'dotnet.py' -Resolve
+$dotnetDirectory= Join-Path $PSScriptRoot 'dotnet'
+
+if (Test-Path $dotnetDirectory){
+    Write-Host "Removing $dotnetDirectory ..."
+    Remove-Item  $dotnetDirectory -Recurse
+}
+
+Write-Host "Downloading dotnet from channel $Channel"
+python $dotnetScript install --channels $Channel --install-dir $dotnetDirectory
+
+if (!$?){
+    Write-Host "Dotnet installation failed."
+    Exit 1
+}
+
+$env:DOTNET_CLI_TELEMETRY_OPTOUT='1'
+$env:DOTNET_MULTILEVEL_LOOKUP='0'
+$env:UseSharedCompilation='false'
+$env:DOTNET_ROOT=$dotnetDirectory
+$env:Path="$dotnetDirectory;$env:Path"
+
+dotnet --info
+
+

--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -1,2 +1,26 @@
+if [[ -z $1 ]]; then
+    echo "Please specify a channel to download dotnet from; example: ./init.sh <channel>"
+    exit 1
+fi
+
 ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export PYTHONPATH=$PYTHONPATH:$ABSOLUTE_PATH/../../scripts:$ABSOLUTE_PATH
+SCRIPT_PATH="$ABSOLUTE_PATH/../../scripts"
+export PYTHONPATH=$PYTHONPATH:$SCRIPT_PATH:$ABSOLUTE_PATH
+DOTNET_SCRIPT="$SCRIPT_PATH/dotnet.py"
+DOTNET_DIRECTORY="$ABSOLUTE_PATH/dotnet"
+
+if [[ -d $DOTNET_DIRECTORY ]]; then
+    echo "Removing $DOTNET_DIRECTORY"
+    rm -r $DOTNET_DIRECTORY
+fi
+
+echo "Downloading dotnet from channel $1"
+python $DOTNET_SCRIPT install --channels $1 --install-dir $DOTNET_DIRECTORY
+
+export DOTNET_CLI_TELEMETRY_OPTOUT='1'
+export DOTNET_MULTILEVEL_LOOKUP='0'
+export UseSharedCompilation='false'
+export DOTNET_ROOT=$DOTNET_DIRECTORY
+export PATH="$DOTNET_DIRECTORY:$PATH"
+
+dotnet --info


### PR DESCRIPTION
- Extend the functionality of ```init.ps1``` and ```init.sh``` so it can use a specific version of dotnet when running on client desktops
- In ```dotnet.py```, get supported channels from ChannelMap instead of harcoding