### PR TITLE
remove PAShort benchmark that uses 1 byte long input and add a "Medim" that consists of 6 bytes

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.NetworkInformation/PhysicalAddressTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.NetworkInformation/PhysicalAddressTests.cs
@@ -11,11 +11,11 @@ namespace System.Net.NetworkInformation.Tests
     [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public class PhysicalAddressTests
     {
-        private readonly PhysicalAddress _short = new PhysicalAddress(new byte[1] { 42 });
+        private readonly PhysicalAddress _medium = new PhysicalAddress(new byte[6] { 42, 64, 128, 0, 8, 12 });
         private readonly PhysicalAddress _long = new PhysicalAddress(Enumerable.Range(0, 256).Select(i => (byte)i).ToArray());
 
         [Benchmark]
-        public void PAShort() => _short.ToString();
+        public void PAMedium() => _medium.ToString();
 
         [Benchmark]
         public void PALong() => _long.ToString();


### PR DESCRIPTION
As agreed in https://github.com/dotnet/runtime/issues/39720 measuring the performance of `.ToString` operation of a single byte address does not add any value

As suggested in https://github.com/dotnet/runtime/issues/39720#issuecomment-678320654 I have added a six bytes benchmark. I hope it's OK.

