### PR TITLE
update init scripts

### DIFF
--- a/src/scenarios/init.ps1
+++ b/src/scenarios/init.ps1
@@ -1,9 +1,23 @@
+[CmdletBinding(PositionalBinding=$false)]
 Param(
-    [string] $InstallDotnetFromChannel,
+    [string] $Channel,
     [string] $DotnetDirectory
 )
 
-If ($DotnetDirectory -eq ""){
+function Print-Usage(){
+    Write-Host "Invalid argument. Usage:"
+    Write-Host ".\init.ps1"
+    Write-Host ".\init.ps1 -DotnetDirectory <custom dotnet directory>"
+    Write-Host ".\init.ps1 -Channel <channel to download new dotnet>"
+    Exit 1
+}
+
+# Parse arguments
+If (($Channel -ne "") -and ($DotnetDirectory -ne "")) {
+    Print-Usage
+}
+
+If ($DotnetDirectory -eq "" ){
     $DotnetDirectory = Join-Path $PSScriptRoot '..\..\tools\dotnet\x64'
 }
 
@@ -11,13 +25,11 @@ If ($DotnetDirectory -eq ""){
 $scripts = Join-Path $PSScriptRoot '..\..\scripts' -Resolve
 $env:PYTHONPATH="$scripts;$PSScriptRoot"
 
-$channel = $InstallDotnetFromChannel
-
-If (($channel -ne "")){
+If (($Channel -ne "")){
     # Download dotnet from the specified channel
     Write-Host "Downloading dotnet from channel $channel"
     $dotnetScript= Join-Path "$scripts" 'dotnet.py' -Resolve
-    python $dotnetScript install --channels $channel
+    python $dotnetScript install --channels $channel -v
     If (!$?){
         Write-Host "Dotnet installation failed."
         Exit 1

--- a/src/scenarios/init.ps1
+++ b/src/scenarios/init.ps1
@@ -1,24 +1,45 @@
 Param(
-    $Channel = 'master' # default is master
+    [string] $InstallDotnetFromChannel,
+    [string] $DotnetDirectory
 )
 
+# Add scripts and current directory to PYTHONPATH
 $scripts = Join-Path $PSScriptRoot '..\..\scripts' -Resolve
 $env:PYTHONPATH="$scripts;$PSScriptRoot"
-$dotnetScript= Join-Path "$scripts" 'dotnet.py' -Resolve
-$dotnetDirectory = Join-Path $PSScriptRoot '..\..\tools\dotnet\x64'
 
-Write-Host "Downloading dotnet from channel $Channel"
-python $dotnetScript install --channels $Channel -v
+If (($InstallDotnetFromChannel -ne "") -and ($DotnetDirectory -eq "")){
+    # Download dotnet from the specified channel
+    
+    $installDirectory= Join-Path $PSScriptRoot 'dotnet'
+    # Remove existing dotnet directory to make sure we only have one version of dotnet
+    If (Test-Path $installDirectory){
+        Write-Host "Removing $installDirectory ..."
+        Remove-Item  $installDirectory -Recurse
+    }
 
-if (!$?){
-    Write-Host "Dotnet installation failed."
-    Exit 1
+    Write-Host "Downloading dotnet from channel $InstallDotnetFromChannel"
+    $dotnetScript= Join-Path "$scripts" 'dotnet.py' -Resolve
+    python $dotnetScript install --channels $InstallDotnetFromChannel --install-dir $installDirectory
+
+    If (!$?){
+        Write-Host "Dotnet installation failed."
+        Exit 1
+    }
+}
+
+If ($DotnetDirectory -ne ""){
+    $env:Path="$DotnetDirectory;$env:Path"
+    $env:DOTNET_ROOT=$DotnetDirectory
+}
+Elseif ($installDirectory -ne ""){
+    $env:Path="$installDirectory;$env:Path"
+    $env:DOTNET_ROOT=$installDirectory
 }
 
 $env:DOTNET_CLI_TELEMETRY_OPTOUT='1'
 $env:DOTNET_MULTILEVEL_LOOKUP='0'
 $env:UseSharedCompilation='false'
-$env:DOTNET_ROOT=$dotnetDirectory
-$env:Path="$dotnetDirectory;$env:Path"
+
+dotnet --info
 
 

--- a/src/scenarios/init.ps1
+++ b/src/scenarios/init.ps1
@@ -3,43 +3,32 @@ Param(
     [string] $DotnetDirectory
 )
 
+If ($DotnetDirectory -eq ""){
+    $DotnetDirectory = Join-Path $PSScriptRoot '..\..\tools\dotnet\x64'
+}
+
 # Add scripts and current directory to PYTHONPATH
 $scripts = Join-Path $PSScriptRoot '..\..\scripts' -Resolve
 $env:PYTHONPATH="$scripts;$PSScriptRoot"
 
-If (($InstallDotnetFromChannel -ne "") -and ($DotnetDirectory -eq "")){
+$channel = $InstallDotnetFromChannel
+
+If (($channel -ne "")){
     # Download dotnet from the specified channel
-    
-    $installDirectory= Join-Path $PSScriptRoot 'dotnet'
-    # Remove existing dotnet directory to make sure we only have one version of dotnet
-    If (Test-Path $installDirectory){
-        Write-Host "Removing $installDirectory ..."
-        Remove-Item  $installDirectory -Recurse
-    }
-
-    Write-Host "Downloading dotnet from channel $InstallDotnetFromChannel"
+    Write-Host "Downloading dotnet from channel $channel"
     $dotnetScript= Join-Path "$scripts" 'dotnet.py' -Resolve
-    python $dotnetScript install --channels $InstallDotnetFromChannel --install-dir $installDirectory
-
+    python $dotnetScript install --channels $channel
     If (!$?){
         Write-Host "Dotnet installation failed."
         Exit 1
     }
 }
 
-If ($DotnetDirectory -ne ""){
-    $env:Path="$DotnetDirectory;$env:Path"
-    $env:DOTNET_ROOT=$DotnetDirectory
-}
-Elseif ($installDirectory -ne ""){
-    $env:Path="$installDirectory;$env:Path"
-    $env:DOTNET_ROOT=$installDirectory
-}
-
+$env:Path="$DotnetDirectory;$env:Path"
+$env:DOTNET_ROOT=$DotnetDirectory
 $env:DOTNET_CLI_TELEMETRY_OPTOUT='1'
 $env:DOTNET_MULTILEVEL_LOOKUP='0'
 $env:UseSharedCompilation='false'
 
-dotnet --info
 
 

--- a/src/scenarios/init.ps1
+++ b/src/scenarios/init.ps1
@@ -42,7 +42,7 @@ ElseIf ($DotnetDirectory -ne ""){
     Setup-Env -directory $DotnetDirectory
 }
 ElseIf ($Channel -ne "") {
+    Download-Dotnet -channel $Channel
     $DotnetDirectory = Join-Path $PSScriptRoot '..\..\tools\dotnet\x64'
     Setup-Env -directory $DotnetDirectory
-    Download-Dotnet -channel $Channel
 }

--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -1,19 +1,47 @@
-if [[ -z $1 ]]; then
-    CHANNEL='master'
-else
-    CHANNEL=$1
+# Add scripts and current directory to PYTHONPATH
+absolutePath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scriptPath="$absolutePath/../../scripts"
+export PYTHONPATH=$PYTHONPATH:$scriptPath:$absolutePath
+
+dotnetDirectory=""
+channel=""
+# Parse arguments
+if [ "$1" == "-dotnetdir" ]
+then
+    dotnetDirectory="$2"
+elif [ "$1" == "-installdotnetfromchannel" ]
+then
+    channel="$2"
 fi
 
-ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT_PATH="$ABSOLUTE_PATH/../../scripts"
-export PYTHONPATH=$PYTHONPATH:$SCRIPT_PATH:$ABSOLUTE_PATH
-DOTNET_SCRIPT="$SCRIPT_PATH/dotnet.py"
-DOTNET_DIRECTORY="$ABSOLUTE_PATH/../../tools/dotnet/x64"
-echo "Downloading dotnet from channel $CHANNEL"
-python3 $DOTNET_SCRIPT install --channels $CHANNEL -v
+# Download dotnet from the specified channel
+if [ "$channel" != "" ]
+then
+    installDirectory="$absolutePath/dotnet"
+    # Remove existing dotnet directory to make sure we only have one version of dotnet 
+    if [ -d "$installDirectory" ]
+    then
+        echo "Removing $installDirectory"
+        rm -r $installDirectory
+    fi
+    dotnetScript="$scriptPath/dotnet.py"
+    echo "Downloading dotnet from channel $channel"
+    echo installDir: $installDirectory
+    python3 $dotnetScript install --channels $channel --install-dir $installDirectory
+fi
+
+if [ "$dotnetDirectory" != "" ]
+then
+    export DOTNET_ROOT=$dotnetDirectory
+    export PATH="$dotnetDirectory:$PATH"
+elif [ "$installDirectory" != "" ]
+then
+    export DOTNET_ROOT=$installDirectory
+    export PATH="$installDirectory:$PATH"
+fi
 
 export DOTNET_CLI_TELEMETRY_OPTOUT='1'
 export DOTNET_MULTILEVEL_LOOKUP='0'
 export UseSharedCompilation='false'
-export DOTNET_ROOT=$DOTNET_DIRECTORY
-export PATH="$DOTNET_DIRECTORY:$PATH"
+
+dotnet --info

--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -3,7 +3,7 @@ absolutePath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scriptPath="$absolutePath/../../scripts"
 export PYTHONPATH=$PYTHONPATH:$scriptPath:$absolutePath
 
-dotnetDirectory=""
+dotnetDirectory="$absolutePath/../../tools/dotnet/x64"
 channel=""
 # Parse arguments
 if [ "$1" == "-dotnetdir" ]
@@ -17,31 +17,13 @@ fi
 # Download dotnet from the specified channel
 if [ "$channel" != "" ]
 then
-    installDirectory="$absolutePath/dotnet"
-    # Remove existing dotnet directory to make sure we only have one version of dotnet 
-    if [ -d "$installDirectory" ]
-    then
-        echo "Removing $installDirectory"
-        rm -r $installDirectory
-    fi
     dotnetScript="$scriptPath/dotnet.py"
     echo "Downloading dotnet from channel $channel"
-    echo installDir: $installDirectory
-    python3 $dotnetScript install --channels $channel --install-dir $installDirectory
+    python3 $dotnetScript install --channels $channel -v
 fi
 
-if [ "$dotnetDirectory" != "" ]
-then
-    export DOTNET_ROOT=$dotnetDirectory
-    export PATH="$dotnetDirectory:$PATH"
-elif [ "$installDirectory" != "" ]
-then
-    export DOTNET_ROOT=$installDirectory
-    export PATH="$installDirectory:$PATH"
-fi
-
+export DOTNET_ROOT=$dotnetDirectory
+export PATH="$dotnetDirectory:$PATH"
 export DOTNET_CLI_TELEMETRY_OPTOUT='1'
 export DOTNET_MULTILEVEL_LOOKUP='0'
 export UseSharedCompilation='false'
-
-dotnet --info

--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -6,13 +6,26 @@ print_usage() {
     exit 1
 }
 
+# $1 is dotnet directory
+setup_env() {
+    export DOTNET_ROOT="$1"
+    export PATH="$1:$PATH"
+    export DOTNET_CLI_TELEMETRY_OPTOUT='1'
+    export DOTNET_MULTILEVEL_LOOKUP='0'
+    export UseSharedCompilation='false'
+}
+
+# $1 is channel
+download_dotnet() {
+    dotnetScript="$scriptPath/dotnet.py"
+    echo "Downloading dotnet from channel $1"
+    python3 $dotnetScript install --channels $1 -v
+}
+
 # Add scripts and current directory to PYTHONPATH
 absolutePath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scriptPath="$absolutePath/../../scripts"
 export PYTHONPATH=$PYTHONPATH:$scriptPath:$absolutePath
-
-dotnetDirectory="$absolutePath/../../tools/dotnet/x64"
-channel=""
 
 # Parse arguments
 if [ "$#" -gt 2 ]
@@ -21,24 +34,14 @@ then
 elif [ "$1" == "-dotnetdir" ] && [ "$2" != "" ]
 then
     dotnetDirectory="$2"
+    setup_env $dotnetDirectory
 elif [ "$1" == "-channel" ] && [ "$2" != "" ]
 then
     channel="$2"
+    download_dotnet $channel
+    dotnetDirectory="$absolutePath/../../tools/dotnet/x64"
+    setup_env $dotnetDirectory
 elif [ "$#" -gt 0 ]
 then 
     print_usage
 fi
-
-# Download dotnet from the specified channel
-if [ "$channel" != "" ]
-then
-    dotnetScript="$scriptPath/dotnet.py"
-    echo "Downloading dotnet from channel $channel"
-    python3 $dotnetScript install --channels $channel -v
-fi
-
-export DOTNET_ROOT=$dotnetDirectory
-export PATH="$dotnetDirectory:$PATH"
-export DOTNET_CLI_TELEMETRY_OPTOUT='1'
-export DOTNET_MULTILEVEL_LOOKUP='0'
-export UseSharedCompilation='false'

--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -1,3 +1,11 @@
+print_usage() {
+    echo "Invalid argument. Usage:"
+    echo "./init.sh"
+    echo "./init.sh -dotnetdir <custom dotnet directory>"
+    echo "./init.sh -channel <channel to download new dotnet>"
+    exit 1
+}
+
 # Add scripts and current directory to PYTHONPATH
 absolutePath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scriptPath="$absolutePath/../../scripts"
@@ -5,13 +13,20 @@ export PYTHONPATH=$PYTHONPATH:$scriptPath:$absolutePath
 
 dotnetDirectory="$absolutePath/../../tools/dotnet/x64"
 channel=""
+
 # Parse arguments
-if [ "$1" == "-dotnetdir" ]
+if [ "$#" -gt 2 ]
+then 
+    print_usage
+elif [ "$1" == "-dotnetdir" ] && [ "$2" != "" ]
 then
     dotnetDirectory="$2"
-elif [ "$1" == "-installdotnetfromchannel" ]
+elif [ "$1" == "-channel" ] && [ "$2" != "" ]
 then
     channel="$2"
+elif [ "$#" -gt 0 ]
+then 
+    print_usage
 fi
 
 # Download dotnet from the specified channel


### PR DESCRIPTION
The new version of ```init.ps1``` and ```init.sh``` would work in the following way:

- To use the default dotnet: ```./init.ps1```
- To install dotnet from a specific channel and use the installed dotnet: ```./init.ps1 -InstallDotnetFromChannel <channel> ```
- To use a specific dotnet source: ```./init.ps1 -DotnetDirectory <path>```

All three modes will set up basic environment variables such as ```PYTHONPATH```, ```DOTNET_MULTILEVEL_LOOKUP``` 