### PR TITLE
Make high_memory GC tests stable and more consistent

### DIFF
--- a/src/benchmarks/gc/src/exec/env/build.cmd
+++ b/src/benchmarks/gc/src/exec/env/build.cmd
@@ -1,4 +1,4 @@
-rd /s /q out
+rd /s out
 mkdir out
 cd out
 cmake ..

--- a/src/benchmarks/gc/src/exec/env/build.cmd
+++ b/src/benchmarks/gc/src/exec/env/build.cmd
@@ -1,4 +1,7 @@
-rd /s out
+@echo off
+if exist out\ (
+    rd /s /q out
+)
 mkdir out
 cd out
 cmake ..

--- a/src/benchmarks/gc/src/exec/env/build.cmd
+++ b/src/benchmarks/gc/src/exec/env/build.cmd
@@ -1,4 +1,4 @@
-rd /s out
+rd /s /q out
 mkdir out
 cd out
 cmake ..

--- a/src/benchmarks/gc/src/exec/env/make_memory_load.c
+++ b/src/benchmarks/gc/src/exec/env/make_memory_load.c
@@ -403,6 +403,8 @@ int main(const int argc, char** argv)
         if (ak == adjust_kind_no_adjust)
         {
             // No need to adjust as we got the memory load we required.
+            // Do NOT change this message, as run_single_test.py is expecting it
+            // to know everything went fine here.
             fprintf(stderr, "make_memory_load finished starting up\n");
             break;
         }
@@ -414,7 +416,7 @@ int main(const int argc, char** argv)
             // which is later parsed by run_single_test.py.
             fprintf(
                 stderr,
-                "threshold memory achieved, %.5f\n",
+                "threshold memory achieved,%.5f\n",
                 get_memory_used_fraction_from_mem(get_memory_status()) * 100.0
             );
             break;

--- a/src/benchmarks/gc/src/exec/env/make_memory_load.c
+++ b/src/benchmarks/gc/src/exec/env/make_memory_load.c
@@ -93,7 +93,7 @@ static void print_memory_status()
     puts("\n=======================");
     puts("Memory Status Achieved:");
     puts("=======================");
-    printf("Memory load achieved: %d%%\n",
+    printf("Memory Load Achieved: %d%%\n",
            (int) round(100 * get_memory_used_fraction_from_mem(mem)));
     printf("Total Physical Memory: %f GB\n",     bytes_to_gb(mem.total_physical_bytes));
     printf("Available Physical Memory: %f GB\n", bytes_to_gb(mem.available_bytes));

--- a/src/benchmarks/gc/src/exec/env/make_memory_load.c
+++ b/src/benchmarks/gc/src/exec/env/make_memory_load.c
@@ -276,7 +276,7 @@ static AdjustKind adjust(Mem* mem, int iteration_num)
     if (to_allocate != 0 && iteration_num == MEMORY_LOAD_NUM_ATTEMPTS)
     {
         double acc_mem_delta =   ((double) mem->desired_available_bytes)
-                               * ((double) ACCEPTABLE_MEMORY_DELTA_PCT / 100);
+                               * ((double) ACCEPTABLE_MEMORY_DELTA_PCT / 100.0);
         double current_delta = fabs(
             ((double) current_available_bytes) - ((double) mem->desired_available_bytes)
         );
@@ -324,9 +324,6 @@ static AdjustKind adjust(Mem* mem, int iteration_num)
             mem->total_memory_committed += size;
         }
 
-#if VERBOSE
-        printf("Current Memory Load Percentage: %.4f%%\n\n", *memory_load_pct);
-#endif
         return adjust_kind_was_too_low;
     }
     else if (to_allocate < 0)
@@ -356,10 +353,6 @@ static AdjustKind adjust(Mem* mem, int iteration_num)
 
             mem->total_memory_committed = new_total_memory_committed;
             mem->total_memory_reset += size;
-
-#if VERBOSE
-            printf("Current Memory Load Percentage: %.4f%%\n\n", *memory_load_pct);
-#endif
             return size == 0 ? adjust_kind_was_too_high_and_cant_free : adjust_kind_was_too_high;
         }
     }

