### PR TITLE
Added multiple executables support for running and diffing tests in GC Infra

### DIFF
--- a/src/benchmarks/gc/README.md
+++ b/src/benchmarks/gc/README.md
@@ -128,6 +128,8 @@ Each test `.yaml` file looks something like the example described below:
 
 ```yaml
 vary: coreclr
+test_executables:
+  defgcperfsim: <path to the GCPerfSim dll built in the earlier steps>
 coreclrs:
   a:
     core_root: <path to first CoreCLR core root>
@@ -179,15 +181,18 @@ command_groups: {}
 ```
 
 GC Benchmarking Infra will read one by one each of the specified files under *bench_files*,
-and run *GCPerfSim* accordingly. If any test fails, Infra will proceed to run the next one
-and will display a summary of the encountered problems at the end of the run.
+and run their specified executables accordingly. If any test fails, Infra will
+proceed to run the next one and will display a summary of the encountered problems
+at the end of the run.
 
 The *command_groups* tag is used to store sets of other commands you might want to run in bulk,
 rather than individually. For simplicity, it is left empty in this example.
 
-It is important that a full suite-run of the default scenarios is run when *GCPerfSim*
-is modified. This is to ensure no regressions have occurred and the tool continues
-to work properly.
+When *GCPerfSim* is modified, it is important to run the full suite of default
+scenarios with both, the original and the modified versions of *GCPerfSim*. You
+only need to make sure to keep a copy before rebuilding it, and then specify
+both dll's under the `test_executables` group in the `yaml` file. This is to
+ensure no regressions have occurred and the tool continues to work properly.
 
 For full information regarding suites, check the full documentation [here](docs/suites.md).
 
@@ -199,8 +204,10 @@ Let's run *low_memory_container* for this example.
 py . run bench/suite/low_memory_container.yaml
 ```
 
-On Windows, all tests must be run as administrator as PerfView requires this.
-(Unless `collect: none` is set the benchfile's options. See [Running Without Traces](#Running Without Traces).)
+On Windows, all tests must be run as administrator as PerfView requires this,
+unless `collect: none` is set the benchfile's options. See [Running Without Traces](#Running%20Without%20Traces)
+for more details.
+
 On Linux, only tests with containers require super user privileges.
 
 You might get errors due to `dotnet` or `dotnet-trace` not being found. Or you might see an error:
@@ -217,7 +224,7 @@ A fatal error occurred, the default install location cannot be obtained.
 
 To fix either of these, specify `dotnet_path` and `dotnet_trace_path` in `options:` in the benchfile. (Use `which dotnet` and `which dotnet-trace` to get these values.)
 
-(Note that if you recently built coreclr, that probably left a `dotnet` process open that `run` will ask you to kill. Just do so and run again with `--overwrite`.)
+Note that if you recently built coreclr, that probably left a `dotnet` process open that `run` will ask you to kill. Just do so and run again with `--overwrite`.
 
 This simple scenario should take under 2 minutes. Other ones require more time.
 We aim for an individual test to take about 20 seconds and this does 2 iterations for each of the 2 *coreclrs*.
@@ -226,9 +233,9 @@ Running this produced a directory called `bench/suite/low_memory_container.yaml.
 This contains a trace file (and some other small files) for each of the tests. (If you had specified `collect: none` in `options:` in the benchfile, there would be no trace file and the other files would contain all information.)
 Each trace file can be opened in PerfView if you need to.
 
-Each trace file will be named `{coreclr_name}__{config_name}__{benchmark_name}__{iteration}`, e.g.  `clr_a__smaller__nosurvive__0`.
+Each trace file will be named `{executable_name}__{coreclr_name}__{config_name}__{benchmark_name}__{iteration}`, e.g.  `defgcperfsim__clr_a__smaller__nosurvive__0`.
 
-_ARM NOTE_: Container tests are not supported on ARM/ARM64.
+_ARM NOTE_: Container tests and high memory loading tests are not supported on ARM/ARM64.
 
 ### Running with .NET Desktop
 
@@ -309,8 +316,8 @@ Now let's analyze the results.
 py . diff bench/suite/low_memory_container.yaml
 ```
 
-(Like most commands operating on the output of the benchfile,
-this take the benchfile as input, not the `.out` directory.)
+Like most commands operating on the output of the benchfile,
+this takes the benchfile as input, not the `.out` directory.
 
 This produces something like:
 
@@ -381,7 +388,7 @@ Analysis commands are based on metrics.
 
 A metric is the name of a measurement we might take. The 'metric' is the *name* of the measurement, not the metric itself. Length is a metric, 3 meters is a 'metric value'.
 
-A run-metric is the name a measurement of some property of an entire run of a test. For example, `FirstToLastGCSeconds` is the metric that measures the time a test took. Another example is `PauseDurationMSec_Mean` which is the mean pause duration of a GC. (Since getting the average requires looking at every GC, it is considered a metric of the whole run, not a single-gc-metric.)
+A run-metric is the name a measurement of some property of an entire run of a test. For example, `FirstToLastGCSeconds` is the metric that measures the time a test took. Another example is `PauseDurationMSec_Mean` which is the mean pause duration of a GC. Since getting the average requires looking at every GC, it is considered a metric of the whole run, not a single-gc-metric.
 
 A single-gc-metric is the name of a measurement of some property of a single GC within a test. For example, `PauseDurationMSec` measures the time of that individual GC (and as we've seen, we can add `_Mean` to get a run-metric.)
 
@@ -497,18 +504,18 @@ If you don't have a trace, you are limited in the metrics you can use. No single
 See [example](docs/example.md) for a more detailed example involving more commands.
 
 Use `py . help` to see all commands.
-Also see the `docs` directory for other topics, especially [commands syntax](docs/commands syntax.md).
+Also see the `docs` directory for other topics, especially [commands syntax](docs/commands%20syntax.md).
 
 Before modifying benchfiles, you should read [bench_file](docs/bench_file.md) which lists everything you can specify in a benchfile.
 
-Commands can be run in a Jupyter notebook instead of on the command line. See [jupyter notebook](docs/jupyter notebook.md).
+Commands can be run in a Jupyter notebook instead of on the command line. See [jupyter notebook](docs/jupyter%20notebook.md).
 
 # Terms
 
 ### Metric
 
 The name of a measurement we might take.
-See more in `docs/metrics.md`.
+See more in the [metrics doc](docs/metrics.md).
 
 ### Benchfile
 

--- a/src/benchmarks/gc/docs/bench_file.md
+++ b/src/benchmarks/gc/docs/bench_file.md
@@ -7,6 +7,8 @@ Each is a map with keys being arbitrary names.
 Here's an example benchfile:
 
 ```yaml
