### PR TITLE
don't create empty "perf-lab-report.json" files when not running in the lab

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -23,8 +23,6 @@ namespace BenchmarkDotNet.Extensions
         public override void ExportToLog(Summary summary, ILogger logger)
         {
             var reporter = Reporter.CreateReporter();
-            if (!reporter.InLab) // not running in the perf lab
-                return;
 
             DisassemblyDiagnoser disassemblyDiagnoser = summary.Reports
                 .FirstOrDefault()? // dissasembler was either enabled for all or none of them (so we use the first one)

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -8,6 +8,7 @@ using Perfolizer.Horology;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using System.Collections.Generic;
+using Reporting;
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -45,12 +46,16 @@ namespace BenchmarkDotNet.Extensions
                 .AddFilter(new ExclusionFilter(exclusionFilterValue))
                 .AddFilter(new CategoryExclusionFilter(categoryExclusionFilterValue))
                 .AddExporter(JsonExporter.Full) // make sure we export to Json
-                .AddExporter(new PerfLabExporter())
                 .AddColumn(StatisticColumn.Median, StatisticColumn.Min, StatisticColumn.Max)
                 .AddValidator(TooManyTestCasesValidator.FailOnError)
                 .AddValidator(new UniqueArgumentsValidator()) // don't allow for duplicated arguments #404
                 .AddValidator(new MandatoryCategoryValidator(mandatoryCategories))
                 .WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(36)); // the default is 20 and trims too aggressively some benchmark results
+
+            if (Reporter.CreateReporter().InLab)
+            {
+                config = config.AddExporter(new PerfLabExporter());
+            }
 
             if (getDiffableDisasm)
             {


### PR DESCRIPTION
so far the `PerfLabExporter` was creating empty `perf-lab-report.json` files when running benchmarks outside of perf lab

If we don't enable the exporter, we don't get empty files and it's simply easier to copy the results (using scp or similar tools)