### PR TITLE
The analysis-single command does not work with a trace file, it needs the test status file

### DIFF
--- a/src/benchmarks/gc/README.md
+++ b/src/benchmarks/gc/README.md
@@ -399,7 +399,12 @@ You can see all available metrics [here](docs/metrics.md).
 Most analysis commands require you to specify the metrics you want (although many provide defaults). The simplest example is `analyze-single` which can take a single trace and print out metrics.
 
 ```sh
-py . analyze-single bench/suite/low_memory_container.yaml.out/a__only_config__tlgb0.2__0.etl --run-metrics FirstToLastGCSeconds --single-gc-metrics DurationMSec --single-heap-metrics InMB OutMB
+py . analyze-single bench/suite/low_memory_container.yaml.out/defgcperfsim__a__only_config__tlgb0.2__0.yaml --run-metrics FirstToLastGCSeconds --single-gc-metrics DurationMSec --single-heap-metrics InMB OutMB
+```
+
+Alternatively, the can also be done by using the process and path arguments:
+```sh
+py . analyze-single --process name:corerun --path bench\suite\low_memory_container.etl.out\defgcperfsim__a__only_config__tlgb0.2__0.etl --run-metrics FirstToLastGCSeconds --single-gc-metrics DurationMSec --single-heap-metrics InMB OutMB
 ```
 
 The output will look like:


### PR DESCRIPTION
Here is what I get running the given command
```
C:\Dev\performance\src\benchmarks\gc>py . analyze-single bench/suite/low_memory_container.yaml.out/a__only_config__tlgb0.2__0.etl --run-metrics FirstToLastGCSeconds --single-gc-metrics DurationMSec --single-heap-metrics InMB OutMB
Traceback (most recent call last):
  File "C:\Users\andrewau\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\andrewau\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File ".\__main__.py", line 9, in <module>
    run_command(ALL_COMMANDS)
  File ".\src\commonlib\command.py", line 87, in run_command
    run_command_worker(commands, cmd_and_args)
  File ".\src\commonlib\command.py", line 243, in run_command_worker
    cast(Callable[[Any], None], command.fn)(args)
  File ".\src\analysis\analyze_single.py", line 105, in analyze_single
    handle_doc(_get_analyze_single_document(args), output_options_from_args(args))
  File ".\src\analysis\analyze_single.py", line 187, in _get_analyze_single_document
    need_join_info=False,
  File ".\src\analysis\process_trace.py", line 105, in get_processed_trace
    need_mechanisms_and_reasons=need_mechanisms_and_reasons,
  File ".\src\analysis\process_trace.py", line 145, in _get_processed_trace_from_process
    lambda _: "Didn't specify --process and there's no test status to specify PID\n"
  File ".\src\commonlib\result_utils.py", line 35, in unwrap
    raise Exception(str(err))
Exception: Didn't specify --process and there's no test status to specify PID
 (hint: maybe specify the test output '.yaml' file instead of the trace file)
```

Here is what I get using the yaml file instead
```
C:\Dev\performance\src\benchmarks\gc>py . analyze-single bench/suite/low_memory_container.yaml.out/a__only_config__tlgb0.2__0.yaml --run-metrics FirstToLastGCSeconds --single-gc-metrics DurationMSec --single-heap-metrics InMB OutMB
WARN: GC 1 has 6 heaps, but 0 ServerGcHeapHistories. It's a NGC2.
... [the correct analysis output]
```

Therefore we should change the documentation to reflect that.