+test_executables:
+  defgcperfsim: /performance/artifacts/bin/GCPerfSim/release/netcoreapp5.0/GCPerfSim.dll
 coreclrs:
   clr_a:
     core_root: coreclr
@@ -56,8 +58,12 @@ benchmarks:
 comment: `str | None`
   (ignored)
 
-vary: `"machine" | "coreclr" | "config" | "benchmark" | None`
+vary: `"machine" | "executable" | "coreclr" | "config" | "benchmark" | None`
   Preferred property to vary when using `py . diff`
+
+test_executables: `Mapping[str, Path]`
+  Mapping from an (arbitrary) executable name to its path.
+  Paths to the dll's that will be run with the Core_Root.
 
 configs_vary_by: `[ConfigsVaryBy](#ConfigsVaryBy) | None`
   This is mostly set just for information.

--- a/src/benchmarks/gc/docs/contributing.md
+++ b/src/benchmarks/gc/docs/contributing.md
@@ -20,7 +20,9 @@ Metrics always return a `Result` -- this allows the metric to fail without causi
 
 We should make sure the code is clean with respect to the linter. Run `py . lint` to make sure it is clean. For now, do not worry about upgrading the dependencies as suggested by the linter, it won't work.
 
-When GCPerfSim is modified, it is important to run the full default suite again to ensure no functionality was broken with the new changes and GCPerfSim works properly.
+When GCPerfSim is modified, it is important to run the full default suite with both versions, the unchanged one and the modified one, to ensure no functionality was broken with the new changes and GCPerfSim works properly.
+
+A full example on how to do this is [found here](modifying_and_testing_gcperfsim.md).
 
 # C# and C dependencies
 

--- a/src/benchmarks/gc/docs/example.md
+++ b/src/benchmarks/gc/docs/example.md
@@ -7,13 +7,15 @@ This document uses command line syntax for simplicity, but the same things can b
 We're going to see how changing gen0size affects performance. We'll start by creating a benchfile `bench/compare_gen0size.yaml`.
 
 ```yaml
-options:
-  collect: thread_times
-  default_iteration_count: 3
 vary: config
+test_executables:
+  defgcperfsim: /performance/artifacts/bin/GCPerfSim/release/netcoreapp5.0/GCPerfSim.dll
 coreclrs:
   a:
     core_root: ./coreclr
+options:
+  collect: thread_times
+  default_iteration_count: 3
 common_config:
   complus_gcserver: true
   complus_gcconcurrent: false
@@ -36,6 +38,10 @@ benchmarks:
 ```
 
 This benchfile expects a Core_Root to have been moved to `bench/coreclr`. (Meaning it is now named `coreclr` instead of `Core_Root`.)
+
+The path in `defgcperfsim` under `test_executables` is just the default where
+`GCPerfSim.dll` is built inside the repo. Make sure you write the full path in
+your bench files.
 
 We would normally start an investigation with `collect: gc` or `collect: none` instead of `collect: thread_times` but for an example it's more convenient to only have to run tests once.
 

