### PR TITLE
Fix wrong SOH size range in GCPerfSim

### DIFF
--- a/src/benchmarks/gc/src/commonlib/bench_file.py
+++ b/src/benchmarks/gc/src/commonlib/bench_file.py
@@ -606,7 +606,7 @@ class GCPerfSimArgs:
     totalMins: Optional[float] = None
     lohar: int = 0
     pohar: int = 0
-    sohsr: str = "10-4000"
+    sohsr: str = "100-4000"
     lohsr: str = "102400-204800"
     pohsr: str = "100-204800"
     sohsi: int = 0


### PR DESCRIPTION
This PR fixes issue #1616.

The test bench files were being created with a size range of *10-4000* for SOH objects, when running `suite-create`. Having a low boundary this small was causing `GCPerfSim` to fail with an `Arithmetic Exception` when attempting to create `SimpleRefPayload` objects. This is the code snippet that failed:

```csharp
    public SimpleRefPayLoad(uint size, bool isPinned, bool isPoh)
    {
        uint sizePayload = size - Overhead;
        if (isPoh)
        {
#if NET5_0
            payload = GC.AllocateArray<byte>((int)sizePayload, pinned: true);
#else
            throw new Exception("UNREACHABLE: POH allocations require netcoreapp5.0 or higher");
#endif
        }
        else
        {
            payload = new byte[sizePayload];
        }
        (...)
    }
```

Having a boundary as low as 10 caused `sizePayload` to be negative in certain iterations, thus throwing the exception. This makes sense because this value is then used to create the `payload` array.

The fix was to set the lower boundary to 100 in the Python suite create, in order to match GCPerfSim's default value.