### PR TITLE
Fix Color Palette in GC Benchmarking Infra Charts

### DIFF
--- a/src/benchmarks/gc/src/analysis/chart_utils.py
+++ b/src/benchmarks/gc/src/analysis/chart_utils.py
@@ -215,7 +215,6 @@ AnyChart = Union[BasicLineChart, BasicHistogram]
 
 def basic_chart(charts: Sequence[AnyChart]) -> None:
     _fig, axes = subplots(len(charts), individual_figure_size=(8, 4))
-    # cool = (1.0, 0.0, 0.0, 1.0)
     for ax, chart in zip(axes, charts):
         map_option(chart.name, ax.set_title)
         map_option(chart.x_label, ax.set_xlabel)

--- a/src/benchmarks/gc/src/analysis/chart_utils.py
+++ b/src/benchmarks/gc/src/analysis/chart_utils.py
@@ -48,6 +48,8 @@ Color = Tuple[float, float, float, float]
 
 
 def get_colors(n: int) -> Sequence[Color]:
+    # Coolwarm, RdBu, and seismic are also good neutral color palettes.
+    # If you change this, keep in mind these names are case-sensitive.
     cmap = get_cmap("rainbow")
     return [cmap(i) for i in _linspace(0.1, 0.9, n)]
 

--- a/src/benchmarks/gc/src/analysis/chart_utils.py
+++ b/src/benchmarks/gc/src/analysis/chart_utils.py
@@ -215,6 +215,7 @@ AnyChart = Union[BasicLineChart, BasicHistogram]
 
 def basic_chart(charts: Sequence[AnyChart]) -> None:
     _fig, axes = subplots(len(charts), individual_figure_size=(8, 4))
+    # cool = (1.0, 0.0, 0.0, 1.0)
     for ax, chart in zip(axes, charts):
         map_option(chart.name, ax.set_title)
         map_option(chart.x_label, ax.set_xlabel)
@@ -222,10 +223,12 @@ def basic_chart(charts: Sequence[AnyChart]) -> None:
         if isinstance(chart, BasicLineChart):
             map_option(chart.x_label, ax.set_xlabel)
             map_option(chart.y_label, ax.set_ylabel)
-            for line in chart.lines:
-                # line.name is Optional[str], this is fine although mypy thinks it isn't
+            for line, color in zip_with_colors(chart.lines):
+                # line.name is Optional[str], this is fine although mypy thinks
+                # it isn't.
                 # TODO: customizable marker
-                ax.plot(line.xs, line.ys, label=cast(str, line.name), marker="*")
+                ax.plot(line.xs, line.ys, label=cast(str, line.name),
+                        marker="*", color=color)
             if any(line.name is not None for line in chart.lines):
                 ax.legend()
         else:


### PR DESCRIPTION
GC Benchmarking Infra provides the capability to chart trace analysis for easier data presentation and comparison. However, the basic chart functionality was not applying the specified color palette, which sometimes yielded graphs hard to read. This PR fixes this.