### PR TITLE
Eliminate usage of volatile variables used to prevent dead code elimination 

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.HashCode.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.HashCode.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
@@ -11,23 +10,6 @@ namespace System.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_HashCode
     {
-        private static volatile int _valueStorage;
-
-        // Prevents the jitter from eliminating code that
-        // we want to test.
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void DontDiscard(int value)
-        {
-            _valueStorage = value;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static int DontFold(int value)
-        {
-            return value + _valueStorage;
-        }
-
         [Benchmark]
         public int Add()
         { 
@@ -41,114 +23,128 @@ namespace System.Tests
             return hc.ToHashCode();
         }
 
-        
         [Benchmark]
-        public void Combine_1()
-        { 
+        public int Combine_1()
+        {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             { 
-                DontDiscard(HashCode.Combine(
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result);
             }
-        }
-
-
-        [Benchmark]
-        public void Combine_2()
-        {
-            for (int i = 0; i < 10000; i++)
-            {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i)));
-            }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_3()
+        public int Combine_2()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result);
             }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_4()
+        public int Combine_3()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result);
             }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_5()
+        public int Combine_4()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result);
             }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_6()
+        public int Combine_5()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result);
             }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_7()
+        public int Combine_6()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result);
             }
+            return result;
         }
 
         [Benchmark]
-        public void Combine_8()
+        public int Combine_7()
         {
+            int result = 0;
             for (int i = 0; i < 10000; i++)
             {
-                DontDiscard(HashCode.Combine(
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i),
-                    DontFold(i)));
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result);
             }
