### PR TITLE
add commandline to stdout

### DIFF
--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
@@ -1442,6 +1442,8 @@ class ArgsParser
             totalMinutesToRun = 1;
         }
 
+        Console.WriteLine(Process.GetCurrentProcess().ProcessName + " " + Environment.CommandLine);
+
         ulong livePerThread = (totalLiveBytes ?? 0) / threadCount;
         ulong allocPerThread = (totalAllocBytes ?? 0) / threadCount;
         if (allocPerThread != 0) Console.WriteLine("allocating {0:n0} per thread", allocPerThread);


### PR DESCRIPTION
this is just so that we have it in the resulting .yaml, eg a__only_config__0gb__0.yaml would display:
```
stdout:
  "CoreRun C:\infra1\artifacts\bin\GCPerfSim\release\netcoreapp5.0\GCPerfSim.dll -tc 1 -tagb 150.0 -tlgb 0.0 -lohar 0 -sohsi 0 -lohsi 0 -pohsi 0 -sohpi 0 -lohpi 0 -pohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time
  allocating 161,061,273,600 per thread
```

if you want to just run the test with the commandline the infra used, you don't have to go construct it yourself.