### PR TITLE
Added support for btl trace files to GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/src/analysis/core_analysis.py
+++ b/src/benchmarks/gc/src/analysis/core_analysis.py
@@ -193,7 +193,7 @@ def get_process_names_and_process_info(
 ) -> Tuple[ThreadToProcessToName, ProcessInfo]:
     p = get_traced_processes(clr, trace_path, collect_event_names)
     kind = get_trace_kind(trace_path)
-    if kind == TraceKind.Etl:
+    if kind == TraceKind.Etl_or_Btl:
         process = find_process(clr, p.processes, process_predicate)
     else:
         processes = tuple(p.processes)

--- a/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
+++ b/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
@@ -509,7 +509,7 @@ namespace GCPerf
             Util.Assert(source != null, $"PrintEventsWithoutTraceLog: Bad path {tracePath}.");
 
             uint n = 0;
-            source.AllEvents += (TraceEvent te) =>
+            source!.AllEvents += (TraceEvent te) =>
             {
                 if ((maxEvents == null || n < maxEvents.Value) && filter(te))
                 {
@@ -586,7 +586,7 @@ namespace GCPerf
             if (collectPerHeapHistoryTimes)
             {
                 perHeapHistoryTimes = new List<double>();
-                source.Clr.GCPerHeapHistory += (GCPerHeapHistoryTraceData data) =>
+                source!.Clr.GCPerHeapHistory += (GCPerHeapHistoryTraceData data) =>
                 {
                     perHeapHistoryTimes.Add(data.TimeStampRelativeMSec);
                 };
@@ -602,7 +602,7 @@ namespace GCPerf
 #endif
 
             eventNames = new Dictionary<string, uint>();
-            source.AllEvents += (TraceEvent te) =>
+            source!.AllEvents += (TraceEvent te) =>
             {
                 /*if (tt is CSwitchTraceData cs)
                 {

--- a/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
+++ b/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
@@ -505,11 +505,11 @@ namespace GCPerf
 
         public static void PrintEventsWithoutTraceLog(string tracePath, Func<TraceEvent, bool> filter, uint? maxEvents)
         {
-            using TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(tracePath);
+            using TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(tracePath)!;
             Util.Assert(source != null, $"PrintEventsWithoutTraceLog: Bad path {tracePath}.");
 
             uint n = 0;
-            source!.AllEvents += (TraceEvent te) =>
+            source.AllEvents += (TraceEvent te) =>
             {
                 if ((maxEvents == null || n < maxEvents.Value) && filter(te))
                 {
@@ -517,8 +517,8 @@ namespace GCPerf
                     n++;
                 }
             };
-            TraceLoadedDotNetRuntimeExtensions.NeedLoadedDotNetRuntimes(source!);
-            source!.Process();
+            TraceLoadedDotNetRuntimeExtensions.NeedLoadedDotNetRuntimes(source);
+            source.Process();
             Console.WriteLine("done");
         }
 
@@ -574,7 +574,7 @@ namespace GCPerf
 
         public static TracedProcesses GetTracedProcesses(string tracePath, bool collectEventNames, bool collectPerHeapHistoryTimes)
         {
-            using TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(tracePath);
+            using TraceEventDispatcher source = TraceEventDispatcher.GetDispatcherFromFileName(tracePath)!;
             Util.Assert(source != null, $"GetTracedProcesses: Bad path {tracePath}.");
 
             Dictionary<string, uint>? eventNames = null;
@@ -586,7 +586,7 @@ namespace GCPerf
             if (collectPerHeapHistoryTimes)
             {
                 perHeapHistoryTimes = new List<double>();
-                source!.Clr.GCPerHeapHistory += (GCPerHeapHistoryTraceData data) =>
+                source.Clr.GCPerHeapHistory += (GCPerHeapHistoryTraceData data) =>
                 {
                     perHeapHistoryTimes.Add(data.TimeStampRelativeMSec);
                 };
@@ -602,7 +602,7 @@ namespace GCPerf
 #endif
 
             eventNames = new Dictionary<string, uint>();
-            source!.AllEvents += (TraceEvent te) =>
+            source.AllEvents += (TraceEvent te) =>
             {
                 /*if (tt is CSwitchTraceData cs)
                 {
@@ -639,12 +639,12 @@ namespace GCPerf
             };
             
 
-            var kernelParser = new KernelTraceEventParser(source!);
+            var kernelParser = new KernelTraceEventParser(source);
 
-            TraceLoadedDotNetRuntimeExtensions.NeedLoadedDotNetRuntimes(source!);
-            source!.Process();
+            TraceLoadedDotNetRuntimeExtensions.NeedLoadedDotNetRuntimes(source);
+            source.Process();
 
-            TraceProcesses processes = TraceProcessesExtensions.Processes(source!);
+            TraceProcesses processes = TraceProcessesExtensions.Processes(source);
 
             /*Dictionary<ProcessID, string> processNames = new Dictionary<ProcessID, string>();
             foreach (TraceProcess process in processes)
@@ -665,7 +665,7 @@ namespace GCPerf
             foreach ((ProcessID pid, long timeQPC) in processIDsAndTimes)
             {
                 //Console.WriteLine($"Seen process ID: {pid} at {timeQPC}");
-                string name = source!.ProcessName(pid, timeQPC);
+                string name = source.ProcessName(pid, timeQPC);
                 if (name == "")
                 {
                     Console.WriteLine("Skipping, empty process name");

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1158,7 +1158,7 @@ class TestResult:
 
 
 class TraceKind(Enum):
-    Etl = 0
+    Etl_or_Btl = 0
     Nettrace = 1
     Perfcollect = 2
 
@@ -1174,9 +1174,9 @@ def get_trace_kind(trace_path: Path) -> TraceKind:
 
 
 def _try_get_trace_kind(trace_path: Path) -> Optional[TraceKind]:
-    name = trace_path.name
-    if name.endswith(".etl"):
-        return TraceKind.Etl
+    name = trace_path.name.lower()
+    if name.endswith(".etl") or name.endswith(".btl"):
+        return TraceKind.Etl_or_Btl
     elif name.endswith(".nettrace"):
         return TraceKind.Nettrace
     elif name.endswith(".trace.zip"):


### PR DESCRIPTION
Btl is another file format for traces that is fully supported by PerfView. GC Benchmarking Infra did not recognize it and therefore failed. This PR adds the necessary support to be able to analyze these traces as well.