### PR TITLE
remove 3.1 branch for scenario tests:

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,10 +62,9 @@ jobs:
       projectFile: scenarios.proj
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         # - release/3.1.3xx
-        - 3.1
         - 3.0
   
-  # Windows x64 Blazor 3.2 scenario benchmarks
+  # Windows x64 Blazor scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
       osName: windows
@@ -263,7 +262,6 @@ jobs:
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported channels
         # - release/3.1.2xx
         - 3.0
-        - 3.1
 
   # Windows x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml


### PR DESCRIPTION
3.1 branch for scenarios tests was added for blazor 3.2 template tests. https://github.com/dotnet/performance/pull/1357 We are good to remove it since blazor is using its own template now.