### PR TITLE
[Utf8JsonWriter] Testing with Memory from MemoryManager

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -97,4 +97,9 @@
     <None Include="**/*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="libraries\Common\SimpleArrayBufferWriter.cs" />
+    <None Remove="libraries\Common\SimpleMemoryManagerBufferWriter.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/benchmarks/micro/libraries/Common/SimpleArrayBufferWriter.cs
+++ b/src/benchmarks/micro/libraries/Common/SimpleArrayBufferWriter.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace MicroBenchmarks.libraries.Common
+{
+    public sealed class SimpleArrayBufferWriter<T> : IBufferWriter<T>
+    {
+        private readonly T[] _array;
+        private int _index;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SimpleArrayBufferWriter(int length)
+        {
+            _array = new T[length];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int count)
+        {
+            var index = _index + count;
+            if (index >= _array.Length)
+                ThrowInvalidOperationException();
+            _index = index;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+                sizeHint = 1; // at least 1
+            if (_index + sizeHint >= _array.Length)
+                ThrowOutOfMemoryException();
+            return _array.AsMemory(_index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> GetSpan(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+                sizeHint = 1; // at least 1
+            if (_index + sizeHint >= _array.Length)
+                ThrowOutOfMemoryException();
+            return _array.AsSpan(_index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear()
+        {
+            _index = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowOutOfMemoryException()
+        {
+            throw new OutOfMemoryException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidOperationException()
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/Common/SimpleMemoryManagerBufferWriter.cs
+++ b/src/benchmarks/micro/libraries/Common/SimpleMemoryManagerBufferWriter.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MicroBenchmarks.libraries.Common
+{
+    public sealed class SimpleMemoryManagerBufferWriter<T> : MemoryManager<T>, IBufferWriter<T>
+    {
+        private int refCount = 0;
+        private IntPtr memory;
+        private int length;
+        private int _index;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SimpleMemoryManagerBufferWriter(int length)
+        {
+            this.memory = Marshal.AllocHGlobal(Marshal.SizeOf<T>() * length);
+            this.length = length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int count)
+        {
+            var index = _index + count;
+            if (index >= length)
+                ThrowInvalidOperationException();
+            _index = index;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Memory<T> GetMemory(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+                sizeHint = 1; // at least 1
+            if (_index + sizeHint > length)
+                ThrowOutOfMemoryException();
+            return this.Memory.Slice(_index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe Span<T> GetSpan(int sizeHint = 0)
+        {
+            if (sizeHint == 0)
+                sizeHint = 1; // at least 1
+            int spanLength = length - _index;
+            if (spanLength < sizeHint)
+                ThrowOutOfMemoryException();
+            return new Span<T>(Unsafe.Add<T>((void*)memory, _index), spanLength);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clear()
+        {
+            _index = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowOutOfMemoryException()
+        {
+            throw new OutOfMemoryException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidOperationException()
+        {
+            throw new InvalidOperationException();
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        ~SimpleMemoryManagerBufferWriter()
+        {
+            Dispose(false);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe override Span<T> GetSpan() => new Span<T>((void*)memory, length);
+
+        private bool IsRetained => refCount > 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override MemoryHandle Pin(int elementIndex = 0)
+        {
+            unsafe
+            {
+                Retain();
+                if ((uint)elementIndex > length) throw new ArgumentOutOfRangeException(nameof(elementIndex));
+                void* pointer = Unsafe.Add<T>((void*)memory, elementIndex);
+                return new MemoryHandle(pointer, default, this);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Release()
+        {
+            int newRefCount = Interlocked.Decrement(ref refCount);
+
+            if (newRefCount < 0)
+            {
+                throw new InvalidOperationException("Unmatched Release/Retain");
+            }
+
+            return newRefCount != 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Retain()
+        {
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(SimpleMemoryManagerBufferWriter<T>));
+            }
+
+            Interlocked.Increment(ref refCount);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            // typically this would call into a native method appropriate for the platform
+            Marshal.FreeHGlobal(memory);
+            memory = IntPtr.Zero;
+
+            IsDisposed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool TryGetArray(out ArraySegment<T> arraySegment)
+        {
+            // cannot expose managed array
+            arraySegment = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override void Unpin()
+        {
+            Release();
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.Booleans.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.Booleans.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using MicroBenchmarks.libraries.Common;
 
 namespace System.Text.Json.Tests
 {
@@ -13,9 +14,13 @@ namespace System.Text.Json.Tests
     {
         private const int DataSize = 100_000;
 
-        private ArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleMemoryManagerBufferWriter<byte> _memoryManagerBufferWriter;
 
         private bool[] _boolArrayValues;
+
+        [Params(true, false)]
+        public bool WithMemoryManager;
 
         [Params(true, false)]
         public bool Formatted;
@@ -26,7 +31,8 @@ namespace System.Text.Json.Tests
         [GlobalSetup]
         public void Setup()
         {
-            _arrayBufferWriter = new ArrayBufferWriter<byte>();
+            _arrayBufferWriter = new SimpleArrayBufferWriter<byte>(1024 * 1024);
+            _memoryManagerBufferWriter = new SimpleMemoryManagerBufferWriter<byte>(1024 * 1024);
 
             var random = new Random(42);
 
@@ -42,7 +48,9 @@ namespace System.Text.Json.Tests
         public void WriteBooleans()
         {
             _arrayBufferWriter.Clear();
-            using (var json = new Utf8JsonWriter(_arrayBufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
+            _memoryManagerBufferWriter.Clear();
+            var bufferWriter = WithMemoryManager ? (IBufferWriter<byte>)_memoryManagerBufferWriter : _arrayBufferWriter;
+            using (var json = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
             {
 
                 json.WriteStartArray();

--- a/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.DateTimes.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.DateTimes.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using MicroBenchmarks.libraries.Common;
 
 namespace System.Text.Json.Tests
 {
@@ -13,9 +14,13 @@ namespace System.Text.Json.Tests
     {
         private const int DataSize = 100_000;
 
-        private ArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleMemoryManagerBufferWriter<byte> _memoryManagerBufferWriter;
 
         private DateTime[] _dateArrayValues;
+
+        [Params(true, false)]
+        public bool WithMemoryManager;
 
         [Params(true, false)]
         public bool Formatted;
@@ -26,7 +31,8 @@ namespace System.Text.Json.Tests
         [GlobalSetup]
         public void Setup()
         {
-            _arrayBufferWriter = new ArrayBufferWriter<byte>();
+            _arrayBufferWriter = new SimpleArrayBufferWriter<byte>(4 * 1024 * 1024);
+            _memoryManagerBufferWriter = new SimpleMemoryManagerBufferWriter<byte>(4 * 1024 * 1024);
 
             _dateArrayValues = new DateTime[DataSize];
 
@@ -42,8 +48,9 @@ namespace System.Text.Json.Tests
         public void WriteDateTimes()
         {
             _arrayBufferWriter.Clear();
-
-            using (var json = new Utf8JsonWriter(_arrayBufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
+            _memoryManagerBufferWriter.Clear();
+            var bufferWriter = WithMemoryManager ? (IBufferWriter<byte>)_memoryManagerBufferWriter : _arrayBufferWriter;
+            using (var json = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
             {
 
                 json.WriteStartArray();

--- a/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.Guids.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Utf8JsonWriter/Perf.Guids.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using MicroBenchmarks.libraries.Common;
 
 namespace System.Text.Json.Tests
 {
@@ -13,9 +14,13 @@ namespace System.Text.Json.Tests
     {
         private const int DataSize = 100_000;
 
-        private ArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleArrayBufferWriter<byte> _arrayBufferWriter;
+        private SimpleMemoryManagerBufferWriter<byte> _memoryManagerBufferWriter;
 
         private Guid[] _guidArrayValues;
+
+        [Params(true, false)]
+        public bool WithMemoryManager;
 
         [Params(true, false)]
         public bool Formatted;
@@ -26,7 +31,8 @@ namespace System.Text.Json.Tests
         [GlobalSetup]
         public void Setup()
         {
-            _arrayBufferWriter = new ArrayBufferWriter<byte>();
+            _arrayBufferWriter = new SimpleArrayBufferWriter<byte>(8 * 1024 * 1024);
+            _memoryManagerBufferWriter = new SimpleMemoryManagerBufferWriter<byte>(8 * 1024 * 1024);
 
             _guidArrayValues = new Guid[DataSize];
 
@@ -40,7 +46,9 @@ namespace System.Text.Json.Tests
         public void WriteGuids()
         {
             _arrayBufferWriter.Clear();
-            using (var json = new Utf8JsonWriter(_arrayBufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
+            _memoryManagerBufferWriter.Clear();
+            var bufferWriter = WithMemoryManager ? (IBufferWriter<byte>)_memoryManagerBufferWriter : _arrayBufferWriter;
+            using (var json = new Utf8JsonWriter(bufferWriter, new JsonWriterOptions { Indented = Formatted, SkipValidation = SkipValidation }))
             {
 
                 json.WriteStartArray();


### PR DESCRIPTION
Currently the tests for Utf8JsonWriter only used the IBufferWriter implementation that works on top of managed arrays. But the Memory performance characteristics may vary depending on what underlying mechanism is used in the Memory internals. And that could be useful to know what is changed for different Memory types with the newer .Net versions in the future.

Utf8JsonWriter is currently implemented using the IBufferWriter.GetMemory(). That potentially could be changed to use IBufferWriter.GetSpan(). The tests could be useful to check how the changes affect the performance for both buffer writer types.

I've created a simple buffer writer that shares the memory via the MemoryManager.
Also I've created a simple buffer writer that uses a managed array and replaced the current ArrayBuffer with that. That is needed to be able to compare the results from both types of the Memory.