### PR TITLE
Update Core_Root building docs with the new changes in the runtime repo

### DIFF
--- a/src/benchmarks/gc/docs/building_coreroot.md
+++ b/src/benchmarks/gc/docs/building_coreroot.md
@@ -12,47 +12,46 @@ This means the targeted OS and Architecture will be deduced by the runtime from 
 
 If you want to build for another OS/Architecture, use the `-os/--os` and `-arch/--arch` flags when calling the first two build scripts. For the third one (Core_Root), prepend your target architecture with a `-`(e.g. `-x64`) and the OS with the `-os`(e.g. `-os Linux`) flag on both, Windows and Linux.
 
-### Build CoreCLR
+### Build CoreCLR and Libraries
 
 From the root of the `runtime` repo, issue the following command:
 
 On Windows
+```powershell
+.\build.cmd -s clr+libs -lc Release -rc Release
+```
+
+On Linux
 ```sh
+./build.sh -s clr+libs -lc Release -rc Release
+```
+
+Breaking down this command into parts to explain their meaning:
+
+* **-s clr+libs**: This tells the script to build the CoreCLR and Libraries subsets.
+* **-lc Release**: Build the libraries under Release configuration.
+* **-rc Release**: Build the runtime under Release configuration.
+
+If for some reason you can't build them together, already have one built, etc,
+you can also ask the script to build them separately. For example, for just the runtime:
+
+```powershell
 .\build.cmd -s clr -c Release
-```
-
-On Linux
-```sh
-./build.sh -s clr -c Release
-```
-
-### Build the Libraries
-
-Once CoreCLR has been built, you need to build the libraries, which are required to later generate the `Core_Root`.
-
-On Windows
-```sh
-.\build.cmd -s libs -c Release
-```
-
-On Linux
-```sh
-./build.sh -s libs -c Release
 ```
 
 ### Build the Core_Root
 
 At this point, the stage has been set to generate the `Core_Root`.
-This time, move to the CoreCLR directory: `/runtime/src/coreclr/`. There, issue the following command:
+This time, move to the tests directory: `/runtime/src/tests/`. There, issue the following command:
 
 On Windows
-```sh
-.\build-test.cmd release generatelayoutonly
+```powershell
+.\build.cmd Release generatelayoutonly
 ```
 
 On Linux
 ```sh
-./build-test.sh -release -generatelayoutonly
+./build.sh -release -generatelayoutonly
 ```
 
 Once that's finished, you can find your new _Core_Root_ within the artifacts path. For example:

--- a/src/benchmarks/gc/docs/contributing.md
+++ b/src/benchmarks/gc/docs/contributing.md
@@ -30,12 +30,6 @@ Non-Python code is handled by `build.py` which builds C# and C dependencies.
 When you modify C# or C code (or dlls they depend on), they should automatically be rebuilt.
 The code for building C dependencies is Windows-specific as currently only Windows needs these dependencies.
 
-## TraceEvent (from PerfView)
-
-You may need to modify TraceEvent (which is part of PerfView) when working `managed-lib`, which uses it heavily.
-
-Run `py . use-local-trace-event path/to/perfview` to set NuGet to use the TraceEvent your local build of PerfView. Running an analysis command will cause `managed-lib` to be rebuilt using your local PerfVIew build. Use `py . undo-use-local-trace-event` to go back to using the PerfView from nuget.org.
-
 # Using a Custom TraceEvent
 
 You may need to modify TraceEvent (which is part of PerfView) when working `managed-lib`, which uses it heavily. To do this:


### PR DESCRIPTION
This PR updates `docs/building_coreroot.md` within GC Benchmarking Infra, as the way of generating the *Core_Root* from the *runtime* repo has changed. Previously, one would run `build-test` from `src/coreclr`, but that script is no longer located there. It is now called just `build` and was moved to `src/tests`. So, the command was changed:

From:

```powershell
cd \path\to\runtime\src\coreclr\
.\build-test.cmd Release generatelayoutonly
```

To:

```powershell
cd \path\to\runtime\src\tests\
.\build.cmd Release generatelayoutonly
```

The same applies to the Linux sh script.

This PR also changed the steps to build the runtime and libraries in the doc, to use `clr+libs` in one single command instead of building them separately. Notes on those flags were added as well.