### PR TITLE
FileStream benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -74,7 +74,7 @@ namespace System.IO.Tests
             
             using (FileStream reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.None))
             {
-                for (int i = 0; i < TotalSize / BufferSize; i++)
+                while (bytesRead < TotalSize)
                 {
                     bytesRead += reader.Read(buffer, 0, buffer.Length);
                 }
@@ -92,7 +92,7 @@ namespace System.IO.Tests
             
             using (FileStream reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
             {
-                for (int i = 0; i < TotalSize / BufferSize; i++)
+                while (bytesRead < TotalSize)
                 {
                     bytesRead += await reader.ReadAsync(buffer, 0, buffer.Length);
                 }

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -30,7 +30,7 @@ namespace System.IO.Tests
             _userBuffers = new Dictionary<int, byte[]>()
             {
                 { HalfKiloByte, ValuesGenerator.Array<byte>(HalfKiloByte) },
-                { FourKiloBytes, ValuesGenerator.Array<byte>(HalfKiloByte) },
+                { FourKiloBytes, ValuesGenerator.Array<byte>(FourKiloBytes) },
             };
             _sourceFilePaths = fileSizes.ToDictionary(size => size, size => CreateFileWithRandomContent(size));
             _destinationFilePaths = fileSizes.ToDictionary(size => size, size => CreateFileWithRandomContent(size));

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -70,6 +70,7 @@ namespace System.IO.Tests
         [Benchmark]
         [Arguments(OneKibibyte , FileOptions.None)]
         [Arguments(OneKibibyte , FileOptions.Asynchronous)]
+        [AllowedOperatingSystems("Lock and Unlock are supported only on Windows and Linux", OS.Linux, OS.Windows)]
         public void LockUnlock(long fileSize, FileOptions options)
         {
             string filePath = _sourceFilePaths[fileSize];

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -52,7 +52,8 @@ namespace System.IO.Tests
             }
         }
 
-        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(LockUnlock), nameof(SeekForward), nameof(SeekBackward), nameof(ReadByte), nameof(WriteByte) })]
+        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(LockUnlock), nameof(SeekForward), nameof(SeekBackward), 
+            nameof(ReadByte), nameof(WriteByte), nameof(Flush), nameof(FlushAsync) })]
         public void SetuOneKibibyteBenchmarks() => Setup(OneKibibyte );
 
         [Benchmark]
@@ -245,6 +246,39 @@ namespace System.IO.Tests
             }
         }
 #endif
+
+        [Benchmark]
+        [Arguments(OneKibibyte, FileOptions.None)]
+        [Arguments(OneKibibyte, FileOptions.Asynchronous)]
+        public void Flush(long fileSize, FileOptions options)
+        {
+            using (FileStream fileStream = new FileStream(_destinationFilePaths[fileSize], FileMode.Create, FileAccess.Write, FileShare.Read, FourKibibytes, options))
+            {
+                for (int i = 0; i < fileSize; i++)
+                {
+                    fileStream.WriteByte(default); // make sure that Flush has something to actualy flush to disk
+
+                    fileStream.Flush();
+                }
+            }
+        }
+
+        [Benchmark]
+        [Arguments(OneKibibyte, FileOptions.None)]
+        [Arguments(OneKibibyte, FileOptions.Asynchronous)]
+        public async Task FlushAsync(long fileSize, FileOptions options)
+        {
+            using (FileStream fileStream = new FileStream(_destinationFilePaths[fileSize], FileMode.Create, FileAccess.Write, FileShare.Read, FourKibibytes, options))
+            {
+                for (int i = 0; i < fileSize; i++)
+                {
+                    fileStream.WriteByte(default);
+
+                    await fileStream.FlushAsync();
+                }
+            }
+        }
+
 
         [Benchmark]
         [Arguments(OneKibibyte , FileOptions.None)]

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -304,46 +304,5 @@ namespace System.IO.Tests
                 await source.CopyToAsync(destination);
             }
         }
