### PR TITLE
Add support for POH allocations in GCPerfSim from GC Benchmarking Infra

### DIFF
--- a/src/benchmarks/gc/docs/bench_file.md
+++ b/src/benchmarks/gc/docs/bench_file.md
@@ -35,12 +35,12 @@ benchmarks:
       tagb: 500
       tlgb: 1
       lohar: 0
+      pohar: 0
       sohsi: 50
       lohsi: 0
       pohsi: 0
       sohpi: 0
       lohpi: 0
-      pohpi: 0
       sohfi: 0
       lohfi: 0
       pohfi: 0
@@ -394,12 +394,12 @@ tagb: `float`
 tlgb: `float`
 totalMins: `float | None`
 lohar: `int`
+pohar: `int`
 sohsi: `int`
 lohsi: `int`
 pohsi: `int`
 sohpi: `int`
 lohpi: `int`
-pohpi: `int`
 sohfi: `int`
 lohfi: `int`
 pohfi: `int`

--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -578,12 +578,12 @@ class TestKind(Enum):
 @doc_field("tlgb", None)
 @doc_field("totalMins", None)
 @doc_field("lohar", None)
+@doc_field("pohar", None)
 @doc_field("sohsi", None)
 @doc_field("lohsi", None)
 @doc_field("pohsi", None)
 @doc_field("sohpi", None)
 @doc_field("lohpi", None)
-@doc_field("pohpi", None)
 @doc_field("sohfi", None)
 @doc_field("lohfi", None)
 @doc_field("pohfi", None)
@@ -602,12 +602,12 @@ class GCPerfSimArgs:
     tlgb: float
     totalMins: Optional[float] = None
     lohar: int = 0
+    pohar: int = 0
     sohsi: int = 0
     lohsi: int = 0
     pohsi: int = 0
     sohpi: int = 0
     lohpi: int = 0
-    pohpi: int = 0
     sohfi: int = 0
     lohfi: int = 0
     pohfi: int = 0
@@ -621,12 +621,12 @@ class GCPerfSimArgs:
             "-tlgb": str(self.tlgb),
             **(empty_mapping() if self.totalMins is None else {"totalMins": str(self.totalMins)}),
             "-lohar": str(self.lohar),
+            "-pohar": str(self.pohar),
             "-sohsi": str(self.sohsi),
             "-lohsi": str(self.lohsi),
             "-pohsi": str(self.pohsi),
             "-sohpi": str(self.sohpi),
             "-lohpi": str(self.lohpi),
-            "-pohpi": str(self.pohpi),
             "-sohfi": str(self.sohfi),
             "-lohfi": str(self.lohfi),
             "-pohfi": str(self.pohfi),

--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
@@ -1286,7 +1286,6 @@ class ArgsParser
         uint pohAllocHigh = DEFAULT_POH_ALLOC_HIGH;
 
 #if NET5_0
-        uint pohPinInterval = DEFAULT_POH_PINNING_INTERVAL;
         uint pohFinalizableInterval = DEFAULT_POH_FINALIZABLE_INTERVAL;
         uint pohSurvInterval = DEFAULT_POH_SURV_INTERVAL;
 
@@ -1394,15 +1393,6 @@ class ArgsParser
                     lohFinalizableInterval = ParseUInt32(args[++i]);
                     break;
 
-                case "-pohPinningInterval":
-                case "-pohpi":
-#if NET5_0
-                    pohPinInterval = ParseUInt32(args[++i]);
-#else
-                    Console.WriteLine("The flag {0} is only supported on .NET Core 5+. Skipping in this run.",
-                                      args[i++]);
-#endif
-                    break;
                 case "-pohFinalizableInterval":
                 case "-pohfi":
 #if NET5_0
@@ -1451,7 +1441,15 @@ class ArgsParser
         List<BucketSpec> bucketList = new List<BucketSpec>();
         uint sohWeight = 1000;
 
