### PR TITLE
Add sod

### DIFF
--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Xml.Schema;
 using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Reporting

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml.Schema;
 using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Reporting
@@ -39,12 +41,11 @@ namespace Reporting
         {
             var ret = new Reporter();
             ret.environment = environment == null ? new EnvironmentProvider() : environment;
-            if (!ret.CheckEnvironment())
+            if (ret.CheckEnvironment())
             {
-                return null;
+                ret.Init();
             }
                         
-            ret.Init();
             return ret;
         }
 
@@ -89,6 +90,10 @@ namespace Reporting
         }
         public string GetJson()
         {
+            if (!CheckEnvironment())
+            { 
+                return null;
+            }
             var jsonobj = new
             {
                 build,
@@ -103,6 +108,46 @@ namespace Reporting
             return JsonConvert.SerializeObject(jsonobj, Formatting.Indented, settings);
         }
 
+        public string WriteResultTable()
+        {
+            StringBuilder ret = new StringBuilder();
+            foreach (var test in tests)
+            {
+                var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
+                var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
+                var restCounters = test.Counters.Where(c => !(c.TopCounter || c.DefaultCounter));
+                var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
+                var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
+                ret.AppendLine(test.Name);
+                ret.AppendLine($"{Justify("Metric", counterWidth)}|{Justify("Average",resultWidth)}|{Justify("Min", resultWidth)}|{Justify("Max",resultWidth)}");
+                ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
+
+           
+                ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
+                foreach(var counter in topCounters)
+                {
+                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                }
+                foreach (var counter in restCounters)
+                {
+                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                }
+            }
+            return ret.ToString();
+        }
+        private string Print(Counter counter, int counterWidth, int resultWidth)
+        {
+            string average = $"{counter.Results.Average():F3} {counter.MetricName}";
+            string max = $"{counter.Results.Max():F3} {counter.MetricName}";
+            string min = $"{counter.Results.Min():F3} {counter.MetricName}";
+            return $"{Justify(counter.Name, counterWidth)}|{Justify(average, resultWidth)}|{Justify(min, resultWidth)}|{Justify(max, resultWidth)}";
+        }
+
+        private string Justify(string str, int width)
+        {
+            return String.Format("{0,-" + width + "}", str);
+        }
+        
         private bool CheckEnvironment()
         {
             return environment.GetEnvironmentVariable("PERFLAB_INLAB")?.Equals("1") ?? false;

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -118,7 +118,7 @@ namespace Reporting
                 var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
                 var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
                 ret.AppendLine(test.Name);
-                ret.AppendLine($"{Justify("Metric", counterWidth)}|{Justify("Average",resultWidth)}|{Justify("Min", resultWidth)}|{Justify("Max",resultWidth)}");
+                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average",resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max",resultWidth)}");
                 ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
 
            
@@ -139,10 +139,10 @@ namespace Reporting
             string average = $"{counter.Results.Average():F3} {counter.MetricName}";
             string max = $"{counter.Results.Max():F3} {counter.MetricName}";
             string min = $"{counter.Results.Min():F3} {counter.MetricName}";
-            return $"{Justify(counter.Name, counterWidth)}|{Justify(average, resultWidth)}|{Justify(min, resultWidth)}|{Justify(max, resultWidth)}";
+            return $"{LeftJustify(counter.Name, counterWidth)}|{LeftJustify(average, resultWidth)}|{LeftJustify(min, resultWidth)}|{LeftJustify(max, resultWidth)}";
         }
 
-        private string Justify(string str, int width)
+        private string LeftJustify(string str, int width)
         {
             return String.Format("{0,-" + width + "}", str);
         }

