### PR TITLE
Fixes a typo

### DIFF
--- a/src/benchmarks/gc/docs/building_coreroot.md
+++ b/src/benchmarks/gc/docs/building_coreroot.md
@@ -47,7 +47,7 @@ This time, move to the CoreCLR directory: `/runtime/src/coreclr/`. There, issue 
 
 On Windows
 ```sh
-.\build-test.cmd -release -generatelayoutonly
+.\build-test.cmd release generatelayoutonly
 ```
 
 On Linux


### PR DESCRIPTION
It appears to me that the hyphens are not needed (in fact the build would fail if included).
@ivdiazsa 