### PR TITLE
Fixed the missing GC's from trace analysis.

### DIFF
--- a/src/benchmarks/gc/src/analysis/core_analysis.py
+++ b/src/benchmarks/gc/src/analysis/core_analysis.py
@@ -224,7 +224,7 @@ def _get_gcs_from_mang(
     mang: AbstractTraceLoadedDotNetRuntime, name: str
 ) -> Sequence[AbstractTraceGC]:
     # Skip the first two GCs which often have incomplete events
-    unfiltered_gcs = mang.GC.GCs[2:]
+    unfiltered_gcs = mang.GC.GCs
 
     def flt(i: int, gc: AbstractTraceGC) -> bool:
         gc_type = GCType(gc.Type)

--- a/src/benchmarks/gc/src/analysis/process_trace.py
+++ b/src/benchmarks/gc/src/analysis/process_trace.py
@@ -163,6 +163,8 @@ def _get_processed_trace_from_process(
         collect_event_names=True,
     )
 
+    assert len(proc.gcs) > 0, f"Trace file {proc.trace_path.name} has no GC's to analyze."
+
     # TODO: just do this lazily (getting join info)
     join_info = (
         get_join_info_for_all_gcs(clr, proc) if need_join_info else Err("Did not request join info")


### PR DESCRIPTION
Originally, the tool was always skipping the first two GC's under the assumption they would always have incomplete data. This is not always the case, and makes the analysis fail for some scenarios, like for example, traces with lots of events that are stopped at the first long GC. This is fairly common and removing GC's can entirely break the analysis.

Also, in this PR, I added a safeguard to make the tool fail gracefully under the case a bad trace comes across and has no GC's to analyze.

@Maoni0 @cshung 