### PR TITLE
Add latest Fannkuch and BinaryTrees from Benchmarks Game

### DIFF
--- a/src/benchmarks/micro/runtime/BenchmarksGame/THIRD-PARTY-NOTICES.TXT
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,30 @@
+.NET Runtime uses third-party libraries or other resources that may be
+distributed under licenses different than the .NET Runtime software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           dotnet@microsoft.com
+
+The attached notices are provided for information only.
+
+
+License notice for The Computer Language Benchmarks Game
+--------------------------------------------------------
+
+Revised BSD license
+This is a specific instance of the Open Source Initiative (OSI) BSD license template.
+
+Copyright (c) 2004-2008 Brent Fulgham, 2005-2020 Isaac Gouy
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name "The Computer Language Benchmarks Game" nor the name "The Benchmarks Game" nor the name "The Computer Language Shootout Benchmarks" nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
@@ -68,7 +68,7 @@ namespace BenchmarksGame
                     tasks[t] = Task.Run(() =>
                     {
                         var check2 = 0;
-                        for (int i2 = n; i2 > 0; i--)
+                        for (int i2 = n; i2 > 0; i2--)
                             check2 += TreeNode.Create(depth).Check();
                         return check2;
                     });

--- a/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
@@ -23,7 +23,7 @@ using MicroBenchmarks;
 namespace BenchmarksGame
 {
     [MaxIterationCount(40)] // the default 20 is not enough, the benchmark has multimodal distribution and needs more runs
-    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame)]
+    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame, Categories.JIT)]
     public class BinaryTrees_6
     {
         const int MinDepth = 4;

--- a/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Adapted from binary-trees C# .NET Core #6 program
+// https://salsa.debian.org/benchmarksgame-team/benchmarksgame/-/blob/master/public/download/benchmarksgame-sourcecode.zip
+// Best-scoring C# .NET Core version as of 2020-08-12
+
+// The Computer Language Benchmarks Game
+// https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+//
+// contributed by Marek Safar
+// concurrency added by Peperud
+// fixed long-lived tree by Anthony Lloyd
+// ported from F# version by Anthony Lloyd
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace BenchmarksGame
+{
+    [MaxIterationCount(40)] // the default 20 is not enough, the benchmark has multimodal distribution and needs more runs
+    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame)]
+    public class BinaryTrees_6
+    {
+        const int MinDepth = 4;
+        const int NoTasks = 4;
+
+        // 16 is about 80ms
+        // 18 is about 500ms
+        // 20 is about 3.9s
+        // 21 is used in official numbers; about 7.8s
+        const int N = 18;
+
+        [Benchmark(Description = nameof(BinaryTrees_6))]
+        public int RunBench() => Bench(N, verbose: false);
+
+        static int Bench(int param, bool verbose)
+        {
+            int maxDepth = Math.Max(MinDepth + 2, param);
+
+            var stretchTreeCheck = Task.Run(() =>
+            {
+                int stretchDepth = maxDepth + 1;
+                return "stretch tree of depth " + stretchDepth + "\t check: " +
+                            TreeNode.Create(stretchDepth).Check();
+            });
+
+            var longLivedTree = TreeNode.Create(maxDepth);
+            var longLivedText = Task.Run(() =>
+            {
+                return "long lived tree of depth " + maxDepth +
+                            "\t check: " + longLivedTree.Check();
+            });
+
+            var results = new string[(maxDepth - MinDepth) / 2 + 1];
+
+            for (int i = 0; i < results.Length; i++)
+            {
+                int depth = i * 2 + MinDepth;
+                int n = (1 << maxDepth - depth + MinDepth) / NoTasks;
+                var tasks = new Task<int>[NoTasks];
+                for (int t = 0; t < tasks.Length; t++)
+                {
+                    tasks[t] = Task.Run(() =>
+                    {
+                        var check = 0;
+                        for (int i = n; i > 0; i--)
+                            check += TreeNode.Create(depth).Check();
+                        return check;
+                    });
+                }
+                var check = tasks[0].Result;
+                for (int t = 1; t < tasks.Length; t++)
+                    check += tasks[t].Result;
+                results[i] = (n * NoTasks) + "\t trees of depth " + depth +
+                                "\t check: " + check;
+            }
+
+            if (verbose)
+            {
+                Console.WriteLine(stretchTreeCheck.Result);
+
+                for (int i = 0; i < results.Length; i++)
+                    Console.WriteLine(results[i]);
+
+                Console.WriteLine(longLivedText.Result);
+            }
+
+            return 0;
+        }
+
+        struct TreeNode
+        {
+            class Next { public TreeNode left, right; }
+            readonly Next next;
+
+            TreeNode(TreeNode left, TreeNode right) =>
+                next = new Next { left = left, right = right };
+
+            internal static TreeNode Create(int d)
+            {
+                return d == 1 ? new TreeNode(new TreeNode(), new TreeNode())
+                              : new TreeNode(Create(d - 1), Create(d - 1));
+            }
+
+            internal int Check()
+            {
+                int c = 1;
+                var current = next;
+                while (current != null)
+                {
+                    c += current.right.Check() + 1;
+                    current = current.left.next;
+                }
+                return c;
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/binarytrees-6.cs
@@ -67,10 +67,10 @@ namespace BenchmarksGame
                 {
                     tasks[t] = Task.Run(() =>
                     {
-                        var check = 0;
-                        for (int i = n; i > 0; i--)
-                            check += TreeNode.Create(depth).Check();
-                        return check;
+                        var check2 = 0;
+                        for (int i2 = n; i2 > 0; i--)
+                            check2 += TreeNode.Create(depth).Check();
+                        return check2;
                     });
                 }
                 var check = tasks[0].Result;

--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -1,3 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Adapted from fannkuch-redux C# .NET Core #9 program
+// https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/fannkuchredux-csharpcore-9.html
+// Best-scoring single-threaded C# .NET Core version as of 2020-08-13
+
 // The Computer Language Benchmarks Game
 // https://benchmarksgame-team.pages.debian.net/benchmarksgame/
 //

--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -21,7 +21,7 @@ using MicroBenchmarks;
 
 namespace BenchmarksGame
 {
-    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame)]
+    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame, Categories.JIT)]
     public unsafe class FannkuchRedux_9
     {
         static int taskCount;

--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -1,0 +1,176 @@
+// The Computer Language Benchmarks Game
+// https://benchmarksgame-team.pages.debian.net/benchmarksgame/
+//
+// contributed by Flim Nik
+// small optimisations by Anthony Lloyd
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace BenchmarksGame
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame)]
+    public unsafe class FannkuchRedux_9
+    {
+        static int taskCount;
+        static int[] fact, chkSums, maxFlips;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void FirstPermutation(short* p, short* pp, int* count, int n, int idx)
+        {
+            for (int i = 0; i < n; ++i) p[i] = (byte)i;
+            for (int i = n - 1; i > 0; --i)
+            {
+                int d = idx / fact[i];
+                count[i] = d;
+                if (d > 0)
+                {
+                    idx %= fact[i];
+                    for (int j = i; j >= 0; --j) pp[j] = p[j];
+                    for (int j = 0; j <= i; ++j) p[j] = pp[(j + d) % (i + 1)];
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void NextPermutation(short* p, int* count)
+        {
+            var first = p[1];
+            p[1] = p[0];
+            p[0] = first;
+            int i = 1;
+            while (++count[i] > i)
+            {
+                count[i++] = 0;
+                var next = p[1];
+                p[0] = next;
+                for (int j = 1; j < i;) p[j] = p[++j];
+                p[i] = first;
+                first = next;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void Copy(short* p, short* pp, int n)
+        {
+            var startL = (long*)p;
+            var stateL = (long*)pp;
+            var lengthL = n / 4;
+            int i = 0;
+            for (; i < lengthL; i++)
+            {
+                stateL[i] = startL[i];
+            }
+            for (i = lengthL * 4; i < n; i++)
+            {
+                pp[i] = p[i];
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int CountFlips(short* p, short* pp, int n)
+        {
+            int flips = 1;
+            int first = *p;
+            short temp;
+            if (p[first] != 0)
+            {
+                Copy(p, pp, n);
+                do
+                {
+                    ++flips;
+                    if (first > 2)
+                    {
+                        short* lo = pp + 1, hi = pp + first - 1;
+                        do
+                        {
+                            temp = *lo;
+                            *lo = *hi;
+                            *hi = temp;
+                        } while (++lo < --hi);
+                    }
+                    temp = pp[first];
+                    pp[first] = (short)first;
+                    first = temp;
+                } while (pp[first] != 0);
+            }
+            return flips;
+        }
+
+        static void Run(int n, int taskSize)
+        {
+            int* count = stackalloc int[n];
+            int taskId, chksum = 0, maxflips = 0;
+            short* p = stackalloc short[n];
+            short* pp = stackalloc short[n];
+            while ((taskId = Interlocked.Decrement(ref taskCount)) >= 0)
+            {
+                FirstPermutation(p, pp, count, n, taskId * taskSize);
+                if (*p != 0)
+                {
+                    var flips = CountFlips(p, pp, n);
+                    chksum += flips;
+                    if (flips > maxflips) maxflips = flips;
+                }
+                for (int i = 1; i < taskSize; i++)
+                {
+                    NextPermutation(p, count);
+                    if (*p != 0)
+                    {
+                        var flips = CountFlips(p, pp, n);
+                        chksum += (1 - (i & 1) * 2) * flips;
+                        if (flips > maxflips) maxflips = flips;
+                    }
+                }
+            }
+            chkSums[-taskId - 1] = chksum;
+            maxFlips[-taskId - 1] = maxflips;
+        }
+
+        [Benchmark(Description = nameof(FannkuchRedux_5))]
+        [Arguments(12, 3968050)]
+        public int RunBench(int n, int expectedSum)
+        {
+            int chkSum = Bench(n, false);
+            if (chkSum != expectedSum)
+                    throw new Exception($"Expected {expectedSum} actual {chkSum}");
+            return chkSum;
+        }
+
+        public static int Bench(int n, bool verbose)
+        {
+            fact = new int[n + 1];
+            fact[0] = 1;
+
+            for (int i = 1; i < fact.Length; i++)
+            {
+                fact[i] = fact[i - 1] * i;
+            }
+
+            var PC = Environment.ProcessorCount;
+            taskCount = n > 11 ? fact[n] / (9 * 8 * 7 * 6 * 5 * 4 * 3 * 2) : PC;
+            int taskSize = fact[n] / taskCount;
+            chkSums = new int[PC];
+            maxFlips = new int[PC];
+            var threads = new Thread[PC];
+            for (int i = 1; i < PC; i++)
+            {
+                (threads[i] = new Thread(() => Run(n, taskSize))).Start();
+            }
+            Run(n, taskSize);
+
+            for (int i = 1; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+            int chkSum = chkSums.Sum();
+            if (verbose) Console.WriteLine(chkSum + "\nPfannkuchen(" + n + ") = " + maxFlips.Max());
+
+            return chkSum;
+        }
+    }
+}

--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -140,7 +140,7 @@ namespace BenchmarksGame
         }
 
         // Official runs use [Arguments(12, 3968050)] which takes ~4.2 sec vs ~330ms for 11
-        [Benchmark(Description = nameof(FannkuchRedux_5))]
+        [Benchmark(Description = nameof(FannkuchRedux_9))]
         [Arguments(11, 556355)]
         public int RunBench(int n, int expectedSum)
         {

--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -139,8 +139,9 @@ namespace BenchmarksGame
             maxFlips[-taskId - 1] = maxflips;
         }
 
+        // Official runs use [Arguments(12, 3968050)] which takes ~4.2 sec vs ~330ms for 11
         [Benchmark(Description = nameof(FannkuchRedux_5))]
-        [Arguments(12, 3968050)]
+        [Arguments(11, 556355)]
         public int RunBench(int n, int expectedSum)
         {
             int chkSum = Bench(n, false);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/performance/issues/1452

Official Benchmark Games numbers suggest a small regression from 3.1->5.0 preview 7 in binary-trees and fannkuch-redux. 
https://benchmarksgame-team.pages.debian.net/benchmarksgame/fastest/csharpcore-csharppreview.html

I am adding the latest ones for binary-trees and fannkuch because of the regression claim. In both cases, I dialed back the parameters to make the runtime ~500ms rather than 4-8 sec. I did run locally with the regular parameters and saw the same patterns between 3.1->5.0 which is suggestive that the smaller input sizes are still representative.

Below are Windows numbers for this PR.
``` ini

BenchmarkDotNet=v0.12.1.1405-nightly, OS=Windows 10.0.19042
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.1.20380.2
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.37113, CoreFX 5.0.20.37113), X64 RyuJIT
  Job-ZDIFOG : .NET Core 2.1.20 (CoreCLR 4.6.29017.01, CoreFX 4.6.29018.12), X64 RyuJIT
  Job-URLWRJ : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  Job-QQWOVI : .NET Core 5.0.0 (CoreCLR 5.0.20.37113, CoreFX 5.0.20.37113), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|          Method |        Job |       Runtime |     Toolchain |  n | expectedSum |     Mean |   Error |  StdDev |   Median |      Min |      Max | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |----------- |-------------- |-------------- |--- |------------ |---------:|--------:|--------:|---------:|---------:|---------:|------:|------:|------:|------:|----------:|
| FannkuchRedux_5 | Job-ZDIFOG | .NET Core 2.1 | netcoreapp2.1 | 11 |      556355 | 322.0 ms | 2.34 ms | 1.96 ms | 321.6 ms | 319.5 ms | 326.5 ms |  1.00 |     - |     - |     - |    2.3 KB |
| FannkuchRedux_5 | Job-URLWRJ | .NET Core 3.1 | netcoreapp3.1 | 11 |      556355 | 354.6 ms | 3.98 ms | 3.73 ms | 354.2 ms | 349.9 ms | 361.6 ms |  1.10 |     - |     - |     - |   2.47 KB |
| FannkuchRedux_5 | Job-QQWOVI | .NET Core 5.0 | netcoreapp5.0 | 11 |      556355 | 326.7 ms | 1.30 ms | 1.15 ms | 327.0 ms | 324.9 ms | 328.6 ms |  1.01 |     - |     - |     - |   2.47 KB |

``` ini

BenchmarkDotNet=v0.12.1.1405-nightly, OS=Windows 10.0.19042
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-rc.1.20380.2
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.37113, CoreFX 5.0.20.37113), X64 RyuJIT
  Job-ILWLGV : .NET Core 2.1.20 (CoreCLR 4.6.29017.01, CoreFX 4.6.29018.12), X64 RyuJIT
  Job-GHVTWZ : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  Job-KZZGNJ : .NET Core 5.0.0 (CoreCLR 5.0.20.37113, CoreFX 5.0.20.37113), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms  
MaxIterationCount=40  MinIterationCount=15  WarmupCount=1  

```
|        Method |        Job |       Runtime |     Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD |       Gen 0 |      Gen 1 |     Gen 2 |  Allocated |
|-------------- |----------- |-------------- |-------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|------------:|-----------:|----------:|-----------:|
| BinaryTrees_6 | Job-ILWLGV | .NET Core 2.1 | netcoreapp2.1 | 596.1 ms | 21.53 ms | 38.26 ms | 594.9 ms | 509.9 ms | 669.4 ms |  1.00 |    0.00 | 225000.0000 | 41000.0000 | 4000.0000 |    8.01 MB |
| BinaryTrees_6 | Job-GHVTWZ | .NET Core 3.1 | netcoreapp3.1 | 605.1 ms | 22.02 ms | 39.14 ms | 605.6 ms | 514.1 ms | 679.7 ms |  1.02 |    0.10 | 221000.0000 | 39000.0000 | 3000.0000 | 1037.34 MB |
| BinaryTrees_6 | Job-KZZGNJ | .NET Core 5.0 | netcoreapp5.0 | 523.9 ms | 18.03 ms | 32.04 ms | 525.9 ms | 463.1 ms | 574.4 ms |  0.88 |    0.09 | 224000.0000 | 39000.0000 | 4000.0000 | 1037.35 MB |

There's no regression there, but of course they measure on Ubuntu.