### PR TITLE
Remove netcoreapp3.0 from micro benchmarks projects and docs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,6 @@ jobs:
       channels:
         - master
         - release/3.1.2xx
-        - 3.0
         - 2.1
 
   # Windows x64 net461 micro benchmarks
@@ -148,7 +147,7 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
-      channels: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
+      channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -163,7 +162,7 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
-      channels: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
+      channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
         
@@ -182,7 +181,6 @@ jobs:
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - master
         - release/3.1.2xx
-        - 3.0
         - 2.1
 
   # Ubuntu 1804 x64 ML.NET benchmarks
@@ -197,7 +195,7 @@ jobs:
       container: ubuntu_x64_build_container
       runCategories: 'mldotnet'
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
-      channels: # for ML.NET jobs we want to check .NET Core 3.0 and 5.0 only
+      channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -213,7 +211,7 @@ jobs:
       container: ubuntu_x64_build_container
       runCategories: 'roslyn'
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
-      channels: # for Roslyn jobs we want to check .NET Core 3.0 and 5.0 only
+      channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -248,7 +246,7 @@ jobs:
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
       
@@ -263,7 +261,7 @@ jobs:
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -278,7 +276,7 @@ jobs:
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -293,7 +291,7 @@ jobs:
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -309,7 +307,7 @@ jobs:
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 
@@ -325,7 +323,7 @@ jobs:
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
   
@@ -341,7 +339,7 @@ jobs:
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'
-      channels: # for private jobs we want to benchmark .NET Core 3.0 and 5.0 only
+      channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
         - master
         - release/3.1.2xx
 

--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -59,7 +59,7 @@ In order to build or run the benchmarks you will need the **.NET Core command-li
 
 ### Using .NET Cli
 
-To build the benchmarks you need to have the right `dotnet cli`. This repository allows to benchmark .NET Core 2.1, 3.0, 3.1 and 5.0 so you need to install all of them.
+To build the benchmarks you need to have the right `dotnet cli`. This repository allows to benchmark .NET Core 2.1, 3.1 and 5.0 so you need to install all of them.
 
 All you need to do is run the following command:
 
@@ -70,7 +70,7 @@ dotnet build -c Release
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [MicroBenchmarks.csproj](../src/benchmarks/micro/MicroBenchmarks.csproj) file.
 
 ```diff
--<TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+-<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
 +<TargetFrameworks>netcoreapp5.0</TargetFrameworks>
 ```
 
@@ -81,7 +81,7 @@ The alternative is to set `PERFLAB_TARGET_FRAMEWORKS` environment variable to se
 If you don't want to install `dotnet cli` manually, we have a Python 3 script which can do that for you. All you need to do is to provide the frameworks:
 
 ```cmd
-py .\scripts\benchmarks_ci.py --frameworks netcoreapp3.0
+py .\scripts\benchmarks_ci.py --frameworks netcoreapp3.1
 ```
 
 ## Running the Benchmarks
@@ -91,7 +91,7 @@ py .\scripts\benchmarks_ci.py --frameworks netcoreapp3.0
 To run the benchmarks in interactive mode you have to execute `dotnet run -c Release -f $targetFrameworkMoniker` in the folder with benchmarks project.
 
 ```cmd
-C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f netcoreapp3.0
+C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f netcoreapp3.1
 Available Benchmarks:
   #0   Burgers
   #1   ByteMark
@@ -122,31 +122,31 @@ The glob patterns are applied to full benchmark name: namespace.typeName.methodN
 - Run all the benchmarks from BenchmarksGame namespace:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter BenchmarksGame*
+dotnet run -c Release -f netcoreapp3.1 --filter BenchmarksGame*
 ```
 
 - Run all the benchmarks with type name Richards:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter *.Richards.*
+dotnet run -c Release -f netcoreapp3.1 --filter *.Richards.*
 ```
 
 - Run all the benchmarks with method name ToStream:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter *.ToStream
+dotnet run -c Release -f netcoreapp3.1 --filter *.ToStream
 ```
 
 - Run ALL benchmarks:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter *
+dotnet run -c Release -f netcoreapp3.1 --filter *
 ```
 
 - You can provide many filters (logical disjunction):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter System.Collections*.Dictionary* *.Perf_Dictionary.*
+dotnet run -c Release -f netcoreapp3.1 --filter System.Collections*.Dictionary* *.Perf_Dictionary.*
 ```
 
 - To print a **joined summary** for all of the benchmarks (by default printed per type), use `--join`:
