### PR TITLE
Update Roslyn real-world test

### DIFF
--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
@@ -29,7 +28,7 @@ namespace CompilerBenchmarks
 
         private static async Task Setup()
         {
-            string cscSourceDownloadLink = "https://github.com/dotnet/roslyn/releases/download/perf-assets-v1/CodeAnalysisReproWithAnalyzers.zip";
+            string cscSourceDownloadLink = "https://github.com/dotnet/roslyn/releases/download/perf-assets-v2/CodeAnalysisReproWithAnalyzers.zip";
             string sourceDownloadDir = Path.Combine(AppContext.BaseDirectory, "roslynSource");
             var sourceDir = Path.Combine(sourceDownloadDir, "CodeAnalysisReproWithAnalyzers");
             if (!Directory.Exists(sourceDir))

--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -3,42 +3,28 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
+using CompilerBenchmarks;
 
-namespace CompilerBenchmarks
+string cscSourceDownloadLink = "https://github.com/dotnet/roslyn/releases/download/perf-assets-v2/CodeAnalysisReproWithAnalyzers.zip";
+string sourceDownloadDir = Path.Combine(AppContext.BaseDirectory, "roslynSource");
+var sourceDir = Path.Combine(sourceDownloadDir, "CodeAnalysisReproWithAnalyzers");
+if (!Directory.Exists(sourceDir))
 {
-    public class Program
-    {
-        public static async Task<int> Main(string[] args)
-        {
-            await Setup();
-
-            return BenchmarkSwitcher
-                .FromAssembly(typeof(Program).Assembly)
-                .Run(args, RecommendedConfig.Create(
-                               artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location),
-                                                                             "BenchmarkDotNet.Artifacts")),
-                               mandatoryCategories: ImmutableHashSet.Create("Roslyn"),
-                               job: Job.Default.WithMaxRelativeError(0.01)))
-                .ToExitCode();
-        }
-
-        private static async Task Setup()
-        {
-            string cscSourceDownloadLink = "https://github.com/dotnet/roslyn/releases/download/perf-assets-v2/CodeAnalysisReproWithAnalyzers.zip";
-            string sourceDownloadDir = Path.Combine(AppContext.BaseDirectory, "roslynSource");
-            var sourceDir = Path.Combine(sourceDownloadDir, "CodeAnalysisReproWithAnalyzers");
-            if (!Directory.Exists(sourceDir))
-            {
-                await FileTasks.DownloadAndUnzip(cscSourceDownloadLink, sourceDownloadDir);
-            }
-
-            // Benchmark.NET creates a new process to run the benchmark, so the easiest way
-            // to communicate information is pass by environment variable
-            Environment.SetEnvironmentVariable(Helpers.TestProjectEnvVarName, sourceDir);
-        }
-    }
+    await FileTasks.DownloadAndUnzip(cscSourceDownloadLink, sourceDownloadDir);
 }
+
+// Benchmark.NET creates a new process to run the benchmark, so the easiest way
+// to communicate information is pass by environment variable
+Environment.SetEnvironmentVariable(Helpers.TestProjectEnvVarName, sourceDir);
+
+return BenchmarkSwitcher
+    .FromAssembly(typeof(Helpers).Assembly)
+    .Run(args, RecommendedConfig.Create(
+                   artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Helpers).Assembly.Location),
+                                                                 "BenchmarkDotNet.Artifacts")),
+                   mandatoryCategories: ImmutableHashSet.Create("Roslyn"),
+                   job: Job.Default.WithMaxRelativeError(0.01)))
+    .ToExitCode();

--- a/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
+++ b/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.Compilation;
 
 namespace CompilerBenchmarks
@@ -108,6 +107,11 @@ namespace CompilerBenchmarks
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: default);
+
+            if (!success)
+            {
+                throw new InvalidOperationException("Did not successfully compile methods");
+            }
 
             _comp.GenerateResourcesAndDocumentationComments(
                 _moduleBeingBuilt,


### PR DESCRIPTION
Updates the Roslyn real-world test to use a 3.9.0 version of the source. This has more real-world usage of nullabe and similar to better reflect actual code.