-        uint lohWeight = GetLohAllocWeight(lohAllocRatioArg, sohAllocLow: sohAllocLow, sohAllocHigh: sohAllocHigh, lohAllocLow: lohAllocLow, lohAllocHigh: lohAllocHigh, pohAllocLow, pohAllocHigh);
+        uint lohWeight = GetLohAllocWeight(
+            lohAllocRatio: lohAllocRatioArg,
+            sohAllocLow: sohAllocLow,
+            sohAllocHigh: sohAllocHigh,
+            lohAllocLow: lohAllocLow,
+            lohAllocHigh: lohAllocHigh,
+            pohAllocLow: pohAllocLow,
+            pohAllocHigh: pohAllocHigh);
+
         if (lohWeight > 0)
         {
             BucketSpec lohBucket = new BucketSpec(
@@ -1466,13 +1464,21 @@ class ArgsParser
         }
 
 #if NET5_0
-        uint pohWeight = GetPohAllocWeight(pohAllocRatioArg, sohAllocLow: sohAllocLow, sohAllocHigh: sohAllocHigh, lohAllocLow: lohAllocLow, lohAllocHigh: lohAllocHigh, pohAllocLow, pohAllocHigh);
+        uint pohWeight = GetPohAllocWeight(
+            pohAllocRatio: pohAllocRatioArg,
+            sohAllocLow: sohAllocLow,
+            sohAllocHigh: sohAllocHigh,
+            lohAllocLow: lohAllocLow,
+            lohAllocHigh: lohAllocHigh,
+            pohAllocLow: pohAllocLow,
+            pohAllocHigh: pohAllocHigh);
+
         if (pohWeight > 0)
         {
             BucketSpec pohBucket = new BucketSpec(
                 sizeRange: new SizeRange(pohAllocLow, pohAllocHigh),
                 survInterval: pohSurvInterval,
-                pinInterval: pohPinInterval,
+                pinInterval: 0,
                 finalizableInterval: pohFinalizableInterval,
                 weight: pohWeight,
                 isPoh: true);

--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
@@ -82,8 +82,8 @@ we allocate POH that's randomly chosen between this range.
 
 -sohSurvInterval/-sohsi: g_sohSurvInterval
 meaning every Nth SOH object allocated will survive. This is something we will consider changing to survival rate
-later. When the allocated objects are of similiar sizes the surv rate is 1/g_sohSurvInterval but we may not want them
-to all be similiar sizes.
+later. When the allocated objects are of similar sizes the surv rate is 1/g_sohSurvInterval but we may not want them
+to all be similar sizes.
 
 -lohSurvInterval/-lohsi: g_lohSurvInterval
 meaning every Nth LOH object allocated will survive. 
@@ -91,17 +91,14 @@ meaning every Nth LOH object allocated will survive.
 -pohSurvInterval/-pohsi:
 meaning every Nth POH object allocated will survive.
 
-Note that -sohSurvInterval/-lohSurvInterval are only applicable for steady state, during initialization everything
-survives.
+Note that -sohSurvInterval/-lohSurvInterval are only applicable for steady state.
+During initialization everything survives.
 
 -sohPinningInterval/-sohpi: g_sohPinningInterval
 meaning every Nth SOH object survived will be pinned. 
 
 -lohPinningInterval/-lohpi: g_lohPinningInterval
 meaning every Nth LOH object survived will be pinned. 
-
--pohPinningInterval/-pohpi:
-meaning every Nth POH object survived will be pinned.
 
 -allocType/-at: g_allocType
 What kind of objects are we allocating? Current supported types: 


### PR DESCRIPTION
*GCPerfSim*, the tool that runs GC Infra's tests, has support for Pinned Object Heap allocations. However, the only way to trigger them was by calling GCPerfSim directly in the command line and passing the `-pohar` (Pinned Object Heap Allocation Ratio) flag there. This was because the infra's `yaml` benchmark files did not support this value.

This PR adds it to the `suite-create` command and also removed the `-pohpi` flag. This one stood for Pinned Object Heap Pinning Interval. However, all items by default are pinned when allocated in POH so it made no sense to have it. With these changes, the `benchmark` sections of the `yaml` files will look like this:

```yaml
benchmarks:
  2gb:
    arguments:
      tc: 6
      tagb: 300
      tlgb: 2
      lohar: 0
      pohar: 0  # This is the new flag.
      sohsi: 50
      lohsi: 0
      pohsi: 0
      sohpi: 0
      lohpi: 0
      sohfi: 0
      lohfi: 0
      pohfi: 0
      allocType: reference
      testKind: time
# "pohpi" was removed because it didn't provide any additional functionality.
```