### PR TITLE
Handle errors gracefully instead of failing in GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/src/commonlib/collection_util.py
+++ b/src/benchmarks/gc/src/commonlib/collection_util.py
@@ -130,7 +130,7 @@ def index_of_max(s: Sequence[T]) -> int:
     return max(indices(s), key=lambda i: s[i])
 
 
-def is_empty(l: Union[FrozenSet[T], Mapping[K, V], Sequence[T]]) -> bool:
+def is_empty(l: Union[FrozenSet[T], List[T], Mapping[K, V], Sequence[T]]) -> bool:
     return len(l) == 0
 
 

--- a/src/benchmarks/gc/src/commonlib/util.py
+++ b/src/benchmarks/gc/src/commonlib/util.py
@@ -29,7 +29,7 @@ from xml.etree.ElementTree import Element, parse as parse_xml
 from psutil import process_iter
 from result import Err, Ok, Result
 
-from .collection_util import find, identity, is_empty, min_max_float
+from .collection_util import add, find, identity, is_empty, min_max_float
 from .option import option_or
 from .type_utils import check_cast, T, U, V, with_slots
 
@@ -320,20 +320,83 @@ def exec_cmd(args: ExecArgs) -> timedelta:
 
 @with_slots
 @dataclass(frozen=True)
-class BenchmarkErrorInfo:
+class BenchmarkRunErrorInfo:
     name: str
+    iteration_num: int
     message: str
     trace: List[str]
 
     def print(self) -> None:
         print(
-            f"\n=== Benchmark: '{self.name}' ===\n"
-            f"\nError Message: {self.message}\n"
-            f"\nStack Trace:\n{self.__rebuild_trace()}"
+            f"- Benchmark: '{self.name}' -\n"
+            f"Iteration: {self.iteration_num}\n"
+            f"Error Message: {self.message}\n"
+            f"\nStack Trace:\n{self.__rebuild_trace()}\n"
         )
 
     def __rebuild_trace(self) -> str:
         return ''.join(self.trace)
+
+
+@with_slots
+@dataclass(frozen=True)
+class ConfigRunErrorInfo:
+    name: str
+    benchmarks_run: BenchmarkErrorList
+
+    def print(self) -> None:
+        print(f"=== Configuration '{self.name}' ===\n")
+        for bench in self.benchmarks_run:
+            bench.print()
+
+    def add_benchmark(self, new_bench: BenchmarkRunErrorInfo) -> None:
+        self.benchmarks_run.append(new_bench)
+
+
+@with_slots
+@dataclass(frozen=True)
+class CoreRunErrorInfo:
+    name: str
+    configs_run: ConfigurationErrorMap
+
+    def print(self) -> None:
+        print(f"===== Core '{self.name}' =====\n")
+        for config in self.configs_run.values():
+            config.print()
+
+    def add_config(self, new_config: ConfigRunErrorInfo) -> None:
+        add(self.configs_run, new_config.name, new_config)
+
+
+RunErrorMap = Mapping[str, CoreRunErrorInfo]
+ConfigurationErrorMap = Mapping[str, ConfigRunErrorInfo]
+BenchmarkErrorList = List[BenchmarkRunErrorInfo]
+
+
+def add_new_error(
+    run_errors: RunErrorMap,
+    core_name: str,
+    config_name: str,
+    bench_name: str,
+    iteration_num: int,
+    message: str,
+    trace: List[str]
+) -> None:
+    if core_name not in run_errors:
+        bench_list = [BenchmarkRunErrorInfo(bench_name, iteration_num, message, trace)]
+        config_dict = {config_name : ConfigRunErrorInfo(config_name, bench_list)}
+        add(run_errors, core_name, CoreRunErrorInfo(core_name, config_dict))
+
+    else:
+        core_info = run_errors[core_name]
+
+        if config_name not in core_info.configs_run:
+            bench_list = [BenchmarkRunErrorInfo(bench_name, iteration_num, message, trace)]
+            core_info.add_config(ConfigRunErrorInfo(config_name, bench_list))
+
+        else:
+            config_info = core_info.configs_run[config_name]
+            config_info.add_benchmark(BenchmarkRunErrorInfo(bench_name, iteration_num, message, trace))
 
 
 @with_slots

--- a/src/benchmarks/gc/src/commonlib/util.py
+++ b/src/benchmarks/gc/src/commonlib/util.py
@@ -23,7 +23,7 @@ from statistics import median, StatisticsError
 from sys import argv
 from threading import Event, Thread
 from time import sleep, time
-from typing import Any, Callable, cast, Iterable, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, cast, Iterable, List, Mapping, Optional, Sequence, Union
 from xml.etree.ElementTree import Element, parse as parse_xml
 
 from psutil import process_iter
@@ -316,6 +316,24 @@ def _call_and_allow_interrupts(args: ExecArgs) -> timedelta:
 def exec_cmd(args: ExecArgs) -> timedelta:
     args.print()
     return _call_and_allow_interrupts(args)
+
+
+@with_slots
+@dataclass(frozen=True)
+class BenchmarkErrorInfo:
+    name: str
+    message: str
+    trace: List[str]
+
+    def print(self) -> None:
+        print(
+            f"\n=== Benchmark: '{self.name}' ===\n"
+            f"\nError Message: {self.message}\n"
+            f"\nStack Trace:\n{self.__rebuild_trace()}"
+        )
+
+    def __rebuild_trace(self) -> str:
+        return ''.join(self.trace)
 
 
 @with_slots

