### PR TITLE
don't check the check sum because it can be different for different number of processors

### DIFF
--- a/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs
@@ -142,13 +142,7 @@ namespace BenchmarksGame
         // Official runs use [Arguments(12, 3968050)] which takes ~4.2 sec vs ~330ms for 11
         [Benchmark(Description = nameof(FannkuchRedux_9))]
         [Arguments(11, 556355)]
-        public int RunBench(int n, int expectedSum)
-        {
-            int chkSum = Bench(n, false);
-            if (chkSum != expectedSum)
-                    throw new Exception($"Expected {expectedSum} actual {chkSum}");
-            return chkSum;
-        }
+        public int RunBench(int n, int expectedSum) => Bench(n, false);
 
         public static int Bench(int n, bool verbose)
         {


### PR DESCRIPTION
I've compared `FannkuchRedux_5` vs `FannkuchRedux_9` and:

* `FannkuchRedux_5` returns `maxFlips`, `FannkuchRedux_9`  returns `checkSum`: https://github.com/dotnet/performance/blob/ce1417e53e9af9cf3a158f327608d20a05594c67/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-5.cs#L136
https://github.com/dotnet/performance/blob/ce1417e53e9af9cf3a158f327608d20a05594c67/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-9.cs#L182
* the `checkSum` calculated by both FannkuchRedux_5 vs FannkuchRedux_9 is different depending on `Environment.ProcessorCount`, we can not rely on it

In my opinion, the best solution for `FannkuchRedux_9` is just to not assert the returned value, similarly to what `FannkuchRedux_5 ` already does:

https://github.com/dotnet/performance/blob/ce1417e53e9af9cf3a158f327608d20a05594c67/src/benchmarks/micro/runtime/BenchmarksGame/fannkuch-redux-5.cs#L106-L107

I've kept the unused `expectedSum` argument to keep the benchmark ID unchanged.

@DrewScoggins PTAL

