### PR TITLE
build-server shutdown workaround 

### DIFF
--- a/src/scenarios/shared/sdk_iteration_setup.py
+++ b/src/scenarios/shared/sdk_iteration_setup.py
@@ -1,10 +1,11 @@
 import os
 import shutil
-from shared import const
+from shared import const, util
 from dotnet import shutdown_server
 from performance.logger import setup_loggers
 from logging import getLogger
 from argparse import ArgumentParser
+
 
 SETUP_BUILD = 'setup_build'
 SETUP_NEW = 'setup_new'
@@ -19,7 +20,7 @@ def main():
     setup_loggers(True)
 
     if args.operation == SETUP_BUILD:
-        shutdown_server(verbose=True)
+        shutdown_dotnet_servers()
         if not os.path.isdir(const.TMPDIR):
             if not os.path.isdir(const.APPDIR):
                 raise Exception("\'app\' folder should exist. Please run pre.py.")
@@ -41,6 +42,14 @@ def main():
             getLogger().info("Removing project directory...")
             shutil.rmtree(const.APPDIR)
 
+
+def shutdown_dotnet_servers():
+    # shutdown_server(verbose=True) # This is the correct way to shut down dotnet build servers, but it has been disabled due to https://github.com/dotnet/sdk/issues/10573
+    getLogger().info("Shutting down dotnet build servers...")
+    if util.iswin():
+        os.system('TASKKILL /F /T /IM dotnet.exe || TASKKILL /F /T /IM VSTest.Console.exe || TASKKILL /F /T /IM msbuild.exe')
+    else:
+        os.system('killall -9 dotnet || killall -9 VSTest.Console || killall -9 msbuild')
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The issue can be found here: https://github.com/dotnet/sdk/issues/10573