### PR TITLE
Remove wait for lock

### DIFF
--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -14,8 +14,6 @@
   <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
     <ScenariosDir>$(WorkItemDirectory)/src/scenarios/</ScenariosDir>
     <HelixPreCommands>$(HelixPreCommands);export PYTHONPATH=$HELIX_CORRELATION_PAYLOAD/scripts:$HELIX_CORRELATION_PAYLOAD</HelixPreCommands>
-    <HelixPreCommands>$(HelixPreCommands);sudo lsof /var/lib/dpkg/lock-frontend</HelixPreCommands>
-    <HelixPreCommands>$(HelixPreCommands);sudo tail --pid=$(sudo lsof -t /var/lib/dpkg/lock-frontend) -f /dev/null</HelixPreCommands>
   </PropertyGroup>  
 
   <ItemGroup>


### PR DESCRIPTION
The original HelixPrecommand was added to avoid [this core-eng issue](https://github.com/dotnet/core-eng/issues/9647). Removing the commands since the issue is fixed. 