### PR TITLE
specify output folder for crossgen tests

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -162,7 +162,12 @@ class Runner:
         elif self.testtype == const.CROSSGEN:
             startup = StartupWrapper()
             crossgenexe = 'crossgen%s' % extension()
-            crossgenargs = '/nologo /p %s %s\%s' % (self.coreroot, self.coreroot, self.crossgenfile)
+            filename, ext = os.path.splitext(self.crossgenfile)
+            outputdir = os.path.join(self.coreroot, 'crossgen.out')
+            if not os.path.exists(outputdir):
+                os.mkdir(outputdir)
+            outputfile = os.path.join(outputdir, filename+'.ni'+ext )
+            crossgenargs = '/nologo /out %s /p %s %s\%s' % (outputfile, self.coreroot, self.coreroot, self.crossgenfile)
             if self.coreroot is not None and not os.path.isdir(self.coreroot):
                 getLogger().error('Cannot find CORE_ROOT at %s', self.coreroot)
                 return
@@ -195,7 +200,7 @@ class Runner:
                 referencefiles = [os.path.join(self.coreroot, filename) for filename in referencefilenames]
                 # single assembly filename: example.dll
                 filename, ext = os.path.splitext(self.singlefile)
-                outputdir = os.path.join(self.coreroot, 'out')
+                outputdir = os.path.join(self.coreroot, 'single.out')
                 if not os.path.exists(outputdir):
                     os.mkdir(outputdir)
                 outputfile = os.path.join(outputdir, filename+'.ni'+ext )

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -163,7 +163,7 @@ class Runner:
             startup = StartupWrapper()
             crossgenexe = 'crossgen%s' % extension()
             filename, ext = os.path.splitext(self.crossgenfile)
-            outputdir = os.path.join(self.coreroot, 'crossgen.out')
+            outputdir = os.path.join(os.getcwd(), 'crossgen.out')
             if not os.path.exists(outputdir):
                 os.mkdir(outputdir)
             outputfile = os.path.join(outputdir, filename+'.ni'+ext )
@@ -200,7 +200,7 @@ class Runner:
                 referencefiles = [os.path.join(self.coreroot, filename) for filename in referencefilenames]
                 # single assembly filename: example.dll
                 filename, ext = os.path.splitext(self.singlefile)
-                outputdir = os.path.join(self.coreroot, 'single.out')
+                outputdir = os.path.join(os.getcwd(), 'single.out')
                 if not os.path.exists(outputdir):
                     os.mkdir(outputdir)
                 outputfile = os.path.join(outputdir, filename+'.ni'+ext )
@@ -210,7 +210,7 @@ class Runner:
                 # composite rsp filename: ..\example.dll.rsp
                 dllname, _ = os.path.splitext(os.path.basename(self.compositefile))
                 filename, ext = os.path.splitext(dllname)
-                outputdir = os.path.join(self.coreroot, 'composite.out')
+                outputdir = os.path.join(os.getcwd(), 'composite.out')
                 if not os.path.exists(outputdir):
                     os.mkdir(outputdir)
                 outputfile = os.path.join(outputdir, filename+'.ni'+ext )


### PR DESCRIPTION
Crossgen2 and Crossgen tests share the same payload so we shouldn't output artifacts to the payload folder directly. Specifically, crossgen2 composite scenario uses ```*.dll``` to include assemblies in Core_Root to compile and ```*.ni.dll``` from crossgen should be excluded from the list. Changing crossgen's output to a subfolder here to avoid this problem.