### PR TITLE
Crossgen2 scenarios update

### DIFF
--- a/src/scenarios/crossgen2/framework-r2r.dll.rsp
+++ b/src/scenarios/crossgen2/framework-r2r.dll.rsp
@@ -126,7 +126,6 @@ System.Runtime.Extensions.dll
 System.Runtime.Handles.dll
 System.Runtime.InteropServices.dll
 System.Runtime.InteropServices.RuntimeInformation.dll
-System.Runtime.InteropServices.WindowsRuntime.dll
 System.Runtime.Intrinsics.dll
 System.Runtime.Intrinsics.Experimental.dll
 System.Runtime.Loader.dll
@@ -136,7 +135,6 @@ System.Runtime.Serialization.Formatters.dll
 System.Runtime.Serialization.Json.dll
 System.Runtime.Serialization.Primitives.dll
 System.Runtime.Serialization.Xml.dll
-System.Runtime.WindowsRuntime.UI.Xaml.dll
 System.Security.AccessControl.dll
 System.Security.Claims.dll
 System.Security.Cryptography.Algorithms.dll

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -189,8 +189,6 @@ class Runner:
                 sys.exit(1)
         
             compiletype = const.CROSSGEN2_COMPOSITE if self.compositefile else const.CROSSGEN2_SINGLEFILE
-            crossgen2exe = 'crossgen2%s' % extension()
-
 
             if compiletype == const.CROSSGEN2_SINGLEFILE:
                 referencefilenames = ['System.*.dll', 'Microsoft.*.dll', 'netstandard.dll', 'mscorlib.dll']
@@ -216,11 +214,11 @@ class Runner:
             self.traits.add_traits(overwrite=True,
                                    startupmetric=const.STARTUP_CROSSGEN2,
                                    workingdir=self.coreroot,
-                                   appargs=crossgen2args
+                                   appargs='%s %s' % (os.path.join('crossgen2', 'crossgen2.dll'), crossgen2args)
                                    )
             self.traits.add_traits(overwrite=False,
                                    scenarioname='Crossgen2 Throughput - %s - %s' % ( compiletype, filename),
-                                   apptorun=os.path.join(self.coreroot, os.path.join('crossgen2', crossgen2exe))
+                                   apptorun=os.path.join(self.coreroot, 'CoreRun%s' % extension())
                                   ) 
             startup.runtests(self.traits)
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -210,6 +210,8 @@ class Runner:
                     os.mkdir(outputdir)
                 outputfile = os.path.join(outputdir, filename+'.ni'+ext )
                 crossgen2args = '--composite -o %s -O @%s' % (outputfile, self.compositefile)
+                self.traits.add_traits( overwrite=True,
+                                        skipprofile='true')
 
             self.traits.add_traits(overwrite=True,
                                    startupmetric=const.STARTUP_CROSSGEN2,

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -94,6 +94,8 @@ class StartupWrapper(object):
             startup_args.extend(['--cleanup-args', traits.cleanupargs])
         if traits.measurementdelay:
             startup_args.extend(['--measurement-delay', traits.measurementdelay])
+        if traits.skipprofile:
+            startup_args.extend(['--skip-profile-iteration'])
             
         RunCommand(startup_args, verbose=True).run()
 

--- a/src/scenarios/shared/testtraits.py
+++ b/src/scenarios/shared/testtraits.py
@@ -30,6 +30,7 @@ class TestTraits:
         self.processwillexit = ''
         self.measurementdelay = ''
         self.environmentvariables = ''
+        self.skipprofile = ''
 
         # add test types to traits
         for testtype in testtypes:

--- a/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
@@ -40,12 +40,12 @@ namespace ScenarioMeasurement
 
             var processTimeParser = new ProcessTimeParser();
             Counter processTimeCounter = null;
-           /* foreach (var counter in processTimeParser.Parse(mergeTraceFile, processName, pids, commandLine))
+            foreach (var counter in processTimeParser.Parse(mergeTraceFile, processName, pids, commandLine))
             {
                 if(counter.Name == "Process Time"){
                     processTimeCounter = counter;
                 }
-            }*/
+            }
 
             return new[] {
                 processTimeCounter,


### PR DESCRIPTION
Patches to PR #1335
- Removing WindowsRuntime assemblies since they are not supported in runtime any more
- Disabling profiling composite scenarios until the issue that causes failure is identified
- Uncommenting mistakenly commented code
- Using ```CoreRun.exe```