--- a/src/benchmarks/gc/src/exec/env/make_memory_load.c
+++ b/src/benchmarks/gc/src/exec/env/make_memory_load.c
@@ -90,12 +90,13 @@ static size_t get_current_available_bytes()
 static void print_memory_status()
 {
     const Memory mem = get_memory_status();
-    printf(
-        "Memory load is %d%%. Total phys GB is %f, avail phys GB is %f\n",
-        (int) round(100 * get_memory_used_fraction_from_mem(mem)),
-        bytes_to_gb(mem.total_physical_bytes),
-        bytes_to_gb(mem.available_bytes)
-    );
+    puts("\n=======================");
+    puts("Memory Status Achieved:");
+    puts("=======================");
+    printf("Memory load achieved: %d%%\n",
+           (int) round(100 * get_memory_used_fraction_from_mem(mem)));
+    printf("Total Physical Memory: %f GB\n",     bytes_to_gb(mem.total_physical_bytes));
+    printf("Available Physical Memory: %f GB\n", bytes_to_gb(mem.available_bytes));
 }
 
 typedef struct Args
@@ -105,7 +106,9 @@ typedef struct Args
     bool no_readjust;
 } Args;
 
-const char* USAGE = "Usage: make_memory_load.exe -percent 50 [-neverRelease]\n";
+// TODO: Add Verbose/Debug option to show all the stats while running without
+// having to uncomment source code here.
+const char* USAGE = "Usage: make_memory_load.exe -percent 50 [-neverRelease] [-noReadjust]\n";
 
 static int parse_args(Args* args, const int argc, char** argv)
 {
@@ -171,6 +174,8 @@ typedef struct Mem
     byte* const memory;
 } Mem;
 
+// #define VERBOSE TRUE
+
 static Mem init_mem(const Args args)
 {
     SYSTEM_INFO system_info;
@@ -182,6 +187,18 @@ static Mem init_mem(const Args args)
     const size_t desired_available_bytes = (size_t) round((1.0 - args.desired_mem_usage_fraction) * total_phys_bytes);
 
     const size_t total_memory = round_down_to_nearest(total_phys_bytes, allocation_granularity);
+
+#if VERBOSE
+    puts("\n====================");
+    puts("System Information:");
+    puts("====================");
+    printf("Desired Available Memory: %.2f MB\n", bytes_to_mb(desired_available_bytes));
+    printf("Page Size: %.2f KB\n",                bytes_to_kb(page_size));
+    printf("Allocation Granularity: %.2f KB\n",   bytes_to_kb(allocation_granularity));
+    printf("Allocation Granularity: %zu\n",       allocation_granularity);
+    printf("Total Physical Memory: %.2f MB\n",    bytes_to_mb(total_phys_bytes));
+    printf("Total Memory: %.2f MB\n",             bytes_to_mb(total_memory));
+#endif
 
     LPVOID alloced = VirtualAlloc(NULL, total_memory, MEM_RESERVE, PAGE_READWRITE);
     assert(alloced);
@@ -206,10 +223,9 @@ static void write_to_every_page(byte* start, size_t size, size_t page_size)
     }
 }
 
