### PR TITLE
fix the Data Contract mismatch in ResultsComparer

### DIFF
--- a/src/tools/ResultsComparer/DataTransferContracts.cs
+++ b/src/tools/ResultsComparer/DataTransferContracts.cs
@@ -87,7 +87,7 @@ namespace DataTransferContracts // generated with http://json2csharp.com/#
         public int Gen0Collections { get; set; }
         public int Gen1Collections { get; set; }
         public int Gen2Collections { get; set; }
-        public int TotalOperations { get; set; }
+        public long TotalOperations { get; set; }
         public long BytesAllocatedPerOperation { get; set; }
     }
 


### PR DESCRIPTION
Fixes #1328

The ResultsComparer data contract definition was using `int`, while it should have been using a `long` as BDN:

https://github.com/dotnet/BenchmarkDotNet/blob/3223c94a92050147a02482a3810860703f0c5171/src/BenchmarkDotNet/Engines/GcStats.cs#L39

cc @ filipnavara 