### PR TITLE
add --disasm-diff argument

### DIFF
--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -19,12 +19,14 @@ namespace MicroBenchmarks
             int? partitionCount;
             int? partitionIndex;
             List<string> exclusionFilterValue;
+            bool getDiffableDisasm;
 
             // Parse and remove any additional parameters that we need that aren't part of BDN
             try {
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out partitionCount);
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out partitionIndex);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out exclusionFilterValue);
+                CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--disasm-diff", out getDiffableDisasm);
 
                 CommandLineOptions.ValidatePartitionParameters(partitionCount, partitionIndex);
             }
@@ -41,7 +43,8 @@ namespace MicroBenchmarks
                     mandatoryCategories: ImmutableHashSet.Create(Categories.Libraries, Categories.Runtime, Categories.ThirdParty),
                     partitionCount: partitionCount,
                     partitionIndex: partitionIndex,
-                    exclusionFilterValue: exclusionFilterValue))
+                    exclusionFilterValue: exclusionFilterValue,
+                    getDiffableDisasm: getDiffableDisasm))
                 .ToExitCode();
         }
     }

--- a/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
@@ -53,6 +53,22 @@ namespace BenchmarkDotNet.Extensions
             return argsList;
         }
 
+        public static void ParseAndRemoveBooleanParameter(List<string> argsList, string parameter, out bool parameterValue)
+        {
+            int parameterIndex = argsList.IndexOf(parameter);
+
+            if (parameterIndex != -1)
+            {
+                argsList.RemoveAt(parameterIndex);
+
+                parameterValue = true;
+            }
+            else
+            {
+                parameterValue = false;
+            }
+        }
+
         public static void ValidatePartitionParameters(int? count, int? index)
         {
             // Either count and index must both be specified or neither specified

--- a/src/harness/BenchmarkDotNet.Extensions/DiffableDisassemblyExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/DiffableDisassemblyExporter.cs
@@ -1,0 +1,90 @@
+﻿using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Disassemblers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace BenchmarkDotNet.Extensions
+{
+    // a simplified copy of internal BDN type: https://github.com/dotnet/BenchmarkDotNet/blob/0445917bf93059f17cb09e7d48cdb5e27a096c37/src/BenchmarkDotNet/Disassemblers/Exporters/GithubMarkdownDisassemblyExporter.cs#L35-L80
+    internal static class DiffableDisassemblyExporter
+    {
+        private static readonly Lazy<Func<object, SourceCode>> GetSource = new Lazy<Func<object, SourceCode>>(() => GetElementGetter<SourceCode>("Source"));
+        private static readonly Lazy<Func<object, string>> GetTextRepresentation = new Lazy<Func<object, string>>(() => GetElementGetter<string>("TextRepresentation"));
+
+        private static readonly Lazy<Func<DisassembledMethod, DisassemblyResult, DisassemblyDiagnoserConfig, string, IReadOnlyList<object>>> Prettify
+            = new Lazy<Func<DisassembledMethod, DisassemblyResult, DisassemblyDiagnoserConfig, string, IReadOnlyList<object>>>(GetPrettifyMethod);
+
+        internal static string BuildDisassemblyString(DisassemblyResult disassemblyResult, DisassemblyDiagnoserConfig config)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            int methodIndex = 0;
+            foreach (var method in disassemblyResult.Methods.Where(method => string.IsNullOrEmpty(method.Problem)))
+            {
+                sb.AppendLine("```assembly");
+
+                sb.AppendLine($"; {method.Name}");
+
+                var pretty = Prettify.Value.Invoke(method, disassemblyResult, config, $"M{methodIndex++:00}");
+
+                ulong totalSizeInBytes = 0;
+                foreach (var element in pretty)
+                {
+                    if (element.Source() is Asm asm)
+                    {
+                        checked
+                        {
+                            totalSizeInBytes += (uint)asm.Instruction.ByteLength;
+                        }
+
+                        sb.AppendLine($"       {element.TextRepresentation()}");
+                    }
+                    else // it's a DisassemblyPrettifier.Label (internal type..)
+                    {
+                        sb.AppendLine($"{element.TextRepresentation()}:");
+                    }
+                }
+
+                sb.AppendLine($"; Total bytes of code {totalSizeInBytes}");
+                sb.AppendLine("```");
+            }
+
+            return sb.ToString();
+        }
+
+        private static SourceCode Source(this object element) => GetSource.Value.Invoke(element);
+
+        private static string TextRepresentation(this object element) => GetTextRepresentation.Value.Invoke(element);
+
+        private static Func<object, T> GetElementGetter<T>(string name)
+        {
+            var type = typeof(DisassemblyDiagnoser).Assembly.GetType("BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier");
+
+            type = type.GetNestedType("Element", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var property = type.GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var method = property.GetGetMethod(nonPublic: true);
+
+            var generic = typeof(Func<,>).MakeGenericType(type, typeof(T));
+
+            var @delegate = method.CreateDelegate(generic);
+
+            return (obj) => (T)@delegate.DynamicInvoke(obj); // cast to (Func<object, T>) throws
+        }
+
+        private static Func<DisassembledMethod, DisassemblyResult, DisassemblyDiagnoserConfig, string, IReadOnlyList<object>> GetPrettifyMethod()
+        {
+            var type = typeof(DisassemblyDiagnoser).Assembly.GetType("BenchmarkDotNet.Disassemblers.Exporters.DisassemblyPrettifier");
+
+            var method = type.GetMethod("Prettify", BindingFlags.Static | BindingFlags.NonPublic);
+
+            var @delegate = method.CreateDelegate(typeof(Func<DisassembledMethod, DisassemblyResult, DisassemblyDiagnoserConfig, string, IReadOnlyList<object>>));
+
+            return (Func<DisassembledMethod, DisassemblyResult, DisassemblyDiagnoserConfig, string, IReadOnlyList<object>>)@delegate;
+        }
+    }
+}

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -2,18 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
-using BenchmarkDotNet.Parameters;
 using BenchmarkDotNet.Reports;
-using BenchmarkDotNet.Running;
 using Reporting;
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -21,14 +15,20 @@ namespace BenchmarkDotNet.Extensions
     {
         protected override string FileExtension => "json";
         protected override string FileCaption => "perf-lab-report";
+
         public PerfLabExporter()
         {
         }
+
         public override void ExportToLog(Summary summary, ILogger logger)
         {
             var reporter = Reporter.CreateReporter();
             if (!reporter.InLab) // not running in the perf lab
                 return;
+
+            DisassemblyDiagnoser disassemblyDiagnoser = summary.Reports
+                .FirstOrDefault()? // dissasembler was either enabled for all or none of them (so we use the first one)
+                .BenchmarkCase.Config.GetDiagnosers().OfType<DisassemblyDiagnoser>().FirstOrDefault();
 
             foreach (var report in summary.Reports)
             {
@@ -86,6 +86,13 @@ namespace BenchmarkDotNet.Extensions
                 }
 
                 reporter.AddTest(test);
+
+                if (disassemblyDiagnoser != null && disassemblyDiagnoser.Results.TryGetValue(report.BenchmarkCase, out var disassemblyResult))
+                {
+                    string disassembly = DiffableDisassemblyExporter.BuildDisassemblyString(disassemblyResult, disassemblyDiagnoser.Config);
+
+                    // TODO: do sth with the disassembly
+                }
             }
 
             logger.WriteLine(reporter.GetJson());


### PR DESCRIPTION
@DrewScoggins I've added a new `--disasm-diff` command line argument and extended the `PerfLabExporter` to build a string that contains the formatted disassembly. I had to use some reflection because some of the BDN types were internal. I'll later expose them in BDN so they become public in the next release. 