--- a/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
+++ b/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Util", "Util\Util.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Reporting", "..\Reporting\Reporting\Reporting.csproj", "{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SizeOnDisk", "SizeOnDisk\SizeOnDisk.csproj", "{F915B017-D1D8-47EA-A51D-34B7A051E83F}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Startup.Tests", "Startup.Tests\Startup.Tests.csproj", "{4905858E-0871-4DDD-B93F-490E106029B6}"
 EndProject
 Global
@@ -29,6 +31,10 @@ Global
 		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A871E0D-F5E0-4A61-B336-D7B080BC30A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F915B017-D1D8-47EA-A51D-34B7A051E83F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F915B017-D1D8-47EA-A51D-34B7A051E83F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F915B017-D1D8-47EA-A51D-34B7A051E83F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F915B017-D1D8-47EA-A51D-34B7A051E83F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4905858E-0871-4DDD-B93F-490E106029B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4905858E-0871-4DDD-B93F-490E106029B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4905858E-0871-4DDD-B93F-490E106029B6}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -1,0 +1,134 @@
+﻿using Reporting;
+using System;
+using System.Collections.Generic;
+using System.CommandLine.DragonFruit;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ScenarioMeasurement
+{
+    class SizeOnDisk
+    {
+        /// <summary>
+        /// SizeOnDisk reports breakdown information about file sizes under a directory (or set of directories)
+        /// </summary>
+        /// <param name="scenarioName">Scenario name for logging purposes</param>
+        /// <param name="dirs">One or more directories to scan.</param>
+        /// <param name="reportJsonPath">Output path for lab reporting purposes</param>
+        /// <returns></returns>
+        static int Main(string scenarioName,
+                        string[] dirs,
+                        string reportJsonPath = "")
+        {
+            if (string.IsNullOrEmpty(scenarioName) || dirs is null || dirs.Length == 0)
+            {
+                Console.WriteLine("Usage: SizeOnDisk <dir0> <dir1> <dirN>");
+                return -1;
+            }
+
+            foreach(var dir in dirs)
+            {
+                if(!Directory.Exists(dir))
+                {
+                    Console.WriteLine($"Directory {dir} does not exist");
+                    return -1;
+                }
+            }
+            var directories = new Dictionary<string, Dictionary<string, long>>();
+            foreach(var dir in dirs)
+            {
+                FindVersionNumbers(dir);
+                directories.Add(dir, GetDirSize(dir));
+            }
+            var counters = new List<Counter>();
+            long totalSize = 0;
+            int totalCount = 0;
+            bool directoryIsTop = dirs.Length > 1; // if we were asked to log more than one directory, include the summary info as top counters.
+            foreach (var directory in directories)
+            {
+                var resultSize = directory.Value.Values.Sum();
+                var resultCount = directory.Value.Values.Count();
+                var name = RemoveVersions(directory.Key);
+                totalSize += resultSize;
+                totalCount += resultCount;
+                counters.Add(new Counter { MetricName = "bytes", TopCounter = directoryIsTop, Name = $"{RemoveVersions(directory.Key)}", Results = new[] { (double)resultSize } });
+                counters.Add(new Counter { MetricName = "count", TopCounter = directoryIsTop, Name = $"{RemoveVersions(directory.Key)}", Results = new[] { (double)resultCount } });
+                foreach (var file in directory.Value)
+                {
+                    counters.Add(new Counter { MetricName = "bytes", Name = $"{RemoveVersions(file.Key)}", Results = new[] { (double)file.Value } });
+                }
+            }
+            counters.Add(new Counter { MetricName = "bytes", Name = scenarioName, DefaultCounter = true, TopCounter = true, Results = new[] { (double)totalSize } });
+            counters.Add(new Counter { MetricName = "count", Name = scenarioName, TopCounter = true, Results = new[] { (double)totalCount } });
+            var reporter = Reporter.CreateReporter();
+            if (reporter != null)
+            {
+                var test = new Test();
+                test.Categories.Add("SizeOnDisk");
+                test.Name = scenarioName;
+                test.AddCounter(counters);
+                reporter.AddTest(test);
+                if (!String.IsNullOrEmpty(reportJsonPath))
+                {
+                    var json = reporter.GetJson();
+                    if(json != null)
+                    {
+                        File.WriteAllText(reportJsonPath, json);
+                    }
+                }
+            }
+            Console.WriteLine(reporter.WriteResultTable());
+            return 0;
+        }
+
+        static HashSet<string> versions = new HashSet<string>();
+
+        static string RemoveVersions(string name)
+        {
+            foreach(var version in versions)
+            {
+                name = name.Replace(version, "VERSION");
+            }
+            return name;
+        }
+
+        static void FindVersionNumbers(string path)
+        {
+            var sdkDir = Path.Combine(path, "sdk");
+            if (!Directory.Exists(sdkDir))
+                return;
+            var sharedDir = Path.Combine(path, "shared");
+            var sdkVersion =  new DirectoryInfo(Directory.GetDirectories(sdkDir).First()).Name;
+            var templateDir = Path.Combine(path, "templates");
+
+            versions.Add(sdkVersion);
+            // the Templates dir seems to have the same version as the SDK version, but with a slightly different format
+            versions.Add(Regex.Replace(sdkVersion, @"(\d+\.\d+\.\d)00", "$1"));
+
+            versions.Add(new DirectoryInfo(Directory.GetDirectories(templateDir).First()).Name);
+            
+            foreach(var dir in Directory.GetDirectories(sharedDir))
+            {
+                versions.Add(new DirectoryInfo(Directory.GetDirectories(dir).First()).Name);
+            }
+            foreach (var version in versions) Console.WriteLine(version);
+        }
+
+        static Dictionary<string, long> GetDirSize(string dir)
+        {
+            var ret = new Dictionary<string, long>();
+            var dirInfo = new DirectoryInfo(dir);
+            var options = new EnumerationOptions();
+            options.AttributesToSkip ^= options.AttributesToSkip; // include hidden and system files
+            options.RecurseSubdirectories = true;
+            options.MatchType = MatchType.Win32;
+            foreach (var fileInfo in dirInfo.EnumerateFiles("*", options))
+            {
+                ret.Add(fileInfo.FullName.Replace(dirInfo.FullName, ""), fileInfo.Length);
+            }
+            return ret;
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -1,10 +1,8 @@
 ﻿using Reporting;
 using System;
 using System.Collections.Generic;
-using System.CommandLine.DragonFruit;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace ScenarioMeasurement
@@ -27,21 +25,19 @@ namespace ScenarioMeasurement
                 Console.WriteLine("Usage: SizeOnDisk <dir0> <dir1> <dirN>");
                 return -1;
             }
+            var directories = new Dictionary<string, Dictionary<string, long>>();
 
-            foreach(var dir in dirs)
+            foreach (var dir in dirs)
             {
                 if(!Directory.Exists(dir))
                 {
                     Console.WriteLine($"Directory {dir} does not exist");
                     return -1;
                 }
-            }
-            var directories = new Dictionary<string, Dictionary<string, long>>();
-            foreach(var dir in dirs)
-            {
                 FindVersionNumbers(dir);
                 directories.Add(dir, GetDirSize(dir));
             }
+
             var counters = new List<Counter>();
             long totalSize = 0;
             int totalCount = 0;

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -96,18 +96,18 @@ namespace ScenarioMeasurement
             if (!Directory.Exists(sdkDir))
                 return;
             var sharedDir = Path.Combine(path, "shared");
-            var sdkVersion =  new DirectoryInfo(Directory.GetDirectories(sdkDir).First()).Name;
+            var sdkVersion =  new DirectoryInfo(Directory.GetDirectories(sdkDir).Single()).Name;
             var templateDir = Path.Combine(path, "templates");
 
             versions.Add(sdkVersion);
             // the Templates dir seems to have the same version as the SDK version, but with a slightly different format
             versions.Add(Regex.Replace(sdkVersion, @"(\d+\.\d+\.\d)00", "$1"));
 
-            versions.Add(new DirectoryInfo(Directory.GetDirectories(templateDir).First()).Name);
+            versions.Add(new DirectoryInfo(Directory.GetDirectories(templateDir).Single()).Name);
             
             foreach(var dir in Directory.GetDirectories(sharedDir))
             {
-                versions.Add(new DirectoryInfo(Directory.GetDirectories(dir).First()).Name);
+                versions.Add(new DirectoryInfo(Directory.GetDirectories(dir).Single()).Name);
             }
             foreach (var version in versions) Console.WriteLine(version);
         }

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFramework>
+    <!-- Supported target frameworks -->
+    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp3.0</TargetFramework>
+    <RootNamespace>ScenarioMeasurement</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="2.0.0-beta1.20074.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Util\Util.csproj" />
+    <ProjectReference Include="..\..\Reporting\Reporting\Reporting.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tools/ScenarioMeasurement/Startup.Tests/Startup.Tests.csproj
+++ b/src/tools/ScenarioMeasurement/Startup.Tests/Startup.Tests.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -189,7 +189,6 @@ namespace ScenarioMeasurement
 
                 var counters = parser.Parse(traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
 
-                WriteResultTable(counters, logger);
 
                 CreateTestReport(scenarioName, counters, reportJsonPath);
             }
@@ -268,18 +267,7 @@ namespace ScenarioMeasurement
         }
 
 
