### PR TITLE
Fixed setup issue when cache sizes are unknown on Linux on GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/src/commonlib/host_info.py
+++ b/src/benchmarks/gc/src/commonlib/host_info.py
@@ -116,7 +116,7 @@ def _get_host_info(built: Built) -> HostInfo:
     ](built)
 
 
-_UNKNOWN_SIZE_MSG: str = "unknown size"
+_UNKNOWN_MSG: str = "unknown"
 
 def _get_host_info_posix() -> HostInfo:
     # lscpu output is a bunch of lines all of the form key: value. Make a dict from that.
@@ -132,7 +132,7 @@ def _get_host_info_posix() -> HostInfo:
         return map_option(get_opt(name), float)
 
     def get_opt_kb(name: str) -> Optional[int]:
-        if name.lower() == _UNKNOWN_SIZE_MSG:
+        if _UNKNOWN_MSG in get_opt(name).lower():
             return None
         return map_option(get_opt(name), lambda s: int(remove_str_end(s, "K")))
 

--- a/src/benchmarks/gc/src/commonlib/host_info.py
+++ b/src/benchmarks/gc/src/commonlib/host_info.py
@@ -116,6 +116,8 @@ def _get_host_info(built: Built) -> HostInfo:
     ](built)
 
 
+_UNKNOWN_SIZE_MSG: str = "unknown size"
+
 def _get_host_info_posix() -> HostInfo:
     # lscpu output is a bunch of lines all of the form key: value. Make a dict from that.
     dct = _parse_keys_values_lines(exec_and_get_output(ExecArgs(("lscpu",), quiet_print=True)))
@@ -130,6 +132,8 @@ def _get_host_info_posix() -> HostInfo:
         return map_option(get_opt(name), float)
 
     def get_opt_kb(name: str) -> Optional[int]:
+        if name.lower() == _UNKNOWN_SIZE_MSG:
+            return None
         return map_option(get_opt(name), lambda s: int(remove_str_end(s, "K")))
 
     # Note: "CPU MHz" is the *current* cpu rate which varies. Going with max here.

--- a/src/benchmarks/gc/src/commonlib/host_info.py
+++ b/src/benchmarks/gc/src/commonlib/host_info.py
@@ -132,7 +132,8 @@ def _get_host_info_posix() -> HostInfo:
         return map_option(get_opt(name), float)
 
     def get_opt_kb(name: str) -> Optional[int]:
-        if _UNKNOWN_MSG in get_opt(name).lower():
+        opt = get_opt(name)
+        if opt is not None and _UNKNOWN_MSG in opt.lower():
             return None
         return map_option(get_opt(name), lambda s: int(remove_str_end(s, "K")))
 

--- a/src/benchmarks/gc/src/commonlib/host_info.py
+++ b/src/benchmarks/gc/src/commonlib/host_info.py
@@ -135,7 +135,7 @@ def _get_host_info_posix() -> HostInfo:
         opt = get_opt(name)
         if opt is not None and _UNKNOWN_MSG in opt.lower():
             return None
-        return map_option(get_opt(name), lambda s: int(remove_str_end(s, "K")))
+        return map_option(opt, lambda s: int(remove_str_end(s, "K")))
 
     # Note: "CPU MHz" is the *current* cpu rate which varies. Going with max here.
     # TODO: Max is probably wrong, we want a typical value.


### PR DESCRIPTION
Fixes #1250.

There is a possibility that `lscpu` might return the value _"unknown size"_ when it is not configured correctly or can't retrieve the cache sizes appropriately. GC Benchmarking Infra parses the output from `lscpu` as a Dictionary. When it attempts to read the cache size values, it expects a number followed by a "K", and therefore fails when receiving this "unknown" output.

This PR fixes this by setting the cache size to `None` should this scenario occur, as it already supports dealing with this value.

@Maoni0 @cshung @VSadov 