### PR TITLE
Extend timeout for mvcapptemplate

### DIFF
--- a/src/scenarios/mvcapptemplate/test.py
+++ b/src/scenarios/mvcapptemplate/test.py
@@ -9,6 +9,7 @@ EXENAME = 'mvcapptemplate'
 def main():
     traits = TestTraits(exename=EXENAME,
                         guiapp='false', 
+                        timeout= f'{const.MINUTE*10}'
                         )
     runner = Runner(traits)
     runner.run()


### PR DESCRIPTION
Fix frequent timeout of ```SDK ASP.NET MVC App Template netcoreapp<X> Clean Build``` test on Ubuntu. [Log here](https://helix.dot.net/api/2019-06-17/jobs/65c8a79c-5a22-419c-ad93-5f00559c5f5e/workitems/SDK%20ASP.NET%20MVC%20App%20Template%20netcoreapp3.0%20Clean%20Build/console)