### PR TITLE
Introduce MathF.CopySign and Math.CopySign micro benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/Math/Functions/Double/CopySignDouble.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Double/CopySignDouble.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.CopySign(double) over 5000 iterations for the domain -1, +1
+
+        private const double copySignDelta = 0.0004;
+        private const int copySignExpectedResult = 0;
+
+        [Benchmark]
+        public void CopySign() => CopySignTest();
+
+        public static void CopySignTest()
+        {
+            double result = 0.0, value = -1.0;
+
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                value += copySignDelta;
+                result += Math.CopySign(result, value);
+            }
+
+            if (value != copySignExpectedResult)
+            {
+                throw new Exception($"Expected Result {copySignExpectedResult}; Actual Result {result}");
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/runtime/Math/Functions/Single/CopySignSingle.cs
+++ b/src/benchmarks/micro/runtime/Math/Functions/Single/CopySignSingle.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace System.MathBenchmarks
+{
+    public partial class Single
+    {
+        // Tests Math.CopySign(float) over 5000 iterations for the domain -1, +1
+
+        private const float copySignDelta = 0.0004f;
+        private const int copySignExpectedResult = 0;
+
+        [Benchmark]
+        public void CopySign() => CopySignTest();
+
+        public static void CopySignTest()
+        {
+            float result = 0.0f, value = -1.0f;
+
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                value += copySignDelta;
+                result += MathF.CopySign(result, value);
+            }
+
+            if (value != copySignExpectedResult)
+            {
+                throw new Exception($"Expected Result {copySignExpectedResult}; Actual Result {result}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/dotnet/runtime/pull/35456

Introduce benchmarks for the CopySign methods, which just test with 2500 iters of sign being 0 and 2500 with sign being 1. Criticism welcome as I am not really sure what i am doing here 😃