-
-        [GlobalSetup(Targets = new[] { nameof(ReadWithCancellationTokenAsync), nameof(WriteWithCancellationTokenAsync) })]
-        public void SetupCancellationTokenBenchmarks() => Setup(OneMibibyte);
-
-        [Benchmark]
-        [Arguments(OneMibibyte, HalfKibibyte, FileOptions.Asynchronous)] // only two test cases to compare the overhead of using CancellationToken
-        [Arguments(OneMibibyte, FourKibibytes, FileOptions.Asynchronous)]
-        [BenchmarkCategory(Categories.NoWASM)]
-        public async Task<long> ReadWithCancellationTokenAsync(long fileSize, int userBufferSize, FileOptions options)
-        {
-            CancellationToken cancellationToken = CancellationToken.None;
-            byte[] userBuffer = _userBuffers[userBufferSize];
-            long bytesRead = 0;
-
-            using (FileStream fileStream = new FileStream(_sourceFilePaths[fileSize], FileMode.Open, FileAccess.Read, FileShare.Read, FourKibibytes, options))
-            {
-                while (bytesRead < fileSize)
-                {
-                    bytesRead += await fileStream.ReadAsync(userBuffer, 0, userBuffer.Length, cancellationToken);
-                }
-            }
-
-            return bytesRead;
-        }
-
-        [Benchmark]
-        [Arguments(OneMibibyte, HalfKibibyte, FileOptions.Asynchronous)]
-        [Arguments(OneMibibyte, FourKibibytes, FileOptions.Asynchronous)]
-        [BenchmarkCategory(Categories.NoWASM)]
-        public async Task WriteWithCancellationTokenAsync(long fileSize, int userBufferSize, FileOptions options)
-        {
-            CancellationToken cancellationToken = CancellationToken.None;
-            byte[] userBuffer = _userBuffers[userBufferSize];
-            using (FileStream fileStream = new FileStream(_destinationFilePaths[fileSize], FileMode.Create, FileAccess.Write, FileShare.Read, FourKibibytes, options))
-            {
-                for (int i = 0; i < fileSize / userBufferSize; i++)
-                {
-                    await fileStream.WriteAsync(userBuffer, 0, userBuffer.Length, cancellationToken);
-                }
-            }
-        }
     }
 }

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -52,8 +52,8 @@ namespace System.IO.Tests
             }
         }
 
-        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(OpenCloseAsync), nameof(LockUnlock), nameof(LockUnlockAsync) })]
-        public void SetupOpenAndLockBenchmarks() => Setup(OneKiloByte);
+        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(OpenCloseAsync), nameof(LockUnlock), nameof(LockUnlockAsync), nameof(SeekForward), nameof(SeekBackward) })]
+        public void SetuOneKiloByteBenchmarks() => Setup(OneKiloByte);
 
         [Benchmark]
         public bool OpenClose()
@@ -98,6 +98,34 @@ namespace System.IO.Tests
                 reader.Lock(0, reader.Length);
 
                 reader.Unlock(0, reader.Length);
+            }
+        }
+
+        [Benchmark]
+        [Arguments(OneKiloByte)]
+        public void SeekForward(long fileSize)
+        {
+            string filePath = _sourceFilePaths[fileSize];
+            using (FileStream reader = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKiloBytes, FileOptions.None))
+            {
+                for (long offset = 0; offset < fileSize; offset++)
+                {
+                    reader.Seek(offset, SeekOrigin.Begin);
+                }
+            }
+        }
+
+        [Benchmark]
+        [Arguments(OneKiloByte)]
+        public void SeekBackward(long fileSize)
+        {
+            string filePath = _sourceFilePaths[fileSize];
+            using (FileStream reader = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKiloBytes, FileOptions.None))
+            {
+                for (long offset = fileSize - 1; offset >= 0; offset--)
+                {
+                    reader.Seek(offset, SeekOrigin.End);
+                }
             }
         }
 

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -21,13 +21,14 @@ namespace System.IO.Tests
         public int TotalSize;
 
         private byte[] _buffer;
