### PR TITLE
Added PyPI notes when using the Jupyter Notebook

### DIFF
--- a/src/benchmarks/gc/docs/jupyter notebook.md
+++ b/src/benchmarks/gc/docs/jupyter notebook.md
@@ -20,3 +20,27 @@ A jupyter notebook has already been set up in `jupyter_notebook.py`. So far it's
 * If you edit code in any other file you will have to reload the whole notebook.
   See the ⟲ icon in the top-right.
 * You can also do any custom analysis on the trace. The `custom` section at the bottom shows how to manually sum all GC times.
+
+## Programming Notes
+
+Here are some internal implementation notes to be aware of when doing simple tests using the Jupyter Notebook.
+
+### Individual GC Information
+
+Each time you process a trace, each GC's information (such as whether it's Gen1,
+uses compaction, etc) is stored in an object called `ProcessedGC`. Some of these
+property values can show unexpected behavior in remote cases, such as not
+existing, and to avoid unnecessary failures, they are wrapped in custom-defined
+types called `Failable` types. The downside to this is it becomes harder to get
+the actual value when doing detailed inspections of traces.
+
+These `Failable` types are defined under `src/analysis/types.py`. They implement
+the _Result_ type from the [_PyPI_ API](https://pypi.org/project/result/), which
+wraps the value in either an `Ok()` or an `Err()` object.
+
+You can either validate or extract the actual received value with the following
+functions:
+
+* To validate: Use `.is_ok()` or `.is_err()`.
+* To extract the value: Use `.value`.
+    * If you know what behavior happened, you can also use `.ok()` and `.err()` respectively.


### PR DESCRIPTION
An important use case of the Jupyter Notebook in GC Benchmarking Infra, is to analyze individual GC information from a trace on the fly. However, due to how the ProcessedGC` class is implemented, it is not as straightforward to retrieve the desired values.

These fields are wrapped in PyPI's Result Type. This PR adds documentation on how this works in a nutshell and how to apply it in the Jupyter Notebook to retrieve the information you want.