### PR TITLE
Enable scenarios tests on Ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,21 @@ jobs:
         # - release/3.1.2xx
         - 3.0
 
+  # Ubuntu x64 scenario benchmarks
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: ubuntu
+      osVersion: 1804
+      kind: scenarios
+      architecture: x64
+      pool: Hosted Ubuntu 1604
+      queue: Ubuntu.1804.Amd64.Open
+      container: ubuntu_x64_build_container
+      projectFile: scenarios.proj
+      channels:
+        - master
+        #- release/3.1.2xx
+
   # Windows x64 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
@@ -89,7 +104,7 @@ jobs:
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       projectFile: sdk_scenarios.proj
-      channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+      channels: 
         - master
         #- release/3.1.2xx
 

--- a/src/tools/ScenarioMeasurement/Startup/ParserUtility.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ParserUtility.cs
@@ -86,7 +86,14 @@ namespace ScenarioMeasurement
             if (!source.IsWindows)
             {
                 // For Linux both pid and tid should match
-                if (!pids.Contains((int)GetPayloadValue(evt, "PayloadThreadID")))
+                if (evt.ThreadID != 0 )
+                {
+                    if (!pids.Contains(evt.ThreadID)){
+                        return CompareResult.Mismatch;
+                    }
+                }
+                // Linux Kernel events uses 'PayloadThreadID' as tid
+                else if (!pids.Contains((int)GetPayloadValue(evt, "PayloadThreadID")))
                 {
                     return CompareResult.Mismatch;
                 }


### PR DESCRIPTION
TimeToMain parser is supposed to function on Linux now with the runtime fix https://github.com/dotnet/runtime/pull/35737 and we are good to turn on Linux scenarios job on master (bug fixed in .NET 5). However, the fix is not rolled out in 3.x release branches. 