### PR TITLE
update manual run parameters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -511,29 +511,28 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual')) }}:
 
-  - ${{ if eq($(manual_test_name), 'sdk_windows_x64') }}:
   # Windows x64 SDK scenario benchmarks
-    - template: /eng/performance/scenarios.yml
-      parameters:
-        osName: windows
-        osVersion: RS5
-        architecture: x64 # specify architecture
-        pool: Hosted VS2017
-        kind: sdk_scenarios
-        queue: Windows.10.Amd64.19H1.Tiger.Perf
-        projectFile: sdk_scenarios.proj
-        channels:
-          - $(channel) # for manual runs we can specify channel variable 
-  
-  - ${{ if eq($(manual_test_name), 'sdk_windows_x86') }}: 
-    - template: /eng/performance/scenarios.yml
-      parameters:
-        osName: windows
-        osVersion: RS5
-        architecture: x86 # specify architecture
-        pool: Hosted VS2017
-        kind: sdk_scenarios
-        queue: Windows.10.Amd64.19H1.Tiger.Perf
-        projectFile: sdk_scenarios.proj
-        channels:
-          - $(channel)
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: windows
+      osVersion: RS5
+      architecture: x64
+      pool: Hosted VS2017
+      kind: sdk_scenarios
+      queue: Windows.10.Amd64.19H1.Tiger.Perf
+      projectFile: sdk_scenarios.proj
+      channels:
+        - $(channel) # for manual runs we can specify channel variable 
+
+  # Windows x86 SDK scenario benchmarks
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: windows
+      osVersion: RS5
+      architecture: x86
+      pool: Hosted VS2017
+      kind: sdk_scenarios
+      queue: Windows.10.Amd64.19H1.Tiger.Perf
+      projectFile: sdk_scenarios.proj
+      channels:
+        - $(channel) # for manual runs we can specify channel variable 


### PR DESCRIPTION
The conditional statements in manual section are invalid because the pipeline variable ```$(manual_test_run)``` are processed after compile time. The easiest workaround is to run jobs with both architectures for manual run. 