--- a/src/benchmarks/gc/src/suite.py
+++ b/src/benchmarks/gc/src/suite.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast, Mapping, Optional, Sequence, Type
+from typing import cast, List, Mapping, Optional, Sequence, Type
 
 from .analysis.diffable import get_diffables
 from .analysis.process_trace import ProcessedTraces
@@ -30,7 +30,7 @@ from .commonlib.bench_file import (
     Vary,
 )
 from .commonlib.get_built import get_corerun_path_from_core_root
-from .commonlib.collection_util import combine_mappings
+from .commonlib.collection_util import add, combine_mappings, is_empty
 from .commonlib.command import Command, CommandKind, CommandsMapping, run_command_worker
 from .commonlib.document import handle_doc, OutputOptions
 from .commonlib.frozen_dict import FrozenDict
@@ -39,9 +39,9 @@ from .commonlib.option import option_or
 from .commonlib.parse_and_serialize import load_yaml, write_yaml_file
 from .commonlib.score_spec import ScoreElement, ScoreSpec
 from .commonlib.type_utils import argument, with_slots
-from .commonlib.util import ensure_empty_dir
+from .commonlib.util import BenchmarkErrorInfo, ensure_empty_dir
 
-from .exec.run_tests import run, RunArgs
+from .exec.run_tests import run_test, RunArgs
 
 
 SuiteCommand = str
@@ -139,16 +139,37 @@ class SuiteRunArgs:
 
 def suite_run(args: SuiteRunArgs) -> None:
     suite = load_yaml(SuiteFile, args.suite_path)
+    suite_errors: Mapping[str, List[BenchmarkErrorInfo]] = {}
+
     for file in suite.bench_files:
         bench_file_path = args.suite_path.parent / file
+        test_errors: List[BenchmarkErrorInfo] = []
+
         print(f"\n=== {bench_file_path} ===\n")
-        run(
+        run_test(
             RunArgs(
                 bench_file_path=bench_file_path,
                 overwrite=args.overwrite,
                 skip_where_exists=args.skip_where_exists,
-            )
+            ),
+            test_errors,
+            True
         )
+
+        if not is_empty(test_errors):
+            add(suite_errors, bench_file_path, test_errors)
+
+    if is_empty(suite_errors):
+        print("\n*** Suite run finished successfully! ***\n")
+    else:
+        print(
+            f"\n*WARNING*: One or more tests in the suite encountered errors.\n"
+            "\n*** Here is a summary of the problems found: ***"
+        )
+        for file, errors in suite_errors.items():
+            print(f"\n======= {file} =======\n")
+            for bench_err in errors:
+                bench_err.print()
 
 
 @with_slots


### PR DESCRIPTION
Whenever any benchmark test fails in GC Benchmarking Infra, the entire run is automatically finished at that point. While this is not so bad when running individual tests, it can certainly hamper productivity when running big suites.

This PR introduces a new mechanism, which captures any errors occurred while running benchmarks, and allows tests to continue running. At the end, it displays the user a summary of the problems encountered, if any. It is worth mentioning it comes into play on both previously mentioned scenarios:
- Individual Tests with `py . run`
- Suite Tests with `py . suite-run`

Here are some output examples with an artificially introduced exception:

**Individual Test**

``` text
*WARNING*: Test 'C:\Git\performance\src\benchmarks\gc\bench\suite\normal_workstation.yaml' encountered errors.

*** Here is a summary of the problems found: ***

=== Benchmark: '0gb' ===

Error Message: Pause Exception.

Stack Trace:
  File ".\src\exec\run_tests.py", line 182, in _run_all_benchmarks
    t.out,
  File ".\src\exec\run_single_test.py", line 110, in run_single_test
    partial_test_status = _do_run_single_test(built, t, out)
  File ".\src\exec\run_single_test.py", line 186, in _do_run_single_test
    return _run_single_test_windows_perfview(built, t, out)
  File ".\src\exec\run_single_test.py", line 369, in _run_single_test_windows_perfview
    assert False, "Pause Exception."
```

**Suite Test**

``` text
*WARNING*: One or more tests in the suite encountered errors.

*** Here is a summary of the problems found: ***

======= C:\Git\performance\src\benchmarks\gc\bench\suite\normal_workstation.yaml =======


=== Benchmark: '0gb' ===

Error Message: Pause Exception.

Stack Trace:
  File ".\src\exec\run_tests.py", line 182, in _run_all_benchmarks
    t.out,
  File ".\src\exec\run_single_test.py", line 110, in run_single_test
    partial_test_status = _do_run_single_test(built, t, out)
  File ".\src\exec\run_single_test.py", line 186, in _do_run_single_test
    return _run_single_test_windows_perfview(built, t, out)
  File ".\src\exec\run_single_test.py", line 369, in _run_single_test_windows_perfview
    assert False, "Pause Exception."


======= C:\Git\performance\src\benchmarks\gc\bench\suite\normal_server.yaml =======


=== Benchmark: '0gb' ===

Error Message: Pause Exception.

Stack Trace:
  File ".\src\exec\run_tests.py", line 182, in _run_all_benchmarks
    t.out,
  File ".\src\exec\run_single_test.py", line 110, in run_single_test
    partial_test_status = _do_run_single_test(built, t, out)
  File ".\src\exec\run_single_test.py", line 186, in _do_run_single_test
    return _run_single_test_windows_perfview(built, t, out)
  File ".\src\exec\run_single_test.py", line 369, in _run_single_test_windows_perfview
    assert False, "Pause Exception."
```

Additionally, I added a nice message that is displayed when a `suite-run` finishes successfully!

@Maoni0 @VSadov @cshung 