+            return result;
+        }
+
+        [Benchmark]
+        public int Combine_8()
+        {
+            int result = 0;
+            for (int i = 0; i < 10000; i++)
+            {
+                result = HashCode.Combine(
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result,
+                    i + result);
+            }
+            return result;
         }
     }
 }

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Cache.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Cache.cs
@@ -13,7 +13,6 @@ namespace System.Text.RegularExpressions.Tests
     public class Perf_Regex_Cache
     {
         private const int MaxConcurrency = 4;
-        private volatile bool _isMatch;
         private int _cacheSizeOld;
         private IReadOnlyDictionary<(int total, int unique), string[]> _patterns;
 
@@ -42,20 +41,22 @@ namespace System.Text.RegularExpressions.Tests
         [Arguments(40_000, 1_600, 15)]    // default size, to compare when cache used
         [Arguments(40_000, 1_600, 800)]    // larger size, to test cache is not O(n)
         [Arguments(40_000, 1_600, 3_200)]  // larger size, to test cache always hit
-        public void IsMatch(int total, int unique, int cacheSize)
+        public bool IsMatch(int total, int unique, int cacheSize)
         {
             if (Regex.CacheSize != cacheSize)
                 Regex.CacheSize = cacheSize;
             
             string[] patterns = _patterns[(total, unique)];
 
-            RunTest(0, total, patterns);        
+            return RunTest(0, total, patterns);
         }
 
-        private void RunTest(int start, int total, string[] regexps)
+        private bool RunTest(int start, int total, string[] regexps)
         {
+            bool isMatch = false;
             for (var i = 0; i < total; i++)
-                _isMatch = Regex.IsMatch("0123456789", regexps[start + i]);
+                isMatch ^= Regex.IsMatch("0123456789", regexps[start + i]);
+            return isMatch;
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/Bisect.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/Bisect.cs
@@ -15,13 +15,8 @@ public class Bisect
 {
     public const int Iterations = 400000;
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     [Benchmark(Description = nameof(Bisect))]
     public bool Test()

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/DMath.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/DMath.cs
@@ -16,12 +16,9 @@ public class DMath
     public const int Iterations = 100000;
 
     private const double Deg2Rad = 57.29577951;
-    private static volatile object s_volatileObject;
 
-    private static void Escape(object obj)
-    {
-        s_volatileObject = obj;
-    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Escape(object _) { }
 
     private static double Fact(double n)
     {

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/FFT.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/FFT.cs
@@ -17,13 +17,9 @@ public class FFT
     public const int Iterations = 300000;
 
     private static readonly int s_points = 16;
-    public static volatile object VolatileObject;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     [Benchmark(Description = nameof(FFT))]
     public bool Test()

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/LLoops.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/LLoops.cs
@@ -104,13 +104,8 @@ public class LLoops
         0.171449024000e+06, -0.510829560800e+07
     };
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     private static T[][] AllocArray<T>(int n1, int n2)
     {

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/NewtR.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/NewtR.cs
@@ -15,13 +15,8 @@ public class NewtR
 {
     public const int Iterations = 80000000;
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     [Benchmark(Description = nameof(NewtR))]
     public bool Test()

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/Regula.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/Regula.cs
@@ -15,13 +15,8 @@ public class Regula
 {
     public const int Iterations = 4000000;
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     [Benchmark(Description = nameof(Regula))]
     public bool Test()

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/Secant.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/Secant.cs
@@ -15,13 +15,8 @@ public class Secant
 {
     public const int Iterations = 3000000;
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void Escape(object obj)
-    {
-        VolatileObject = obj;
-    }
+    private static void Escape(object _) { }
 
     [Benchmark(Description = nameof(Secant))]
     public bool Test()

--- a/src/benchmarks/micro/runtime/Benchstones/BenchF/Whetsto.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchF/Whetsto.cs
@@ -17,21 +17,8 @@ public class Whetsto
     private static int s_j, s_k, s_l;
     private static double s_t, s_t2;
 
-    public static volatile int Volatile_out;
-
-    private static void Escape(int n, int j, int k, double x1, double x2, double x3, double x4)
-    {
-        Volatile_out = n;
-        Volatile_out = j;
-        Volatile_out = k;
-        Volatile_out = (int)x1;
-        Volatile_out = (int)x2;
-        Volatile_out = (int)x3;
-        Volatile_out = (int)x4;
-    }
-
     [Benchmark(Description = nameof(Whetsto))]
-    public bool Test()
+    public double Test()
     {
         double[] e1 = new double[4];
         double x1, x2, x3, x4, x, y, z, t1;
@@ -60,7 +47,6 @@ public class Whetsto
             x3 = (x1 - x2 + x3 + x4) * s_t;
             x4 = (-x1 + x2 + x3 + x4) * s_t;
         }
-        Escape(n1, n1, n1, x1, x2, x3, x4);
 
         /* MODULE 2:  array elements */
         e1[0] = 1.0;
@@ -72,14 +58,12 @@ public class Whetsto
             e1[2] = (e1[0] - e1[1] + e1[2] + e1[3]) * s_t;
             e1[3] = (-e1[0] + e1[1] + e1[2] + e1[3]) * s_t;
         }
-        Escape(n2, n3, n2, e1[0], e1[1], e1[2], e1[3]);
 
         /* MODULE 3:  array as parameter */
         for (i = 1; i <= n3; i += 1)
         {
             PA(e1);
         }
-        Escape(n3, n2, n2, e1[0], e1[1], e1[2], e1[3]);
 
         /* MODULE 4:  conditional jumps */
         s_j = 1;
@@ -110,7 +94,6 @@ public class Whetsto
                 s_j = 0;
             }
         }
-        Escape(n4, s_j, s_j, x1, x2, x3, x4);
 
         /* MODULE 5:  omitted */
         /* MODULE 6:  integer Math */
@@ -125,7 +108,6 @@ public class Whetsto
             e1[s_l - 2] = s_j + s_k + s_l;
             e1[s_k - 2] = s_j * s_k * s_l;
         }
-        Escape(n6, s_j, s_k, e1[0], e1[1], e1[2], e1[3]);
 
         /* MODULE 7:  trig. functions */
         x = y = 0.5;
@@ -134,7 +116,6 @@ public class Whetsto
             x = s_t * System.Math.Atan(s_t2 * System.Math.Sin(x) * System.Math.Cos(x) / (System.Math.Cos(x + y) + System.Math.Cos(x - y) - 1.0));
             y = s_t * System.Math.Atan(s_t2 * System.Math.Sin(y) * System.Math.Cos(y) / (System.Math.Cos(x + y) + System.Math.Cos(x - y) - 1.0));
         }
-        Escape(n7, s_j, s_k, x, x, y, y);
 
         /* MODULE 8:  procedure calls */
         x = y = z = 1.0;
@@ -142,7 +123,6 @@ public class Whetsto
         {
             P3(x, y, out z);
         }
-        Escape(n8, s_j, s_k, x, y, z, z);
 
         /* MODULE9:  array references */
         s_j = 1;
@@ -155,7 +135,6 @@ public class Whetsto
         {
             P0(e1);
         }
-        Escape(n9, s_j, s_k, e1[0], e1[1], e1[2], e1[3]);
 
         /* MODULE10:  integer System.Math */
         s_j = 2;
@@ -167,7 +146,6 @@ public class Whetsto
             s_j = s_k - s_j;
             s_k = s_k - s_j - s_j;
         }
-        Escape(n10, s_j, s_k, x1, x2, x3, x4);
 
         /* MODULE11:  standard functions */
         x = 0.75;
@@ -175,9 +153,12 @@ public class Whetsto
         {
             x = System.Math.Sqrt(System.Math.Exp(System.Math.Log(x) / t1));
         }
-        Escape(n11, s_j, s_k, x, x, x, x);
 
-        return true;
+        return n1 + n2 + n3 + n4 + n6 + n7 +n8 + n9 + n10 + n11
+                + x1 + x2 + x3 + x4
+                + x + y + z
+                + e1[0] + e1[1] + e1[2] + e1[3]
+                + s_j + s_k;
     }
 
     private static void PA(double[] e)

--- a/src/benchmarks/micro/runtime/Benchstones/BenchI/AddArray.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/BenchI/AddArray.cs
@@ -14,12 +14,8 @@ public class AddArray
 {
     const int Size = 6000;
 
-    public static volatile object VolatileObject;
-
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void Escape(object obj) {
-        VolatileObject = obj;
-    }
+    static void Escape(object _) { }
 
     [Benchmark(Description = nameof(AddArray))]
     public bool Test() {

--- a/src/benchmarks/micro/runtime/Linq/Linq.cs
+++ b/src/benchmarks/micro/runtime/Linq/Linq.cs
@@ -119,13 +119,6 @@ public class LinqBenchmarks
     public const int IterationsCount00 = 1000000;
     public const int IterationsOrder00 = 25000;
     
-    private static volatile object s_volatileObject;
-
-    private static void Escape(object obj)
-    {
-        s_volatileObject = obj;
-    }
-    
     #region Where00
 
     [Benchmark]
@@ -327,7 +320,6 @@ public class LinqBenchmarks
             var productsInPriceOrder = from prod in products orderby prod.UnitPrice descending select prod;
             int count = productsInPriceOrder.Count();
             medianPricedProduct = productsInPriceOrder.ElementAt<Product>(count / 2);
-            Escape(medianPricedProduct);
         }
 
         return (medianPricedProduct.ProductID == 57);
@@ -343,7 +335,6 @@ public class LinqBenchmarks
             var productsInPriceOrder = products.OrderByDescending(p => p.UnitPrice);
             int count = productsInPriceOrder.Count();
             medianPricedProduct = productsInPriceOrder.ElementAt<Product>(count / 2);
-            Escape(medianPricedProduct);
         }
 
         return (medianPricedProduct.ProductID == 57);
@@ -360,7 +351,6 @@ public class LinqBenchmarks
             Array.Sort<Product>(productsInPriceOrder, delegate (Product x, Product y) { return -x.UnitPrice.CompareTo(y.UnitPrice); });
             int count = productsInPriceOrder.Count();
             medianPricedProduct = productsInPriceOrder[count / 2];
-            Escape(medianPricedProduct);
         }
 
         return (medianPricedProduct.ProductID == 57);


### PR DESCRIPTION
fixes #1444

The reported timings can only decrease, so this change should not trigger a regression in the auto-filing issue