@@ -329,7 +329,7 @@ Please use this option only when you are sure that the benchmarks you want to ru
 It's possible to benchmark private builds of [dotnet/runtime](https://github.com/dotnet/runtime) using CoreRun.
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --coreRun $thePath
+dotnet run -c Release -f netcoreapp3.1 --coreRun $thePath
 ```
 
 **Note:** You can provide more than 1 path to CoreRun. In such case, the first path will be the baseline and all the benchmarks are going to be executed for all CoreRuns you have specified.
@@ -355,7 +355,7 @@ public void PrintInfo()
 You can also use any dotnet cli to build and run the benchmarks.
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --cli "C:\Projects\performance\.dotnet\dotnet.exe"
+dotnet run -c Release -f netcoreapp3.1 --cli "C:\Projects\performance\.dotnet\dotnet.exe"
 ```
 
 This is very useful when you want to compare different builds of .NET Core SDK.

--- a/docs/microbenchmark-design-guidelines.md
+++ b/docs/microbenchmark-design-guidelines.md
@@ -104,7 +104,7 @@ public int[] Reverse()
 Profile it using the [ETW Profiler](./benchmarkdotnet.md#Profiling):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter *.Reverse --profiler ETW
+dotnet run -c Release -f netcoreapp3.1 --filter *.Reverse --profiler ETW
 ```
 
 And open the produced trace file with [PerfView](https://github.com/Microsoft/perfview):

--- a/docs/profiling-workflow-dotnet-runtime.md
+++ b/docs/profiling-workflow-dotnet-runtime.md
@@ -643,7 +643,7 @@ namespace ProfilingDocs
 **Note:** You can just build the repro app on your Windows dev machine and copy the output app to your Linux VM using `scp`.
 
 ```cmd
-scp -r "C:\Users\adsitnik\source\repos\ProfilingDocs\ProfilingDocs\bin\Release\netcoreapp3.0\ProfilingDocs.dll" adsitnik@11.222.33.444:/home/adsitnik/Projects/coreclr/bin/tests/Linux.x64.Release/Tests/Core_Root/ProfilingDocs.dll
+scp -r "C:\Users\adsitnik\source\repos\ProfilingDocs\ProfilingDocs\bin\Release\netcoreapp3.1\ProfilingDocs.dll" adsitnik@11.222.33.444:/home/adsitnik/Projects/coreclr/bin/tests/Linux.x64.Release/Tests/Core_Root/ProfilingDocs.dll
 ```
 
 ## Collecting a Trace

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -70,7 +70,7 @@
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.1')">
     <Compile Remove="runtime\Math\Functions\Double\FusedMultiplyAdd.cs" />
     <Compile Remove="runtime\Math\Functions\Double\ILogB.cs" />
     <Compile Remove="runtime\Math\Functions\Double\Log2.cs" />
@@ -83,7 +83,7 @@
     <Compile Remove="libraries\System.Text.Json\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0') OR '$(IsARM)' == 'true'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.1') OR '$(IsARM)' == 'true'">
     <Compile Remove="runtime\PacketTracer\**\*.cs" />
   </ItemGroup>
 

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,7 +12,7 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.0|netcoreapp3.1|netcoreapp5.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp5.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|netcoreapp5.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp5.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 
@@ -51,14 +51,14 @@ dotnet run -c Release -f netcoreapp3.1 --filter * --runtimes netcoreapp3.1 netco
 If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 --filter $YourFilter \
+dotnet run -c Release -f netcoreapp3.1 --filter $YourFilter \
     --corerun C:\Projects\runtime\artifacts\bin\testhost\netcoreapp5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe
 ```
 
 To make sure that your changes don't introduce any regressions, you can provide paths to CoreRuns with and without your changes and use the Statistical Test feature to detect regressions/improvements ([read more](../../../docs/benchmarkdotnet.md#Regressions)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.0 \
+dotnet run -c Release -f netcoreapp3.1 \
     --filter BenchmarksGame* \
     --statisticalTest 3ms \
     --coreRun \

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <IsShipping>false</IsShipping>
     <!-- this app is using internal Roslyn API and needs to be signed -->
     <SignAssembly>true</SignAssembly>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
3.0 reached  end of life yesterday

3.0 branch snapshot: https://github.com/dotnet/performance/tree/3.0

Fixes #1137