### PR TITLE
Disable Random tests breaking runs

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
@@ -53,6 +53,7 @@ namespace System.Tests
         public void NextBytes_span_unseeded() => _randomUnseeded.NextBytes(_bytes.AsSpan());
 #endif
 
+#if false // https://github.com/dotnet/performance/issues/1642
 #if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP3_1 && !NET5_0 // New API in .NET 6.0
         [Benchmark]
         public long Next_long() => _random.NextInt64(2^20);
@@ -71,6 +72,7 @@ namespace System.Tests
 
         [Benchmark]
         public float NextSingle_unseeded() => _randomUnseeded.NextSingle();
+#endif
 #endif
     }
 }


### PR DESCRIPTION
These tests are broken in the runtime repo until #1642 is fixed.