### PR TITLE
Crossgen/Crossgen2 size-on-disk tests

### DIFF
--- a/docs/crossgen-scenarios.md
+++ b/docs/crossgen-scenarios.md
@@ -2,27 +2,19 @@
 # Crossgen Scenarios
 An introduction of how to run scenario tests can be found in [Scenarios Tests Guide](./scenarios-workflow.md). The current document has specific instruction to run:
 
-- [Crossgen Throughput Scenario](#crossgen-throughput)
-- [Crossgen2 Throughput Scenario](#crossgen2-throughput)
+- [Crossgen Throughput Scenario](#crossgen-throughput-scenario)
+- [Crossgen2 Throughput Scenario](#crossgen2-throughput-scenario)
+- [Size on Disk Scenario](#Size-on-Disk-Scenario)
 
-
-## Crossgen Throughput Scenario
-**Crossgen Throughput** is a scenario test that measures the throughput of [crossgen compilation](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/crossgen.md). To be more specific, our test *implicitly* calls
-```
-.\crossgen.exe <assembly to compile>
-``` 
-with other applicable arguments and measures its throughput.
-
-We will walk through crossgen compiling `System.Private.Xml.dll` as an example.
-
+## Before Running Any Scenario
 ### Prerequisites
 - python3 or newer
 - dotnet runtime 3.0 or newer
 - terminal/command prompt **in Admin Mode** (for collecting kernel traces)
 - clean state of the test machine (anti-virus scan is off and no other user program's running -- to minimize the influence of environment on the test)
 
-### Step 0 Generate Core Root
-To run the test, we need to generate [Core_Root](https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/using-corerun.md) for the crossgen tool itself and other runtime assmblies as compilation input. Core_Root is an intermediate output from the runtime build, which contains runtime assemblies and tools.
+### 1. Generate Core_Root
+These performance tests use the built runtime test directory [Core_Root](https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/using-corerun.md) for the crossgen tool itself and other runtime assmblies as compilation input. Core_Root is an intermediate output from the runtime build, which contains runtime assemblies and tools.
 
 You can skip this step if you already have Core_Root. To generate Core_Root directory, first clone [dotnet/runtime repo](https://github.com/dotnet/runtime) and follow [the instruction of building coreclr tests](https://github.com/dotnet/runtime/blob/master/docs/workflow/testing/coreclr/windows-test-instructions.md), which creates Core_Root directory.
 
@@ -30,19 +22,27 @@ If the build's successful, you should have Core_Root with the path like:
 ```
  runtime\artifacts\tests\coreclr\<OS>.<Arch>.<BuildType>\Tests\Core_Root
 ```
-
-### Step 1 Initialize Environment
+### 2. Initialize Environment
 Same instruction of [Scenario Tests Guide - Step 1](./scenarios-workflow.md#step-1-initialize-environment).
-### Step 2 Run Precommand
+
+## Crossgen Throughput Scenario
+**Crossgen Throughput** is a scenario test that measures the throughput of [crossgen compilation](https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/crossgen.md). To be more specific, our test *implicitly* calls
+```
+.\crossgen.exe <assembly to compile>
+``` 
+with other applicable arguments and measures its throughput. We will walk through crossgen compiling `System.Private.Xml.dll` as an example.
+
+Ensure you've first followed the [preparatory steps](#Before-Running-Any-Scenario).
+### 1. Run Precommand
 For **Crossgen Throughput** scenario, unlike other scenarios there's no need to run any precommand (`pre.py`). Just switch to the test asset directory:
 ```
 cd crossgen
 ```
-### Step 3 Run Test
+### 2. Run Test
 Now run the test, in our example we use `System.Private.Xml.dll` under Core_Root as the input assembly to compile, and you can replace it with other assemblies **under Core_Root**.
 
 ```
-python3 test.py crossgen --core-root <path to core_root>\Core_Root --test-name System.Private.Xml.dll
+python3 test.py crossgen --core-root <path to core_root>\Core_Root --single System.Private.Xml.dll
 ```
 This will run the test harness [Startup Tool](https://github.com/dotnet/performance/tree/master/src/tools/ScenarioMeasurement/Startup), which runs crossgen compilation in several iterations and measures its throughput. The result will be something like this:
 
@@ -56,8 +56,8 @@ This will run the test harness [Startup Tool](https://github.com/dotnet/performa
 ```
 
 
-### Step 4 Run Postcommand
-Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
+### 3. Run Postcommand
+Same instructions as [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
  
 ## Crossgen2 Throughput Scenario
 Compared to `Crossgen Throughput` scenario, `Crossgen2 Throughput` Scenario measures more metrics, which are:
@@ -67,20 +67,15 @@ Compared to `Crossgen Throughput` scenario, `Crossgen2 Throughput` Scenario meas
 - Jit Interval
 - Compilation Interval
   
-Steps to run **Crossgen2 Throughput** scenario are very similar to those of **Crossgen Throughput**. Inn addition to compilation of a single file, composite compilation is enabled in crossgen2, so the test command is different.
+Steps to run **Crossgen2 Throughput** scenario are very similar to those of **Crossgen Throughput**. In addition to compilation of a single file, composite compilation is enabled in crossgen2, so the test command is different.
 
-### Prerequisites
-Same as [Crossgen Throughput Prerequisites](#prerequisites)
-### Step 0 Generate Core_Root
-Same as [Crossgen Throughput Step 0](#step-0-generate-core-root)
-### Step 1 Initialize Environment
-Same as [Crossgen Throughput Step 1](#step-1-initialize-environment)
-### Step 2 Run Precommand
+Ensure you've first followed the [preparatory steps](#Before-Running-Any-Scenario).
+### 1. Run Precommand
 Same as **Crossgen Throughput** scenario, there's no need to run any precommand (`pre.py`). Just switch to the test asset directory:
 ```
 cd crossgen2
 ```
-### Step 3 Run Test
+### 2. Run Test
 For scenario which compiles a **single assembly**, we use `System.Private.Xml.dll` as an example, you can replace it with other assembly **under Core_Root**:
 ```
 python3 test.py crossgen2 --core-root <path to core_root>\Core_Root --single System.Private.Xml.dll
@@ -106,16 +101,56 @@ The test command runs the test harness [Startup Tool](https://github.com/dotnet/
 [2020/09/25 10:25:15][INFO] Jit Interval         |9464.402 ms    |9464.402 ms    |9464.402 ms
 [2020/09/25 10:25:15][INFO] Compilation Interval |12827.350 ms   |12827.350 ms   |12827.350 ms
  ```
- ### Step 4 Run Postcommand
-Same instruction of [Scenario Tests Guide - Step 4](./scenarios-workflow.md#step-4-run-postcommand).
+### 3. Run Postcommand
+```
+python3 post.py
+```
+
+## Size on Disk Scenario
+The size on disk scenario for crossgen/crossgen2 measures the sizes of generated ready-to-run images. These tests use the precommand to generate a ready-to-run image, then run the size-on-disk tool on the containing directory.
+
+Ensure you've first followed the [preparatory steps](#Before-Running-Any-Scenario).
+### 1. Run Precommand
+```
+cd crossgen|crossgen2
+python3 pre.py crossgen|crossgen2 --core-root <path to core_root> --single System.Private.Xml.dll
+```
+`--single` takes any framework assembly available in core_root.
+
+### 2. Run Test
+For scenario which compiles a **single assembly**, we use `System.Private.Xml.dll` as an example, you can replace it with other assembly **under Core_Root**:
+```
+python3 test.py sod --dirs ./crossgen.out
+```
+
+The size-on-disk tool outputs an accounting of the file sizes under the crossgen output directory:
+```
+[2020/10/26 19:00:06][INFO] Crossgen2 Size On Disk
+[2020/10/26 19:00:06][INFO] Metric                                   |Average           |Min               |Max
+[2020/10/26 19:00:06][INFO] -----------------------------------------|------------------|------------------|------------------
+[2020/10/26 19:00:06][INFO] Crossgen2 Size On Disk                   |8412672.000 bytes |8412672.000 bytes |8412672.000 bytes
+[2020/10/26 19:00:06][INFO] Crossgen2 Size On Disk - Count           |1.000 count       |1.000 count       |1.000 count
+[2020/10/26 19:00:06][INFO] .\crossgen\                              |8412672.000 bytes |8412672.000 bytes |8412672.000 bytes
+[2020/10/26 19:00:06][INFO] .\crossgen\ - Count                      |1.000 count       |1.000 count       |1.000 count
+[2020/10/26 19:00:06][INFO] .\crossgen\System.Private.Xml.ni.dll     |8412672.000 bytes |8412672.000 bytes |8412672.000 bytes
+[2020/10/26 19:00:06][INFO] Aggregate - .dll                         |8412672.000 bytes |8412672.000 bytes |8412672.000 bytes
+[2020/10/26 19:00:06][INFO] Aggregate - .dll - Count                 |1.000 count       |1.000 count       |1.000 count
+```
+### 3. Run Postcommand
+```
+python3 post.py
+```
+
 
 ## Command Matrix
 For the purpose of quick reference, the commands can be summarized into the following matrix:
-| Scenario                               | Asset Directory | Precommand | Testcommand                                                                      | Postcommand | Supported Framework | Supported Platform      |
-|----------------------------------------|-----------------|------------|----------------------------------------------------------------------------------|-------------|---------------------|-------------------------|
-| Crossgen Throughput                    | crossgen        | N/A        | test.py crossgen --core-root <path to Core_Root> --test-name <assembly name> | post.py     | N/A                 | Windows-x64;Windows-x86 |
-| Crossgen2 Throughput (single assembly) | crossgen2       | N/A        | test.py crossgen2 --core-root <path to Core_Root> --single <assembly name>       | post.py     | N/A                 | Windows-x64;Linux       |
-| Crossgen2 Throughput (composite)       | crossgen2       | N/A        | test.py crossgen2 --core-root <path to Core_Root> --composite <path to .rsp>     | post.py     | N/A                 | Windows-x64;Linux       |
+| Scenario                               | Asset Directory | Precommand                                                                     | Testcommand                                                                       | Postcommand | Supported Framework | Supported Platform      |
+|----------------------------------------|-----------------|--------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|-------------|---------------------|-------------------------|
+| Crossgen Throughput                    | crossgen        | N/A                                                                            | test.py crossgen --core-root \<path to Core_Root> --single \<assembly name>       | post.py     | N/A                 | Windows-x64;Windows-x86 |
+| Crossgen2 Throughput (single assembly) | crossgen2       | N/A                                                                            | test.py crossgen2 --core-root \<path to Core_Root> --single \<assembly name>      | post.py     | N/A                 | Windows-x64;Linux       |
+| Crossgen2 Throughput (composite)       | crossgen2       | N/A                                                                            | test.py crossgen2 --core-root \<path to Core_Root> --composite \<path to .rsp>    | post.py     | N/A                 | Windows-x64;Linux       |
+| Crossgen Size on Disk                  | crossgen        | pre.py crossgen --core-root \<path to Core_Root> --single \<assembly name>     | test.py sod --dirs crossgen.out                                                   | post.py     | N/A                 | Windows-x64;Linux       |
+| Crossgen2 Size on Disk                 | crossgen2       | pre.py crossgen2 --core-root \<path to Core_Root> --single \<assembly name>    | test.py sod --dirs crossgen.out                                                   | post.py     | N/A                 | Windows-x64;Linux       |
 
 ## Relevant Links
 [Crossgen2 Compilation Structure Enhancements](https://github.com/dotnet/runtime/blob/master/docs/design/features/crossgen2-compilation-structure-enhancements.md)

--- a/src/scenarios/crossgen/post.py
+++ b/src/scenarios/crossgen/post.py
@@ -1,0 +1,7 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+
+clean_directories()

--- a/src/scenarios/crossgen/pre.py
+++ b/src/scenarios/crossgen/pre.py
@@ -1,0 +1,12 @@
+'''
+pre-command
+'''
+import sys
+from performance.logger import setup_loggers
+from shared import const
+from shared.precommands import PreCommands
+from test import EXENAME
+
+setup_loggers(True)
+precommands = PreCommands()
+precommands.execute()

--- a/src/scenarios/crossgen2/post.py
+++ b/src/scenarios/crossgen2/post.py
@@ -1,0 +1,7 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+
+clean_directories()

--- a/src/scenarios/crossgen2/pre.py
+++ b/src/scenarios/crossgen2/pre.py
@@ -1,0 +1,12 @@
+'''
+pre-command
+'''
+import sys
+from performance.logger import setup_loggers
+from shared import const
+from shared.precommands import PreCommands
+from test import EXENAME
+
+setup_loggers(True)
+precommands = PreCommands()
+precommands.execute()

--- a/src/scenarios/shared/const.py
+++ b/src/scenarios/shared/const.py
@@ -24,6 +24,7 @@ TRACEDIR = 'traces'
 SRCDIR = 'src' # used for checked in source.
 TMPDIR = 'tmp'
 ARTIFACTDIR = 'artifacts'
+CROSSGENDIR = 'crossgen.out'
 
 CLEAN_BUILD = 'clean_build'
 BUILD_NO_CHANGE = 'build_no_change'

--- a/src/scenarios/shared/crossgen.py
+++ b/src/scenarios/shared/crossgen.py
@@ -1,0 +1,199 @@
+'''
+Module for running Crossgen
+'''
+
+import sys
+import os
+
+from logging import getLogger
+from argparse import ArgumentParser
+from shared import const
+
+class CrossgenArguments:
+    '''
+    Common helper for parsing crossgen args
+    This is intended for runtime tests where we must execute crossgen directly.
+    AOT code for SDK and higher level tests is generated during publish.
+    '''
+
+    def __init__(self):
+        self.coreroot = None
+        self.singlefile = None
+        self.compositefile = None
+        self.singlethreaded = None
+
+    def add_crossgen_arguments(self, parser: ArgumentParser):
+        "Arguments to generate AOT code with Crossgen"
+
+        parser.add_argument('--test-name', 
+                                    dest='single', 
+                                    type=str, 
+                                    required=False,
+                                    help=
+'''
+[Deprecated - use --single] input assembly under Core_Root to compile
+ex: System.Private.Xml.dll
+'''
+                                    )
+        parser.add_argument('--single', 
+                                    dest='single', 
+                                    type=str, 
+                                    required=False,
+                                    help=
+'''
+input assembly under Core_Root to compile
+ex: System.Private.Xml.dll
+'''
+                                    )
+
+        parser.add_argument('--core-root', 
+                                    dest='coreroot', 
+                                    type=str, 
+                                    required=True,
+                                    help=
+r'''
+path of Core_Root generated from runtime build
+ex: C:\repos\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root
+'''                                 )
+
+    def add_crossgen2_arguments(self, parser: ArgumentParser):
+        "Arguments to generate AOT code with Crossgen2"
+        
+        parser.add_argument('--core-root', 
+                            dest='coreroot', 
+                            type=str, 
+                            required=True,
+                            help=
+r'''
+path of Core_Root generated from runtime build
+ex: C:\repos\runtime\artifacts\tests\coreclr\Windows_NT.x64.Release\Tests\Core_Root
+'''
+                            )
+        parser.add_argument('--single', 
+                            dest='single', 
+                            type=str, 
+                            required=False,
+                            help=
+r'''
+a single input assembly under Core_Root to compile
+ex: System.Private.Xml.dll
+'''                                  
+                            )
+        parser.add_argument('--composite', 
+                            dest='composite', 
+                            type=str, 
+                            required=False,
+                            help=
+r'''
+path to an rsp file that represents a collection of assemblies
+ex: C:\repos\performance\src\scenarios\crossgen2\framework-r2r.dll.rsp
+'''
+                            )
+        parser.add_argument('--singlethreaded', 
+                            dest='singlethreaded', 
+                            required=False,
+                            help=
+r'''
+Suppress internal Crossgen2 parallelism
+'''
+                            )
+
+    def parse_crossgen_args(self, args):
+        self.singlefile = args.single
+        self.coreroot = args.coreroot
+
+        if self.coreroot is not None and not os.path.isdir(self.coreroot):
+            getLogger().error('Cannot find CORE_ROOT at %s', self.coreroot)
+            sys.exit(1)
+        if self.singlefile is None:
+            getLogger().error('Specify an assembly to crossgen with --single <assembly name>')
+            sys.exit(1)
+    
+    def parse_crossgen2_args(self, args):
+        self.coreroot = args.coreroot
+        self.singlefile = args.single
+        self.compositefile = args.composite
+        self.singlethreaded = args.singlethreaded
+
+        if self.coreroot is not None and not os.path.isdir(self.coreroot):
+            getLogger().error('Cannot find CORE_ROOT at %s', self.coreroot)
+            sys.exit(1)
+        if bool(self.singlefile) == bool(self.compositefile):
+            getLogger().error("Please specify either --single <single assembly name> or --composite <absolute path of rsp file>")
+            sys.exit(1)
+
+    def get_crossgen_command_line(self):
+        "Returns the computed crossgen command line arguments"
+        filename, ext = os.path.splitext(self.singlefile)
+        outputdir = os.path.join(os.getcwd(), const.CROSSGENDIR)
+        if not os.path.exists(outputdir):
+            os.mkdir(outputdir)
+        outputfile = os.path.join(outputdir, filename+'.ni'+ext )
+
+        crossgenargs = [
+            '/nologo',
+            '/out', outputfile,
+            '/p', self.coreroot,
+            os.path.join(self.coreroot, self.singlefile) 
+        ]
+        
+        return crossgenargs
+        
+    def get_crossgen2_command_line(self):
+        "Returns the computed crossgen2 command line arguments"
+        compiletype = self.crossgen2_compiletype()
+
+        if compiletype == const.CROSSGEN2_SINGLEFILE:
+            referencefilenames = ['System.*.dll', 'Microsoft.*.dll', 'netstandard.dll', 'mscorlib.dll']
+            # single assembly filename: example.dll
+            filename, ext = os.path.splitext(self.singlefile)
+            outputdir = os.path.join(os.getcwd(), const.CROSSGENDIR)
+            if not os.path.exists(outputdir):
+                os.mkdir(outputdir)
+            outputfile = os.path.join(outputdir, filename+'.ni'+ext )
+            
+            crossgen2args = [
+                os.path.join(self.coreroot, self.singlefile),
+                '-o', outputfile,
+                '-O'
+            ]
+
+            for reffile in referencefilenames:
+                crossgen2args.extend(['-r', os.path.join(self.coreroot, reffile)])
+            
+            return crossgen2args
+        
+        elif compiletype == const.CROSSGEN2_COMPOSITE:
+            # composite rsp filename: ..\example.dll.rsp
+            dllname, _ = os.path.splitext(os.path.basename(self.compositefile))
+            filename, ext = os.path.splitext(dllname)
+            outputdir = os.path.join(os.getcwd(), const.CROSSGENDIR)
+            if not os.path.exists(outputdir):
+                os.mkdir(outputdir)
+            outputfile = os.path.join(outputdir, filename+'.ni'+ext )
+
+            crossgen2args = [
+                '--composite',
+                '-o', outputfile,
+                '-O',
+                '@%s' % (self.compositefile)
+            ]
+            
+        if self.singlethreaded:
+            crossgen2args += ['--parallelism', '1']
+
+        return crossgen2args
+
+    def crossgen2_compiletype(self):
+        return const.CROSSGEN2_COMPOSITE if self.compositefile else const.CROSSGEN2_SINGLEFILE
+
+    def crossgen2_scenario_filename(self):
+        "Returns the name of the assembly being compiled or composite image generated, without file extension"
+        compiletype = self.crossgen2_compiletype()
+
+        if compiletype == const.CROSSGEN2_SINGLEFILE:
+            filename, _ = os.path.splitext(self.singlefile)
+        elif compiletype == const.CROSSGEN2_COMPOSITE:
+            dllname, _ = os.path.splitext(os.path.basename(self.compositefile))
+            filename, _ = os.path.splitext(dllname)
+        return filename

--- a/src/scenarios/shared/crossgen.py
+++ b/src/scenarios/shared/crossgen.py
@@ -1,5 +1,5 @@
 '''
-Module for running Crossgen
+Module for parsing Crossgen args
 '''
 
 import sys

--- a/src/scenarios/shared/postcommands.py
+++ b/src/scenarios/shared/postcommands.py
@@ -1,8 +1,8 @@
-from shared.const import APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR
+from shared.const import APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR
 from performance.common import remove_directory
 
 def clean_directories():
-    to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR)
+    to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR)
     print(f"Removing {','.join(to_remove)} if exist ...")
     for dir in to_remove:
         remove_directory(dir)


### PR DESCRIPTION
* Add support for size-on-disk assembly testing for crossgen/crossgen2
* This works by running crossgen in the precommand phase to generate a ready-to-run image for the assembly in the given test scenario. The test phase runs the size-on-disk tool to collect size information for the ready-to-run binary.
* Allow crossgen / crossgen2 execution to be hooked into pre.py scripts by factoring out the command line argument handling. crossgen.py can be used as a subparser during argument parsing (via `add_crossgen[2]_arguments`), when populating the evaluated args (`parse_crossgen[2]_args`), and finally returning the crossgen command line arguments to execute the scenario (via `get_crossgen[2]_command_line`).
* Align the crossgen and crossgen2 arguments. We were using `--test-name` and `--single` to represent assembly name. For now, accept both for crossgen until we stop using `--test-name` in Arcade. Later we can remove the deprecated option.
* Always emit crossgen images to `crossgen.out` and clean that up in `post.py`. We can add hierarchy there if we need, but we were starting to pollute the directory structure that the post.py commands take care to clean.
* Add documentation for the new scenario along with example pre, test, post commands