### PR TITLE
Initial attempt at expanding Crossgen2 perf testing

### DIFF
--- a/eng/common/performance/crossgen_perf.proj
+++ b/eng/common/performance/crossgen_perf.proj
@@ -27,11 +27,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SingleAssembly Include="System.Private.Xml.dll"/>
-    <SingleAssembly Include="System.Linq.Expressions.dll"/>
-    <SingleAssembly Include="Microsoft.CodeAnalysis.VisualBasic.dll"/>
-    <SingleAssembly Include="Microsoft.CodeAnalysis.CSharp.dll"/>
-    <SingleAssembly Include="System.Private.CoreLib.dll"/>
+    <SingleAssembly Include="System.Net.WebProxy.dll"/>                 <!-- Approx. 10 KB -->
+    <SingleAssembly Include="System.Net.Http.Json.dll"/>                <!-- Approx. 20 KB -->
+    <SingleAssembly Include="System.Drawing.Primitives.dll"/>           <!-- Approx. 50 KB -->
+    <SingleAssembly Include="System.ServiceModel.Syndication.dll"/>     <!-- Approx. 100 KB -->
+    <SingleAssembly Include="System.Net.Sockets.dll"/>                  <!-- Approx. 200 KB -->
+    <SingleAssembly Include="System.Linq.Expressions.dll"/>             <!-- Approx. 500 KB -->
+    <SingleAssembly Include="System.Data.Common.dll"/>                  <!-- Approx. 1 MB -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.dll"/>              <!-- Approx. 2 MB -->
+    <SingleAssembly Include="System.Private.Xml.dll"/>                  <!-- Approx. 3 MB -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.VisualBasic.dll"/>  <!-- Approx. 4 MB -->
+    <SingleAssembly Include="Microsoft.CodeAnalysis.CSharp.dll"/>       <!-- Approx. 4 MB -->
+    <SingleAssembly Include="System.Private.CoreLib.dll"/>              <!-- Approx. 10 MB -->
   </ItemGroup>
   <ItemGroup>
     <Composite Include="framework-r2r.dll.rsp"/>
@@ -51,6 +58,13 @@
     </Crossgen2WorkItem>
   </ItemGroup>
 
+  <ItemGroup> 
+    <Crossgen2SingleThreadedWorkItem Include="@(SingleAssembly)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --single %(Identity) --singlethreaded True</Command>
+    </Crossgen2SingleThreadedWorkItem>
+  </ItemGroup>
+
   <ItemGroup>
     <!-- Enable crossgen tests on Windows x64 and Windows x86 -->
     <HelixWorkItem Include="@(CrossgenWorkItem -> 'Crossgen %(Identity)')" Condition="'$(AGENT_OS)' == 'Windows_NT'">
@@ -58,6 +72,9 @@
     </HelixWorkItem>
     <!-- Enable crossgen2 tests on Windows x64 and Linux x64 -->
     <HelixWorkItem Include="@(Crossgen2WorkItem -> 'Crossgen2 %(Identity)')" Condition="'$(Architecture)' == 'x64'">
+      <Timeout>4:00</Timeout>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(Crossgen2SingleThreadedWorkItem -> 'Crossgen2 single-threaded %(Identity)')" Condition="'$(Architecture)' == 'x64'">
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
     <HelixWorkItem Include="Crossgen2 Composite Framework R2R" Condition="'$(Architecture)' == 'x64'">

--- a/eng/common/performance/crossgen_perf.proj
+++ b/eng/common/performance/crossgen_perf.proj
@@ -27,18 +27,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SingleAssembly Include="System.Net.WebProxy.dll"/>                 <!-- Approx. 10 KB -->
-    <SingleAssembly Include="System.Net.Http.Json.dll"/>                <!-- Approx. 20 KB -->
-    <SingleAssembly Include="System.Drawing.Primitives.dll"/>           <!-- Approx. 50 KB -->
-    <SingleAssembly Include="System.ServiceModel.Syndication.dll"/>     <!-- Approx. 100 KB -->
-    <SingleAssembly Include="System.Net.Sockets.dll"/>                  <!-- Approx. 200 KB -->
-    <SingleAssembly Include="System.Linq.Expressions.dll"/>             <!-- Approx. 500 KB -->
-    <SingleAssembly Include="System.Data.Common.dll"/>                  <!-- Approx. 1 MB -->
-    <SingleAssembly Include="Microsoft.CodeAnalysis.dll"/>              <!-- Approx. 2 MB -->
-    <SingleAssembly Include="System.Private.Xml.dll"/>                  <!-- Approx. 3 MB -->
-    <SingleAssembly Include="Microsoft.CodeAnalysis.VisualBasic.dll"/>  <!-- Approx. 4 MB -->
-    <SingleAssembly Include="Microsoft.CodeAnalysis.CSharp.dll"/>       <!-- Approx. 4 MB -->
-    <SingleAssembly Include="System.Private.CoreLib.dll"/>              <!-- Approx. 10 MB -->
+    <SingleAssembly Include="System.Private.Xml.dll"/>
+    <SingleAssembly Include="System.Linq.Expressions.dll"/>
+    <SingleAssembly Include="Microsoft.CodeAnalysis.VisualBasic.dll"/>
+    <SingleAssembly Include="Microsoft.CodeAnalysis.CSharp.dll"/>
+    <SingleAssembly Include="System.Private.CoreLib.dll"/>
   </ItemGroup>
   <ItemGroup>
     <Composite Include="framework-r2r.dll.rsp"/>
