### PR TITLE
Upgrade ResultsComparer to .NET 5.0

### DIFF
--- a/src/tools/ResultsComparer/ResultsComparer.csproj
+++ b/src/tools/ResultsComparer/ResultsComparer.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFramework Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworks)' == ''">net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Bump the *.csproj `TargetFramework` to `net5.0`.

Also looked for any Roslyn analyzer errors/warnings/info automatic suggestions to fix. Only found instances of this info message:

> IDE0042 - Variable declaration can be deconstructed

cc @adamsitnik @jeffhandley