-//#define VERBOSE TRUE
-
 typedef enum AdjustKind {
     adjust_kind_no_adjust,
+    adjust_kind_within_threshold,
     adjust_kind_was_too_low,
     adjust_kind_was_too_high,
     adjust_kind_was_too_high_and_cant_free,
@@ -220,13 +236,15 @@ const char* adjust_kind_to_string(AdjustKind ak)
     switch (ak)
     {
         case adjust_kind_no_adjust:
-            return "No adjust";
+            return "no adjust";
+        case adjust_kind_within_threshold:
+            return "within threshold";
         case adjust_kind_was_too_low:
-            return "Memory usage was too low";
+            return "too low";
         case adjust_kind_was_too_high:
-            return "Memory usage was too high";
+            return "too high";
         case adjust_kind_was_too_high_and_cant_free:
-            return "Memory usage was too high, and make_memory_load has nothing to free";
+            return "too high, and make_memory_load has nothing to free";
         default:
             assert(0);
             return "<<error>>";
@@ -234,7 +252,7 @@ const char* adjust_kind_to_string(AdjustKind ak)
 }
 
 // Returns true if it did adjust
-static AdjustKind adjust(Mem* mem)
+static AdjustKind adjust(Mem* mem, int iteration_num)
 {
     assert(is_multiple(mem->total_memory_committed, mem->allocation_granularity));
     assert(is_multiple(mem->total_memory_reset, mem->allocation_granularity));
@@ -245,20 +263,45 @@ static AdjustKind adjust(Mem* mem)
     const ptrdiff_t to_allocate = round_to_nearest((ptrdiff_t) current_available_bytes - (ptrdiff_t) mem->desired_available_bytes, mem->allocation_granularity);
 
 #if VERBOSE
-    printf("Current available GB: %.2fGB, desired: %.2fGB\n", bytes_to_gb(current_available_bytes), bytes_to_gb(mem->desired_available_bytes));
+    printf("Current Available Memory: %.2f MB\n", bytes_to_mb(current_available_bytes));
+    printf("Desired Available Memory: %.2f MB\n", bytes_to_mb(mem->desired_available_bytes));
 #endif
+
+    // If we reach the final attempt to load the desired amount of memory, and
+    // we are not there yet but within an acceptable tolerance range, then allow
+    // the program to continue running rather than failing.
+    //
+    // The tolerance range is currently set to +-5% of the desired available
+    // memory, and is defined in util.h inside the current directory.
+    if (to_allocate != 0 && iteration_num == MEMORY_LOAD_NUM_ATTEMPTS)
+    {
+        double acc_mem_delta =   ((double) mem->desired_available_bytes)
+                               * ((double) ACCEPTABLE_MEMORY_DELTA_PCT / 100);
+        double current_delta = fabs(
+            ((double) current_available_bytes) - ((double) mem->desired_available_bytes)
+        );
+
+#if VERBOSE
+        printf("Acceptable Memory Delta: %.2f MB\n", bytes_to_mb(acc_mem_delta));
+        printf("Current Memory Delta: %.2f MB\n",  bytes_to_mb(current_delta));
+#endif
+
+        if (current_delta < acc_mem_delta)
+            return adjust_kind_within_threshold;
+    }
 
     if (to_allocate > 0)
     {
         // unreset / commit some more
         if (mem->total_memory_reset != 0)
         {
-#if VERBOSE
-            printf("Unresetting memory: %.2fMB\n", bytes_to_mb(to_allocate));
-#endif
-
             // Unreset the memory
             const size_t size = min(mem->total_memory_reset, (size_t)to_allocate);
+
+#if VERBOSE
+            printf("Unresetting Memory: %.2f MB\n\n", bytes_to_mb(size));
+#endif
+
             byte* const start = mem->memory + mem->total_memory_committed;
             //VirtualAlloc(start, size, MEM_RESET_UNDO, PAGE_READWRITE);
             // Just write to it to bring it back
@@ -268,18 +311,22 @@ static AdjustKind adjust(Mem* mem)
         }
         else
         {
-#if VERBOSE
-            printf("Committing more memory: %.2fMB\n", bytes_to_mb(to_allocate));
-#endif
-
             // Commmit some more memory
             const size_t size = min(mem->total_memory - mem->total_memory_committed, (size_t)to_allocate);
+
+#if VERBOSE
+            printf("Committing Memory: %.2f MB\n\n", bytes_to_mb(size));
+#endif
+
             byte* const start = mem->memory + mem->total_memory_committed;
             VirtualAlloc(start, size, MEM_COMMIT, PAGE_READWRITE);
             write_to_every_page(start, size, mem->page_size);
             mem->total_memory_committed += size;
         }
 
+#if VERBOSE
+        printf("Current Memory Load Percentage: %.4f%%\n\n", *memory_load_pct);
+#endif
         return adjust_kind_was_too_low;
     }
     else if (to_allocate < 0)
@@ -295,7 +342,8 @@ static AdjustKind adjust(Mem* mem)
             const size_t new_total_memory_committed = mem->total_memory_committed - size;
 
 #if VERBOSE
-        printf("Resetting memory: want to reset %.2fMB, actual size to reset %.2fMB\n", bytes_to_mb(-to_allocate), bytes_to_mb(size));
+            printf("Want to Reset Memory: %.2f MB\n", bytes_to_mb(-to_allocate));
+            printf("Actual Reset: %.2f MB\n\n", bytes_to_mb(size));
 #endif
 
             // Note: last argument is ignored
@@ -308,11 +356,18 @@ static AdjustKind adjust(Mem* mem)
 
             mem->total_memory_committed = new_total_memory_committed;
             mem->total_memory_reset += size;
+
+#if VERBOSE
+            printf("Current Memory Load Percentage: %.4f%%\n\n", *memory_load_pct);
+#endif
             return size == 0 ? adjust_kind_was_too_high_and_cant_free : adjust_kind_was_too_high;
         }
     }
     else
     {
+#if VERBOSE
+        puts("Success!");
+#endif
         return adjust_kind_no_adjust;
     }
 }
