### PR TITLE
Updated the PerfView and .NET Core versions in GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/src/commonlib/setup.py
+++ b/src/benchmarks/gc/src/commonlib/setup.py
@@ -32,7 +32,7 @@ def setup() -> None:
         )
 
 
-_PERFVIEW_URL = "https://github.com/microsoft/perfview/releases/download/P2.0.44/PerfView.exe"
+_PERFVIEW_URL = "https://github.com/microsoft/perfview/releases/download/P2.0.52/PerfView.exe"
 _SIGCHECK_URL = "https://download.sysinternals.com/files/Sigcheck.zip"
 _SIGCHECK_ZIP_PATH = SIGCHECK64_PATH.parent / "Sigcheck.zip"
 _SIGCHECK_PARENT_PATH = SIGCHECK64_PATH.parent

--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- For a desktop build, you could add e.g. `net472;` here. -->
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>gcperfsim_core</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
The GC Benchmarking Infrastructure remained using _PerfView_ version _2.0.44_ and _.NET Core_ version _3.0_ (with support for _2.2_) for the GCPerfSim test. This PR updates to PerfView 2.0.52 (the most recent one) and adds 3.1 to GCPerfSim.

Also, it includes a new mechanism to automatically select the latest .NET Core version available for GCPerfSim. Let me elaborate on this. When GCPerfSim is built, usually three versions are deployed, one for each of the supported versions of .NET Core. Should an error prevent any of these binaries from being generated, the other ones can still be built just fine. So, this new mechanism allows the benchmarking tests to run with previous versions of Core should any issues arise with the most recent one.

@Maoni0 @VSadov @cshung 