### PR TITLE
Fixed Test Status Files in GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -24,7 +24,7 @@ from .collection_util import (
     optional_mapping,
 )
 from .option import map_option, non_null, optional_to_iter, option_or, option_or_3
-from .parse_and_serialize import HexInt, load_yaml, SerializeMappings, write_yaml_file
+from .parse_and_serialize import HexInt, load_yaml, SerializeMappings, write_test_yaml_file
 from .score_spec import ScoreSpec
 from .type_utils import (
     combine_dataclasses_with_optional_fields,
@@ -1271,7 +1271,7 @@ class TestPaths:
         return map_option(test_status.trace_file_name, lambda n: self.out_path_base.parent / n)
 
     def write_test_status(self, test_status: TestRunStatus) -> None:
-        write_yaml_file(self.test_status_path, test_status)
+        write_test_yaml_file(self.test_status_path, test_status)
 
 
 @with_slots

--- a/src/benchmarks/gc/src/commonlib/parse_and_serialize.py
+++ b/src/benchmarks/gc/src/commonlib/parse_and_serialize.py
@@ -301,7 +301,11 @@ def _format_result_yaml_fields(content: OrderedDict, indent_size: int, result: [
             result.append('{field: >{width}}'.format(field=text, width=len(text) + indent_size))
             _format_result_yaml_fields(v.items(), indent_size + 2, result)
         else:
-            text = f"{k}: \"{v}\"\n" if k == 'stdout' else f"{k}: {v}\n"
+            if (k == 'stdout'):
+                v = v.rstrip("\n").replace("\n", "\n  ")
+                text = f"{k}:\n  \"{v}\"\n"
+            else:
+                text = f"{k}: {v}\n"
             result.append('{field: >{width}}'.format(field=text, width=len(text) + indent_size))
 
 

--- a/src/benchmarks/gc/src/commonlib/parse_and_serialize.py
+++ b/src/benchmarks/gc/src/commonlib/parse_and_serialize.py
@@ -292,3 +292,22 @@ def write_yaml_file(path: Path, content: object, overwrite: bool = False) -> Non
     serializable = to_serializable(content)
     with path.open("w") as f:
         dump(serializable, f, Dumper=MyDumper, default_flow_style=False)
+
+
+def _format_result_yaml_fields(content: OrderedDict, indent_size: int, result: [str]) -> None:
+    for k, v in content:
+        if isinstance(v, Dict):
+            text = f"{k}:\n"
+            result.append('{field: >{width}}'.format(field=text, width=len(text) + indent_size))
+            _format_result_yaml_fields(v.items(), indent_size + 2, result)
+        else:
+            text = f"{k}: \"{v}\"\n" if k == 'stdout' else f"{k}: {v}\n"
+            result.append('{field: >{width}}'.format(field=text, width=len(text) + indent_size))
+
+
+def write_test_yaml_file(path: Path, content: object) -> None:
+    yaml_items = []
+    _format_result_yaml_fields(to_serializable(content).items(), 0, yaml_items)
+
+    with path.open("w") as f:
+        f.writelines(yaml_items)


### PR DESCRIPTION
Whenever benchmarking tests are run using GC Benchmarking Infra's scenarios, it generates *yaml* test status files, which contain information regarding the scenario run, such as benchmark configuration, coreclr information, etc. One of these fields is the *stdout* produced by *GCPerfSim*. The dumping function previously used has problems when dealing with multiline strings, and writes them with strange backslashes and '\n' characters. After investigation and experiments, no configuration was found to help with this.

To solve this issue, this PR adds a new small system to process test results and write their yaml test status files properly. This does not affect any other yaml writing component within GC infra.