### PR TITLE
Fix build issue related to rename of ReferenceHandler

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadPreservedReferences.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadPreservedReferences.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Tests
         [GlobalSetup]
         public void Setup()
         {
-            _options = new JsonSerializerOptions { ReferenceHandling = ReferenceHandling.Preserve };
+            _options = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
 
             _settings = new JsonSerializerSettings { PreserveReferencesHandling = PreserveReferencesHandling.All };
 
@@ -39,7 +39,7 @@ namespace System.Text.Json.Serialization.Tests
             }
             else
             {
-                // Use payload that does not contain metadata in order to see what is the penalty of having ReferenceHandling.Preserve set.
+                // Use payload that does not contain metadata in order to see what is the penalty of having ReferenceHandler.Preserve set.
                 _serialized = JsonConvert.SerializeObject(value);
             }
         }

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WritePreservedReferences.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WritePreservedReferences.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             _value = DataGenerator.Generate<T>();
 
-            _options = new JsonSerializerOptions { ReferenceHandling = ReferenceHandling.Preserve };
+            _options = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
 
             _settings = new JsonSerializerSettings { PreserveReferencesHandling = PreserveReferencesHandling.All };
         }


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/pull/36829 changes that rename ReferenceHandling to ReferenceHandler in `JsonSerializerOptions`.

This PR makes that existing benchmarks using `RefrenceHandling` now use the proper property name.

Fixes https://github.com/dotnet/runtime/issues/37319