@@ -329,38 +384,66 @@ int main(const int argc, char** argv)
     Mem mem = init_mem(args);
 
     // Initial adjust may take a while as it writes to all the pages.
-    // Just to be sure, adjust twice with a sleep in between.
+    // Therefore, do various attempts to get the right load going.
     int attempts = 0;
+
     while (TRUE) {
-        AdjustKind ak = adjust(&mem);
+
+#if VERBOSE
+        printf("\nITERATION NUMBER: %d\n", attempts + 1);
+#endif
+
+        // If by the last attempt to get the desired memory load we have an
+        // acceptable difference (+-5%), then allow the test to continue with a
+        // message warning the user of this delta.
+        //
+        // NOTE: DO NOT add commas to any fprintf messages. Run_single_test.py
+        // expects a very specific format depending on the AdjustKind result here.
+        AdjustKind ak = adjust(&mem, attempts);
         if (ak == adjust_kind_no_adjust)
         {
-            // No need to adjust
+            // No need to adjust as we got the memory load we required.
+            fprintf(stderr, "make_memory_load finished starting up\n");
             break;
         }
-        else if (attempts == 5)
+        else if (ak == adjust_kind_within_threshold)
+        {
+            // No need to adjust as we are within the acceptable memory load threshold.
+            // This is the ONLY fprintf message that should have ONE comma. This
+            // is to separate the message from the achieved memory load percentage,
+            // which is later parsed by run_single_test.py.
+            fprintf(
+                stderr,
+                "threshold memory achieved, %.5f\n",
+                get_memory_used_fraction_from_mem(get_memory_status()) * 100.0
+            );
+            break;
+        }
+        else if (attempts == MEMORY_LOAD_NUM_ATTEMPTS)
         {
             fprintf(
                 stderr,
-                "Failed to get memory to the desired load (%d%%) after 5 attempts: Last memory was %s\n",
+                "Failed to get memory to the desired load (%d%%) after %d attempts: Last memory was %s\n",
                 (int) round(args.desired_mem_usage_fraction * 100),
+                attempts,
                 adjust_kind_to_string(ak));
             return 1;
         }
         attempts++;
     }
 
-    // NOTE: code in run_single_test.py is waiting for exactly this line to print to stderr.
-    fprintf(stderr, "make_memory_load finished starting up\n");
-    
-    // print_memory_status();
+#if VERBOSE
+    print_memory_status();
+#endif
 
     while (TRUE)
     {
         Sleep(100); // milliseconds
         if (!args.no_readjust)
         {
-            adjust(&mem);
+            // Memory adjustment has to happen throughout the test, so we simply
+            // no longer take into account the number of iterations.
+            adjust(&mem, 0);
         }
     }
 

--- a/src/benchmarks/gc/src/exec/env/make_memory_load.c
+++ b/src/benchmarks/gc/src/exec/env/make_memory_load.c
@@ -106,8 +106,6 @@ typedef struct Args
     bool no_readjust;
 } Args;
 
-// TODO: Add Verbose/Debug option to show all the stats while running without
-// having to uncomment source code here.
 const char* USAGE = "Usage: make_memory_load.exe -percent 50 [-neverRelease] [-noReadjust]\n";
 
 static int parse_args(Args* args, const int argc, char** argv)

--- a/src/benchmarks/gc/src/exec/env/util.h
+++ b/src/benchmarks/gc/src/exec/env/util.h
@@ -3,9 +3,11 @@
    See the LICENSE file in the project root for more information. */
 
 
+#define ACCEPTABLE_MEMORY_DELTA_PCT 5
 #define BYTES_IN_KB 1024
 #define BYTES_IN_MB (1024 * 1024)
 #define BYTES_IN_GB (1024 * 1024 * 1024)
+#define MEMORY_LOAD_NUM_ATTEMPTS 5
 
 
 static BOOL streq(const char* a, const char* b)
@@ -23,6 +25,11 @@ static size_t kb_to_bytes(double kb)
 {
     assert(kb >= 0 && kb <= 10000000);
     return (size_t) (kb * 1024.0);
+}
+
+double bytes_to_kb(const size_t bytes)
+{
+    return ((double) bytes) / BYTES_IN_KB;
 }
 
 double bytes_to_mb(const size_t bytes)

