### PR TITLE
make sure that benchmarks with explicit InvocationCount are promoted to Tier 1 BEFORE Actual Workloads

### DIFF
--- a/src/benchmarks/micro/libraries/System.Collections/Sort.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Sort.cs
@@ -17,6 +17,7 @@ namespace System.Collections
     [GenericTypeArguments(typeof(IntClass))] // custom reference type, sort in managed code
     [GenericTypeArguments(typeof(BigStruct))] // custom value type, sort in managed code
     [InvocationCount(InvocationsPerIteration)]
+    [MinWarmupCount(6, forceAutoWarmup: true)] // when InvocationCount is set, BDN does not run Pilot Stage, so to get the code promoted to Tier 1 before Actual Workload, we enforce more Warmups
     public class Sort<T> where T : IComparable<T>
     {
         private static readonly ComparableComparerClass _comparableComparerClass = new ComparableComparerClass();

--- a/src/benchmarks/micro/runtime/Span/Sorting.cs
+++ b/src/benchmarks/micro/runtime/Span/Sorting.cs
@@ -13,6 +13,7 @@ namespace Span
 {
     [BenchmarkCategory(Categories.Runtime)]
     [InvocationCount(InvocationsPerIteration)]
+    [MinWarmupCount(6, forceAutoWarmup: true)] // when InvocationCount is set, BDN does not run Pilot Stage, so to get the code promoted to Tier 1 before Actual Workload, we enforce more Warmups
     public class Sorting
     {
         private const int InvocationsPerIteration = 1000;


### PR DESCRIPTION
when InvocationCount is set, BDN does not run Pilot Stage, so to get the code promoted to Tier 1 before Actual Workload, we enforce more Warmups

Before:

![obraz](https://user-images.githubusercontent.com/6011991/94246456-0cf87c80-ff1c-11ea-8d36-5d6caa95020c.png)

![obraz](https://user-images.githubusercontent.com/6011991/94246462-0f5ad680-ff1c-11ea-8827-7c8984bc8e7e.png)

After:

![obraz](https://user-images.githubusercontent.com/6011991/94246479-14b82100-ff1c-11ea-9063-cc9b48af8589.png)

![obraz](https://user-images.githubusercontent.com/6011991/94246489-17b31180-ff1c-11ea-9709-9a4a6c0a672f.png)

