### PR TITLE
Adding tests for Matrix3x2, Plane, and Quaternion. Adding more tests for Vector2, Vector3, Vector4, and Matrix4x4

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -106,4 +106,5 @@
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />
   </ItemGroup>
+
 </Project>

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Matrix3x2.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Matrix3x2.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Numerics.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Matrix3x2
+    {
+        public const float PI = 3.14159265f;
+
+        [Benchmark]
+        public Matrix3x2 CreateFromScalars() => new Matrix3x2(1.1f, 1.2f,
+                                                              2.1f, 2.2f,
+                                                              3.1f, 3.2f);
+
+        [Benchmark]
+        public Matrix3x2 IdentityBenchmark() => Matrix3x2.Identity;
+
+        [Benchmark]
+        public bool IsIdentityBenchmark() => Matrix3x2.Identity.IsIdentity;
+
+        [Benchmark]
+        public Matrix3x2 AddOperatorBenchmark() => Matrix3x2.Identity + Matrix3x2.Identity;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Matrix3x2.Identity == Matrix3x2.Identity;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Matrix3x2.Identity != Matrix3x2.Identity;
+
+        [Benchmark]
+        public Matrix3x2 MultiplyByMatrixOperatorBenchmark() => Matrix3x2.Identity * Matrix3x2.Identity;
+
+        [Benchmark]
+        public Matrix3x2 MultiplyByScalarOperatorBenchmark() => Matrix3x2.Identity * 0.5f;
+
+        [Benchmark]
+        public Matrix3x2 SubtractOperatorBenchmark() => Matrix3x2.Identity - Matrix3x2.Identity;
+
+        [Benchmark]
+        public Matrix3x2 NegationOperatorBenchmark() => -Matrix3x2.Identity;
+
+        [Benchmark]
+        public Matrix3x2 AddBenchmark() => Matrix3x2.Add(Matrix3x2.Identity, Matrix3x2.Identity);
+
+        [Benchmark]
+        public Matrix3x2 CreateRotationBenchmark() => Matrix3x2.CreateRotation(PI / 2.0f);
+
+        [Benchmark]
+        public Matrix3x2 CreateRotationWithCenterBenchmark() => Matrix3x2.CreateRotation(PI / 2.0f, Vector2.Zero);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromScalarXYBenchmark() => Matrix3x2.CreateScale(1.0f, 2.0f);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromScalarWithCenterBenchmark() => Matrix3x2.CreateScale(1.0f, Vector2.Zero);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromScalarXYWithCenterBenchmark() => Matrix3x2.CreateScale(1.0f, 2.0f, Vector2.Zero);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromScalarBenchmark() => Matrix3x2.CreateScale(1.0f);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromVectorBenchmark() => Matrix3x2.CreateScale(Vector2.UnitX);
+
+        [Benchmark]
+        public Matrix3x2 CreateScaleFromVectorWithCenterBenchmark() => Matrix3x2.CreateScale(Vector2.UnitX, Vector2.Zero);
+
+        [Benchmark]
+        public Matrix3x2 CreateSkewFromScalarXYBenchmark() => Matrix3x2.CreateSkew(1.0f, 2.0f);
+
+        [Benchmark]
+        public Matrix3x2 CreateSkewFromScalarXYWithCenterBenchmark() => Matrix3x2.CreateSkew(1.0f, 2.0f, Vector2.Zero);
+
+        [Benchmark]
+        public Matrix3x2 CreateTranslationFromVectorBenchmark() => Matrix3x2.CreateTranslation(Vector2.UnitX);
+
+        [Benchmark]
+        public Matrix3x2 CreateTranslationFromScalarXY() => Matrix3x2.CreateTranslation(1.0f, 2.0f);
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Matrix3x2.Identity.Equals(Matrix3x2.Identity);
+
+        [Benchmark]
+        public float GetDeterminantBenchmark() => Matrix3x2.Identity.GetDeterminant();
+
+        [Benchmark]
+        public bool InvertBenchmark() => Matrix3x2.Invert(Matrix3x2.Identity, out Matrix3x2 result);
+
+        [Benchmark]
+        public Matrix3x2 LerpBenchmark() => Matrix3x2.Lerp(default, Matrix3x2.Identity, 0.5f);
+
+        [Benchmark]
+        public Matrix3x2 MultiplyByMatrixBenchmark() => Matrix3x2.Multiply(Matrix3x2.Identity, Matrix3x2.Identity);
+
+        [Benchmark]
+        public Matrix3x2 MultiplyByScalarBenchmark() => Matrix3x2.Multiply(Matrix3x2.Identity, 0.5f);
+
+        [Benchmark]
+        public Matrix3x2 NegateBenchmark() => Matrix3x2.Negate(Matrix3x2.Identity);
+
+        [Benchmark]
+        public Matrix3x2 SubtractBenchmark() => Matrix3x2.Subtract(Matrix3x2.Identity, Matrix3x2.Identity);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Matrix4x4.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Matrix4x4.cs
@@ -13,6 +13,15 @@ namespace System.Numerics.Tests
         public const float PI = 3.14159265f;
 
         [Benchmark]
+        public Matrix4x4 CreateFromMatrix3x2() => new Matrix4x4(Matrix3x2.Identity);
+
+        [Benchmark]
+        public Matrix4x4 CreateFromScalars() => new Matrix4x4(1.1f, 1.2f, 1.3f, 1.4f,
+                                                              2.1f, 2.2f, 2.3f, 2.4f,
+                                                              3.1f, 3.2f, 3.3f, 3.4f,
+                                                              4.1f, 4.2f, 4.3f, 4.4f);
+
+        [Benchmark]
         public Matrix4x4 IdentityBenchmark() => Matrix4x4.Identity;
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Plane.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Plane.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Numerics.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Plane
+    {
+        [Benchmark]
+        public Plane CreateFromVector4Benchmark() => new Plane(Vector4.UnitX);
+
+        [Benchmark]
+        public Plane CreateFromVector3WithScalarDBenchmark() => new Plane(Vector3.UnitX, 4.0f);
+
+        [Benchmark]
+        public Plane CreateFromScalarXYZDBenchmark() => new Plane(1.0f, 2.0f, 3.0f, 4.0f);
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => default == VectorTests.PlaneValue;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => default != VectorTests.PlaneValue;
+
+        [Benchmark]
+        public Plane CreateFromVerticesBenchmark() => Plane.CreateFromVertices(Vector3.UnitX, Vector3.UnitY, Vector3.UnitZ);
+
+        [Benchmark]
+        public float DotBenchmark() => Plane.Dot(VectorTests.PlaneValue, Vector4.UnitX);
+
+        [Benchmark]
+        public float DotCoordinateBenchmark() => Plane.DotCoordinate(VectorTests.PlaneValue, Vector3.UnitX);
+
+        [Benchmark]
+        public float DotNormalBenchmark() => Plane.DotNormal(VectorTests.PlaneValue, Vector3.UnitX);
+
+        [Benchmark]
+        public bool EqualsBenchmark() => VectorTests.PlaneValue.Equals(VectorTests.PlaneValue);
+
+        [Benchmark]
+        public Plane NormalizeBenchmark() => Plane.Normalize(VectorTests.PlaneValue);
+
+        [Benchmark]
+        public Plane TransformByMatrix4x4Benchmark() => Plane.Transform(VectorTests.PlaneValue, Matrix4x4.Identity);
+
+        [Benchmark]
+        public Plane TransformByQuaternionBenchmark() => Plane.Transform(VectorTests.PlaneValue, Quaternion.Identity);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Quaternion.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Quaternion.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Numerics.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Quaternion
+    {
+        public const float PI = 3.14159265f;
+
+        [Benchmark]
+        public Quaternion CreateFromVector3WithScalarBenchmark() => new Quaternion(Vector3.UnitX, 4.0f);
+
+        [Benchmark]
+        public Quaternion CreateFromScalarXYZWBenchmark() => new Quaternion(1.0f, 2.0f, 3.0f, 4.0f);
+
+        [Benchmark]
+        public Quaternion IdentityBenchmark() => Quaternion.Identity;
+
+        [Benchmark]
+        public bool IsIdentityBenchmark() => Quaternion.Identity.IsIdentity;
+
+        [Benchmark]
+        public Quaternion AddOperatorBenchmark() => Quaternion.Identity + Quaternion.Identity;
+
+        [Benchmark]
+        public Quaternion DivisionOperatorBenchmark() => Quaternion.Identity / Quaternion.Identity;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Quaternion.Identity == Quaternion.Identity;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Quaternion.Identity != Quaternion.Identity;
+
+        [Benchmark]
+        public Quaternion MultiplyByQuaternionOperatorBenchmark() => Quaternion.Identity * Quaternion.Identity;
+
+        [Benchmark]
+        public Quaternion MultiplyByScalarOperatorBenchmark() => Quaternion.Identity * 0.5f;
+
+        [Benchmark]
+        public Quaternion SubtractionOperatorBenchmark() => Quaternion.Identity - Quaternion.Identity;
+
+        [Benchmark]
+        public Quaternion NegationOperatorBenchmark() => -Quaternion.Identity;
+
+        [Benchmark]
+        public Quaternion AddBenchmark() => Quaternion.Add(Quaternion.Identity, Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion ConcatenateBenchmark() => Quaternion.Concatenate(Quaternion.Identity, Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion ConjugateBenchmark() => Quaternion.Conjugate(Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion CreateFromAxisAngleBenchmark() => Quaternion.CreateFromAxisAngle(Vector3.UnitX, PI / 2.0f);
+
+        [Benchmark]
+        public Quaternion CreateFromRotationMatrixBenchmark() => Quaternion.CreateFromRotationMatrix(Matrix4x4.Identity);
+
+        [Benchmark]
+        public Quaternion CreateFromYawPitchRollBenchmark() => Quaternion.CreateFromYawPitchRoll(PI, PI / 2.0f, PI / 4.0f);
+
+        [Benchmark]
+        public Quaternion DivideBenchmark() => Quaternion.Add(Quaternion.Identity, Quaternion.Identity);
+
+        [Benchmark]
+        public float DotBenchmark() => Quaternion.Dot(Quaternion.Identity, Quaternion.Identity);
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Quaternion.Identity.Equals(Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion InverseBenchmark() => Quaternion.Inverse(Quaternion.Identity);
+
+        [Benchmark]
+        public float LengthBenchmark() => Quaternion.Identity.Length();
+
+        [Benchmark]
+        public float LengthSquaredBenchmark() => Quaternion.Identity.LengthSquared();
+
+        [Benchmark]
+        public Quaternion LerpBenchmark() => Quaternion.Lerp(default, Quaternion.Identity, 0.5f);
+
+        [Benchmark]
+        public Quaternion MultiplyByQuaternionBenchmark() => Quaternion.Multiply(Quaternion.Identity, Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion MultiplyByScalarBenchmark() => Quaternion.Multiply(Quaternion.Identity, 0.5f);
+
+        [Benchmark]
+        public Quaternion NegateBenchmark() => Quaternion.Negate(Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion NormalizeBenchmark() => Quaternion.Normalize(Quaternion.Identity);
+
+        [Benchmark]
+        public Quaternion SlerpBenchmark() => Quaternion.Lerp(default, Quaternion.Identity, 0.5f);
+
+        [Benchmark]
+        public Quaternion SubtractBenchmark() => Quaternion.Subtract(Quaternion.Identity, Quaternion.Identity);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector2.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector2.cs
@@ -12,54 +12,126 @@ namespace System.Numerics.Tests
     public class Perf_Vector2
     {
         [Benchmark]
+        public Vector2 CreateFromScalar() => new Vector2(1.0f);
+
+        [Benchmark]
+        public Vector2 CreateFromScalarXYBenchmark() => new Vector2(1.0f, 2.0f);
+
+        [Benchmark]
+        public Vector2 OneBenchmark() => Vector2.One;
+
+        [Benchmark]
+        public Vector2 UnitXBenchmark() => Vector2.UnitX;
+
+        [Benchmark]
+        public Vector2 UnitYBenchmark() => Vector2.UnitY;
+
+        [Benchmark]
+        public Vector2 ZeroBenchmark() => Vector2.Zero;
+
+        [Benchmark]
         public Vector2 AddOperatorBenchmark() => VectorTests.Vector2Value + VectorTests.Vector2Delta;
-        
-        [Benchmark]
-        public Vector2 AddFunctionBenchmark() => Vector2.Add(VectorTests.Vector2Value, VectorTests.Vector2Delta);
 
         [Benchmark]
-        public Vector2 SubtractOperatorBenchmark() => VectorTests.Vector2Value - VectorTests.Vector2Delta;
+        public Vector2 DivideByVector2OperatorBenchmark() => VectorTests.Vector2Value / VectorTests.Vector2Delta;
 
         [Benchmark]
-        public Vector2 SubtractFunctionBenchmark() => Vector2.Subtract(VectorTests.Vector2Value, VectorTests.Vector2Delta);
+        public Vector2 DivideByScalarOperatorBenchmark() => VectorTests.Vector2Value / 0.5f;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => VectorTests.Vector2Value == VectorTests.Vector2ValueInverted;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => VectorTests.Vector2Value != VectorTests.Vector2ValueInverted;
 
         [Benchmark]
         public Vector2 MultiplyOperatorBenchmark() => VectorTests.Vector2Value * VectorTests.Vector2Delta;
 
         [Benchmark]
-        public Vector2 MultiplyFunctionBenchmark() => Vector2.Multiply(VectorTests.Vector2Value, VectorTests.Vector2Delta);
-        
-        [Benchmark]
-        public float DistanceSquaredBenchmark() => Vector2.DistanceSquared(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+        public Vector2 MultiplyByScalarOperatorBenchmark() => VectorTests.Vector2Value * 0.5f;
 
         [Benchmark]
-        public float LengthSquaredBenchmark() => VectorTests.Vector2Value.LengthSquared();
+        public Vector2 SubtractOperatorBenchmark() => VectorTests.Vector2Value - VectorTests.Vector2Delta;
 
         [Benchmark]
-        public int GetHashCodeBenchmark() => VectorTests.Vector2Value.GetHashCode();
+        public Vector2 NegateOperatorBenchmark() => -VectorTests.Vector2Value;
 
         [Benchmark]
-        public float DistanceBenchmark() => Vector2.Distance(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+        public Vector2 AbsBenchmark() => Vector2.Abs(VectorTests.Vector2Value);
 
         [Benchmark]
-        public float DotBenchmark() => Vector2.Dot(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
-
-        [Benchmark]
-        public float LengthBenchmark() => VectorTests.Vector2Value.Length();
-
-        [Benchmark]
-        public Vector2 SquareRootBenchmark() => Vector2.SquareRoot(VectorTests.Vector2Value);
-
-        [Benchmark]
-        public Vector2 NormalizeBenchmark() => Vector2.Normalize(VectorTests.Vector2Value);
+        public Vector2 AddFunctionBenchmark() => Vector2.Add(VectorTests.Vector2Value, VectorTests.Vector2Delta);
 
         [Benchmark]
         public Vector2 ClampBenchmark() => Vector2.Clamp(VectorTests.Vector2Value, VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
 
         [Benchmark]
-        public Vector2 MinBenchmark() => Vector2.Min(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+        public float DistanceBenchmark() => Vector2.Distance(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public float DistanceSquaredBenchmark() => Vector2.DistanceSquared(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 DivideByVector2Benchmark() => Vector2.Divide(VectorTests.Vector2Value, VectorTests.Vector2Delta);
+
+        [Benchmark]
+        public Vector2 DivideByScalarBenchmark() => Vector2.Divide(VectorTests.Vector2Value, 0.5f);
+
+        [Benchmark]
+        public float DotBenchmark() => Vector2.Dot(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public bool EqualsBenchmark() => VectorTests.Vector2Value.Equals(VectorTests.Vector2Value);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => VectorTests.Vector2Value.GetHashCode();
+
+        [Benchmark]
+        public float LengthBenchmark() => VectorTests.Vector2Value.Length();
+
+        [Benchmark]
+        public float LengthSquaredBenchmark() => VectorTests.Vector2Value.LengthSquared();
+
+        [Benchmark]
+        public Vector2 LerpBenchmark() => Vector2.Lerp(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted, 0.5f);
 
         [Benchmark]
         public Vector2 MaxBenchmark() => Vector2.Max(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 MinBenchmark() => Vector2.Min(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 MultiplyFunctionBenchmark() => Vector2.Multiply(VectorTests.Vector2Value, VectorTests.Vector2Delta);
+
+        [Benchmark]
+        public Vector2 NegateBenchmark() => Vector2.Negate(VectorTests.Vector2Value);
+
+        [Benchmark]
+        public Vector2 NormalizeBenchmark() => Vector2.Normalize(VectorTests.Vector2Value);
+
+        [Benchmark]
+        public Vector2 ReflectBenchmark() => Vector2.Reflect(VectorTests.Vector2Value, VectorTests.Vector2ValueInverted);
+
+        [Benchmark]
+        public Vector2 SquareRootBenchmark() => Vector2.SquareRoot(VectorTests.Vector2Value);
+
+        [Benchmark]
+        public Vector2 SubtractFunctionBenchmark() => Vector2.Subtract(VectorTests.Vector2Value, VectorTests.Vector2Delta);
+
+        [Benchmark]
+        public Vector2 TransformByMatrix3x2Benchmark() => Vector2.Transform(VectorTests.Vector2Value, Matrix3x2.Identity);
+
+        [Benchmark]
+        public Vector2 TransformByMatrix4x4Benchmark() => Vector2.Transform(VectorTests.Vector2Value, Matrix4x4.Identity);
+
+        [Benchmark]
+        public Vector2 TransformByQuaternionBenchmark() => Vector2.Transform(VectorTests.Vector2Value, Quaternion.Identity);
+
+        [Benchmark]
+        public Vector2 TransformNormalByMatrix3x2Benchmark() => Vector2.TransformNormal(VectorTests.Vector2Value, Matrix3x2.Identity);
+
+        [Benchmark]
+        public Vector2 TransformNormalByMatrix4x4Benchmark() => Vector2.TransformNormal(VectorTests.Vector2Value, Matrix4x4.Identity);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector3.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector3.cs
@@ -11,57 +11,132 @@ namespace System.Numerics.Tests
     public class Perf_Vector3
     {
         [Benchmark]
-        public Vector3 AddOperatorBenchmark() => VectorTests.Vector3Value + VectorTests.Vector3Delta;
-        
+        public Vector3 CreateFromScalar() => new Vector3(1.0f);
+
         [Benchmark]
-        public Vector3 AddFunctionBenchmark() => Vector3.Add(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+        public Vector3 CreateFromVector2WithScalarBenchmark() => new Vector3(VectorTests.Vector2Value, 3.0f);
+
+        [Benchmark]
+        public Vector3 CreateFromScalarXYZBenchmark() => new Vector3(1.0f, 2.0f, 3.0f);
+
+        [Benchmark]
+        public Vector3 OneBenchmark() => Vector3.One;
+
+        [Benchmark]
+        public Vector3 UnitXBenchmark() => Vector3.UnitX;
+
+        [Benchmark]
+        public Vector3 UnitYBenchmark() => Vector3.UnitY;
+
+        [Benchmark]
+        public Vector3 UnitZBenchmark() => Vector3.UnitZ;
+
+        [Benchmark]
+        public Vector3 ZeroBenchmark() => Vector3.Zero;
+
+        [Benchmark]
+        public Vector3 AddOperatorBenchmark() => VectorTests.Vector3Value + VectorTests.Vector3Delta;
+
+        [Benchmark]
+        public Vector3 DivideByVector3OperatorBenchmark() => VectorTests.Vector3Value / VectorTests.Vector3Delta;
+
+        [Benchmark]
+        public Vector3 DivideByScalarOperatorBenchmark() => VectorTests.Vector3Value / 0.5f;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => VectorTests.Vector3Value == VectorTests.Vector3ValueInverted;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => VectorTests.Vector3Value != VectorTests.Vector3ValueInverted;
 
         [Benchmark]
         public Vector3 MultiplyOperatorBenchmark() => VectorTests.Vector3Value * VectorTests.Vector3Delta;
 
         [Benchmark]
-        public Vector3 MultiplyFunctionBenchmark() => Vector3.Multiply(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+        public Vector3 MultiplyByScalarOperatorBenchmark() => VectorTests.Vector3Value * 0.5f;
 
         [Benchmark]
         public Vector3 SubtractOperatorBenchmark() => VectorTests.Vector3Value - VectorTests.Vector3Delta;
 
         [Benchmark]
-        public Vector3 SubtractFunctionBenchmark() => Vector3.Subtract(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+        public Vector3 NegateOperatorBenchmark() => -VectorTests.Vector3Value;
 
         [Benchmark]
-        public float DistanceSquaredBenchmark() => Vector3.DistanceSquared(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+        public Vector3 AbsBenchmark() => Vector3.Abs(VectorTests.Vector3Value);
 
         [Benchmark]
-        public float LengthSquaredBenchmark() => VectorTests.Vector3Value.LengthSquared();
-
-        [Benchmark]
-        public int GetHashCodeBenchmark() => VectorTests.Vector3Value.GetHashCode();
-
-        [Benchmark]
-        public Vector3 SquareRootBenchmark() => Vector3.SquareRoot(VectorTests.Vector3Value);
-
-        [Benchmark]
-        public Vector3 NormalizeBenchmark() => Vector3.Normalize(VectorTests.Vector3Value);
-
-        [Benchmark]
-        public float DotBenchmark() => Vector3.Dot(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
-
-        [Benchmark]
-        public float DistanceBenchmark() => Vector3.Distance(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
-
-        [Benchmark]
-        public float LengthBenchmark() => VectorTests.Vector3Value.Length();
-
-        [Benchmark]
-        public Vector3 CrossBenchmark() => Vector3.Cross(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+        public Vector3 AddFunctionBenchmark() => Vector3.Add(VectorTests.Vector3Value, VectorTests.Vector3Delta);
 
         [Benchmark]
         public Vector3 ClampBenchmark() => Vector3.Clamp(VectorTests.Vector3Value, VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
 
         [Benchmark]
-        public Vector3 MinBenchmark() => Vector3.Min(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+        public Vector3 CrossBenchmark() => Vector3.Cross(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public float DistanceBenchmark() => Vector3.Distance(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public float DistanceSquaredBenchmark() => Vector3.DistanceSquared(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 DivideByVector3Benchmark() => Vector3.Divide(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+
+        [Benchmark]
+        public Vector3 DivideByScalarBenchmark() => Vector3.Divide(VectorTests.Vector3Value, 0.5f);
+
+        [Benchmark]
+        public float DotBenchmark() => Vector3.Dot(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public bool EqualsBenchmark() => VectorTests.Vector3Value.Equals(VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => VectorTests.Vector3Value.GetHashCode();
+
+        [Benchmark]
+        public float LengthBenchmark() => VectorTests.Vector3Value.Length();
+
+        [Benchmark]
+        public float LengthSquaredBenchmark() => VectorTests.Vector3Value.LengthSquared();
+
+        [Benchmark]
+        public Vector3 LerpBenchmark() => Vector3.Lerp(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted, 0.5f);
 
         [Benchmark]
         public Vector3 MaxBenchmark() => Vector3.Max(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 MinBenchmark() => Vector3.Min(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 MultiplyFunctionBenchmark() => Vector3.Multiply(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+
+        [Benchmark]
+        public Vector3 MultiplyByScalarBenchmark() => Vector3.Multiply(VectorTests.Vector3Value, 0.5f);
+        
+        [Benchmark]
+        public Vector3 NegateBenchmark() => Vector3.Negate(VectorTests.Vector3Value);
+
+        [Benchmark]
+        public Vector3 NormalizeBenchmark() => Vector3.Normalize(VectorTests.Vector3Value);
+
+        [Benchmark]
+        public Vector3 ReflectBenchmark() => Vector3.Reflect(VectorTests.Vector3Value, VectorTests.Vector3ValueInverted);
+
+        [Benchmark]
+        public Vector3 SquareRootBenchmark() => Vector3.SquareRoot(VectorTests.Vector3Value);
+
+        [Benchmark]
+        public Vector3 SubtractFunctionBenchmark() => Vector3.Subtract(VectorTests.Vector3Value, VectorTests.Vector3Delta);
+
+        [Benchmark]
+        public Vector3 TransformByMatrix4x4Benchmark() => Vector3.Transform(VectorTests.Vector3Value, Matrix4x4.Identity);
+
+        [Benchmark]
+        public Vector3 TransformByQuaternionBenchmark() => Vector3.Transform(VectorTests.Vector3Value, Quaternion.Identity);
+
+        [Benchmark]
+        public Vector3 TransformNormalByMatrix4x4Benchmark() => Vector3.TransformNormal(VectorTests.Vector3Value, Matrix4x4.Identity);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
@@ -89,7 +89,7 @@ namespace System.Numerics.Tests
         public Vector4 DivideBenchmark() => Vector4.Divide(VectorTests.Vector4Value, VectorTests.Vector4Delta);
 
         [Benchmark]
-        public Vector4 DivideByScalarrBenchmark() => Vector4.Divide(VectorTests.Vector4Value, 0.5f);
+        public Vector4 DivideByScalarBenchmark() => Vector4.Divide(VectorTests.Vector4Value, 0.5f);
 
         [Benchmark]
         public float DotBenchmark() => Vector4.Dot(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_Vector4.cs
@@ -11,13 +11,73 @@ namespace System.Numerics.Tests
     public class Perf_Vector4
     {
         [Benchmark]
+        public Vector4 CreateFromScalar() => new Vector4(1.0f);
+
+        [Benchmark]
+        public Vector4 CreateFromVector3WithScalarBenchmark() => new Vector4(VectorTests.Vector3Value, 4.0f);
+
+        [Benchmark]
+        public Vector4 CreateFromVector2WithScalarBenchmark() => new Vector4(VectorTests.Vector2Value, 3.0f, 4.0f);
+
+        [Benchmark]
+        public Vector4 CreateFromScalarXYZWBenchmark() => new Vector4(1.0f, 2.0f, 3.0f, 4.0f);
+
+        [Benchmark]
+        public Vector4 OneBenchmark() => Vector4.One;
+
+        [Benchmark]
+        public Vector4 UnitXBenchmark() => Vector4.UnitX;
+
+        [Benchmark]
+        public Vector4 UnitYBenchmark() => Vector4.UnitY;
+
+        [Benchmark]
+        public Vector4 UnitZBenchmark() => Vector4.UnitZ;
+
+        [Benchmark]
+        public Vector4 UnitWBenchmark() => Vector4.UnitW;
+
+        [Benchmark]
+        public Vector4 ZeroBenchmark() => Vector4.Zero;
+
+        [Benchmark]
         public Vector4 AddOperatorBenchmark() => VectorTests.Vector4Value + VectorTests.Vector4Delta;
+
+        [Benchmark]
+        public Vector4 DivideOperatorBenchmark() => VectorTests.Vector4Value / VectorTests.Vector4Delta;
+
+        [Benchmark]
+        public Vector4 DivideByScalarOperatorBenchmark() => VectorTests.Vector4Value / 0.5f;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => VectorTests.Vector4Value == VectorTests.Vector4ValueInverted;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => VectorTests.Vector4Value != VectorTests.Vector4ValueInverted;
+
+        [Benchmark]
+        public Vector4 MultiplyOperatorBenchmark() => VectorTests.Vector4Value * VectorTests.Vector4Delta;
+
+        [Benchmark]
+        public Vector4 MultiplyByScalarOperatorBenchmark() => VectorTests.Vector4Value * 0.5f;
+
+        [Benchmark]
+        public Vector4 SubtractOperatorBenchmark() => VectorTests.Vector4Value - VectorTests.Vector4Delta;
+
+        [Benchmark]
+        public Vector4 NegateOperatorBenchmark() => -VectorTests.Vector4Value;
+
+        [Benchmark]
+        public Vector4 AbsBenchmark() => Vector4.Abs(VectorTests.Vector4Value);
 
         [Benchmark]
         public Vector4 AddFunctionBenchmark() => Vector4.Add(VectorTests.Vector4Value, VectorTests.Vector4Delta);
 
         [Benchmark]
-        public Vector4 SubtractOperatorBenchmark() => VectorTests.Vector4Value - VectorTests.Vector4Delta;
+        public Vector4 ClampBenchmark() => Vector4.Clamp(VectorTests.Vector4Value, VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+
+        [Benchmark]
+        public float DistanceBenchmark() => Vector4.Distance(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
 
         [Benchmark]
         public float DistanceSquaredBenchmark() => Vector4.DistanceSquared(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
@@ -26,42 +86,69 @@ namespace System.Numerics.Tests
         public float DistanceSquaredJitOptimizeCanaryBenchmark() => Vector4.DistanceSquared(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
 
         [Benchmark]
-        public Vector4 MultiplyOperatorBenchmark() => VectorTests.Vector4Value * VectorTests.Vector4Delta;
+        public Vector4 DivideBenchmark() => Vector4.Divide(VectorTests.Vector4Value, VectorTests.Vector4Delta);
 
         [Benchmark]
-        public Vector4 SubtractFunctionBenchmark() => Vector4.Subtract(VectorTests.Vector4Value, VectorTests.Vector4Delta);
-
-        [Benchmark]
-        public Vector4 MultiplyFunctionBenchmark() => Vector4.Multiply(VectorTests.Vector4Value, VectorTests.Vector4Delta);
-
-        [Benchmark]
-        public float LengthSquaredBenchmark() => VectorTests.Vector4Value.LengthSquared();
-
-        [Benchmark]
-        public int GetHashCodeBenchmark() => VectorTests.Vector4Value.GetHashCode();
-
-        [Benchmark]
-        public Vector4 SquareRootBenchmark() => Vector4.SquareRoot(VectorTests.Vector4Value);
-
-        [Benchmark]
-        public Vector4 NormalizeBenchmark() => Vector4.Normalize(VectorTests.Vector4Value);
-
-        [Benchmark]
-        public float DistanceBenchmark() => Vector4.Distance(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
-
-        [Benchmark]
-        public float LengthBenchmark() => VectorTests.Vector4Value.Length();
+        public Vector4 DivideByScalarrBenchmark() => Vector4.Divide(VectorTests.Vector4Value, 0.5f);
 
         [Benchmark]
         public float DotBenchmark() => Vector4.Dot(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
 
         [Benchmark]
-        public Vector4 ClampBenchmark() => Vector4.Clamp(VectorTests.Vector4Value, VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+        public bool EqualsBenchmark() => VectorTests.Vector4Value.Equals(VectorTests.Vector4ValueInverted);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => VectorTests.Vector4Value.GetHashCode();
+
+        [Benchmark]
+        public float LengthBenchmark() => VectorTests.Vector4Value.Length();
+
+        [Benchmark]
+        public float LengthSquaredBenchmark() => VectorTests.Vector4Value.LengthSquared();
+
+        [Benchmark]
+        public Vector4 LerpBenchmark() => Vector4.Lerp(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted, 0.5f);
+
+        [Benchmark]
+        public Vector4 MaxBenchmark() => Vector4.Max(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
 
         [Benchmark]
         public Vector4 MinBenchmark() => Vector4.Min(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
 
         [Benchmark]
-        public Vector4 MaxBenchmark() => Vector4.Max(VectorTests.Vector4Value, VectorTests.Vector4ValueInverted);
+        public Vector4 MultiplyFunctionBenchmark() => Vector4.Multiply(VectorTests.Vector4Value, VectorTests.Vector4Delta);
+
+        [Benchmark]
+        public Vector4 MultiplyByScalarBenchmark() => Vector4.Multiply(VectorTests.Vector4Value, 0.5f);
+
+        [Benchmark]
+        public Vector4 NegateBenchmark() => Vector4.Negate(VectorTests.Vector4Value);
+
+        [Benchmark]
+        public Vector4 NormalizeBenchmark() => Vector4.Normalize(VectorTests.Vector4Value);
+
+        [Benchmark]
+        public Vector4 SquareRootBenchmark() => Vector4.SquareRoot(VectorTests.Vector4Value);
+
+        [Benchmark]
+        public Vector4 SubtractFunctionBenchmark() => Vector4.Subtract(VectorTests.Vector4Value, VectorTests.Vector4Delta);
+
+        [Benchmark]
+        public Vector4 TransformByQuaternionBenchmark() => Vector4.Transform(VectorTests.Vector3Value, Quaternion.Identity);
+
+        [Benchmark]
+        public Vector4 TransformByMatrix4x4Benchmark() => Vector4.Transform(VectorTests.Vector3Value, Matrix4x4.Identity);
+
+        [Benchmark]
+        public Vector4 TransformVector3ByQuaternionBenchmark() => Vector4.Transform(VectorTests.Vector3Value, Quaternion.Identity);
+
+        [Benchmark]
+        public Vector4 TransformVector3ByMatrix4x4Benchmark() => Vector4.Transform(VectorTests.Vector3Value, Matrix4x4.Identity);
+
+        [Benchmark]
+        public Vector4 TransformVector2ByQuaternionBenchmark() => Vector4.Transform(VectorTests.Vector2Value, Quaternion.Identity);
+
+        [Benchmark]
+        public Vector4 TransformVector2ByMatrix4x4Benchmark() => Vector4.Transform(VectorTests.Vector2Value, Matrix4x4.Identity);
     }
 }

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/VectorTests.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/VectorTests.cs
@@ -12,6 +12,8 @@ namespace System.Numerics.Tests
 
         private const float SingleNegativeDelta = -1.0f / DefaultInnerIterationsCount;
 
+        public static readonly Plane PlaneValue = new Plane(Vector3.UnitY, 0.0f);
+
         public static readonly Vector2 Vector2Delta = new Vector2(SinglePositiveDelta, SingleNegativeDelta);
 
         public static readonly Vector2 Vector2Value = new Vector2(-1.0f, 1.0f);


### PR DESCRIPTION
For Vector2, Vector3, and Vector4 the existing tests were reordered but otherwise left unmodified.