--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -371,9 +371,11 @@ def _run_single_test_windows_perfview(
 
     # Start with the memory load
     mem_load = t.config.memory_load
+    # print(f"\nMemory Load: {mem_load}")
     mem_load_process = None
     if mem_load is not None:
-        print("setting up memory load...")
+        # print(f"BuiltWinMakeMemLd: {str(built.win.make_memory_load)}")
+        print("Setting up memory load...")
         mem_load_args: Sequence[str] = (
             str(built.win.make_memory_load),
             "-percent",
@@ -382,12 +384,17 @@ def _run_single_test_windows_perfview(
         )
         mem_load_process = Popen(args=mem_load_args, stderr=PIPE)
         assert mem_load_process.stderr is not None
+
         # Wait on it to start up
-        line = decode_stdout(mem_load_process.stderr.readline())
-        assert (
-            line == "make_memory_load finished starting up"
-        ), f"Unexpected make_memory_load output {line}"
-        print("done")
+        mem_load_msg = decode_stdout(mem_load_process.stderr.readline()).split(',')
+
+        if (len(mem_load_msg) == 2 and mem_load_msg[0].startswith("threshold")):
+            print(f"threshold: {mem_load_msg[1]}")
+        elif (mem_load_msg[0] == "make_memory_load finished starting up"):
+            print(f"Done!")
+        else:
+            mem_load_process.kill()
+            assert (False), f"Error in make_memory_load: {mem_load_msg[0]}"
 
     log_file = out.add_ext("perfview-log.txt")
     trace_file = out.add_ext("etl")

--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -373,7 +373,7 @@ def _run_single_test_windows_perfview(
     mem_load = t.config.memory_load
     mem_load_process = None
     if mem_load is not None:
-        print("Setting up memory load...")
+        print("\nSetting up memory load...")
         mem_load_args: Sequence[str] = (
             str(built.win.make_memory_load),
             "-percent",
@@ -393,10 +393,10 @@ def _run_single_test_windows_perfview(
                 f"slight variations in the resulting traces.\n"
             )
         elif (mem_load_msg[0] == "make_memory_load finished starting up"):
-            print(f"Done!")
+            print(f"Done!\n")
         else:
             mem_load_process.kill()
-            assert (False), f"Error in make_memory_load: {mem_load_msg[0]}"
+            assert (False), f"\nError in make_memory_load: {mem_load_msg[0]}\n"
 
     log_file = out.add_ext("perfview-log.txt")
     trace_file = out.add_ext("etl")

--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -389,7 +389,11 @@ def _run_single_test_windows_perfview(
         mem_load_msg = decode_stdout(mem_load_process.stderr.readline()).split(',')
 
         if (len(mem_load_msg) == 2 and mem_load_msg[0].startswith("threshold")):
-            print(f"threshold: {mem_load_msg[1]}")
+            print(
+                f"\n*WARNING*: Desired memory load was {mem_load.percent}%, "
+                f"but {mem_load_msg[1]}% was achieved. There might be some "
+                f"slight variations in the resulting traces.\n"
+            )
         elif (mem_load_msg[0] == "make_memory_load finished starting up"):
             print(f"Done!")
         else:

--- a/src/benchmarks/gc/src/exec/run_single_test.py
+++ b/src/benchmarks/gc/src/exec/run_single_test.py
@@ -371,10 +371,8 @@ def _run_single_test_windows_perfview(
 
     # Start with the memory load
     mem_load = t.config.memory_load
-    # print(f"\nMemory Load: {mem_load}")
     mem_load_process = None
     if mem_load is not None:
-        # print(f"BuiltWinMakeMemLd: {str(built.win.make_memory_load)}")
         print("Setting up memory load...")
         mem_load_args: Sequence[str] = (
             str(built.win.make_memory_load),


### PR DESCRIPTION
These changes help the _high_memory_ scenario from the GC Benchmarking Infra to be more stable and consistent between runs. The main idea of this scenario is to load the machine's memory to the specified percent in the _yaml_ file, and then run the GC tests.

The problem was that memory loads tend to be quite variable and the tool had almost no tolerance for these changes and would fail. Now, if the required memory load is not achieved but we are within an acceptable tolerance threshold (currently set to &#177;5%), the tool will just issue a warning and allow the tests to run.

Also, some refactoring was made and messages were updated to be more informative and easier to read (both for the tool and debugging).