### PR TITLE
Fix System.IO.Tests.Perf_Copy.RecursiveCreateDeleteDirectory test on Alpine by removing excessively deep tree

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.Directory.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.Directory.cs
@@ -59,7 +59,7 @@ namespace System.IO.Tests
         public void CleanupExists() => Directory.Delete(_testFile, recursive: true);
 
         public IEnumerable<object> RecursiveDepthData()
-            => new object[] { 10, 100, 1000 } // Most Unix distributions have a maximum path length of 1024 characters (1024 UTF-8 bytes). 
+            => new object[] { 10, 100 } // Most Unix distributions have a maximum path length of 1024 characters (1024 UTF-8 bytes). 
                 .Where(depth =>
                     {
                         try

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.Directory.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.Directory.cs
@@ -46,7 +46,7 @@ namespace System.IO.Tests
         public void CleanupDirectoryIteration()
         {
             foreach (var directory in _directoriesToCreate)
-                Directory.Delete(directory);
+                Directory.Delete(directory, recursive: true);
         }
 
         [GlobalSetup(Target = nameof(Exists))]
@@ -56,7 +56,7 @@ namespace System.IO.Tests
         public bool Exists() => Directory.Exists(_testFile);
         
         [GlobalCleanup(Target = nameof(Exists))]
-        public void CleanupExists() => Directory.Delete(_testFile);
+        public void CleanupExists() => Directory.Delete(_testFile, recursive: true);
 
         public IEnumerable<object> RecursiveDepthData()
             => new object[] { 10, 100, 1000 } // Most Unix distributions have a maximum path length of 1024 characters (1024 UTF-8 bytes). 


### PR DESCRIPTION
* Remove the scenario that deletes a directory tree that's over 1000 folders deep. On my box, we cannot successfully delete it. For full gory details see https://github.com/dotnet/runtime/issues/41195. 

I believe this scenario is contrived, and the 100-deep scenario is enough performance coverage of this codepath, so I suggest to remove the 1000 folder scenario. Also the comment says the limit is 1024 UTF8 characters - it's actually creating a tree that's over 2000 characters deep, so perhaps it wasn't what was intended anyway. 

* Before I figured it out, I found a couple lines we were cleaning up without being robust to any files within them. They're reasonable changes, even though turned out to be not necessary.