-        private static void WriteResultTable(IEnumerable<Counter> counters, Logger logger)
-        {
-            logger.Log($"{"Metric",-15}|{"Average",-15}|{"Min",-15}|{"Max",-15}");
-            logger.Log($"---------------|---------------|---------------|---------------");
-            foreach (var counter in counters)
-            {
-                string average = $"{counter.Results.Average():F3} {counter.MetricName}";
-                string max = $"{counter.Results.Max():F3} {counter.MetricName}";
-                string min = $"{counter.Results.Min():F3} {counter.MetricName}";
-                logger.Log($"{counter.Name,-15}|{average,-15}|{min,-15}|{max,-15}");
-            }
-        }
+       
 
         private static Dictionary<string, string> ParseStringToDictionary(string s)
         {

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -190,7 +190,7 @@ namespace ScenarioMeasurement
                 var counters = parser.Parse(traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
 
 
-                CreateTestReport(scenarioName, counters, reportJsonPath);
+                CreateTestReport(scenarioName, counters, reportJsonPath, logger);
             }
 
             // Skip unimplemented Linux profiling
@@ -280,7 +280,7 @@ namespace ScenarioMeasurement
             return dict;
         }
 
-        private static void CreateTestReport(string scenarioName, IEnumerable<Counter> counters, string reportJsonPath)
+        private static void CreateTestReport(string scenarioName, IEnumerable<Counter> counters, string reportJsonPath, Logger logger)
         {
             var reporter = Reporter.CreateReporter();
             if (reporter != null)
@@ -292,9 +292,14 @@ namespace ScenarioMeasurement
                 reporter.AddTest(test);
                 if (!String.IsNullOrEmpty(reportJsonPath))
                 {
-                    File.WriteAllText(reportJsonPath, reporter.GetJson());
+                    var json = reporter.GetJson();
+                    if(json != null)
+                    {
+                        File.WriteAllText(reportJsonPath, reporter.GetJson());
+                    }
                 }
             }
+            logger.Log(reporter.WriteResultTable());
         }
     }
 

--- a/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.csproj
@@ -6,6 +6,7 @@
     <!-- Supported target frameworks -->
     <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp3.0</TargetFramework>
     <LangVersion>Preview</LangVersion>
+    <RootNamespace>ScenarioMeasurement</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There are 3 main changes in this PR:
1) Move writing report tables to the Reporting library so we can use them from more than one place, and clean it up a bit so it will variably size if necessary. This also necessitated fixing / adding some tests.
2) Change Startup to use the central version of report tables.
3) Add SOD tool.