--- a/src/benchmarks/gc/docs/modifying_and_testing_gcperfsim.md
+++ b/src/benchmarks/gc/docs/modifying_and_testing_gcperfsim.md
@@ -1,0 +1,251 @@
+# Modifying and Testing GCPerfSim
+
+When one makes modifications to _GCPerfSim_, it is of utmost importance to run
+benchmarks to ensure the new changes don't break any other components or even
+introduce regressions, which are later harder to find and fix.
+
+This document covers the basics on how to perform these quality tests and do
+basic comparisons between _GCPerfSim_ executables.
+
+## Building and Setting Up
+
+The first step is to do the changes you wish to _GCPerfSim_. Once that is done,
+first make sure to back up its default build somewhere else.
+
+For the purpose of this example, we will be using the following paths:
+
+- **Performance Repo**: `C:\repos\performance`
+- **Safe Backup Location**: `C:\repos\gcperfsim-backup`
+- **Core Root Location**: `C:\repos\core_root`
+
+Now that's established, make sure to copy the default _GCPerfSim_ build to the
+safe location BEFORE building it again with your changes. In our example, this
+would mean:
+
+Copy `C:\repos\performance\artifacts\bin\GCPerfSim` to `C:\repos\gcperfsim-backup\GCPerfSim`.
+
+Once that's done, you can build your new _GCPerfSim_.
+In `C:\repos\performance\src\benchmarks\gc\src\exec\GCPerfSim` run the command:
+
+```powershell
+dotnet build -c release
+```
+
+Now, we have to tell the benchmark _yaml_ file to run using both _GCPerfSim_ dll's.
+
+To ensure software quality remains, one ought to run the entire suite using both
+_GCPerfSim_ builds. However, to keep this example simple, we will only be running
+a simple variation of the _normal\_server_ test this time.
+
+Adding the new _GCPerfSim_ build, the `yaml` file would look like this:
+
+```yml
+vary: executable
+test_executables:
+  orig_gcperfsim: C:\repos\gcperfsim-backup\GCPerfSim\release\netcoreapp5.0\GCPerfSim.dll
+  mod_gcperfsim: C:\repos\performance\artifacts\bin\GCPerfSim\release\netcoreapp5.0\GCPerfSim.dll
+coreclrs:
+  a:
+    core_root: C:\repos\core_root
+options:
+  default_iteration_count: 1
+  default_max_seconds: 300
+common_config:
+  complus_gcserver: true
+  complus_gcconcurrent: true
+  complus_gcheapcount: 6
+benchmarks:
+  2gb:
+    arguments:
+      tc: 6
+      tagb: 300
+      tlgb: 2
+      lohar: 0
+      sohsi: 50
+      lohsi: 0
+      pohsi: 0
+      sohpi: 0
+      lohpi: 0
+      pohpi: 0
+      sohfi: 0
+      lohfi: 0
+      pohfi: 0
+      allocType: reference
+      testKind: time
+scores:
+  speed:
+    FirstToLastGCSeconds:
+      weight: 1
+    PauseDurationMSec_95P:
+      weight: 1
+
+```
+
+We are naming the original _GCPerfSim_ as `orig_gcperfsim`, and the modified
+one as `mod_gcperfsim` in our bench file. For simplicity of this explanation,
+we are only running the **2gb** benchmark. However, it is important you run at
+least all the default benchmarks (0gb, 2gb, 2gb-pinning, 20gb) once, since
+failure in one of them does not necessarily mean the others are affected as well.
+
+Also, in this example we are only using one `Core_Root`. If you wish, you can
+test with different ones although that's not strictly necessary.
+
+Once this is ready, you can proceed to run the tests.
+In `C:\repos\performance\src\benchmarks\gc`, run the following command:
+
+```powershell
+py . run bench\suite\normal_server.yaml
+```
+
+## Comparing Results
+
+We've run our tests by now and everything seemingly went fine. No failures
+happened whatsoever. If something went wrong when running them, then you've
+found a problem you need to fix in your changes before any more development.
+
+Let's check out some numbers to see if we encounter any abnormalities to
+investigate. Run the following command:
+
+```powershell
+py . diff bench\suite\normal_server.yaml
+```
+
+This results in an output like the following one:
+
+```text
+Diff of base = orig_gcperfsim and new = mod_gcperfsim
+
+                          ┌────────────────────────────┐
+                          │ Summary of important stats │
+                          └────────────────────────────┘
+
+
+                                       │    PctTimePausedInGC │ FirstToLastGCSeconds
+                                  name │ Base │  New │ % Diff │ Base │  New │ % Diff
+  ─────────────────────────────────────┼──────┼──────┼────────┼──────┼──────┼───────
+  DESKTOP-S0L8UMK__a__only_config__2gb │ 33.0 │ 30.7 │  -6.96 │ 31.6 │ 30.2 │  -4.46
+
+
+
+                                       │ HeapSizeBeforeMB_Mean │ HeapSizeAfterMB_Mean
+                                  name │ Base │  New │  % Diff │ Base │  New │ % Diff
+  ─────────────────────────────────────┼──────┼──────┼─────────┼──────┼──────┼───────
+  DESKTOP-S0L8UMK__a__only_config__2gb │ 5282 │ 5277 │ -0.0881 │ 4070 │ 4060 │ -0.233
+
+
+
+                                       │ PauseDurationMSec_95PWhereIsGen0 │ PauseDurationMSec_95PWhereIsGen1
+                                  name │ Base │  New │             % Diff │ Base │  New │             % Diff
+  ─────────────────────────────────────┼──────┼──────┼────────────────────┼──────┼──────┼───────────────────
+  DESKTOP-S0L8UMK__a__only_config__2gb │ 45.3 │ 41.6 │              -8.23 │  100 │ 95.9 │              -4.54
+
+
+
+                                       │ PauseDurationMSec_95PWhereIsBackground │ PauseDurationMSec_95PWhereIsBlockingGen2
+                                  name │ Base │  New │                   % Diff │        Base │         New │       % Diff
+  ─────────────────────────────────────┼──────┼──────┼──────────────────────────┼─────────────┼─────────────┼─────────────
+  DESKTOP-S0L8UMK__a__only_config__2gb │ 40.2 │ 36.4 │                    -9.62 │ <no values> │ <no values> │
+
+
+
+                                 ┌──────────────────────────────────────┐
+                                 │ DESKTOP-S0L8UMK__a__only_config__2gb │
+                                 └──────────────────────────────────────┘
+
+
+Improvements (Improvement of 5-20%)
+
+                                          Metric │      Base (run 0) │       New (run 0) │  % Diff │ Abs Diff
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  CountIsBackground                              │                13 │                12 │   -7.69 │       -1
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  FirstEventToFirstGCSeconds                     │             0.655 │             0.615 │   -6.08 │  -0.0398
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_95P                          │              91.2 │              84.7 │   -7.20 │    -6.57
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_95PWhereIsBackground         │              40.2 │              36.4 │   -9.62 │    -3.87
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_95PWhereIsGen0               │              45.3 │              41.6 │   -8.23 │    -3.73
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_Mean                         │              36.9 │              32.9 │   -10.8 │    -3.98
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_MeanWhereIsEphemeral         │              37.3 │              33.2 │   -11.2 │    -4.17
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_Sum                       │              19.5 │              17.4 │   -10.8 │    -2.10
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_SumWhereIsBackground      │              9.45 │              8.48 │   -10.3 │   -0.973
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_SumWhereIsGen1            │              5.49 │              4.99 │   -8.99 │   -0.493
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_SumWhereIsNonBackground   │              10.0 │              8.89 │   -11.3 │    -1.13
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PctTimeInGC_WhereIsNonBackground               │              31.7 │              29.4 │   -7.14 │    -2.26
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PctTimePausedInGC                              │              33.0 │              30.7 │   -6.96 │    -2.30
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  speed                                          │              53.7 │              50.5 │   -5.84 │    -3.13
+
+
+Stale (Same, or percent difference within 5% margin)
+
+                                          Metric │      Base (run 0) │       New (run 0) │  % Diff │ Abs Diff
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  CountIsBlockingGen2                            │                 0 │                 0 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  CountIsGen0                                    │               189 │               189 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  CountIsGen1                                    │                81 │                81 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  CountUsesLOHCompaction                         │ <not implemented> │ <not implemented> │         │
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  FirstToLastGCSeconds                           │              31.6 │              30.2 │   -4.46 │    -1.41
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  HeapCount                                      │                 6 │                 6 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  HeapSizeAfterMB_Max                            │              4419 │              4498 │    1.79 │     79.3
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  HeapSizeAfterMB_Mean                           │              4070 │              4060 │  -0.233 │    -9.47
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  HeapSizeBeforeMB_Max                           │              5673 │              5749 │    1.33 │     75.6
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  HeapSizeBeforeMB_Mean                          │              5282 │              5277 │ -0.0881 │    -4.65
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_95PWhereIsBlockingGen2       │       <no values> │       <no values> │         │
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationMSec_95PWhereIsGen1               │               100 │              95.9 │   -4.54 │    -4.56
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_SumWhereIsBlockingGen2    │                 0 │                 0 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PauseDurationSeconds_SumWhereUsesLOHCompaction │ <not implemented> │ <not implemented> │         │
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PctIsEphemeral                                 │              95.4 │              95.7 │   0.355 │    0.338
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PctReductionInHeapSize_Mean                    │              22.8 │              22.9 │   0.515 │    0.117
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PctUsesCompaction                              │              93.6 │              94.0 │   0.355 │    0.332
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PromotedMB_MeanWhereIsBlockingGen2             │       <no values> │       <no values> │         │
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PromotedMB_MeanWhereIsGen0                     │              51.7 │              51.8 │   0.114 │   0.0588
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  PromotedMB_MeanWhereIsGen1                     │               229 │               228 │  -0.420 │   -0.963
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  TotalAllocatedMB                               │          3.23e+05 │          3.22e+05 │  -0.217 │     -701
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  TotalLOHAllocatedMB                            │              8.01 │              8.01 │       0 │        0
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  TotalNonGCSeconds                              │              22.2 │              21.9 │   -1.51 │   -0.335
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  TotalNumberGCs                                 │               283 │               282 │  -0.353 │       -1
+  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
+  TotalSecondsTaken                              │              32.7 │              31.2 │   -4.58 │    -1.49
+```
+
+If we take a look at these numbers, we can see that the performance was very
+similar between these two _GCPerfSim_ executables.
+
+In this case, assuming the other tests yielded similar results, we would be
+ready to submit our PR to merge these new changes to _GCPerfSim_.
+
+Depending on your use case, you can also do comparisons with different Core Root's
+and different configurations as well.

