### PR TITLE
make tests runnable on OSX with default .NET dependencies

### DIFF
--- a/src/benchmarks/micro/libraries/System.Drawing/Perf_Image_Load.cs
+++ b/src/benchmarks/micro/libraries/System.Drawing/Perf_Image_Load.cs
@@ -50,7 +50,7 @@ namespace System.Drawing.Tests
         {
             try
             {
-                return new [] 
+                return new []
                 {
                     new ImageTestData(ImageFormat.Bmp),
                     new ImageTestData(ImageFormat.Jpeg),
@@ -65,6 +65,11 @@ namespace System.Drawing.Tests
                 Console.ResetColor();
 
                 throw;
+            }
+            catch (Exception) when (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // skip tests on macOS instead of failing
+                return new ImageTestData[0];
             }
         }
 


### PR DESCRIPTION
OSX by default does not have any package manager and .NET itself requires no additional dependencies. 

Drawing tests are only one reason why performance tests do not run on macOS out of the box. 
Since gdi performance is probably not that interesting on macOS, this change will skip tests and make everything else easily runnable. 

The test will still run if proper dependencies are installed.

cc: @safern @adamsitnik 