### PR TITLE
Use Python3.7 for ubuntu runs

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -28,6 +28,8 @@ jobs:
             value: 'call %HELIX_CORRELATION_PAYLOAD%\tools\machine-setup.cmd'
           - name: Python
             value: 'py -3'
+          - name: PythonBuild
+            value: 'py -3'
           - ${{ if ne(parameters.osVersion, 'RS1')}}:
             - name: ArtifactsDirectory
               value: '%HELIX_WORKITEM_UPLOAD_ROOT%\BenchmarkDotNet.Artifacts'
@@ -40,6 +42,8 @@ jobs:
           - name: AdditionalHelixPreCommands
             value: 'chmod +x ./tools/machine-setup.sh;. ./tools/machine-setup.sh'
           - name: Python
+            value: python3.7
+          - name: PythonBuild
             value: python3
           - ${{ if eq(parameters.osVersion, '1804')}}:
             - name: ArtifactsDirectory
@@ -75,11 +79,10 @@ jobs:
             value: 'official'
           - ${{ if eq(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
+              value: '$(Python) -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;$(Python) -m pip install azure.storage.blob==12.0.0 --force-reinstall;$(Python) -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
-
+              value: 'sudo apt-get -y install $(Python)-venv;$(Python) -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
           - group: DotNet-HelixApi-Access
           # perflab upload tokens still exist in this variable group
           - group: dotnet-benchview
@@ -99,9 +102,9 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/parse_props.py --branch-name $(_Channel)
+        - script: $(PythonBuild) scripts/parse_props.py --branch-name $(_Channel)
           displayName: Parse Version.props
-        - script: $(Python) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
+        - script: $(PythonBuild) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -29,6 +29,8 @@ jobs:
             value: 'call %HELIX_CORRELATION_PAYLOAD%\machine-setup$(ScriptExtension);xcopy %HELIX_CORRELATION_PAYLOAD%\NuGet.config %$HELIX_WORKITEM_ROOT%'
           - name: Python
             value: 'py -3'
+          - name: PythonBuild
+            value: 'py -3'
           - name: ArtifactsDirectory
             value: '%HELIX_WORKITEM_UPLOAD_ROOT%\Scenarios'
         - ${{ if ne(parameters.osName, 'windows') }}:
@@ -39,6 +41,8 @@ jobs:
           - name: AdditionalHelixPreCommands
             value: 'chmod +x $HELIX_CORRELATION_PAYLOAD/machine-setup.sh;. $HELIX_CORRELATION_PAYLOAD/machine-setup$(ScriptExtension);cp $HELIX_CORRELATION_PAYLOAD/NuGet.config $$HELIX_WORKITEM_ROOT'
           - name: Python
+            value: python3.7
+          - name: PythonBuild
             value: python3
           - name: ArtifactsDirectory
             value: '$HELIX_WORKITEM_UPLOAD_ROOT/Scenarios'
@@ -58,10 +62,10 @@ jobs:
             value: ''
           - ${{ if eq(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
+              value: '$(Python) -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;$(Python) -m pip install azure.storage.blob==12.0.0 --force-reinstall;$(Python) -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
+              value: 'sudo apt-get -y install $(Python)-venv;$(Python) -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
         workspace:
@@ -79,9 +83,9 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/parse_props.py --branch-name $(_Channel)
+        - script: $(PythonBuild) scripts/parse_props.py --branch-name $(_Channel)
           displayName: Parse Version.props
-        - script: $(Python) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
+        - script: $(PythonBuild) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -36,6 +36,7 @@ class PreCommands:
 
         subparsers = parser.add_subparsers(title='Operations', 
                                            description='Common preperation steps for perf tests.',
+                                           required=True,
                                            dest='operation')
 
         default_parser = subparsers.add_parser(DEFAULT, help='Default operation' )
@@ -48,10 +49,6 @@ class PreCommands:
         self.add_common_arguments(publish_parser)
 
         args = parser.parse_args()
-
-        if not args.operation:
-            getLogger().error("Please specify an operation: %s" % list(OPERATIONS))
-            sys.exit(1)
 
         self.configuration = args.configuration 
         self.operation = args.operation

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -36,7 +36,7 @@ class Runner:
         Parses input args to the script
         '''
         parser = ArgumentParser()
-        subparsers = parser.add_subparsers(title='subcommands for scenario tests', dest='testtype')
+        subparsers = parser.add_subparsers(title='subcommands for scenario tests', required=True, dest='testtype')
         startupparser = subparsers.add_parser(const.STARTUP)
         self.add_common_arguments(startupparser)
 
@@ -60,10 +60,6 @@ class Runner:
         self.add_common_arguments(sodparser)
 
         args = parser.parse_args()
-
-        if not args.testtype:
-            getLogger().error("Please specify a test type: %s" % testtypes)
-            sys.exit(1)
 
         self.testtype = args.testtype
     

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -68,7 +68,7 @@ def pythoncommand():
     if iswin():
         return 'py'
     else:
-        return 'python3'
+        return 'python3.7'
 
 def iswin():
     return sys.platform == 'win32'


### PR DESCRIPTION
After we removed tests on perfsnakes which don't have python3.7 installed, we should be ready for updating our pipeline to use Python3.7 now.