### PR TITLE
Microsoft.Extensions.Caching.Memory.MemoryCache: Initial Benchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -20,12 +20,12 @@
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0-preview.4.20251.6" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
@@ -97,5 +97,4 @@
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />
   </ItemGroup>
-
 </Project>

--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Microsoft.Extensions.Caching.Memory.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public class MemoryCacheTests
+    {
+        private MemoryCache _memCache;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _memCache = new MemoryCache(new MemoryCacheOptions());
+            for (var i = 0; i < 1024; i++)
+            {
+                _memCache.Set(i.ToString(), i.ToString());
+            }
+        }
+
+        [Benchmark]
+        public object GetHit() => _memCache.Get("256");
+        [Benchmark]
+        public object GetMiss() => _memCache.Get("256");
+
+        [Benchmark]
+        public object SetOverride() => _memCache.Set("512", "512");
+    }
+}

--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.Caching.Memory.Tests
         [Benchmark]
         public object GetHit() => _memCache.Get("256");
         [Benchmark]
-        public object GetMiss() => _memCache.Get("256");
+        public object GetMiss() => _memCache.Get("-1");
 
         [Benchmark]
         public object SetOverride() => _memCache.Set("512", "512");

--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Caching.Memory/MemoryCacheTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.Caching.Memory.Tests
 
         [Benchmark]
         public object GetHit() => _memCache.Get("256");
+
         [Benchmark]
         public object GetMiss() => _memCache.Get("-1");
 


### PR DESCRIPTION
Creating some benchmarks for planned MemoryCache optimizations we can upstream - first changes in https://github.com/dotnet/runtime/pull/36775. Adding these for all to use, happy to change anything for styling, etc. just tried to match best I knew first pass!

See #462 for context, the lib in here (also: should it point to non-preview?) gets replaced with a `dotnet/runtime` version if using `coreRun`, which is awesome.