@@ -58,13 +51,6 @@
     </Crossgen2WorkItem>
   </ItemGroup>
 
-  <ItemGroup> 
-    <Crossgen2SingleThreadedWorkItem Include="@(SingleAssembly)">
-      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --single %(Identity) --singlethreaded True</Command>
-    </Crossgen2SingleThreadedWorkItem>
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Enable crossgen tests on Windows x64 and Windows x86 -->
     <HelixWorkItem Include="@(CrossgenWorkItem -> 'Crossgen %(Identity)')" Condition="'$(AGENT_OS)' == 'Windows_NT'">
@@ -72,9 +58,6 @@
     </HelixWorkItem>
     <!-- Enable crossgen2 tests on Windows x64 and Linux x64 -->
     <HelixWorkItem Include="@(Crossgen2WorkItem -> 'Crossgen2 %(Identity)')" Condition="'$(Architecture)' == 'x64'">
-      <Timeout>4:00</Timeout>
-    </HelixWorkItem>
-    <HelixWorkItem Include="@(Crossgen2SingleThreadedWorkItem -> 'Crossgen2 single-threaded %(Identity)')" Condition="'$(Architecture)' == 'x64'">
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
     <HelixWorkItem Include="Crossgen2 Composite Framework R2R" Condition="'$(Architecture)' == 'x64'">

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -117,7 +117,16 @@ ex: System.Private.Xml.dll
 r'''
 path to an rsp file that represents a collection of assemblies
 ex: C:\repos\performance\src\scenarios\crossgen2\framework-r2r.dll.rsp
-'''                                  )
+'''
+                                     )
+        crossgen2parser.add_argument('--singlethreaded', 
+                                     dest='singlethreaded', 
+                                     required=False,
+                                     help=
+r'''
+Suppress internal Crossgen2 parallelism
+'''
+                                     )
         self.add_common_arguments(crossgen2parser)
 
         sodparser = subparsers.add_parser(const.SOD,
@@ -151,6 +160,7 @@ ex: C:\repos\performance;C:\repos\runtime
             self.coreroot = args.coreroot
             self.singlefile = args.single
             self.compositefile = args.composite
+            self.singlethreaded = args.singlethreaded
 
         if self.testtype == const.SOD:
             self.dirs = args.dirs
@@ -290,6 +300,9 @@ ex: C:\repos\performance;C:\repos\runtime
                 crossgen2args = '--composite -o %s -O @%s' % (outputfile, self.compositefile)
                 self.traits.add_traits( overwrite=True,
                                         skipprofile='true')
+
+            if self.singlethreaded:
+                crossgen2args = '%s --parallelism 1' % (crossgen2args)
 
             self.traits.add_traits(overwrite=True,
                                    startupmetric=const.STARTUP_CROSSGEN2,


### PR DESCRIPTION
Based on offline Bill's advice I'm trying to expand on two aspects
of Crossgen2 testing:

1) I have expanded the list of test assemblies to 12 by hand-picking
assemblies covering a broad range of sizes (10K, 20K, 50K, 100K, 200K,
500K, 1M, 2M, 3M, 4M*2, 10M).

2) I have added a new runner argument for crossgen2 "--singlethreaded"
that activates the "--parallelism 1" option for crossgen2.

In my local testing I see the "--singlethreaded" flag propagated
to the Crossgen2 command-line. I'm definitely no Python expert so
please let me know if my change can be done in a more elegant manner.

Thanks

Tomas