### PR TITLE
Removed restriction forcing traces to have same number of GC's when charting

### DIFF
--- a/src/benchmarks/gc/src/analysis/chart_utils.py
+++ b/src/benchmarks/gc/src/analysis/chart_utils.py
@@ -195,13 +195,6 @@ class BasicLineChart:
     def n_values(self) -> int:
         return self.lines[0].n_values
 
-    def __post_init__(self) -> None:
-        for line in self.lines:
-            assert line.n_values == self.n_values, (
-                f"{option_or(line.name, '<unnamed>')} has {line.n_values} data points, "
-                + f"should have {self.n_values}"
-            )
-
 
 @with_slots
 @dataclass(frozen=True)


### PR DESCRIPTION
Certain charting operations in GC Infra, such as `chart_lines_from_fields`, used to fail at an assertion preventing graphics generation of traces with different number of GC's. It is not uncommon to have this scenario, so this PR removes this assertion, as charting these traces like that is harmless.

@Maoni0 @cshung 