### PR TITLE
Make reporting more explicit

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -27,7 +27,7 @@ namespace BenchmarkDotNet.Extensions
         public override void ExportToLog(Summary summary, ILogger logger)
         {
             var reporter = Reporter.CreateReporter();
-            if (reporter == null) // not running in the perf lab
+            if (!reporter.InLab) // not running in the perf lab
                 return;
 
             foreach (var report in summary.Reports)

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -40,7 +40,7 @@ namespace Reporting
         {
             var ret = new Reporter();
             ret.environment = environment == null ? new EnvironmentProvider() : environment;
-            if (ret.CheckEnvironment())
+            if (ret.InLab)
             {
                 ret.Init();
             }
@@ -89,7 +89,7 @@ namespace Reporting
         }
         public string GetJson()
         {
-            if (!CheckEnvironment())
+            if (!InLab)
             { 
                 return null;
             }
@@ -146,10 +146,7 @@ namespace Reporting
         {
             return String.Format("{0,-" + width + "}", str);
         }
-        
-        private bool CheckEnvironment()
-        {
-            return environment.GetEnvironmentVariable("PERFLAB_INLAB")?.Equals("1") ?? false;
-        }
+
+        public bool InLab => environment.GetEnvironmentVariable("PERFLAB_INLAB")?.Equals("1") ?? false;
     }
 }

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -66,13 +66,9 @@ namespace ScenarioMeasurement
                 test.Name = scenarioName;
                 test.AddCounter(counters);
                 reporter.AddTest(test);
-                if (!String.IsNullOrEmpty(reportJsonPath))
+                if (reporter.InLab && !String.IsNullOrEmpty(reportJsonPath))
                 {
-                    var json = reporter.GetJson();
-                    if(json != null)
-                    {
-                        File.WriteAllText(reportJsonPath, json);
-                    }
+                    File.WriteAllText(reportJsonPath, reporter.GetJson());
                 }
             }
             Console.WriteLine(reporter.WriteResultTable());

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -283,21 +283,14 @@ namespace ScenarioMeasurement
         private static void CreateTestReport(string scenarioName, IEnumerable<Counter> counters, string reportJsonPath, Logger logger)
         {
             var reporter = Reporter.CreateReporter();
-            if (reporter != null)
+            var test = new Test();
+            test.Categories.Add("Startup");
+            test.Name = scenarioName;
+            test.AddCounter(counters);
+            reporter.AddTest(test);
+            if (reporter.InLab && !String.IsNullOrEmpty(reportJsonPath))
             {
-                var test = new Test();
-                test.Categories.Add("Startup");
-                test.Name = scenarioName;
-                test.AddCounter(counters);
-                reporter.AddTest(test);
-                if (!String.IsNullOrEmpty(reportJsonPath))
-                {
-                    var json = reporter.GetJson();
-                    if(json != null)
-                    {
-                        File.WriteAllText(reportJsonPath, reporter.GetJson());
-                    }
-                }
+                File.WriteAllText(reportJsonPath, reporter.GetJson());
             }
             logger.Log(reporter.WriteResultTable());
         }


### PR DESCRIPTION
A recent change to the reporting library changed the semantic of how tools should detect whether or not they should try and write results. I missed updating the exporter in the microbenchmarks project. It is only broken when you try to use more than one runtime at once.

Fix is to just expose a property with the information. I don't want to bake it just into the logic of this class because different tools have different ideas of whether or not to use this functionality at all.