### PR TITLE
Math-benchmarks: replaced var with concrete type

### DIFF
--- a/src/benchmarks/micro/runtime/Math/Functions/Double/AbsDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/AbsDouble.cs
@@ -21,15 +21,15 @@ namespace System.MathBenchmarks
 
         public static void AbsTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += absDelta;
                 result += Math.Abs(value);
             }
 
-            var diff = Math.Abs(absExpectedResult - result);
+            double diff = Math.Abs(absExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/AcosDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/AcosDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AcosTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += acosDelta;
                 result += Math.Acos(value);
             }
 
-            var diff = Math.Abs(acosExpectedResult - result);
+            double diff = Math.Abs(acosExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Acosh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Acosh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AcoshTest()
         {
-            var result = 0.0; var value = 1.0;
+            double result = 0.0, value = 1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.Acosh(value);
                 value += acoshDelta;
             }
 
-            var diff = Math.Abs(acoshExpectedResult - result);
+            double diff = Math.Abs(acoshExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/AsinDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/AsinDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AsinTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += asinDelta;
                 result += Math.Asin(value);
             }
 
-            var diff = Math.Abs(asinExpectedResult - result);
+            double diff = Math.Abs(asinExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Asinh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Asinh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AsinhTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.Asinh(value);
                 value += asinhDelta;
             }
 
-            var diff = Math.Abs(asinhExpectedResult - result);
+            double diff = Math.Abs(asinhExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Atan2Double.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Atan2Double.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void Atan2Test()
         {
-            var result = 0.0; var valueX = 1.0; var valueY = -1.0;
+            double result = 0.0, valueX = 1.0, valueY = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 valueX += atan2DeltaX; valueY += atan2DeltaY;
                 result += Math.Atan2(valueY, valueX);
             }
 
-            var diff = Math.Abs(atan2ExpectedResult - result);
+            double diff = Math.Abs(atan2ExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/AtanDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/AtanDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AtanTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += atanDelta;
                 result += Math.Atan(value);
             }
 
-            var diff = Math.Abs(atanExpectedResult - result);
+            double diff = Math.Abs(atanExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Atanh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Atanh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AtanhTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.Atanh(value);
                 value += atanhDelta;
             }
 
-            var diff = Math.Abs(atanhExpectedResult - result);
+            double diff = Math.Abs(atanhExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Cbrt.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Cbrt.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CbrtTest()
         {
-            var result = 0.0; var value = 0.0;
+            double result = 0.0, value = 0.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.Cbrt(value);
                 value += cbrtDelta;
             }
 
-            var diff = Math.Abs(cbrtExpectedResult - result);
+            double diff = Math.Abs(cbrtExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/CeilingDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/CeilingDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CeilingTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += ceilingDelta;
                 result += Math.Ceiling(value);
             }
 
-            var diff = Math.Abs(ceilingExpectedResult - result);
+            double diff = Math.Abs(ceilingExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/CosDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/CosDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CosDoubleTest()
         {
-            var result = 0.0; var value = 0.0;
+            double result = 0.0, value = 0.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += cosDoubleDelta;
                 result += Math.Cos(value);
             }
 
-            var diff = Math.Abs(cosDoubleExpectedResult - result);
+            double diff = Math.Abs(cosDoubleExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/CoshDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/CoshDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CoshTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += coshDelta;
                 result += Math.Cosh(value);
             }
 
-            var diff = Math.Abs(coshExpectedResult - result);
+            double diff = Math.Abs(coshExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/ExpDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/ExpDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void ExpTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += expDelta;
                 result += Math.Exp(value);
             }
 
-            var diff = Math.Abs(expExpectedResult - result);
+            double diff = Math.Abs(expExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/FloorDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/FloorDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void FloorTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += floorDelta;
                 result += Math.Floor(value);
             }
 
-            var diff = Math.Abs(floorExpectedResult - result);
+            double diff = Math.Abs(floorExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/FusedMultiplyAdd.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/FusedMultiplyAdd.cs
@@ -21,15 +21,15 @@ namespace System.MathBenchmarks
 
         public static void FusedMultiplyAddTest()
         {
-            var result = 0.0; var valueX = 2.0; var valueY = -2.0; var valueZ = 1.0;
+            double result = 0.0, valueX = 2.0, valueY = -2.0, valueZ = 1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.FusedMultiplyAdd(valueX, valueY, valueZ);
                 valueX += fusedMultiplyAddDeltaX; valueY += fusedMultiplyAddDeltaY; valueZ += fusedMultiplyAddDeltaZ;
             }
 
-            var diff = Math.Abs(fusedMultiplyAddExpectedResult - result);
+            double diff = Math.Abs(fusedMultiplyAddExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/ILogB.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/ILogB.cs
@@ -19,9 +19,9 @@ namespace System.MathBenchmarks
 
         public static void ILogBTest()
         {
-            var result = 0; var value = 1.0;
+            int result = 0, value = 1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.ILogB(value);
                 value += iLogBDelta;

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/ILogB.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/ILogB.cs
@@ -19,7 +19,8 @@ namespace System.MathBenchmarks
 
         public static void ILogBTest()
         {
-            int result = 0, value = 1.0;
+            int result = 0;
+            double value = 1.0;
 
             for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Log10Double.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Log10Double.cs
@@ -22,15 +22,15 @@ namespace System.MathBenchmarks
 
         public static void Log10Test()
         {
-            var result = 0.0; var value = 0.0;
+            double result = 0.0, value = 0.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += log10Delta;
                 result += Math.Log10(value);
             }
 
-            var diff = Math.Abs(log10ExpectedResult - result);
+            double diff = Math.Abs(log10ExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/Log2.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/Log2.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void Log2Test()
         {
-            var result = 0.0; var value = 1.0;
+            double result = 0.0, value = 1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.Log2(value);
                 value += log2Delta;
             }
 
-            var diff = Math.Abs(log2ExpectedResult - result);
+            double diff = Math.Abs(log2ExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/LogDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/LogDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void LogTest()
         {
-            var result = 0.0; var value = 0.0;
+            double result = 0.0, value = 0.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += logDelta;
                 result += Math.Log(value);
             }
 
-            var diff = Math.Abs(logExpectedResult - result);
+            double diff = Math.Abs(logExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/MaxDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/MaxDouble.cs
@@ -21,13 +21,13 @@ namespace System.MathBenchmarks
         {
             double result = 0.0, val1 = -1.0, val2 = -1.0 - maxDelta;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 val2 += maxDelta;
                 result += Math.Max(val1, val2);
             }
 
-            var diff = Math.Abs(maxExpectedResult - result);
+            double diff = Math.Abs(maxExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/MinDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/MinDouble.cs
@@ -21,13 +21,13 @@ namespace System.MathBenchmarks
         {
             double result = 0.0, val1 = 1.0, val2 = 1.0 + minDelta;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 val2 -= minDelta;
                 result += Math.Min(val1, val2);
             }
 
-            var diff = Math.Abs(minExpectedResult - result);
+            double diff = Math.Abs(minExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/PowDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/PowDouble.cs
@@ -21,15 +21,15 @@ namespace System.MathBenchmarks
 
         public static void PowTest()
         {
-            var result = 0.0; var valueX = 2.0; var valueY = -2.0;
+            double result = 0.0, valueX = 2.0, valueY = -2.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 valueX += powDeltaX; valueY += powDeltaY;
                 result += Math.Pow(valueX, valueY);
             }
 
-            var diff = Math.Abs(powExpectedResult - result);
+            double diff = Math.Abs(powExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/RoundDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/RoundDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void RoundTest()
         {
-            var result = 0.0; var value = -1.5707963267948966;
+            double result = 0.0, value = -1.5707963267948966;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += roundDelta;
                 result += Math.Round(value);
             }
 
-            var diff = Math.Abs(roundExpectedResult - result);
+            double diff = Math.Abs(roundExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/ScaleB.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/ScaleB.cs
@@ -20,15 +20,16 @@ namespace System.MathBenchmarks
 
         public static void ScaleBTest()
         {
-            var result = 0.0; var valueX = -1.0; var valueY = 1;
+            double result = 0.0, valueX = -1.0;
+            int valueY = 1;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += Math.ScaleB(valueX, valueY);
                 valueX += scaleBDeltaX; valueY += scaleBDeltaY;
             }
 
-            var diff = Math.Abs(scaleBExpectedResult - result);
+            double diff = Math.Abs(scaleBExpectedResult - result);
 
             if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/SinDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/SinDouble.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void SinTest()
         {
-            var result = 0.0; var value = -1.5707963267948966;
+            double result = 0.0, value = -1.5707963267948966;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sinDelta;
                 result += Math.Sin(value);
             }
 
-            var diff = Math.Abs(sinExpectedResult - result);
+            double diff = Math.Abs(sinExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/SinhDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/SinhDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void SinhTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sinhDelta;
                 result += Math.Sinh(value);
             }
 
-            var diff = Math.Abs(sinhExpectedResult - result);
+            double diff = Math.Abs(sinhExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/SqrtDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/SqrtDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void SqrtTest()
         {
-            var result = 0.0; var value = 0.0;
+            double result = 0.0, value = 0.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sqrtDelta;
                 result += Math.Sqrt(value);
             }
 
-            var diff = Math.Abs(sqrtExpectedResult - result);
+            double diff = Math.Abs(sqrtExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/TanDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/TanDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void TanTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += tanDelta;
                 result += Math.Tan(value);
             }
 
-            var diff = Math.Abs(tanExpectedResult - result);
+            double diff = Math.Abs(tanExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Double/TanhDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/TanhDouble.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void TanhTest()
         {
-            var result = 0.0; var value = -1.0;
+            double result = 0.0, value = -1.0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += tanhDelta;
                 result += Math.Tanh(value);
             }
 
-            var diff = Math.Abs(tanhExpectedResult - result);
+            double diff = Math.Abs(tanhExpectedResult - result);
 
             if (diff > MathTests.DoubleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/AbsSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/AbsSingle.cs
@@ -21,15 +21,15 @@ namespace System.MathBenchmarks
 
         public static void AbsTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += absDelta;
                 result += Math.Abs(value);
             }
 
-            var diff = Math.Abs(absExpectedResult - result);
+            float diff = Math.Abs(absExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/AcosSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/AcosSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AcosTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += acosDelta;
                 result += MathF.Acos(value);
             }
 
-            var diff = MathF.Abs(acosExpectedResult - result);
+            float diff = MathF.Abs(acosExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Acosh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Acosh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AcoshTest()
         {
-            var result = 0.0f; var value = 1.0f;
+            float result = 0.0f, value = 1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.Acosh(value);
                 value += acoshDelta;
             }
 
-            var diff = MathF.Abs(acoshExpectedResult - result);
+            float diff = MathF.Abs(acoshExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/AsinSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/AsinSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AsinTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += asinDelta;
                 result += MathF.Asin(value);
             }
 
-            var diff = MathF.Abs(asinExpectedResult - result);
+            float diff = MathF.Abs(asinExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Asinh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Asinh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AsinhTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.Asinh(value);
                 value += asinhDelta;
             }
 
-            var diff = MathF.Abs(asinhExpectedResult - result);
+            float diff = MathF.Abs(asinhExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Atan2Single.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Atan2Single.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void Atan2Test()
         {
-            var result = 0.0f; var valueX = 1.0f; var valueY = -1.0f;
+            float result = 0.0f, valueX = 1.0f, valueY = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 valueX += atan2DeltaX; valueY += atan2DeltaY;
                 result += MathF.Atan2(valueY, valueX);
             }
 
-            var diff = MathF.Abs(atan2ExpectedResult - result);
+            float diff = MathF.Abs(atan2ExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/AtanSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/AtanSingle.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void AtanTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += atanDelta;
                 result += MathF.Atan(value);
             }
 
-            var diff = MathF.Abs(atanExpectedResult - result);
+            float diff = MathF.Abs(atanExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Atanh.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Atanh.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void AtanhTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.Atanh(value);
                 value += atanhDelta;
             }
 
-            var diff = MathF.Abs(atanhExpectedResult - result);
+            float diff = MathF.Abs(atanhExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Cbrt.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Cbrt.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CbrtTest()
         {
-            var result = 0.0f; var value = 0.0f;
+            float result = 0.0f, value = 0.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.Cbrt(value);
                 value += cbrtDelta;
             }
 
-            var diff = MathF.Abs(cbrtExpectedResult - result);
+            float diff = MathF.Abs(cbrtExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/CeilingSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/CeilingSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void CeilingTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += ceilingDelta;
                 result += MathF.Ceiling(value);
             }
 
-            var diff = MathF.Abs(ceilingExpectedResult - result);
+            float diff = MathF.Abs(ceilingExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/CosSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/CosSingle.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void CosTest()
         {
-            var result = 0.0f; var value = 0.0f;
+            float result = 0.0f, value = 0.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += cosDelta;
                 result += MathF.Cos(value);
             }
 
-            var diff = MathF.Abs(cosExpectedResult - result);
+            float diff = MathF.Abs(cosExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/CoshSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/CoshSingle.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void CoshTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += coshDelta;
                 result += MathF.Cosh(value);
             }
 
-            var diff = MathF.Abs(coshExpectedResult - result);
+            float diff = MathF.Abs(coshExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/ExpSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/ExpSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void ExpTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += expDelta;
                 result += MathF.Exp(value);
             }
 
-            var diff = MathF.Abs(expExpectedResult - result);
+            float diff = MathF.Abs(expExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/FloorSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/FloorSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void FloorTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += floorDelta;
                 result += MathF.Floor(value);
             }
 
-            var diff = MathF.Abs(floorExpectedResult - result);
+            float diff = MathF.Abs(floorExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/FusedMultiplyAdd.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/FusedMultiplyAdd.cs
@@ -21,15 +21,15 @@ namespace System.MathBenchmarks
 
         public static void FusedMultiplyAddTest()
         {
-            var result = 0.0f; var valueX = 2.0f; var valueY = -2.0f; var valueZ = 1.0f;
+            float result = 0.0f, valueX = 2.0f, valueY = -2.0f, valueZ = 1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.FusedMultiplyAdd(valueX, valueY, valueZ);
                 valueX += fusedMultiplyAddDeltaX; valueY += fusedMultiplyAddDeltaY; valueZ += fusedMultiplyAddDeltaZ;
             }
 
-            var diff = MathF.Abs(fusedMultiplyAddExpectedResult - result);
+            float diff = MathF.Abs(fusedMultiplyAddExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/ILogB.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/ILogB.cs
@@ -19,9 +19,10 @@ namespace System.MathBenchmarks
 
         public static void ILogBTest()
         {
-            var result = 0; var value = 1.0f;
+            int result = 0;
+            float value = 1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.ILogB(value);
                 value += iLogBDelta;

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Log10Single.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Log10Single.cs
@@ -22,15 +22,15 @@ namespace System.MathBenchmarks
 
         public static void Log10Test()
         {
-            var result = 0.0f; var value = 0.0f;
+            float result = 0.0f, value = 0.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += log10Delta;
                 result += MathF.Log10(value);
             }
 
-            var diff = MathF.Abs(log10ExpectedResult - result);
+            float diff = MathF.Abs(log10ExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/Log2.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/Log2.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void Log2Test()
         {
-            var result = 0.0f; var value = 1.0f;
+            float result = 0.0f, value = 1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.Log2(value);
                 value += log2Delta;
             }
 
-            var diff = MathF.Abs(log2ExpectedResult - result);
+            float diff = MathF.Abs(log2ExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/LogSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/LogSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void LogTest()
         {
-            var result = 0.0f; var value = 0.0f;
+            float result = 0.0f, value = 0.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += logDelta;
                 result += MathF.Log(value);
             }
 
-            var diff = MathF.Abs(logExpectedResult - result);
+            float diff = MathF.Abs(logExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/MaxSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/MaxSingle.cs
@@ -21,13 +21,13 @@ namespace System.MathBenchmarks
         {
             float result = 0.0f, val1 = -1.0f, val2 = -1.0f - maxDelta;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 val2 += maxDelta;
                 result += Math.Max(val1, val2);
             }
 
-            var diff = Math.Abs(maxExpectedResult - result);
+            float diff = Math.Abs(maxExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/MinSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/MinSingle.cs
@@ -21,13 +21,13 @@ namespace System.MathBenchmarks
         {
             float result = 0.0f, val1 = 1.0f, val2 = 1.0f + minDelta;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 val2 -= minDelta;
                 result += Math.Min(val1, val2);
             }
 
-            var diff = Math.Abs(minExpectedResult - result);
+            float diff = Math.Abs(minExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/PowSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/PowSingle.cs
@@ -20,15 +20,15 @@ namespace System.MathBenchmarks
 
         public static void PowTest()
         {
-            var result = 0.0f; var valueX = 2.0f; var valueY = -2.0f;
+            float result = 0.0f, valueX = 2.0f, valueY = -2.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 valueX += powDeltaX; valueY += powDeltaY;
                 result += MathF.Pow(valueX, valueY);
             }
 
-            var diff = MathF.Abs(powExpectedResult - result);
+            float diff = MathF.Abs(powExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/RoundSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/RoundSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void RoundTest()
         {
-            var result = 0.0f; var value = -1.57079633f;
+            float result = 0.0f, value = -1.57079633f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += roundDelta;
                 result += MathF.Round(value);
             }
 
-            var diff = MathF.Abs(roundExpectedResult - result);
+            float diff = MathF.Abs(roundExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/ScaleB.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/ScaleB.cs
@@ -20,15 +20,16 @@ namespace System.MathBenchmarks
 
          public static void ScaleBTest()
         {
-            var result = 0.0f; var valueX = -1.0f; var valueY = 0;
+            float result = 0.0f, valueX = -1.0f; 
+            int valueY = 0;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 result += MathF.ScaleB(valueX, valueY);
                 valueX += scaleBDeltaX; valueY += scaleBDeltaY;
             }
 
-            var diff = MathF.Abs(scaleBExpectedResult - result);
+            float diff = MathF.Abs(scaleBExpectedResult - result);
 
             if (float.IsNaN(result) || (diff > MathTests.SingleEpsilon))
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/SinSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/SinSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void SinTest()
         {
-            var result = 0.0f; var value = -1.57079633f;
+            float result = 0.0f, value = -1.57079633f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sinDelta;
                 result += MathF.Sin(value);
             }
 
-            var diff = MathF.Abs(sinExpectedResult - result);
+            float diff = MathF.Abs(sinExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/SinhSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/SinhSingle.cs
@@ -22,15 +22,15 @@ namespace System.MathBenchmarks
 
         public static void SinhTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sinhDelta;
                 result += MathF.Sinh(value);
             }
 
-            var diff = MathF.Abs(sinhExpectedResult - result);
+            float diff = MathF.Abs(sinhExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/SqrtSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/SqrtSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void SqrtTest()
         {
-            var result = 0.0f; var value = 0.0f;
+            float result = 0.0f, value = 0.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += sqrtDelta;
                 result += MathF.Sqrt(value);
             }
 
-            var diff = MathF.Abs(sqrtExpectedResult - result);
+            float diff = MathF.Abs(sqrtExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/TanSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/TanSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void TanTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += tanDelta;
                 result += MathF.Tan(value);
             }
 
-            var diff = MathF.Abs(tanExpectedResult - result);
+            float diff = MathF.Abs(tanExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/TanhSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/TanhSingle.cs
@@ -19,15 +19,15 @@ namespace System.MathBenchmarks
 
         public static void TanhTest()
         {
-            var result = 0.0f; var value = -1.0f;
+            float result = 0.0f, value = -1.0f;
 
-            for (var iteration = 0; iteration < MathTests.Iterations; iteration++)
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
             {
                 value += tanhDelta;
                 result += MathF.Tanh(value);
             }
 
-            var diff = MathF.Abs(tanhExpectedResult - result);
+            float diff = MathF.Abs(tanhExpectedResult - result);
 
             if (diff > MathTests.SingleEpsilon)
             {


### PR DESCRIPTION
Cf. https://github.com/dotnet/performance/pull/1218#issuecomment-593970196

What do you think about bringing https://github.com/dotnet/runtime/blob/master/.editorconfig over here in order to enforce some styling-rules?

In other benchmarks there are quite some `var`s, that could replaced by the concrete type. I didn't do this right now, to keep this PR small.
But together with the editorconfig I could do one pass of "styling".