### PR TITLE
Fix release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,7 +163,7 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        #- LTS # use LTS channel for net461 framework
+        - LTS # use LTS channel for net461 framework
 
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,15 +9,10 @@ trigger:
     include:
     - master
   paths:
+    include:
+    - eng/Version.Details.xml
     exclude: # don't trigger the CI if only a doc file was changed
-    - docs/*
-    - eng/common/README.md
-    - src/benchmarks/micro/Serializers/README.md
-    - src/benchmarks/micro/README.md
-    - src/benchmarks/real-world/JitBench/README.md
-    - src/benchmarks/real-world/Microsoft.ML.Benchmarks/Input/README.md
-    - src/tools/ResultsComparer/README.md
-    - README.md
+    - *
 
 # Trigger builds for PR's targeting master
 pr:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ pr:
     - README.md
 
 schedules:
-- cron: "0 */4 * * *"
-  displayName: Every 4 hour build
+- cron: "0 */12 * * *"
+  displayName: Every 12 hours build
   branches:
     include:
     - master
@@ -155,8 +155,8 @@ jobs:
       channels:
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
-        - 2.1
+        #- release/3.1.3xx
+        #- 2.1
 
   # Windows x64 net461 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -170,7 +170,7 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        - LTS # use LTS channel for net461 framework
+        #- LTS # use LTS channel for net461 framework
 
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -201,7 +201,7 @@ jobs:
       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
+        #- release/3.1.3xx
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -217,7 +217,7 @@ jobs:
       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
+        #- release/3.1.3xx
         
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -234,8 +234,8 @@ jobs:
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
-        - 2.1
+        #- release/3.1.3xx
+        #- 2.1
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -252,7 +252,7 @@ jobs:
       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
+        #- release/3.1.3xx
 
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -269,7 +269,7 @@ jobs:
       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
         - master
         - release/5.0.1xx
-        - release/3.1.3xx
+        #- release/3.1.3xx
 
 ###########################################
 # Private Jobs
@@ -304,7 +304,7 @@ jobs:
       container: ubuntu_x64_build_container
       projectFile: scenarios.proj
       channels:
-        - master
+        #- master
         - release/5.0.1xx
 
   # Windows x64 micro benchmarks
@@ -319,9 +319,9 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -335,9 +335,9 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -351,9 +351,9 @@ jobs:
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -367,9 +367,9 @@ jobs:
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
 
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -384,9 +384,9 @@ jobs:
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -401,9 +401,9 @@ jobs:
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
   
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -418,9 +418,9 @@ jobs:
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        - master
+        #- master
         - release/5.0.1xx
-        - release/3.1.2xx
+        #- release/3.1.2xx
 
 ################################################
 # Scheduled Private jobs
@@ -441,7 +441,7 @@ jobs:
       projectFile: sdk_scenarios.proj
       channels:
         - master
-        - release/5.0.1xx
+        #- release/5.0.1xx
   
   # Windows x86 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -455,7 +455,7 @@ jobs:
       projectFile: sdk_scenarios.proj
       channels:
         - master
-        - release/5.0.1xx
+        #- release/5.0.1xx
 
   # Ubuntu 1804 x64 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -470,7 +470,7 @@ jobs:
       projectFile: sdk_scenarios.proj
       channels:
         - master
-        - release/5.0.1xx
+        #- release/5.0.1xx
         # - release/3.1.2xx
 
   # Windows x64 Blazor 3.2 scenario benchmarks
@@ -485,7 +485,7 @@ jobs:
       projectFile: blazor_scenarios.proj
       channels:
         - master
-        - release/5.0.1xx
+        #- release/5.0.1xx
   
   # Ubuntu 1804 ARM64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,6 @@ trigger:
   paths:
     include:
     - eng/Version.Details.xml
-    exclude: # don't trigger the CI if only a doc file was changed
-    - *
 
 # Trigger builds for PR's targeting master
 pr:

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -99,9 +99,7 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/parse_props.py --branch-name $(_Channel)
-          displayName: Parse Version.props
-        - script: $(Python) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
+        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -79,9 +79,7 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/parse_props.py --branch-name $(_Channel)
-          displayName: Parse Version.props
-        - script: $(Python) scripts/ci_setup.py $(DotnetVersion) --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
+        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e


### PR DESCRIPTION
In order to run the 5.0.1xx branch of installer we need to have darc update
    our Nuget.config to contain the paths to the binaries that match the version.
    As part of this we can no longer have a dependency on the master branch of
    installer. So this change moves all of the master runs over to a scheduled
    kickoff and leaves the CI runs to only by the release branches.