### PR TITLE
Adding some basic perf tests for Vector<T>

### DIFF
--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorOfT.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorOfT.cs
@@ -9,26 +9,16 @@ using MicroBenchmarks;
 
 namespace System.Numerics.Tests
 {
-    public class Perf_VectorOfByte : Perf_VectorOf<byte> { }
-
-    public class Perf_VectorOfDouble : Perf_VectorOf<double> { }
-
-    public class Perf_VectorOfInt16 : Perf_VectorOf<short> { }
-
-    public class Perf_VectorOfInt32 : Perf_VectorOf<int> { }
-
-    public class Perf_VectorOfInt64 : Perf_VectorOf<long> { }
-
-    public class Perf_VectorOfSByte : Perf_VectorOf<sbyte> { }
-
-    public class Perf_VectorOfSingle : Perf_VectorOf<float> { }
-
-    public class Perf_VectorOfUInt16 : Perf_VectorOf<ushort> { }
-
-    public class Perf_VectorOfUInt32 : Perf_VectorOf<uint> { }
-
-    public class Perf_VectorOfUInt64 : Perf_VectorOf<ulong> { }
-
+    [GenericTypeArguments(typeof(byte))]
+    [GenericTypeArguments(typeof(double))]
+    [GenericTypeArguments(typeof(short))]
+    [GenericTypeArguments(typeof(int))]
+    [GenericTypeArguments(typeof(long))]
+    [GenericTypeArguments(typeof(sbyte))]
+    [GenericTypeArguments(typeof(float))]
+    [GenericTypeArguments(typeof(ushort))]
+    [GenericTypeArguments(typeof(uint))]
+    [GenericTypeArguments(typeof(ulong))]
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_VectorOf<T>
         where T : struct

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorOfT.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorOfT.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Numerics.Tests
+{
+    public class Perf_VectorOfByte : Perf_VectorOf<byte> { }
+
+    public class Perf_VectorOfDouble : Perf_VectorOf<double> { }
+
+    public class Perf_VectorOfInt16 : Perf_VectorOf<short> { }
+
+    public class Perf_VectorOfInt32 : Perf_VectorOf<int> { }
+
+    public class Perf_VectorOfInt64 : Perf_VectorOf<long> { }
+
+    public class Perf_VectorOfSByte : Perf_VectorOf<sbyte> { }
+
+    public class Perf_VectorOfSingle : Perf_VectorOf<float> { }
+
+    public class Perf_VectorOfUInt16 : Perf_VectorOf<ushort> { }
+
+    public class Perf_VectorOfUInt32 : Perf_VectorOf<uint> { }
+
+    public class Perf_VectorOfUInt64 : Perf_VectorOf<ulong> { }
+
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_VectorOf<T>
+        where T : struct
+    {
+        private static readonly Vector<T> Value1 = Vector<T>.One;
+
+        private static readonly Vector<T> Value2 = Vector<T>.One + Vector<T>.One;
+
+        private static readonly Vector<T> Value3 = Vector<T>.One + Vector<T>.One + Vector<T>.One;
+
+        [Benchmark]
+        public int CountBenchmark() => Vector<T>.Count;
+
+        [Benchmark]
+        public Vector<T> OneBenchmark() => Vector<T>.One;
+
+        [Benchmark]
+        public Vector<T> ZeroBenchmark() => Vector<T>.Zero;
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Value1.Equals(Value2);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => Value1.GetHashCode();
+
+        [Benchmark]
+        public Vector<T> AddOperatorBenchmark() => Value1 + Value2;
+
+        [Benchmark]
+        public Vector<T> BitwiseAndOperatorBenchmark() => Value1 & Value2;
+
+        [Benchmark]
+        public Vector<T> BitwiseOrOperatorBenchmark() => Value1 | Value2;
+
+        [Benchmark]
+        public Vector<T> DivisionOperatorBenchmark() => Value1 / Value2;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Value1 == Value2;
+
+        [Benchmark]
+        public Vector<T> ExclusiveOrOperatorBenchmark() => Value1 ^ Value2;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Value1 != Value2;
+
+        [Benchmark]
+        public Vector<T> MultiplyOperatorBenchmark() => Value1 * Value2;
+
+        [Benchmark]
+        public Vector<T> OnesComplementOperatorBenchmark() => ~Value1;
+
+        [Benchmark]
+        public Vector<T> SubtractionOperatorBenchmark() => Value1 - Value2;
+
+        [Benchmark]
+        public Vector<T> UnaryNegateOperatorBenchmark() => -Value1;
+
+        [Benchmark]
+        public Vector<T> AbsBenchmark() => Vector.Abs(Value1);
+
+        [Benchmark]
+        public Vector<T> AddBenchmark() => Vector.Add(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> AndNotBenchmark() => Vector.AndNot(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> BitwiseAndBenchmark() => Vector.BitwiseAnd(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> BitwiseOrBenchmark() => Vector.BitwiseOr(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> ConditionalSelectBenchmark() => Vector.ConditionalSelect(Value1, Value2, Value3);
+
+        [Benchmark]
+        public Vector<T> DivideBenchmark() => Vector.Divide(Value1, Value2);
+
+        [Benchmark]
+        public T DotBenchmark() => Vector.Dot(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> EqualsStaticBenchmark() => Vector.Equals(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAllBenchmark() => Vector.EqualsAll(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAnyBenchmark() => Vector.EqualsAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> GreaterThanBenchmark() => Vector.GreaterThan(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAllBenchmark() => Vector.GreaterThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAnyBenchmark() => Vector.GreaterThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> GreaterThanOrEqualBenchmark() => Vector.GreaterThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAllBenchmark() => Vector.GreaterThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAnyBenchmark() => Vector.GreaterThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> LessThanBenchmark() => Vector.LessThan(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAllBenchmark() => Vector.LessThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAnyBenchmark() => Vector.LessThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> LessThanOrEqualBenchmark() => Vector.LessThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAllBenchmark() => Vector.LessThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAnyBenchmark() => Vector.LessThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> MaxBenchmark() => Vector.Max(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> MinBenchmark() => Vector.Min(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> MultiplyBenchmark() => Vector.Multiply(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> NegateBenchmark() => Vector.Negate(Value1);
+
+        [Benchmark]
+        public Vector<T> OnesComplementBenchmark() => Vector.OnesComplement(Value1);
+
+        [Benchmark]
+        public Vector<T> SquareRootBenchmark() => Vector.SquareRoot(Value1);
+
+        [Benchmark]
+        public Vector<T> SubtractBenchmark() => Vector.Subtract(Value1, Value2);
+
+        [Benchmark]
+        public Vector<T> XorBenchmark() => Vector.Xor(Value1, Value2);
+    }
+}


### PR DESCRIPTION
This adds tests covering Vector<T> to finish wrapping up coverage for the hardware accelerated System.Numerics types.

The conversions, constructors, and copy methods are already covered: https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorConvert.cs, https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/libraries/System.Numerics.Vectors/GenericVectorFromSpanConstructorTests.cs, and https://github.com/dotnet/performance/blob/master/src/benchmarks/micro/libraries/System.Numerics.Vectors/GenericVectorConstructorTests.cs

The numbers I got comparing 3.1 to 5.0 are the following. The GetHashCode regressions look to be by design as it is using `HashCode.Add` now rather than `HashHelpers.Combine` which matches the regressions we allowed for other types.

| Slower                                                         | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Numerics.Tests.Perf_VectorOfUInt64.GetHashCodeBenchmark |     18.62 |             1.69 |            31.46 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.GetHashCodeBenchmark  |     15.73 |             1.97 |            30.96 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.GetHashCodeBenchmark |      8.37 |             3.70 |            30.93 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.GetHashCodeBenchmark  |      8.08 |             3.63 |            29.37 |         |
| System.Numerics.Tests.Perf_VectorOfSingle.GetHashCodeBenchmark |      4.41 |             7.50 |            33.08 |         |
| System.Numerics.Tests.Perf_VectorOfDouble.GetHashCodeBenchmark |      4.27 |             4.42 |            18.88 |         |
| System.Numerics.Tests.Perf_VectorOfInt16.GetHashCodeBenchmark  |      3.27 |             9.42 |            30.81 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.GetHashCodeBenchmark |      3.24 |             9.51 |            30.84 |         |
| System.Numerics.Tests.Perf_VectorOfByte.GetHashCodeBenchmark   |      1.71 |            17.88 |            30.57 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.GetHashCodeBenchmark  |      1.56 |            19.68 |            30.72 |         |

| Faster                                                                   | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------------ | ---------:| ----------------:| ----------------:| -------- |
| System.Numerics.Tests.Perf_VectorOfInt16.DotBenchmark                    |     14.66 |            16.16 |             1.10 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.DotBenchmark                   |     13.28 |            14.85 |             1.12 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.DotBenchmark                   |      6.75 |             4.63 |             0.69 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.LessThanOrEqualAnyBenchmark    |      2.94 |             1.23 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.GreaterThanOrEqualAnyBenchmark |      2.92 |             1.22 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.LessThanOrEqualAllBenchmark     |      2.65 |             1.11 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.GreaterThanOrEqualAllBenchmark  |      2.63 |             1.10 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.LessThanOrEqualAllBenchmark     |      2.62 |             1.10 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.GreaterThanOrEqualAllBenchmark  |      2.61 |             1.11 |             0.43 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.LessThanOrEqualAnyBenchmark    |      2.60 |             1.10 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.GreaterThanOrEqualAnyBenchmark |      2.59 |             1.09 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfDouble.LessThanAnyBenchmark           |      2.52 |             0.56 |             0.22 |         |
| System.Numerics.Tests.Perf_VectorOfDouble.GreaterThanOrEqualAnyBenchmark |      2.52 |             0.56 |             0.22 |         |
| System.Numerics.Tests.Perf_VectorOfDouble.GreaterThanAnyBenchmark        |      2.47 |             0.56 |             0.23 |         |
| System.Numerics.Tests.Perf_VectorOfDouble.LessThanOrEqualAnyBenchmark    |      2.47 |             0.57 |             0.23 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.GreaterThanOrEqualAnyBenchmark |      2.35 |             1.00 |             0.43 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.LessThanOrEqualAnyBenchmark    |      2.33 |             1.01 |             0.43 |         |
| System.Numerics.Tests.Perf_VectorOfInt16.LessThanOrEqualAllBenchmark     |      2.26 |             0.92 |             0.41 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.LessThanOrEqualAllBenchmark     |      2.23 |             0.91 |             0.41 |         |
| System.Numerics.Tests.Perf_VectorOfInt16.GreaterThanOrEqualAllBenchmark  |      2.20 |             0.90 |             0.41 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.GreaterThanOrEqualAllBenchmark  |      2.19 |             0.90 |             0.41 |         |
| System.Numerics.Tests.Perf_VectorOfByte.LessThanOrEqualAnyBenchmark      |      2.12 |             0.89 |             0.42 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.LessThanAnyBenchmark           |      2.10 |             0.78 |             0.37 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.GreaterThanAnyBenchmark        |      2.09 |             0.79 |             0.38 | several?|
| System.Numerics.Tests.Perf_VectorOfByte.GreaterThanOrEqualAnyBenchmark   |      2.08 |             0.90 |             0.43 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.GreaterThanOrEqualAllBenchmark |      2.08 |             1.34 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.LessThanOrEqualAllBenchmark    |      2.01 |             1.31 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.GreaterThanAllBenchmark         |      2.00 |             0.76 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.GreaterThanAllBenchmark         |      1.99 |             0.76 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.GreaterThanAnyBenchmark        |      1.99 |             0.75 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.LessThanAllBenchmark            |      1.91 |             0.75 |             0.39 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.GreaterThanAllBenchmark         |      1.91 |             0.77 |             0.40 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.LessThanAllBenchmark            |      1.91 |             0.75 |             0.39 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.GreaterThanAllBenchmark        |      1.91 |             1.18 |             0.62 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.GreaterThanAllBenchmark        |      1.91 |             1.18 |             0.62 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.LessThanAllBenchmark           |      1.90 |             1.19 |             0.63 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.LessThanAllBenchmark           |      1.89 |             1.17 |             0.62 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.LessThanAllBenchmark            |      1.87 |             0.76 |             0.41 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.LessThanAnyBenchmark           |      1.86 |             0.71 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.GreaterThanAnyBenchmark        |      1.84 |             0.70 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfSingle.LessThanOrEqualAllBenchmark    |      1.83 |             0.69 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.MultiplyBenchmark              |      1.82 |            24.24 |            13.29 |         |
| System.Numerics.Tests.Perf_VectorOfSingle.LessThanAllBenchmark           |      1.82 |             0.69 |             0.38 |         |
| System.Numerics.Tests.Perf_VectorOfByte.LessThanAllBenchmark             |      1.80 |             1.12 |             0.62 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.LessThanOrEqualAllBenchmark    |      1.79 |             1.17 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.GreaterThanOrEqualAllBenchmark |      1.78 |             1.15 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.LessThanOrEqualAllBenchmark    |      1.78 |             1.15 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.GreaterThanOrEqualAllBenchmark |      1.77 |             1.16 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfByte.GreaterThanAllBenchmark          |      1.76 |             1.12 |             0.64 |         |
| System.Numerics.Tests.Perf_VectorOfByte.LessThanOrEqualAllBenchmark      |      1.72 |             1.11 |             0.65 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.MultiplyOperatorBenchmark      |      1.70 |            22.94 |            13.48 |         |
| System.Numerics.Tests.Perf_VectorOfByte.GreaterThanOrEqualAllBenchmark   |      1.68 |             1.10 |             0.66 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.MultiplyOperatorBenchmark      |      1.59 |            10.56 |             6.65 | bimodal |
| System.Numerics.Tests.Perf_VectorOfUInt32.MultiplyOperatorBenchmark      |      1.55 |            12.70 |             8.17 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.MultiplyBenchmark               |      1.55 |            43.02 |            27.77 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.SquareRootBenchmark             |      1.54 |            10.26 |             6.65 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.MultiplyOperatorBenchmark       |      1.54 |            43.06 |            27.93 |         |
| System.Numerics.Tests.Perf_VectorOfByte.MultiplyOperatorBenchmark        |      1.51 |            36.04 |            23.86 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.SquareRootBenchmark            |      1.48 |            12.66 |             8.53 |         |
| System.Numerics.Tests.Perf_VectorOfByte.MultiplyBenchmark                |      1.43 |            36.28 |            25.33 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.MultiplyOperatorBenchmark       |      1.43 |            11.61 |             8.14 | several?|
| System.Numerics.Tests.Perf_VectorOfUInt32.MultiplyBenchmark              |      1.39 |            11.62 |             8.35 |         |
| System.Numerics.Tests.Perf_VectorOfInt64.MultiplyBenchmark               |      1.36 |            11.04 |             8.12 |         |
| System.Numerics.Tests.Perf_VectorOfUInt64.MultiplyBenchmark              |      1.33 |            11.00 |             8.29 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.SquareRootBenchmark             |      1.24 |            81.09 |            65.22 |         |
| System.Numerics.Tests.Perf_VectorOfByte.SquareRootBenchmark              |      1.23 |            80.25 |            65.41 |         |
| System.Numerics.Tests.Perf_VectorOfUInt16.SquareRootBenchmark            |      1.14 |            36.06 |            31.60 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.DivisionOperatorBenchmark       |      1.12 |           117.54 |           104.85 |         |
| System.Numerics.Tests.Perf_VectorOfUInt32.SquareRootBenchmark            |      1.12 |            16.60 |            14.82 |         |
| System.Numerics.Tests.Perf_VectorOfSByte.DivideBenchmark                 |      1.11 |           116.34 |           104.43 |         |
| System.Numerics.Tests.Perf_VectorOfByte.DivisionOperatorBenchmark        |      1.11 |           116.06 |           104.48 |         |
| System.Numerics.Tests.Perf_VectorOfInt32.SquareRootBenchmark             |      1.11 |            16.40 |            14.78 |         |
| System.Numerics.Tests.Perf_VectorOfInt16.SquareRootBenchmark             |      1.11 |            34.47 |            31.08 |         |
| System.Numerics.Tests.Perf_VectorOfByte.DivideBenchmark                  |      1.10 |           115.66 |           104.86 |         |
| System.Numerics.Tests.Perf_VectorOfByte.DotBenchmark                     |      1.07 |            27.74 |            25.81 |         |