### PR TITLE
Fix build and execution for windows/arm64

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -9,12 +9,11 @@
 
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <IsARM Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().StartsWith(`arm`, System.StringComparison.OrdinalIgnoreCase))'">true</IsARM>
-    <DebugType Condition="'$(IsARM)' == 'true' AND '$(OS)' == 'Windows_NT'">portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -14,6 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <IsARM Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().StartsWith(`arm`, System.StringComparison.OrdinalIgnoreCase))'">true</IsARM>
+    <DebugType Condition="'$(IsARM)' == 'true' AND '$(OS)' == 'Windows_NT'">portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.IO;
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -30,10 +30,7 @@ namespace BenchmarkDotNet.Extensions
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
 
                 // See https://github.com/dotnet/roslyn/issues/42393
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-                {
-                    job = job.With(new Argument[] { new MsBuildArgument("/p:DebugType=portable") });
-                }
+                job = job.With(new Argument[] { new MsBuildArgument("/p:DebugType=portable") });
             }
 
             return DefaultConfig.Instance

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.IO;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -27,6 +28,12 @@ namespace BenchmarkDotNet.Extensions
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
+
+                // See https://github.com/dotnet/roslyn/issues/42393
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                {
+                    job = job.With(new Argument[] { new MsBuildArgument("/p:DebugType=portable") });
+                }
             }
 
             return DefaultConfig.Instance


### PR DESCRIPTION
When building performance for 

Currently micro benchmarks fails to build on windows/arm64 because of https://github.com/dotnet/roslyn/issues/42393. As a workaround,  we need to pass `/p:DebugType=portable` to build the micro benchmark project. Also, while running the micro benchmarks on windows/arm64 pass this parameter to build the autogenerated project. 

Ref - https://github.com/dotnet/BenchmarkDotNet/issues/1395
