### PR TITLE
Add support for blazor tests in runtime

### DIFF
--- a/src/scenarios/blazor/Directory.Build.targets
+++ b/src/scenarios/blazor/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
  <Target Name="UpdateTargetingAndRuntimePack"
          AfterTargets="ResolveFrameworkReferences"
-         Condition="'$(HELIX_CORRELATION_PAYLOAD)' != ''">
+         Condition="Exists('$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.ref')">
     <PropertyGroup>
         <MicrosoftNetCoreAppRefPackDir>$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.ref</MicrosoftNetCoreAppRefPackDir>
         <MicrosoftNetCoreAppRuntimePackDir>$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.runtime.browser-wasm/$(Configuration)</MicrosoftNetCoreAppRuntimePackDir>

--- a/src/scenarios/blazor/Directory.Build.targets
+++ b/src/scenarios/blazor/Directory.Build.targets
@@ -1,0 +1,21 @@
+<Project>
+ <Target Name="UpdateTargetingAndRuntimePack"
+         AfterTargets="ResolveFrameworkReferences"
+         Condition="'$(HELIX_CORRELATION_PAYLOAD)' != ''">
+    <PropertyGroup>
+        <MicrosoftNetCoreAppRefPackDir>$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.ref</MicrosoftNetCoreAppRefPackDir>
+        <MicrosoftNetCoreAppRuntimePackDir>$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.runtime.browser-wasm/$(Configuration)</MicrosoftNetCoreAppRuntimePackDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <ResolvedTargetingPack Path="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
+                             NuGetPackageVersion="$(ProductVersion)"
+                             PackageDirectory="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
+                            />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)"
+                            />
+      <ResolvedFrameworkReference TargetingPackPath="$(MicrosoftNetCoreAppRefPackDir.TrimEnd('/\'))"
+                                  TargetingPackVersion="$(ProductVersion)"
+                                   />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -59,6 +59,7 @@ class PreCommands:
         self.runtime_identifier = args.runtime
         self.msbuild = args.msbuild
         self.msbuildstatic = args.msbuildstatic
+        self.binlog = args.binlog
 
     def new(self,
             template: str,
@@ -100,6 +101,10 @@ class PreCommands:
                             dest='msbuildstatic',
                             metavar='Foo=Bar;Bas=Blee;...'
                            )
+        parser.add_argument('--binlog',
+                            help='Flag to enable binlog',
+                            dest='binlog',
+                            metavar='<file-name>.binlog')
         parser.set_defaults(configuration=RELEASE)
 
     def existing(self, projectdir: str, projectfile: str):
@@ -158,7 +163,8 @@ class PreCommands:
                              os.path.join(get_packages_directory(), ''), # blazor publish targets require the trailing slash for joining the paths
                              framework,
                              runtime_identifier,
-                             self.msbuild or ""
+                             self.msbuild or "",
+                             '-bl:%s' % self.binlog if self.binlog else ""
                              )
 
     def _restore(self):


### PR DESCRIPTION
- add ```--binlog``` flag to ```precommands.py``` so we can verify the runtime version used in publish; also useful for other diagnosis purpose
- add targets file to blazor project so it uses just-built runtime in the payload on CI