### PR TITLE
Upgrade ScenarioMeasurement to .NET 5.0

### DIFF
--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -12,19 +12,19 @@ namespace Reporting.Tests
     public class ReporterTests
     {
         // this matches the output from the reporter made in GetReporterWithSpecifiedEnvironment
-        private string expectedTestTable = 
+        private readonly string expectedTestTable = 
 @"TestName
 Metric         |Average        |Min            |Max            
 ---------------|---------------|---------------|---------------
 CounterName    |1.100 ns       |1.100 ns       |1.100 ns       
 ";
-        private string longCounterNameTable =
+        private readonly string longCounterNameTable =
 @"TestName
 Metric                   |Average        |Min            |Max            
 -------------------------|---------------|---------------|---------------
 ThisIsALongerCounterName |1.100 ns       |1.100 ns       |1.100 ns       
 ";
-        private string longResultTable =
+        private readonly string longResultTable =
 @"TestName
 Metric         |Average                  |Min                      |Max                      
 ---------------|-------------------------|-------------------------|-------------------------
@@ -33,15 +33,16 @@ CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |100000000000
         private Reporter GetReporterWithSpecifiedEnvironment(PerfLabEnvironmentProviderMock enviroment, string counterName = null, double result = 1.1)
         {
             var reporter = Reporter.CreateReporter(enviroment);
-            var test = new Test();
-            test.Name = "TestName";
+            var test = new Test { Name = "TestName" };
             test.Categories.Add("UnitTest");
-            var counter = new Counter();
-            counter.DefaultCounter = true;
-            counter.HigherIsBetter = false;
-            counter.MetricName = "ns";
-            counter.Name = counterName ?? "CounterName";
-            counter.Results = new[] { result };
+            var counter = new Counter
+            {
+                DefaultCounter = true,
+                HigherIsBetter = false,
+                MetricName = "ns",
+                Name = counterName ?? "CounterName",
+                Results = new[] { result }
+            };
             test.AddCounter(counter);
             reporter.AddTest(test);
             return reporter;
@@ -134,8 +135,7 @@ CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |100000000000
         public void EnforceDefaultCounterConstraint()
         {
             Test t = new Test();
-            Counter c = new Counter();
-            c.DefaultCounter = true;
+            Counter c = new Counter { DefaultCounter = true };
             t.AddCounter(c);
             Assert.Throws<Exception>(() => t.AddCounter(c));
         }
@@ -144,8 +144,7 @@ CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |100000000000
         public void EnforceUniqueTestNames()
         {
             Reporter r = Reporter.CreateReporter(new PerfLabEnvironmentProviderMock());
-            Test t = new Test();
-            t.Name = "Duplicate";
+            Test t = new Test { Name = "Duplicate" };
             r.AddTest(t);
             Assert.Throws<Exception>(() => { r.AddTest(t); });
         }
@@ -153,8 +152,7 @@ CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |100000000000
         [Fact]
         public void EnforceUniqueCounterName()
         {
-            Test t = new Test();
-            t.Name = "Test";
+            Test t = new Test { Name = "Test" };
             Counter c = new Counter { Name = "Duplicate" };
             t.AddCounter(c);
             Assert.Throws<Exception>(() => { t.AddCounter(c); });

--- a/src/tools/Reporting/Reporting/Build.cs
+++ b/src/tools/Reporting/Reporting/Build.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
 
 namespace Reporting
 {

--- a/src/tools/Reporting/Reporting/EnvironmentProvider.cs
+++ b/src/tools/Reporting/Reporting/EnvironmentProvider.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Reporting
 {

--- a/src/tools/Reporting/Reporting/IEnvironment.cs
+++ b/src/tools/Reporting/Reporting/IEnvironment.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Reporting
 {
     public interface IEnvironment

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -19,7 +19,7 @@ namespace Reporting
         private Run run;
         private Os os;
         private Build build;
-        private List<Test> tests = new List<Test>();
+        private readonly List<Test> tests = new List<Test>();
         protected IEnvironment environment;
 
         private Reporter() { }
@@ -38,8 +38,10 @@ namespace Reporting
         /// <returns>A Reporter instance or null if the environment is incorrect.</returns>
         public static Reporter CreateReporter(IEnvironment environment = null)
         {
-            var ret = new Reporter();
-            ret.environment = environment == null ? new EnvironmentProvider() : environment;
+            var ret = new Reporter
+            {
+                environment = environment ?? new EnvironmentProvider()
+            };
             if (ret.InLab)
             {
                 ret.Init();
@@ -57,10 +59,10 @@ namespace Reporting
                 Name = environment.GetEnvironmentVariable("PERFLAB_RUNNAME"),
                 Queue = environment.GetEnvironmentVariable("PERFLAB_QUEUE"),
             };
-            Boolean.TryParse(environment.GetEnvironmentVariable("PERFLAB_HIDDEN"), out bool hidden);
+            bool.TryParse(environment.GetEnvironmentVariable("PERFLAB_HIDDEN"), out bool hidden);
             run.Hidden = hidden;
             var configs = environment.GetEnvironmentVariable("PERFLAB_CONFIGS");
-            if (!String.IsNullOrEmpty(configs)) // configs should be optional.
+            if (!string.IsNullOrEmpty(configs)) // configs should be optional.
             {
                 foreach (var kvp in configs.Split(';'))
                 {
@@ -101,10 +103,14 @@ namespace Reporting
                 run,
                 tests
             };
-            var settings = new JsonSerializerSettings();
-            var resolver = new DefaultContractResolver();
-            resolver.NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false };
-            settings.ContractResolver = resolver;
+            var resolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false }
+            };
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = resolver
+            };
             return JsonConvert.SerializeObject(jsonobj, Formatting.Indented, settings);
         }
 
@@ -145,7 +151,7 @@ namespace Reporting
 
         private string LeftJustify(string str, int width)
         {
-            return String.Format("{0,-" + width + "}", str);
+            return string.Format("{0,-" + width + "}", str);
         }
 
         public bool InLab => environment.GetEnvironmentVariable("PERFLAB_INLAB")?.Equals("1") ?? false;

--- a/src/tools/Reporting/Reporting/Run.cs
+++ b/src/tools/Reporting/Reporting/Run.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Reporting
 {

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Reporting
 {

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Reporting;
 using System;
 using System.Collections.Generic;
@@ -83,7 +87,7 @@ namespace ScenarioMeasurement
                 test.Name = scenarioName;
                 test.AddCounter(counters);
                 reporter.AddTest(test);
-                if (reporter.InLab && !String.IsNullOrEmpty(reportJsonPath))
+                if (reporter.InLab && !string.IsNullOrEmpty(reportJsonPath))
                 {
                     File.WriteAllText(reportJsonPath, reporter.GetJson());
                 }
@@ -95,13 +99,13 @@ namespace ScenarioMeasurement
         private static string GetExtension(string fileName)
         {
             var extension = Path.GetExtension(fileName);
-            if (String.IsNullOrWhiteSpace(extension))
+            if (string.IsNullOrWhiteSpace(extension))
             {
                 return "No Extension";
             }
             return extension;
         }
-        static HashSet<string> versions = new HashSet<string>();
+        static readonly HashSet<string> versions = new HashSet<string>();
 
         static string RemoveVersions(string name)
         {

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFramework>
     <!-- Supported target frameworks -->
-    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net5.0</TargetFramework>
     <RootNamespace>ScenarioMeasurement</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tools/ScenarioMeasurement/Startup.Tests/Startup.Tests.csproj
+++ b/src/tools/ScenarioMeasurement/Startup.Tests/Startup.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
+++ b/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using Reporting;
 using ScenarioMeasurement;
 using System;
@@ -6,14 +10,13 @@ using System.IO;
 using System.Threading;
 using Xunit;
 
-
 namespace Startup.Tests
 {
     public class StartupTests
     {
-        Logger logger = new Logger("test-startup.log");
-        string traceDirectory = Environment.CurrentDirectory;
-        string testAssetDirectory = "inputs";
+        readonly Logger logger = new Logger("test-startup.log");
+        readonly string traceDirectory = Environment.CurrentDirectory;
+        readonly string testAssetDirectory = "inputs";
 
 
         [WindowsOnly]
@@ -123,7 +126,7 @@ namespace Startup.Tests
                 traceFilePath = session.TraceFilePath;
             }
 
-            Assert.False(String.IsNullOrEmpty(traceFilePath));
+            Assert.False(string.IsNullOrEmpty(traceFilePath));
             Assert.True(File.Exists(traceFilePath));
         }
 

--- a/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Reporting;
-using System;
 using System.Collections.Generic;
 
 namespace ScenarioMeasurement

--- a/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Reporting;
 using System;
 using System.Collections.Generic;

--- a/src/tools/ScenarioMeasurement/Startup/IParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/IParser.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using Reporting;
 
 namespace ScenarioMeasurement

--- a/src/tools/ScenarioMeasurement/Startup/LinuxTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/Startup/LinuxTraceSession.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using System.Collections.Generic;
 
 namespace ScenarioMeasurement
@@ -9,7 +13,7 @@ namespace ScenarioMeasurement
         {
             get { return perfCollect?.TraceFilePath; }
         }
-        private PerfCollect perfCollect;
+        private readonly PerfCollect perfCollect;
         private Dictionary<TraceSessionManager.KernelKeyword, PerfCollect.KernelKeyword> kernelKeywords;
         private Dictionary<TraceSessionManager.ClrKeyword, PerfCollect.ClrKeyword> clrKeywords;
 
@@ -51,14 +55,18 @@ namespace ScenarioMeasurement
         private void InitLinuxKeywordMaps()
         {
             // initialize linux kernel keyword map
-            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, PerfCollect.KernelKeyword>();
-            kernelKeywords[TraceSessionManager.KernelKeyword.Process] = PerfCollect.KernelKeyword.LTTng_Kernel_ProcessLifetimeKeyword;
-            kernelKeywords[TraceSessionManager.KernelKeyword.Thread] = PerfCollect.KernelKeyword.LTTng_Kernel_ThreadKeyword;
-            kernelKeywords[TraceSessionManager.KernelKeyword.ContextSwitch] = PerfCollect.KernelKeyword.LTTng_Kernel_ContextSwitchKeyword;
+            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, PerfCollect.KernelKeyword>
+            {
+                [TraceSessionManager.KernelKeyword.Process] = PerfCollect.KernelKeyword.LTTng_Kernel_ProcessLifetimeKeyword,
+                [TraceSessionManager.KernelKeyword.Thread] = PerfCollect.KernelKeyword.LTTng_Kernel_ThreadKeyword,
+                [TraceSessionManager.KernelKeyword.ContextSwitch] = PerfCollect.KernelKeyword.LTTng_Kernel_ContextSwitchKeyword
+            };
 
             // initialize linux clr keyword map
-            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, PerfCollect.ClrKeyword>();
-            clrKeywords[TraceSessionManager.ClrKeyword.Startup] = PerfCollect.ClrKeyword.DotNETRuntimePrivate_StartupKeyword;
+            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, PerfCollect.ClrKeyword>
+            {
+                [TraceSessionManager.ClrKeyword.Startup] = PerfCollect.ClrKeyword.DotNETRuntimePrivate_StartupKeyword
+            };
         }
 
         public void EnableUserProvider(string provider, TraceEventLevel verboseLevel = TraceEventLevel.Verbose)

--- a/src/tools/ScenarioMeasurement/Startup/ParserUtility.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ParserUtility.cs
@@ -1,16 +1,17 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.IO;
-
 
 namespace ScenarioMeasurement
 {
     class ParserUtility
     {
-
         public static bool MatchProcessStart(TraceEvent evt, TraceSourceManager source, string processName, IList<int> pids, string commandLine)
         {
             return MatchCommandLine(evt, source, commandLine) &&

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -9,13 +13,13 @@ namespace ScenarioMeasurement
     public class PerfCollect : IDisposable
     {
         private readonly string startupDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        private ProcessHelper perfCollectProcess;
+        private readonly ProcessHelper perfCollectProcess;
         public string TraceName { get; private set; }
         public string TraceFileName { get; private set; }
         public string TraceDirectory { get; private set; }
         public string TraceFilePath { get; private set; }
-        private List<KernelKeyword> KernelEvents = new List<KernelKeyword>();
-        private List<ClrKeyword> ClrEvents = new List<ClrKeyword>();
+        private readonly List<KernelKeyword> KernelEvents = new List<KernelKeyword>();
+        private readonly List<ClrKeyword> ClrEvents = new List<ClrKeyword>();
         public PerfCollect(string traceName, Logger logger) : this(traceName, Environment.CurrentDirectory, logger)
         {
         }
@@ -28,7 +32,7 @@ namespace ScenarioMeasurement
                 throw new FileNotFoundException($"Pefcollect not found at {perfCollectScript}. Please rebuild the project to download it.");
             }
 
-            if (String.IsNullOrEmpty(traceName))
+            if (string.IsNullOrEmpty(traceName))
             {
                 throw new ArgumentException("Trace file name cannot be empty.");
             }

--- a/src/tools/ScenarioMeasurement/Startup/ProcessTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProcessTimeParser.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Reporting;
 using System.Collections.Generic;
-
 
 namespace ScenarioMeasurement
 {

--- a/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
@@ -1,16 +1,18 @@
-﻿using Microsoft.Diagnostics.Tracing.Session;
-using ScenarioMeasurement;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Reporting;
 using System;
 using System.Collections.Generic;
-using System.Text;
-using Microsoft.Diagnostics.Tracing.Parsers;
-using Reporting;
 
 namespace ScenarioMeasurement
 {
     public class ProfileParser : IParser
     {
-        IParser other;
+        readonly IParser other;
         public ProfileParser(IParser other) => this.other = other;
 
         public void EnableKernelProvider(ITraceSession kernel)

--- a/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFramework>
     <!-- Supported target frameworks -->
-    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp3.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net5.0</TargetFramework>
     <LangVersion>Preview</LangVersion>
     <RootNamespace>ScenarioMeasurement</RootNamespace>
   </PropertyGroup>

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Reporting;
 using System.Collections.Generic;
-
 
 namespace ScenarioMeasurement
 {

--- a/src/tools/ScenarioMeasurement/Startup/TraceSessionManager.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TraceSessionManager.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.Parsers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using System;
 
 namespace ScenarioMeasurement
 {
-
     public interface ITraceSession : IDisposable
     {
         string TraceFilePath { get; }
@@ -19,7 +21,6 @@ namespace ScenarioMeasurement
         public static bool IsWindows { get { return Util.IsWindows(); } }
         public static ITraceSession CreateSession(string sessionName, string traceName, string traceDirectory, Logger logger)
         {
-
             if (IsWindows)
             {
                 return new WindowsTraceSession(sessionName, traceName, traceDirectory, logger);
@@ -42,7 +43,5 @@ namespace ScenarioMeasurement
             Startup
         }
     }
-
-
 }
 

--- a/src/tools/ScenarioMeasurement/Startup/TraceSourceManager.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TraceSourceManager.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using System;
 
 namespace ScenarioMeasurement
 {
-
     public class TraceSourceManager : IDisposable
     {
         public bool IsWindows { get { return Source?.GetType() == typeof(ETWTraceEventSource); } }
@@ -43,7 +46,6 @@ namespace ScenarioMeasurement
         {
             Source.Dispose();
         }
-
     }
 
     public interface IKernelParser
@@ -55,7 +57,7 @@ namespace ScenarioMeasurement
 
     public sealed class LinuxKernelParser : IKernelParser
     {
-        LinuxKernelEventParser parser;
+        readonly LinuxKernelEventParser parser;
         public event Action<TraceEvent> ProcessStart { add { parser.ProcessStart += value; } remove { parser.ProcessStart -= value; } }
         public event Action<TraceEvent> ProcessStop { add { parser.ProcessStop += value; } remove { parser.ProcessStop -= value; } }
         public event Action<TraceEvent> ContextSwitch { add { } remove { } } // not implemented
@@ -67,7 +69,7 @@ namespace ScenarioMeasurement
 
     public sealed class WindowsKernelParser : IKernelParser
     {
-        KernelTraceEventParser parser;
+        readonly KernelTraceEventParser parser;
         public event Action<TraceEvent> ProcessStart { add { parser.ProcessStart += value; } remove { parser.ProcessStart -= value; } }
         public event Action<TraceEvent> ProcessStop { add { parser.ProcessEndGroup += value; } remove { parser.ProcessEndGroup -= value; } }
         public event Action<TraceEvent> ContextSwitch { add { parser.ThreadCSwitch += value; } remove { parser.ThreadCSwitch -= value; } }

--- a/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
@@ -1,4 +1,8 @@
-﻿using Reporting;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Reporting;
 using System.Collections.Generic;
 
 namespace ScenarioMeasurement

--- a/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
@@ -1,15 +1,18 @@
-﻿using Microsoft.Diagnostics.Tracing;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Session;
 using System.Collections.Generic;
 using System.IO;
 
-
 namespace ScenarioMeasurement
 {
     public class WindowsTraceSession : ITraceSession
     {
-        private Logger logger;
+        private readonly Logger logger;
         public string TraceFilePath { get; }
         public TraceEventSession KernelSession { get; set; }
         public TraceEventSession UserSession { get; set; }
@@ -92,14 +95,18 @@ namespace ScenarioMeasurement
         private void InitWindowsKeywordMaps()
         {
             // initialize windows kernel keyword map
-            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, KernelTraceEventParser.Keywords>();
-            kernelKeywords[TraceSessionManager.KernelKeyword.Process] = KernelTraceEventParser.Keywords.Process;
-            kernelKeywords[TraceSessionManager.KernelKeyword.Thread] = KernelTraceEventParser.Keywords.Thread;
-            kernelKeywords[TraceSessionManager.KernelKeyword.ContextSwitch] = KernelTraceEventParser.Keywords.ContextSwitch;
+            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, KernelTraceEventParser.Keywords>
+            {
+                [TraceSessionManager.KernelKeyword.Process] = KernelTraceEventParser.Keywords.Process,
+                [TraceSessionManager.KernelKeyword.Thread] = KernelTraceEventParser.Keywords.Thread,
+                [TraceSessionManager.KernelKeyword.ContextSwitch] = KernelTraceEventParser.Keywords.ContextSwitch
+            };
 
             // initialize windows clr keyword map
-            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, ClrPrivateTraceEventParser.Keywords>();
-            clrKeywords[TraceSessionManager.ClrKeyword.Startup] = ClrPrivateTraceEventParser.Keywords.Startup;
+            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, ClrPrivateTraceEventParser.Keywords>
+            {
+                [TraceSessionManager.ClrKeyword.Startup] = ClrPrivateTraceEventParser.Keywords.Startup
+            };
         }
 
         public void EnableUserProvider(string provider, TraceEventLevel verboseLevel = TraceEventLevel.Verbose)

--- a/src/tools/ScenarioMeasurement/Util/Logger.cs
+++ b/src/tools/ScenarioMeasurement/Util/Logger.cs
@@ -1,6 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace ScenarioMeasurement
 {
@@ -8,7 +10,6 @@ namespace ScenarioMeasurement
     {
         public Logger(string fileName)
         {
-
         }
         public void Log(string message)
         {

--- a/src/tools/ScenarioMeasurement/Util/Util.Windows.cs
+++ b/src/tools/ScenarioMeasurement/Util/Util.Windows.cs
@@ -1,5 +1,8 @@
-﻿using System.Runtime.InteropServices;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 
 namespace ScenarioMeasurement
 {

--- a/src/tools/ScenarioMeasurement/Util/Util.cs
+++ b/src/tools/ScenarioMeasurement/Util/Util.cs
@@ -1,9 +1,11 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System;
 
 namespace ScenarioMeasurement
 {
-
     public partial class Util
     {
 
@@ -16,13 +18,11 @@ namespace ScenarioMeasurement
 
         public static void TakeScreenshot()
         {
-
         }
 
         public static bool IsWindows()
         {
             return Environment.OSVersion.Platform == PlatformID.Win32NT;
         }
-        
     }
 }


### PR DESCRIPTION
Bump the *.csproj `TargetFramework` to `net5.0`.

Also looked for any Roslyn analyzer errors/warnings/info automatic suggestions to fix:

>IDE0044 Make field readonly.
>IDE0017 Object initialization can be simplified.
>IDE0029 Null check can be simplified.
>IDE0063 'using' statement can be simplified.
>IDE0042 Variable declaration can be deconstructed.
>IDE0028 - Collection initialization can be simplified.
>IDE0049: Name can be simplified.
>Remove and sort usings.

Also added missing license header in some files.

Not applied:
> Logger.cs, LinuxTraceSession.cs, Crossgen2Parser.cs: IDE0060 - Remove unused parameter it it is not a shipped public API.
> Unit tests: xUnit1004 - Test methods should not be skipped.

cc @adamsitnik @jeffhandley 