--- a/src/benchmarks/gc/docs/suites.md
+++ b/src/benchmarks/gc/docs/suites.md
@@ -67,7 +67,9 @@ format:
 
 *** Here is a summary of the problems found: ***
 
-======= <Yaml Filename> =======
+========= <Yaml Filename> =========
+
+======= <Executable Name> =======
 
 ===== <Coreclr Name> =====
 

--- a/src/benchmarks/gc/src/analysis/diffable.py
+++ b/src/benchmarks/gc/src/analysis/diffable.py
@@ -65,6 +65,7 @@ def _name_for_vary(test: SingleTestCombination, vary: Vary) -> str:
         Vary.coreclr: test.coreclr_name,
         Vary.config: test.config_name,
         Vary.benchmark: test.benchmark_name,
+        Vary.executable: test.executable_name,
     }[vary]
 
 
@@ -216,8 +217,9 @@ def get_diffables_from_bench_file(
     vary = non_null(bench.vary, "Must provide --vary") if arg_vary is None else arg_vary
 
     unfiltered_all_combinations = [
-        SingleTestCombination(machine=machine, coreclr=coreclr, config=config, benchmark=benchmark)
+        SingleTestCombination(machine=machine, executable=executable, coreclr=coreclr, config=config, benchmark=benchmark)
         for machine in machines
+        for executable in bench.executables_and_names
         for coreclr in bench.coreclrs_and_names
         for config in bench.partial_configs_and_names
         for benchmark in bench.benchmarks_and_names
@@ -228,6 +230,7 @@ def get_diffables_from_bench_file(
 
     common = PartialTestCombination(
         machine=find_common(lambda c: c.machine, filtered_all_combinations),
+        executable_and_name=find_common(lambda c: c.executable, filtered_all_combinations),
         coreclr_and_name=find_common(lambda c: c.coreclr, filtered_all_combinations),
         config_and_name=find_common(lambda c: c.config, filtered_all_combinations),
         benchmark_and_name=find_common(lambda c: c.benchmark, filtered_all_combinations),
@@ -299,6 +302,7 @@ def _get_diffables_by_vary(
 def _rm_varied(c: SingleTestCombination, vary: Vary) -> PartialTestCombination:
     return PartialTestCombination(
         machine=None if vary == Vary.machine else c.machine,
+        executable_and_name=None if vary == Vary.executable else c.executable,
         coreclr_and_name=None if vary == Vary.coreclr else c.coreclr,
         config_and_name=None if vary == Vary.config else c.config,
         benchmark_and_name=None if vary == Vary.benchmark else c.benchmark,

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1430,6 +1430,12 @@ def combine_test_configs(
     )
 
 
+def get_test_executable(bench_file: BenchFile, executable_name: Optional[str]) -> TestExecutableAndName:
+    return find_only_or_only_matching(
+        lambda exn: exn.name, "--executable", executable_name, bench_file.executables_and_names
+    )
+
+
 def get_coreclr(bench_file: BenchFile, coreclr_name: Optional[str]) -> CoreclrAndName:
     return find_only_or_only_matching(
         lambda cn: cn.name, "--coreclr", coreclr_name, bench_file.coreclrs_and_names

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -999,6 +999,7 @@ class TestRunStatus:
 @dataclass(frozen=True)
 class PartialTestCombination:
     machine: Optional[Machine] = None
+    executable_and_name: Optional[TestExecutableAndName] = None
     coreclr_and_name: Optional[CoreclrAndName] = None
     config_and_name: Optional[PartialConfigAndName] = None
     benchmark_and_name: Optional[BenchmarkAndName] = None
@@ -1006,6 +1007,14 @@ class PartialTestCombination:
     @property
     def machine_name(self) -> Optional[str]:
         return None if self.machine is None else self.machine.name
+
+    @property
+    def executable(self) -> Optional[Path]:
+        return None if self.executable_and_name is None else self.executable_and_name.executable_path
+
+    @property
+    def executable_name(self) -> Optional[str]:
+        return None if self.executable_and_name is None else self.executable_and_name.name
 
     @property
     def coreclr_name(self) -> Optional[str]:
@@ -1031,6 +1040,7 @@ class PartialTestCombination:
     def name(self) -> str:
         parts: Sequence[str] = (
             *optional_to_iter(self.machine_name),
+            *optional_to_iter(self.executable_name),
             *optional_to_iter(self.coreclr_name),
             *optional_to_iter(self.config_name),
             *optional_to_iter(self.benchmark_name),
@@ -1043,6 +1053,7 @@ class Vary(Enum):
     coreclr = 1
     config = 2
     benchmark = 3
+    executable = 4
 
 
 VARY_DOC = """

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -1312,6 +1312,14 @@ class SingleTestToRun:
     out: TestPaths
 
     @property
+    def executable_name(self) -> str:
+        return self.test.executable_name
+
+    @property
+    def executable(self) -> Path:
+        return self.test.executable.executable_path
+
+    @property
     def coreclr_name(self) -> str:
         return self.test.coreclr_name
 

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -908,8 +908,16 @@ def parse_machines_arg(machine_args: Optional[Sequence[str]]) -> Sequence[Machin
 
 @with_slots
 @dataclass(frozen=True)
+class TestExecutableAndName:
+    name: str
+    executable_path: Path
+
+
+@with_slots
+@dataclass(frozen=True)
 class SingleTestCombination:
     machine: Machine
+    executable: TestExecutableAndName
     coreclr: CoreclrAndName
     config: PartialConfigAndName
     benchmark: BenchmarkAndName
@@ -917,6 +925,10 @@ class SingleTestCombination:
     @property
     def machine_name(self) -> str:
         return self.machine.name
+
+    @property
+    def executable_name(self) -> str:
+        return self.executable.name
 
     @property
     def coreclr_name(self) -> str:
@@ -933,7 +945,7 @@ class SingleTestCombination:
     @property
     def name(self) -> str:
         return (
-            f"{self.machine_name}__{self.coreclr_name}__{self.config_name}__{self.benchmark_name}"
+            f"{self.machine_name}__{self.executable_name}__{self.coreclr_name}__{self.config_name}__{self.benchmark_name}"
         )
 
 
@@ -1083,6 +1095,7 @@ If omitted, common_config will be used.
 class BenchFile:
     comment: Optional[str] = None
     vary: Optional[Vary] = None
+    test_executables: Mapping[str, Path] = empty_mapping()
     configs_vary_by: Optional[ConfigsVaryBy] = None
     coreclrs: Mapping[str, CoreclrSpecifier] = empty_mapping()
     paths: Optional[Mapping[str, Path]] = None  # Maps name to path
@@ -1096,6 +1109,10 @@ class BenchFile:
         assert not is_empty(self.coreclrs), "Benchfile must have at least one coreclr"
         assert not is_empty(self.benchmarks), "Benchfile must have at least one benchmark"
         assert self.configs is None or not is_empty(self.configs)
+
+    @property
+    def executables_and_names(self) -> Sequence[TestExecutableAndName]:
+        return [TestExecutableAndName(k, v) for k, v in self.test_executables.items()]
 
     @property
     def coreclrs_and_names(self) -> Sequence[CoreclrAndName]:
@@ -1312,10 +1329,11 @@ def iter_test_combinations(
     bench_file: BenchFile, machines: Sequence[Machine]
 ) -> Iterable[SingleTestCombination]:
     for machine in machines:
-        for coreclr in bench_file.coreclrs_and_names:
-            for config in bench_file.partial_configs_and_names:
-                for benchmark in bench_file.benchmarks_and_names:
-                    yield SingleTestCombination(machine, coreclr, config, benchmark)
+        for executable in bench_file.executables_and_names:
+            for coreclr in bench_file.coreclrs_and_names:
+                for config in bench_file.partial_configs_and_names:
+                    for benchmark in bench_file.benchmarks_and_names:
+                        yield SingleTestCombination(machine, executable, coreclr, config, benchmark)
 
 
 def iter_tests_to_run(
@@ -1337,6 +1355,7 @@ def iter_tests_to_run(
                     bench_file=bench_file,
                     test=SingleTestCombination(
                         machine=machine,
+                        executable=t.executable,
                         coreclr=t.coreclr,
                         config=PartialConfigAndName(
                             name=t.config_name,
@@ -1381,7 +1400,7 @@ def get_test_path(
     out_dir: Optional[Path] = None,
 ) -> TestPaths:
     out = out_dir_for_bench_yaml(bench.path, t.machine) if out_dir is None else out_dir
-    return TestPaths(out / f"{t.coreclr.name}__{t.config.name}__{t.benchmark.name}__{iteration}")
+    return TestPaths(out / f"{t.executable_name}__{t.coreclr.name}__{t.config.name}__{t.benchmark.name}__{iteration}")
 
 
 def combine_test_configs(

--- a/src/benchmarks/gc/src/commonlib/get_built.py
+++ b/src/benchmarks/gc/src/commonlib/get_built.py
@@ -105,9 +105,6 @@ class Built:
     coreclrs: Mapping[str, Optional[CoreclrPaths]]
     _win: Optional[BuiltWindowsOnly]
 
-    def __post_init__(self) -> None:
-        assert "GCPerfSim" in self.tests
-
     @property
     def win(self) -> BuiltWindowsOnly:
         # Visual Studio tools are not supported on ARM. Hence, we assert we are
@@ -222,7 +219,7 @@ def get_built_gcperf() -> Sequence[Path]:
     return [assert_file_exists(p) for p in (gcperf_dll_path, traceevent_dll_path)]
 
 
-def _get_latest_testbin_path(test_name: str) -> Path:
+def get_latest_testbin_path(test_name: str) -> Path:
     base_bin_path = _ARTIFACTS_BIN_PATH / test_name / "release"
     bin_build_dirs = [
         str(f.absolute()).split("\\")[-1]
@@ -237,7 +234,7 @@ def _get_latest_testbin_path(test_name: str) -> Path:
 def _get_built_test(name: str, build_kind: BuildKind) -> Path:
     # Apparently, built files go to the root of the performance repo instead of next to the source.
     test_dir = _get_test_path(name)
-    out_path = _get_latest_testbin_path(name)
+    out_path = get_latest_testbin_path(name)
     test_cs = test_dir / f"{name}.cs"
     assert_file_exists(test_cs)
     msg = _is_build_is_out_of_date(_get_cs_files(test_dir), out_path, build_kind)

--- a/src/benchmarks/gc/src/exec/run_tests.py
+++ b/src/benchmarks/gc/src/exec/run_tests.py
@@ -146,11 +146,11 @@ def run_test(
 
     if not is_suite and not is_empty(run_errors):
         print(
-            f"\n======= *WARNING*: Test '{bench_file_path}' encountered errors. =======\n"
+            f"\n========= *WARNING*: Test '{bench_file_path}' encountered errors. =========\n"
             "\n*** Here is a summary of the problems found: ***\n"
         )
-        for core_run in run_errors.values():
-            core_run.print()
+        for executable in run_errors.values():
+            executable.print()
 
 
 # pylint: disable=broad-except
@@ -184,6 +184,7 @@ def _run_all_benchmarks(
             _, exception_message, exception_trace = exc_info()
             add_new_error(
                 run_errors=run_errors,
+                exec_name=t.executable_name,
                 core_name=t.coreclr_name,
                 config_name=t.config_name,
                 bench_name=t.benchmark_name,

--- a/src/benchmarks/gc/src/exec/run_tests.py
+++ b/src/benchmarks/gc/src/exec/run_tests.py
@@ -121,7 +121,7 @@ def run_test(
         else args.out
     )
     built = get_built(
-        bench.content.coreclrs,
+        coreclrs=bench.content.coreclrs,
         build_kind=BuildKind.forbid_out_of_date,
         use_debug_coreclrs=args.use_debug_coreclrs,
         skip_coreclr_checks=args.skip_coreclr_checks,
@@ -174,7 +174,7 @@ def _run_all_benchmarks(
                     SingleTest(
                         test=t.test,
                         coreclr=built.coreclrs[t.coreclr_name],
-                        test_exe=_get_path(built, t.bench_file.paths, t.benchmark.get_executable),
+                        test_exe=t.test.executable.executable_path,
                         options=t.bench_file.options,
                         default_env=default_env,
                     ),

--- a/src/benchmarks/gc/src/suite.py
+++ b/src/benchmarks/gc/src/suite.py
@@ -172,7 +172,7 @@ def suite_run(args: SuiteRunArgs) -> None:
             "\n*** Here is a summary of the problems found: ***"
         )
         for file, test_errors in suite_errors.items():
-            print(f"\n======= {file} =======\n")
+            print(f"\n========= {file} =========\n")
             for err in test_errors.values():
                 err.print()
 

--- a/src/benchmarks/gc/src/suite.py
+++ b/src/benchmarks/gc/src/suite.py
@@ -29,7 +29,7 @@ from .commonlib.bench_file import (
     Config,
     Vary,
 )
-from .commonlib.get_built import get_corerun_path_from_core_root
+from .commonlib.get_built import get_corerun_path_from_core_root, get_latest_testbin_path
 from .commonlib.collection_util import add, combine_mappings, is_empty
 from .commonlib.command import Command, CommandKind, CommandsMapping, run_command_worker
 from .commonlib.document import handle_doc, OutputOptions
@@ -78,13 +78,15 @@ def suite_create(args: SuiteCreateArgs) -> None:
     coreclrs: Mapping[str, CoreclrSpecifier] = _parse_coreclrs(args.coreclrs)
     options = BenchOptions(default_iteration_count=2, default_max_seconds=300)
     proc_count = option_or(args.proc_count, _get_default_proc_count())
+    gcperfsim_path = get_latest_testbin_path("GCPerfSim")
+
     tests: Mapping[str, BenchFile] = {
-        "normal_workstation": _create_scenario_normal_workstation(coreclrs, options),
-        "normal_server": _create_scenario_normal_server(coreclrs, options, proc_count),
-        "high_memory": _create_scenario_high_memory_load(coreclrs, options, proc_count),
+        "normal_workstation": _create_scenario_normal_workstation(coreclrs, options, gcperfsim_path),
+        "normal_server": _create_scenario_normal_server(coreclrs, options, proc_count, gcperfsim_path),
+        "high_memory": _create_scenario_high_memory_load(coreclrs, options, proc_count, gcperfsim_path),
         # TODO: use a low proc_count here?
         "low_memory_container": _create_scenario_low_memory_container(
-            coreclrs, options, proc_count
+            coreclrs, options, proc_count, gcperfsim_path
         ),
     }
 
@@ -263,11 +265,12 @@ LOW_MEMORY_SCORES: Mapping[str, ScoreSpec] = combine_mappings(
 
 
 def _create_scenario_normal_workstation(
-    coreclrs: Mapping[str, CoreclrSpecifier], options: BenchOptions
+    coreclrs: Mapping[str, CoreclrSpecifier], options: BenchOptions, gcperfsim: Path,
 ) -> BenchFile:
     common_config = Config(complus_gcserver=False, complus_gcconcurrent=False)
     return BenchFile(
         vary=Vary.coreclr,
+        test_executables={"defgcperfsim": gcperfsim},
         coreclrs=coreclrs,
         options=options,
         common_config=common_config,
@@ -277,13 +280,17 @@ def _create_scenario_normal_workstation(
 
 
 def _create_scenario_normal_server(
-    coreclrs: Mapping[str, CoreclrSpecifier], options: BenchOptions, proc_count: int
+    coreclrs: Mapping[str, CoreclrSpecifier],
+    options: BenchOptions,
+    proc_count: int,
+    gcperfsim: Path,
 ) -> BenchFile:
     common_config = Config(
         complus_gcserver=True, complus_gcconcurrent=False, complus_gcheapcount=proc_count
     )
     return BenchFile(
         vary=Vary.coreclr,
+        test_executables={"defgcperfsim": gcperfsim},
         coreclrs=coreclrs,
         options=options,
         common_config=common_config,
@@ -293,7 +300,10 @@ def _create_scenario_normal_server(
 
 
 def _create_scenario_high_memory_load(
-    coreclrs: Mapping[str, CoreclrSpecifier], options: BenchOptions, proc_count: int
+    coreclrs: Mapping[str, CoreclrSpecifier],
+    options: BenchOptions,
+    proc_count: int,
+    gcperfsim: Path,
 ) -> BenchFile:
     common_config = Config(
         complus_gcserver=True, complus_gcconcurrent=False, complus_gcheapcount=proc_count
@@ -308,6 +318,7 @@ def _create_scenario_high_memory_load(
     }
     return BenchFile(
         vary=Vary.coreclr,
+        test_executables={"defgcperfsim": gcperfsim},
         coreclrs=coreclrs,
         options=options,
         common_config=common_config,
@@ -318,7 +329,10 @@ def _create_scenario_high_memory_load(
 
 
 def _create_scenario_low_memory_container(
-    coreclrs: Mapping[str, CoreclrSpecifier], options: BenchOptions, proc_count: int
+    coreclrs: Mapping[str, CoreclrSpecifier],
+    options: BenchOptions,
+    proc_count: int,
+    gcperfsim: Path,
 ) -> BenchFile:
     # In a small container, coreclr should choose a low heap count for itself
     common_config = Config(
@@ -335,6 +349,7 @@ def _create_scenario_low_memory_container(
     }
     return BenchFile(
         vary=Vary.coreclr,
+        test_executables={"defgcperfsim": gcperfsim},
         coreclrs=coreclrs,
         options=options,
         common_config=common_config,


### PR DESCRIPTION
# Summary

This PR adds the feature to run multiple test executables (in the form of dll's) and compare results between them. This is done through a new field in the bench _yaml_ files containing the path(s) to this(these) executable(s).

From the user side, the way of running the infra had no changes. The `suite-create` command automatically looks for the _GCPerfSim_ built during the infra's setup steps, and adds it to the bench _yaml_ files. The only action the user needs to take is to set the `vary` field to `executable` if they so desire to do that diff, as `coreclr` remains the default value for that field.

It is important to mention that rebuilding GCPerfSim will always overwrite the previous one. To test your changes and ensure everything still works properly, make sure you back up the original GCPerfSim build (the one you built when you first setup GC infra), before rebuilding. Keep note of the paths because you will need them for the _yaml_ bench files.

# Bench Files

Let's suppose for this example, that you made some changes to GCPerfSim and want to make sure nothing broke in the tests. For simplicity of this example, we will only be using one Core_Root since the main purpose is to compare the GCPerfSim executables. We will label the unchanged GCPerfSim as `orig_gcperfsim` and the modified one as `mod_gcperfsim`. The bench _yaml_ files now would look something like this:

```yaml
vary: executable
test_executables:
  orig_gcperfsim: <path to the GCPerfSim dll without the changes>
  mod_gcperfsim: <path to the GCPerfSim dll with the changes>
coreclrs:
  a:
    core_root: <path to the CoreCLR core root>
options:
   <option configuration such as timeouts, number of iterations, etc>
common_config:
   <configuration values such as number of heaps, concurrent gcs, etc>
benchmarks:
  2gb:
    arguments:
      tc: 10
      tagb: 300
      tlgb: 2
      <other parameters for GCPerfSim>
  <other benchmark tests to run>
```

# Error Reporting During Runs

The error reporting mechanism was also updated. Now, whenever a test fails, it will also show which executable was running aside of the configuration, coreclr, etc. It now looks like shown here:

```text
*WARNING*: One or more tests in the suite encountered errors.

*** Here is a summary of the problems found: ***

========= <Yaml Filename> =========

======= <Executable Name> =======

===== <Coreclr Name> =====

=== <Configuration Name> ===

- <Benchmark Name> -
<Iteration Number>
<Error Message>

<Stack Trace>

<Repeat with other errors that might have occurred>
```

# Comparing Results

When one runs the `diff` command, the `executable` value can now be set to the `vary` field in the _yaml_ file as shown above. A shortened output of how this comparison looks like is shown here:

```text
Diff of base = orig_gcperfsim and new = mod_gcperfsim

                          ┌────────────────────────────┐
                          │ Summary of important stats │
                          └────────────────────────────┘


                                       │    PctTimePausedInGC │ FirstToLastGCSeconds
                                  name │ Base │  New │ % Diff │ Base │  New │ % Diff
  ─────────────────────────────────────┼──────┼──────┼────────┼──────┼──────┼───────
  DESKTOP-S0L8UMK__a__only_config__2gb │ 33.0 │ 30.7 │  -6.96 │ 31.6 │ 30.2 │  -4.46



                                       │ HeapSizeBeforeMB_Mean │ HeapSizeAfterMB_Mean
                                  name │ Base │  New │  % Diff │ Base │  New │ % Diff
  ─────────────────────────────────────┼──────┼──────┼─────────┼──────┼──────┼───────
  DESKTOP-S0L8UMK__a__only_config__2gb │ 5282 │ 5277 │ -0.0881 │ 4070 │ 4060 │ -0.233



                                       │ PauseDurationMSec_95PWhereIsGen0 │ PauseDurationMSec_95PWhereIsGen1
                                  name │ Base │  New │             % Diff │ Base │  New │             % Diff
  ─────────────────────────────────────┼──────┼──────┼────────────────────┼──────┼──────┼───────────────────
  DESKTOP-S0L8UMK__a__only_config__2gb │ 45.3 │ 41.6 │              -8.23 │  100 │ 95.9 │              -4.54



                                       │ PauseDurationMSec_95PWhereIsBackground │ PauseDurationMSec_95PWhereIsBlockingGen2
                                  name │ Base │  New │                   % Diff │        Base │         New │       % Diff
  ─────────────────────────────────────┼──────┼──────┼──────────────────────────┼─────────────┼─────────────┼─────────────
  DESKTOP-S0L8UMK__a__only_config__2gb │ 40.2 │ 36.4 │                    -9.62 │ <no values> │ <no values> │



                                 ┌──────────────────────────────────────┐
                                 │ DESKTOP-S0L8UMK__a__only_config__2gb │
                                 └──────────────────────────────────────┘


Improvements (Improvement of 5-20%)

                                          Metric │      Base (run 0) │       New (run 0) │  % Diff │ Abs Diff
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  CountIsBackground                              │                13 │                12 │   -7.69 │       -1
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  FirstEventToFirstGCSeconds                     │             0.655 │             0.615 │   -6.08 │  -0.0398
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_95P                          │              91.2 │              84.7 │   -7.20 │    -6.57
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_95PWhereIsBackground         │              40.2 │              36.4 │   -9.62 │    -3.87
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_95PWhereIsGen0               │              45.3 │              41.6 │   -8.23 │    -3.73
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_Mean                         │              36.9 │              32.9 │   -10.8 │    -3.98
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_MeanWhereIsEphemeral         │              37.3 │              33.2 │   -11.2 │    -4.17
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_Sum                       │              19.5 │              17.4 │   -10.8 │    -2.10
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_SumWhereIsBackground      │              9.45 │              8.48 │   -10.3 │   -0.973
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_SumWhereIsGen1            │              5.49 │              4.99 │   -8.99 │   -0.493
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_SumWhereIsNonBackground   │              10.0 │              8.89 │   -11.3 │    -1.13
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PctTimeInGC_WhereIsNonBackground               │              31.7 │              29.4 │   -7.14 │    -2.26
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PctTimePausedInGC                              │              33.0 │              30.7 │   -6.96 │    -2.30
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  speed                                          │              53.7 │              50.5 │   -5.84 │    -3.13


Stale (Same, or percent difference within 5% margin)

                                          Metric │      Base (run 0) │       New (run 0) │  % Diff │ Abs Diff
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  CountIsBlockingGen2                            │                 0 │                 0 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  CountIsGen0                                    │               189 │               189 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  CountIsGen1                                    │                81 │                81 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  CountUsesLOHCompaction                         │ <not implemented> │ <not implemented> │         │
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  FirstToLastGCSeconds                           │              31.6 │              30.2 │   -4.46 │    -1.41
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  HeapCount                                      │                 6 │                 6 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  HeapSizeAfterMB_Max                            │              4419 │              4498 │    1.79 │     79.3
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  HeapSizeAfterMB_Mean                           │              4070 │              4060 │  -0.233 │    -9.47
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  HeapSizeBeforeMB_Max                           │              5673 │              5749 │    1.33 │     75.6
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  HeapSizeBeforeMB_Mean                          │              5282 │              5277 │ -0.0881 │    -4.65
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_95PWhereIsBlockingGen2       │       <no values> │       <no values> │         │
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationMSec_95PWhereIsGen1               │               100 │              95.9 │   -4.54 │    -4.56
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_SumWhereIsBlockingGen2    │                 0 │                 0 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PauseDurationSeconds_SumWhereUsesLOHCompaction │ <not implemented> │ <not implemented> │         │
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PctIsEphemeral                                 │              95.4 │              95.7 │   0.355 │    0.338
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PctReductionInHeapSize_Mean                    │              22.8 │              22.9 │   0.515 │    0.117
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PctUsesCompaction                              │              93.6 │              94.0 │   0.355 │    0.332
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PromotedMB_MeanWhereIsBlockingGen2             │       <no values> │       <no values> │         │
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PromotedMB_MeanWhereIsGen0                     │              51.7 │              51.8 │   0.114 │   0.0588
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  PromotedMB_MeanWhereIsGen1                     │               229 │               228 │  -0.420 │   -0.963
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  TotalAllocatedMB                               │          3.23e+05 │          3.22e+05 │  -0.217 │     -701
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  TotalLOHAllocatedMB                            │              8.01 │              8.01 │       0 │        0
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  TotalNonGCSeconds                              │              22.2 │              21.9 │   -1.51 │   -0.335
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  TotalNumberGCs                                 │               283 │               282 │  -0.353 │       -1
  ───────────────────────────────────────────────┼───────────────────┼───────────────────┼─────────┼─────────
  TotalSecondsTaken                              │              32.7 │              31.2 │   -4.58 │    -1.49

<numbers from other configurations, coreclrs, and benchmarks run>
```

When one makes changes to GCPerfSim, we want these differences between original and modified be as small as possible to ensure the new changes did not break existing functionality or made it somehow malfunction.

# Other Changes

All the necessary documentation was updated with the addition of this new parameter, and also some broken links were fixed.