### PR TITLE
Fix broken links in performance docs

### DIFF
--- a/docs/basic-scenarios.md
+++ b/docs/basic-scenarios.md
@@ -12,7 +12,7 @@ Size On Disk, as the name suggests, is a metric that recursively measures the si
 
 We will walk through **Self-Contained Empty Console App Size On Disk** scenario as an example.
 ### Step 1 Initialize Environment
-Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow#step-1-initialize-environment).
+Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow.md#step-1-initialize-environment).
 ### Step 2 Run Precommand
 For **Self-Contained Empty Console App Size On Disk** scenario, run precommand to create an empty console template and publish it: 
 ```
@@ -51,7 +51,7 @@ python3 test.py sod
 [2020/09/29 04:21:36][INFO] pub\api-ms-win-core-file-l2-1-0.dll                       |18696.000 bytes    |18696.000 bytes    |18696.000 bytes34
 ```
 ### Step 4 Run Postcommand
-Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow#step-4-run-postcommand).
+Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
 ## Command Matrix
 - \<tfm> values:
     - netcoreapp2.1

--- a/docs/crossgen-scenarios.md
+++ b/docs/crossgen-scenarios.md
@@ -32,7 +32,7 @@ If the build's successful, you should have Core_Root with the path like:
 ```
 
 ### Step 1 Initialize Environment
-Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow#step-1-initialize-environment).
+Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow.md#step-1-initialize-environment).
 ### Step 2 Run Precommand
 For **Crossgen Throughput** scenario, unlike other scenarios there's no need to run any precommand (`pre.py`). Just switch to the test asset directory:
 ```

--- a/docs/crossgen-scenarios.md
+++ b/docs/crossgen-scenarios.md
@@ -57,7 +57,7 @@ This will run the test harness [Startup Tool](https://github.com/dotnet/performa
 
 
 ### Step 4 Run Postcommand
-Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow#step-4-run-postcommand).
+Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
  
 ## Crossgen2 Throughput Scenario
 Compared to `Crossgen Throughput` scenario, `Crossgen2 Throughput` Scenario measures more metrics, which are:
@@ -107,7 +107,7 @@ The test command runs the test harness [Startup Tool](https://github.com/dotnet/
 [2020/09/25 10:25:15][INFO] Compilation Interval |12827.350 ms   |12827.350 ms   |12827.350 ms
  ```
  ### Step 4 Run Postcommand
-Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow#step-4-run-postcommand).
+Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
 
 ## Command Matrix
 For the purpose of quick reference, the commands can be summarized into the following matrix:

--- a/docs/sdk-scenarios.md
+++ b/docs/sdk-scenarios.md
@@ -22,7 +22,7 @@ There are 2 types of SDK build --- *Clean Build* and *Build No Change*.
   
 We will walk through **SDK Console Template** as an example.
 ### Step 1 Initialize Environment
-Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow#step-1-initialize-environment).
+Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow.md#step-1-initialize-environment).
 ### Step 2 Run Precommand
 If you are running the test NOT for the first time and `app\` folder exists under the asset directory, make sure it's removed so the previous test artifact won't be used. You can use `post.py` to clean it up:
 ```


### PR DESCRIPTION
Add `.md` to a few places where it was omitted so links are navigable.
