### PR TITLE
Support POH allocations in GCPerfSim

### DIFF
--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- For a desktop build, you could add e.g. `net472;` here. -->
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>gcperfsim_core</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Adding support for POH allocations in GCPerfSim and a few knobs to control the allocations.

Light-up of the new features requires building against  `netcoreapp 5.0` with public support for POH. 
(I do not think it shipped yet, should be in the next preview, testing was done with private builds).

The project is backwards compatible and can be compiled to target earlier versions of the runtime such as `netcoreap 3.1`. 
In such case the features related to POH will be unavailable. Attempting to use them will result in exceptions saying that `netcoreapp 5.0` is required.