### PR TITLE
Add JSON benchmarks for missing-property and case-insensitive

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadMissingAndCaseInsensitive.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadMissingAndCaseInsensitive.cs
@@ -38,20 +38,34 @@ namespace System.Text.Json.Serialization.Tests
             };
         }
 
+        /// <summary>
+        /// Uses default settings of case-sensitive comparison and JSON that matches the Pascal-casing
+        /// of the properties on the class.
+        /// </summary>
         [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
         [Benchmark]
-        public T DeserializeBaseline() => JsonSerializer.Deserialize<T>(_serialized, _optionsBaseline);
+        public T Baseline() => JsonSerializer.Deserialize<T>(_serialized, _optionsBaseline);
 
+        /// <summary>
+        /// Properties are missing because the comparison is case-sensitive and the JSON uses camel-casing
+        /// which does not match the properties on the class.
+        /// </summary>
         [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
         [Benchmark]
-        public T DeserializeMissing() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsBaseline);
+        public T MissingProperties() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsBaseline);
 
+        /// <summary>
+        /// Case-insensitive is enabled and the casing in JSON matches the properties on the class.
+        /// </summary>
         [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
         [Benchmark]
-        public T DeserializeCaseMatching() => JsonSerializer.Deserialize<T>(_serialized, _optionsCaseInsensitive);
+        public T CaseInsensitiveMatching() => JsonSerializer.Deserialize<T>(_serialized, _optionsCaseInsensitive);
 
+        /// <summary>
+        /// Case-insensitive is enabled and the casing in JSON does not match the properties on the class.
+        /// </summary>
         [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
         [Benchmark]
-        public T DeserializeCaseNotMatching() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsCaseInsensitive);
+        public T CaseInsensitiveNotMatching() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsCaseInsensitive);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadMissingAndCaseInsensitive.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadMissingAndCaseInsensitive.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using MicroBenchmarks.Serializers;
+using Newtonsoft.Json.Serialization;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    [GenericTypeArguments(typeof(Location))]
+    public class ReadMissingAndCaseInsensitive<T>
+    {
+        private string _serialized;
+        private string _serializedCamelCased;
+        private JsonSerializerOptions _optionsBaseline;
+        private JsonSerializerOptions _optionsCaseInsensitive;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            T value = DataGenerator.Generate<T>();
+            _serialized = JsonSerializer.Serialize(value);
+
+            JsonSerializerOptions options = new JsonSerializerOptions()
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            _serializedCamelCased = JsonSerializer.Serialize(value, options);
+
+            _optionsBaseline = new JsonSerializerOptions();
+
+            _optionsCaseInsensitive = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+        }
+
+        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+        [Benchmark]
+        public T DeserializeBaseline() => JsonSerializer.Deserialize<T>(_serialized, _optionsBaseline);
+
+        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+        [Benchmark]
+        public T DeserializeMissing() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsBaseline);
+
+        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+        [Benchmark]
+        public T DeserializeCaseMatching() => JsonSerializer.Deserialize<T>(_serialized, _optionsCaseInsensitive);
+
+        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+        [Benchmark]
+        public T DeserializeCaseNotMatching() => JsonSerializer.Deserialize<T>(_serializedCamelCased, _optionsCaseInsensitive);
+    }
+}


### PR DESCRIPTION
Adds new benchmarks to track changes made in https://github.com/dotnet/runtime/pull/35848

Verifies ~2x perf improvement on the missing-property and case-insensitive scenarios.

Before changes from the runtime PR linked above:
```
|                     Method |     Mean |     Error |    StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|        DeserializeBaseline | 1.209 us | 0.0139 us | 0.0130 us | 1.207 us | 1.186 us | 1.231 us | 0.0676 |     - |     - |     448 B |
|         DeserializeMissing | 1.593 us | 0.0161 us | 0.0150 us | 1.595 us | 1.557 us | 1.622 us | 0.0386 |     - |     - |     264 B |
|    DeserializeCaseMatching | 1.304 us | 0.0120 us | 0.0112 us | 1.301 us | 1.289 us | 1.329 us | 0.1169 |     - |     - |     752 B |
| DeserializeCaseNotMatching | 2.369 us | 0.0240 us | 0.0224 us | 2.371 us | 2.333 us | 2.411 us | 0.1426 |     - |     - |     928 B |
```

After:
```
|                     Method |       Mean |    Error |   StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
|        DeserializeBaseline | 1,228.1 ns | 12.32 ns | 11.53 ns | 1,226.9 ns | 1,210.2 ns | 1,246.1 ns | 0.0685 |     - |     - |     448 B |
|         DeserializeMissing |   841.5 ns |  6.32 ns |  5.60 ns |   840.0 ns |   831.2 ns |   851.4 ns | 0.0134 |     - |     - |      88 B |
|    DeserializeCaseMatching | 1,224.4 ns | 12.83 ns | 12.00 ns | 1,224.7 ns | 1,209.8 ns | 1,246.2 ns | 0.0676 |     - |     - |     448 B |
| DeserializeCaseNotMatching | 1,234.0 ns |  9.58 ns |  8.49 ns | 1,233.8 ns | 1,223.1 ns | 1,249.1 ns | 0.0688 |     - |     - |     448 B |
```