### PR TITLE
Add benchmarks for VectorX.Min/Max/Clamp

### DIFF
--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector2.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector2.cs
@@ -52,5 +52,14 @@ namespace System.Numerics.Tests
 
         [Benchmark]
         public Vector2 NormalizeBenchmark() => Vector2.Normalize(VectorTests.Vector2Value);
+
+        [Benchmark]
+        public Vector2 ClampBenchmark() => Vector2.Clamp(VectorTests.Vector2Value, VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 MinBenchmark() => Vector2.Min(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 MaxBenchmark() => Vector2.Max(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector3.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector3.cs
@@ -54,5 +54,14 @@ namespace System.Numerics.Tests
 
         [Benchmark]
         public Vector3 CrossBenchmark() => Vector3.Cross(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 ClampBenchmark() => Vector3.Clamp(VectorTests.Vector3Value, VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 MinBenchmark() => Vector3.Min(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 MaxBenchmark() => Vector3.Max(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
@@ -54,5 +54,14 @@ namespace System.Numerics.Tests
 
         [Benchmark]
         public float DotBenchmark() => Vector4.Dot(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+
+        [Benchmark]
+        public Vector4 ClampBenchmark() => Vector4.Clamp(VectorTests.Vector4Value, VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+
+        [Benchmark]
+        public Vector4 MinBenchmark() => Vector4.Min(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+
+        [Benchmark]
+        public Vector4 MaxBenchmark() => Vector4.Max(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
     }
 }


### PR DESCRIPTION
To benchmark [these changes](https://github.com/dotnet/runtime/pull/34896).