### PR TITLE
Stop consuming result of GetPinnedReference()

### DIFF
--- a/src/benchmarks/micro/libraries/System.Memory/ReadOnlySpan.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/ReadOnlySpan.cs
@@ -17,7 +17,7 @@ namespace System.Memory
         [Benchmark]
         public ReadOnlySpan<char> StringAsSpan() => _sampeString.AsSpan();
         
-        [Benchmark(OperationsPerInvoke = 16)]
+        [Benchmark(OperationsPerInvoke = 16 * 2)]
         public char GetPinnableReference()
         {
             ReadOnlySpan<char> span = _sampeString.AsSpan();

--- a/src/benchmarks/micro/libraries/System.Memory/ReadOnlySpan.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/ReadOnlySpan.cs
@@ -13,25 +13,33 @@ namespace System.Memory
     public class ReadOnlySpan
     {
         private readonly string _sampeString = "this is a very nice sample string";
-        private readonly Consumer _consumer = new Consumer();
 
         [Benchmark]
         public ReadOnlySpan<char> StringAsSpan() => _sampeString.AsSpan();
         
         [Benchmark(OperationsPerInvoke = 16)]
-        public void GetPinnableReference()
+        public char GetPinnableReference()
         {
             ReadOnlySpan<char> span = _sampeString.AsSpan();
-            var consumer = _consumer;
-            
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
-            consumer.Consume(span.GetPinnableReference()); consumer.Consume(span.GetPinnableReference());
+            char c;
+
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            c = span.GetPinnableReference(); c = span.GetPinnableReference();
+            return c;
         }
         
         [Benchmark(OperationsPerInvoke = 16)]


### PR DESCRIPTION
We were consuming the values returned from `GetPinnedReference()` API, however
`.Consume()` uses `volatile` and that introduces memory barriers for ARM64.
Since we just want to measure the performance of `GetPinnedReference()` it is
unnecessary to introduce a differentiating factor for 1 architecture and not the
other. Hence I have removed the `.Consume()` and instead just storing the returned
result in a variable.

Before:
```asm
...
G_M52573_IG23:
        79400063          ldrh    w3, [x3]
        D5033BBF          dmb     ish
        79008023          strh    w3, [x1,#64]
        D2800003          mov     x3, #0
        34000040          cbz     w0, G_M52573_IG25
                                                ;; bbWeight=1    PerfScore 15.50
G_M52573_IG24:
        AA0203E3          mov     x3, x2
                                                ;; bbWeight=0.25 PerfScore 0.13
G_M52573_IG25:
        79400063          ldrh    w3, [x3]
        D5033BBF          dmb     ish
        79008023          strh    w3, [x1,#64]
        D2800003          mov     x3, #0
        34000040          cbz     w0, G_M52573_IG27
                                                ;; bbWeight=1    PerfScore 15.50
G_M52573_IG26:
        AA0203E3          mov     x3, x2
                                                ;; bbWeight=0.25 PerfScore 0.13
...

```

After
```asm
...
G_M51552_IG23:
        79400021          ldrh    w1, [x1]
        D2800001          mov     x1, #0
        34000040          cbz     w0, G_M51552_IG25
                                                ;; bbWeight=1    PerfScore 4.50
G_M51552_IG24:
        AA0203E1          mov     x1, x2
                                                ;; bbWeight=0.25 PerfScore 0.13
G_M51552_IG25:
        79400021          ldrh    w1, [x1]
        D2800001          mov     x1, #0
        34000040          cbz     w0, G_M51552_IG27
                                                ;; bbWeight=1    PerfScore 4.50
G_M51552_IG26:
        AA0203E1          mov     x1, x2
                                                ;; bbWeight=0.25 PerfScore 0.13
...

```

This change reduces the ARM64 numbers for this benchmark from 10ns to 1ns. I am not sure if
we should just add `Consume()` method and mark it as `NoInline`. That's what is done for
`System.Memory.Span<T>.GetPinnedReference()` benchmark. I have also increased the number of calls to `GetPinnableReference()` to make sure we can a valid time measurement value.