-        private string _filePath;
+        private string _filePath, _filePath2;
 
         [GlobalSetup]
         public void Setup()
         {
             _buffer = CreateRandomBytes(BufferSize);
             _filePath = CreateFileWithRandomContent(TotalSize);
+            _filePath2 = CreateFileWithRandomContent(TotalSize);
         }
 
         [GlobalCleanup]
@@ -122,12 +123,33 @@ namespace System.IO.Tests
         }
 
         [Benchmark]
+        public void CopyToFile()
+        {
+            using (var reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.None))
+            using (var writer = new FileStream(_filePath2, FileMode.Create, FileAccess.Write, FileShare.Read, DefaultBufferSize, FileOptions.None))
+            {
+                reader.CopyTo(writer);
+            }
+        }
+
+        [Benchmark]
         [BenchmarkCategory(Categories.NoWASM)]
         public async Task CopyToAsync()
         {
             using (var reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
             {
                 await reader.CopyToAsync(Stream.Null);
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoWASM)]
+        public async Task CopyToFileAsync()
+        {
+            using (var reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
+            using (var writer = new FileStream(_filePath2, FileMode.Create, FileAccess.Write, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
+            {
+                await reader.CopyToAsync(writer);
             }
         }
 

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -73,7 +73,7 @@ namespace System.IO.Tests
         public void LockUnlock(long fileSize, FileOptions options)
         {
             string filePath = _sourceFilePaths[fileSize];
-            using (FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKibibytes, options))
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, FourKibibytes, options))
             {
                 fileStream.Lock(0, fileStream.Length);
 

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -33,6 +33,24 @@ namespace System.IO.Tests
         public void Cleanup() => File.Delete(_filePath);
 
         [Benchmark]
+        public bool OpenClose()
+        {
+            using (FileStream reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.None))
+            {
+                return reader.IsAsync; // return something just to consume the reader
+            }
+        }
+
+        [Benchmark]
+        public bool OpenCloseAsync()
+        {
+            using (FileStream reader = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.Asynchronous))
+            {
+                return reader.IsAsync;
+            }
+        }
+
+        [Benchmark]
         public int ReadByte()
         {
             int result = default;

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -52,8 +52,8 @@ namespace System.IO.Tests
             }
         }
 
-        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(OpenCloseAsync) })]
-        public void SetupOpenBenchmarks() => Setup(OneKiloByte);
+        [GlobalSetup(Targets = new[] { nameof(OpenClose), nameof(OpenCloseAsync), nameof(LockUnlock), nameof(LockUnlockAsync) })]
+        public void SetupOpenAndLockBenchmarks() => Setup(OneKiloByte);
 
         [Benchmark]
         public bool OpenClose()
@@ -72,6 +72,32 @@ namespace System.IO.Tests
             using (FileStream reader = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKiloBytes, FileOptions.Asynchronous))
             {
                 return reader.IsAsync;
+            }
+        }
+
+        [Benchmark]
+        [Arguments(OneKiloByte)]
+        public void LockUnlock(long fileSize)
+        {
+            string filePath = _sourceFilePaths[fileSize];
+            using (FileStream reader = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKiloBytes, FileOptions.None))
+            {
+                reader.Lock(0, reader.Length);
+
+                reader.Unlock(0, reader.Length);
+            }
+        }
+
+        [Benchmark]
+        [Arguments(OneKiloByte)]
+        public void LockUnlockAsync(long fileSize)
+        {
+            string filePath = _sourceFilePaths[fileSize];
+            using (FileStream reader = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, FourKiloBytes, FileOptions.Asynchronous))
+            {
+                reader.Lock(0, reader.Length);
+
+                reader.Unlock(0, reader.Length);
             }
         }
 


### PR DESCRIPTION
Main changes:

- add benchmark that copies one file into another (existing benchmark was copying from file to `Stream.Null`)
- add Open&Close benchmark
- add Lock&Unlcok benchmark
- add Seek (forward and backward) benchmarks
- give better names to differentiate user buffer (passed to stream) and internal stream buffer (passed by Stream to OS)
- add more file sizes (1kB, 1MB, 100MB) where it makes sense

cc @stephentoub 