### PR TITLE
Use Release Env since debug msvcrt is not distributed.

### DIFF
--- a/src/benchmarks/gc/src/commonlib/get_built.py
+++ b/src/benchmarks/gc/src/commonlib/get_built.py
@@ -590,11 +590,12 @@ def get_built(
 
 _EXEC_ENV_BUILD_CMD_PATH = EXEC_ENV_PATH / "build.cmd"
 _EXEC_ENV_BUILD_DEBUG_PATH = EXEC_ENV_PATH / "out" / "Debug"
+_EXEC_ENV_BUILD_RELEASE_PATH = EXEC_ENV_PATH / "out" / "Release"
 assert_file_exists(_EXEC_ENV_BUILD_CMD_PATH)
 
 
 def _get_built_c_script(name: str) -> Path:
-    out_path = _EXEC_ENV_BUILD_DEBUG_PATH / f"{name}.exe"
+    out_path = _EXEC_ENV_BUILD_RELEASE_PATH / f"{name}.exe"
     assert out_path.exists(), (
         f"Could not find {out_path}\nMaybe you need to run {_EXEC_ENV_BUILD_CMD_PATH}"
         + " (using a Visual Studio Developer Command Prompt)?"

--- a/src/benchmarks/gc/src/commonlib/get_built.py
+++ b/src/benchmarks/gc/src/commonlib/get_built.py
@@ -589,7 +589,7 @@ def get_built(
 
 
 _EXEC_ENV_BUILD_CMD_PATH = EXEC_ENV_PATH / "build.cmd"
-_EXEC_ENV_BUILD_DEBUG_PATH = EXEC_ENV_PATH / "out" / "Debug"
+# _EXEC_ENV_BUILD_DEBUG_PATH = EXEC_ENV_PATH / "out" / "Debug"
 _EXEC_ENV_BUILD_RELEASE_PATH = EXEC_ENV_PATH / "out" / "Release"
 assert_file_exists(_EXEC_ENV_BUILD_CMD_PATH)
 

--- a/src/benchmarks/gc/src/exec/env/build.cmd
+++ b/src/benchmarks/gc/src/exec/env/build.cmd
@@ -5,5 +5,5 @@ if exist out\ (
 mkdir out
 cd out
 cmake ..
-devenv /build Debug env.sln
+devenv /build Release env.sln
 cd ..


### PR DESCRIPTION
To be able to use the perf harness on a non-VS machine, need to use Release build of Env. 