### PR TITLE
Add benchmarks for BitOperations

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -80,6 +80,7 @@
     <Compile Remove="runtime\Math\Functions\Single\Log2.cs" />
     <Compile Remove="runtime\Math\Functions\Single\ScaleB.cs" />
     <Compile Remove="libraries\System.Memory\SequenceReader.cs" />
+    <Compile Remove="libraries\System.Numerics.BitOperations\Perf_BitOperations.cs" />
     <Compile Remove="libraries\System.Text.Json\**\*.cs" />
   </ItemGroup>
 

--- a/src/benchmarks/micro/libraries/System.Numerics.BitOperations/Perf_BitOperations.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.BitOperations/Perf_BitOperations.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD)]
+    public class Perf_BitOperations
+    {
+        private static Random s_random = new Random(5);
+        private static uint[] input_uint = GenerateRandomValues<uint>();
+        private static ulong[] input_ulong = GenerateRandomValues<ulong>();
+
+        private static T[] GenerateRandomValues<T>() where T : struct
+        {
+            T[] randomValues = new T[1000];
+            for (int i = 0; i < 1000; i++)
+            {
+                var randomRange = s_random.Next(minValue: 2000 * i, maxValue: 5000 * i);
+                randomValues[i] = Unsafe.As<int, T>(ref randomRange);
+            }
+            return randomValues;
+        }
+
+        [Benchmark]
+        public int LeadingZeroCount_uint()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_uint.Length; i++)
+            {
+                sum += BitOperations.LeadingZeroCount(input_uint[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public int LeadingZeroCount_ulong()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_ulong.Length; i++)
+            {
+                sum += BitOperations.LeadingZeroCount(input_ulong[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public int Log2_uint()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_uint.Length; i++)
+            {
+                sum += BitOperations.Log2(input_uint[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public int Log2_ulong()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_ulong.Length; i++)
+            {
+                sum += BitOperations.Log2(input_ulong[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public int TrailingZeroCount_uint()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_uint.Length; i++)
+            {
+                sum += BitOperations.TrailingZeroCount(input_uint[i]);
+            }
+            return sum;
+        }
+
+        [Benchmark]
+        public int TrailingZeroCount_ulong()
+        {
+            int sum = 0;
+            for (int i = 0; i < input_ulong.Length; i++)
+            {
+                sum += BitOperations.TrailingZeroCount(input_ulong[i]);
+            }
+            return sum;
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Numerics.BitOperations/Perf_BitOperations.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.BitOperations/Perf_BitOperations.cs
@@ -6,34 +6,24 @@ using System.Numerics;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Extensions;
 
 namespace System.Numerics.Tests
 {
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD)]
     public class Perf_BitOperations
     {
-        private static Random s_random = new Random(5);
-        private static uint[] input_uint = GenerateRandomValues<uint>();
-        private static ulong[] input_ulong = GenerateRandomValues<ulong>();
-
-        private static T[] GenerateRandomValues<T>() where T : struct
-        {
-            T[] randomValues = new T[1000];
-            for (int i = 0; i < 1000; i++)
-            {
-                var randomRange = s_random.Next(minValue: 2000 * i, maxValue: 5000 * i);
-                randomValues[i] = Unsafe.As<int, T>(ref randomRange);
-            }
-            return randomValues;
-        }
+        private static uint[] input_uint = ValuesGenerator.Array<uint>(1000);
+        private static ulong[] input_ulong = ValuesGenerator.Array<ulong>(1000);
 
         [Benchmark]
         public int LeadingZeroCount_uint()
         {
             int sum = 0;
-            for (int i = 0; i < input_uint.Length; i++)
+            uint[] input = input_uint;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.LeadingZeroCount(input_uint[i]);
+                sum += BitOperations.LeadingZeroCount(input[i]);
             }
             return sum;
         }
@@ -42,9 +32,10 @@ namespace System.Numerics.Tests
         public int LeadingZeroCount_ulong()
         {
             int sum = 0;
-            for (int i = 0; i < input_ulong.Length; i++)
+            ulong[] input = input_ulong;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.LeadingZeroCount(input_ulong[i]);
+                sum += BitOperations.LeadingZeroCount(input[i]);
             }
             return sum;
         }
@@ -53,9 +44,10 @@ namespace System.Numerics.Tests
         public int Log2_uint()
         {
             int sum = 0;
-            for (int i = 0; i < input_uint.Length; i++)
+            uint[] input = input_uint;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.Log2(input_uint[i]);
+                sum += BitOperations.Log2(input[i]);
             }
             return sum;
         }
@@ -64,9 +56,10 @@ namespace System.Numerics.Tests
         public int Log2_ulong()
         {
             int sum = 0;
-            for (int i = 0; i < input_ulong.Length; i++)
+            ulong[] input = input_ulong;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.Log2(input_ulong[i]);
+                sum += BitOperations.Log2(input[i]);
             }
             return sum;
         }
@@ -75,9 +68,10 @@ namespace System.Numerics.Tests
         public int TrailingZeroCount_uint()
         {
             int sum = 0;
-            for (int i = 0; i < input_uint.Length; i++)
+            uint[] input = input_uint;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.TrailingZeroCount(input_uint[i]);
+                sum += BitOperations.TrailingZeroCount(input[i]);
             }
             return sum;
         }
@@ -86,9 +80,10 @@ namespace System.Numerics.Tests
         public int TrailingZeroCount_ulong()
         {
             int sum = 0;
-            for (int i = 0; i < input_ulong.Length; i++)
+            ulong[] input = input_ulong;
+            for (int i = 0; i < input.Length; i++)
             {
-                sum += BitOperations.TrailingZeroCount(input_ulong[i]);
+                sum += BitOperations.TrailingZeroCount(input[i]);
             }
             return sum;
         }

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace BenchmarkDotNet.Extensions
@@ -91,7 +92,12 @@ namespace BenchmarkDotNet.Extensions
                 return (T)(object)(random.NextDouble() > 0.5);
             if (typeof(T) == typeof(string))
                 return (T) (object) GenerateRandomString(random, 1, 50);
-            
+            if (typeof(T) == typeof(uint) || typeof(T) == typeof(ulong))
+            {
+                int randomValue = random.Next(0, int.MaxValue);
+                return Unsafe.As<int, T>(ref randomValue);
+            }
+
             throw new NotImplementedException($"{typeof(T).Name} is not implemented");
         }
 


### PR DESCRIPTION
Add benchmarks for following APIs in `System.Numerics.BitOperations `:
- LeadingZeroCount
- TrailingZeroCount
- Log2