### PR TITLE
Change test failures to warnings when they complete faster

### DIFF
--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -134,11 +134,17 @@ def run_single_test(built: Built, t: SingleTest, out: TestPaths) -> None:
         min_seconds = option_or_3(
             t.benchmark.min_seconds, t.options.default_min_seconds, _TEST_MIN_SECONDS_DEFAULT
         )
+
         if seconds_taken < min_seconds:
             desc = f"coreclr={t.coreclr_name} config={t.config_name} benchmark={t.benchmark_name}"
+            min_secs_origin = (
+                'yaml file' if min_seconds in (t.benchmark.min_seconds,
+                                               t.options.default_min_seconds)
+                else 'default'
+            )
             print(
                 f"\n*WARNING*: Test '{desc}' took {seconds_taken} seconds "
-                f"and minimum set is {min_seconds}.\n"
+                f"and {min_secs_origin} minimum set is {min_seconds}.\n"
             )
     else:
         print("Test failed, continuing...")

--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -136,9 +136,9 @@ def run_single_test(built: Built, t: SingleTest, out: TestPaths) -> None:
         )
         if seconds_taken < min_seconds:
             desc = f"coreclr={t.coreclr_name} config={t.config_name} benchmark={t.benchmark_name}"
-            raise Exception(
-                f"{desc} took {seconds_taken} seconds, minimum is {min_seconds}"
-                "(you could change the benchmark's min_seconds or options.default_min_seconds)"
+            print(
+                f"\n*WARNING*: Test '{desc}' took {seconds_taken} seconds "
+                f"and minimum set is {min_seconds}.\n"
             )
     else:
         print("Test failed, continuing...")


### PR DESCRIPTION
The GC Benchmarking Infra has a minimum time limit for each test (either set by each test's yaml file or the tool's default one). If a test completes sooner than this established limit, the infra will fail. This has shown to cause many unwanted disruptions when running larger suites, as the remaining ones will not be run. This error has been changed to a warning instead to notify the user about potential noise in the traces, but without breaking their entire workflow.

For example, say the minimum is 10 seconds. If a test finishes in 9 seconds, the following message would be displayed:

`*WARNING*: Test '<test description goes here>' took 9.0 seconds and <origin> minimum set is 10.0.`

The test description shows the coreclr, config, and benchmark being run, and origin shows where this minimum time limit came from:
- Yaml File: Specified by either the `min_seconds` or `default_min_seconds` options in the benchmark _yaml_ file.
- Default: The Infra has an inner minimum time limit which is used when the _yaml_ file does not specify any.
