### PR TITLE
React to branding change

### DIFF
--- a/src/benchmarks/gc/src/commonlib/util.py
+++ b/src/benchmarks/gc/src/commonlib/util.py
@@ -454,7 +454,7 @@ def exec_and_get_result(args: ExecArgs) -> ProcessResult:
 
 def decode_stdout(stdout: bytes) -> str:
     # Microsoft trademark confuses python
-    stdout = stdout.replace(b"Microsoft\xae .NET Core", b"Microsoft .NET Core")
+    stdout = stdout.replace(b"\xae", b"")
     return stdout.decode("utf-8").strip().replace("\r", "")
 
 


### PR DESCRIPTION
As of https://github.com/dotnet/runtime/pull/33694, the product name changes from `b"Microsoft \xae .NET Core"` to `b"Microsoft \xae .NET"`. This broke the replacement logic. 

To avoid future failures, fixing it by simply replacing away that offending character. We don't need to be that specific. Any occurrence of that character is going to break the decoding anyway.