### PR TITLE
Updated documentation regarding Core_Root and the runtime repo in GC Infra

### DIFF
--- a/src/benchmarks/gc/README.md
+++ b/src/benchmarks/gc/README.md
@@ -146,7 +146,7 @@ benchmarks:
   <other benchmark tests to run>
 ```
 
-The configuration values that can be used in the test `.yaml` file are described under `docs/bench_file.md`.
+The configuration values that can be used in the test `.yaml` file are described under [docs/bench_file.md](docs/bench_file.md).
 
 ## Running
 
@@ -459,15 +459,10 @@ A YAML file that describes the benchmarks to run and the configs (environment va
 
 ### Core_Root
 
-This is the build output of coreclr that is used to run benchmarks.
+This is the build output of coreclr that is used to run benchmarks. These are specified in the `coreclrs` section of a benchfile.
 
-These are specified in the `coreclrs` section of a benchfile.
-
-This can be found in a directory like `runtime/artifacts/bin/coreclr/Windows_NT.x64.Release/` (adjust for different OS or architecture) of a runtime repository. (The Core_Root can be moved anywhere and doesn't need to remain inside the runtime repository). However, it cannot be used as is after building. Move/Copy all files within `crossgen2` to the Core_Root directory as the benchmark executable currently does not find assemblies or binaries deeper in the directory tree.
-
-A clone of https://github.com/dotnet/runtime, which may be on an arbitrary commit (including one not checked in).
-When you make a change to coreclr within runtime, you will generally make two clones, one at master and one at your branch (which may be on your fork).
-Alternately, you may have only one checkout, build multiple times, copy the builds to somewhere, and specify coreclrs using `core_root` instead of `path`.
+Since the codebase of coreclr was moved to the runtime repo, the way of generating the `core_root` has changed.
+See [docs/building_coreroot.md](docs/building_coreroot.md) for detailed instructions on how to get it.
 
 ### Config
 

--- a/src/benchmarks/gc/docs/building_coreroot.md
+++ b/src/benchmarks/gc/docs/building_coreroot.md
@@ -1,0 +1,71 @@
+# Building Core_Root from the Runtime Repo
+
+First, you need a clone of https://github.com/dotnet/runtime.
+Note that it may be on an arbitrary commit (including one you might be currently working on).
+
+Once you are ready to build the `Core_Root`, follow these steps.
+
+## Building with Default Settings
+
+These steps will assume you want to build the `Core_Root` for the machine you are working on.
+This means the targeted OS and Architecture will be deduced by the runtime from your machine's specs.
+
+If you want to build for another OS/Architecture, use the `-os/--os` and `-arch/--arch` flags when calling the first two build scripts. For the third one (Core_Root), prepend your target architecture with a `-`(e.g. `-x64`) and the OS with the `-os`(e.g. `-os Linux`) flag on both, Windows and Linux.
+
+### Build CoreCLR
+
+From the root of the `runtime` repo, issue the following command:
+
+On Windows
+```sh
+.\build.cmd -s clr -c Release
+```
+
+On Linux
+```sh
+./build.sh -s clr -c Release
+```
+
+### Build the Libraries
+
+Once CoreCLR has been built, you need to build the libraries, which are required to later generate the `Core_Root`.
+
+On Windows
+```sh
+.\build.cmd -s libs -c Release
+```
+
+On Linux
+```sh
+./build.sh -s libs -c Release
+```
+
+### Build the Core_Root
+
+At this point, the stage has been set to generate the `Core_Root`.
+This time, move to the CoreCLR directory: `/runtime/src/coreclr/`. There, issue the following command:
+
+On Windows
+```sh
+.\build-test.cmd -release -generatelayoutonly
+```
+
+On Linux
+```sh
+./build-test.sh -release -generatelayoutonly
+```
+
+Once that's finished, you can find your new _Core_Root_ within the artifacts path. For example:
+`/runtime/artifacts/tests/coreclr/Linux.x64.Release/Tests/Core_Root`
+
+Substitute `Linux` and `x64` with the OS and Architecture you are targeting.
+
+## Building for ARM/ARM64
+
+On Windows, this process is almost the same as for any other architecture. Specify it as explained in the above section.
+
+On Linux, there are additional steps to take. You need to have a `ROOTFS_DIR` and specify the `--cross` (`-cross` for `build-test.sh`) flag when calling the build scripts.
+
+Detailed instructions on how to generate the _ROOTFS_ on Linux and how to cross-build can be found [here](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/cross-building.md).
+
+Another alternative is to use Docker containers. They allow for a more straightforward and less complicated setup and you can find the instructions to use them [here](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/linux-instructions.md). They allow for both, normal and cross building.

--- a/src/benchmarks/gc/docs/jupyter notebook.md
+++ b/src/benchmarks/gc/docs/jupyter notebook.md
@@ -2,14 +2,12 @@
 
 A jupyter notebook has already been set up in `jupyter_notebook.py`. So far it's only been tested with VSCode.
 
-
 ## Using with VSCode
 
-* Run `code .` in the `dotnet-gc-infra` directory.
+* Run `code .` in the `/performance/src/benchmarks/gc` directory.
 * Open `jupyter_notebook.py`.
 * Open your settings and enable `"editor.codeLens": true,`.
 * Wait a minute for CodeLens to show up in the notebook.
-
 
 ## Overview
 


### PR DESCRIPTION
Originally, GC Benchmarking Infrastructure was built when the `coreclr` repo was still the one used by everyone doing development. Since the migration to the `runtime` repo, some things have been changed, such as generating the `Core_Root` and certain paths. This PR updates all the outdated documentation and adds some more necessary information.