### PR TITLE
netcoreapp5.0 => net5.0

### DIFF
--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -70,8 +70,8 @@ dotnet build -c Release
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [MicroBenchmarks.csproj](../src/benchmarks/micro/MicroBenchmarks.csproj) file.
 
 ```diff
--<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
-+<TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+-<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
++<TargetFrameworks>net5.0</TargetFrameworks>
 ```
 
 The alternative is to set `PERFLAB_TARGET_FRAMEWORKS` environment variable to selected Target Framework Moniker.
@@ -285,12 +285,12 @@ M00_L00:
 
 The `--runtimes` or just `-r` allows you to run the benchmarks for **multiple Runtimes**.
 
-Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp2.1, netcoreapp3.0, netcoreapp3.1 and netcoreapp5.0.
+Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp2.1, netcoreapp3.0, netcoreapp3.1 and net5.0.
 
 Example: run the benchmarks for .NET Core 3.1 and 5.0:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 --runtimes netcoreapp3.1 netcoreapp5.0
+dotnet run -c Release -f netcoreapp3.1 --runtimes netcoreapp3.1 net5.0
 ```
 
 **Important: The host process needs to be the lowest common API denominator of the runtimes you want to compare!** In this case, it was`netcoreapp3.1`.
@@ -302,13 +302,13 @@ To perform a Mann–Whitney U Test and display the results in a dedicated column
 Example: run Mann–Whitney U test with relative ratio of 5% for `BinaryTrees_2` for .NET Core 3.1 (base) vs .NET Core 5.0 (diff). .NET Core 3.1 will be baseline because it was first.
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 --filter *BinaryTrees_2* --runtimes netcoreapp3.1 netcoreapp5.0 --statisticalTest 5%
+dotnet run -c Release -f netcoreapp3.1 --filter *BinaryTrees_2* --runtimes netcoreapp3.1 net5.0 --statisticalTest 5%
 ```
 
 |        Method |     Toolchain |     Mean | MannWhitney(5%) |
 |-------------- |-------------- |---------:|---------------- |
 | BinaryTrees_2 | netcoreapp3.1 | 124.4 ms |            Base |
-| BinaryTrees_2 | netcoreapp5.0 | 153.7 ms |          Slower |
+| BinaryTrees_2 |        net5.0 | 153.7 ms |          Slower |
 
 **Note:** to compare the historical results you need to use [Results Comparer](../src/tools/ResultsComparer/README.md)
 

--- a/docs/benchmarking-workflow-dotnet-runtime.md
+++ b/docs/benchmarking-workflow-dotnet-runtime.md
@@ -95,7 +95,7 @@ During the port from xunit-performance to BenchmarkDotNet, the namespaces, type 
 Please remember that you can filter the benchmarks using a glob pattern applied to namespace.typeName.methodName ([read more](./benchmarkdotnet.md#Filtering-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --filter System.Memory*
+dotnet run -c Release -f net5.0 --filter System.Memory*
 ```
 
 (Run the above command on `src/benchmarks/micro/MicroBenchmarks.csproj`.)
@@ -115,7 +115,7 @@ C:\Projects\runtime> build -c Release
 Every time you want to run the benchmarks against local build of [dotnet/runtime](https://github.com/dotnet/runtime) you need to provide the path to CoreRun:
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --filter $someFilter \
+dotnet run -c Release -f net5.0 --filter $someFilter \
     --coreRun C:\Projects\runtime\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe
 ```
 
@@ -142,7 +142,7 @@ Preventing regressions is a fundamental part of our performance culture. The che
 **Before introducing any changes that may impact performance**, you should run the benchmarks that test the performance of the feature that you are going to work on and store the results in a **dedicated** folder.
 
 ```cmd
-C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f netcoreapp5.0 \
+C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f net5.0 \
     --artifacts "C:\results\before" \
     --coreRun "C:\Projects\runtime\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe" \
     --filter System.IO.Pipes*
@@ -157,7 +157,7 @@ After you introduce the changes and rebuild the part of [dotnet/runtime](https:/
 ```cmd
 C:\Projects\runtime\src\libraries\System.IO.Pipes\src> dotnet msbuild /p:Configuration=Release
 
-C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f netcoreapp5.0 \
+C:\Projects\performance\src\benchmarks\micro> dotnet run -c Release -f net5.0 \
     --artifacts "C:\results\after" \
     --coreRun "C:\Projects\runtime\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe" \
     --filter System.IO.Pipes*
@@ -184,7 +184,7 @@ No Slower results for the provided threshold = 2% and noise filter = 0.3ns.
 To run the benchmarks against the latest .NET Core SDK you can use the [benchmarks_ci.py](../scripts/benchmarks_ci.py) script. It's going to download the latest .NET Core SDK(s) for the provided framework(s) and run the benchmarks for you. Please see [Prerequisites](./prerequisites.md#python) for more.
 
 ```cmd
-C:\Projects\performance> py scripts\benchmarks_ci.py -f netcoreapp5.0 \
+C:\Projects\performance> py scripts\benchmarks_ci.py -f net5.0 \
     --bdn-arguments="--artifacts "C:\results\latest_sdk"" \
     --filter System.IO.Pipes*
 ```
@@ -205,7 +205,7 @@ The real performance investigation starts with profiling. We have a comprehensiv
 To profile the benchmarked code and produce an ETW Trace file ([read more](./benchmarkdotnet.md#Profiling)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --profiler ETW --filter $YourFilter
+dotnet run -c Release -f net5.0 --profiler ETW --filter $YourFilter
 ```
 
 The benchmarking tool is going to print the path to the `.etl` trace file. You should open it with PerfView or Windows Performance Analyzer and start the analysis from there. If you are not familiar with PerfView, you should watch [PerfView Tutorial](https://channel9.msdn.com/Series/PerfView-Tutorial) by @vancem first. It's an investment that is going to pay off very quickly.
@@ -222,7 +222,7 @@ If profiling using the `--profiler ETW` is not enough, you should use a differen
 
 BenchmarkDotNet has some extra features that might be useful when doing performance investigation:
 
-- You can run the benchmarks against [multiple Runtimes](./benchmarkdotnet.md#Multiple-Runtimes). It can be very useful when the regression has been introduced between .NET Core releases, for example: between netcoreapp3.1 and netcoreapp5.0.
+- You can run the benchmarks against [multiple Runtimes](./benchmarkdotnet.md#Multiple-Runtimes). It can be very useful when the regression has been introduced between .NET Core releases, for example: between netcoreapp3.1 and net5.0.
 - You can run the benchmarks using provided [dotnet cli](./benchmarkdotnet.md#dotnet-cli). You can download few dotnet SDKs, unzip them and just run the benchmarks to spot the version that has introduced the regression to narrow down your investigation.
 - You can run the benchmarks using few [CoreRuns](./benchmarkdotnet.md#CoreRun). You can build the latest [dotnet/runtime](https://github.com/dotnet/runtime) in Release, create a copy of the folder with CoreRun and use git to checkout an older commit. Then rebuild [dotnet/runtime](https://github.com/dotnet/runtime) and run the benchmarks against the old and new builds. This can narrow down your investigation to the commit that has introduced the bug.
 
@@ -274,7 +274,7 @@ Because the benchmarks are not in the [dotnet/runtime](https://github.com/dotnet
 The first thing you need to do is send a PR with the new API to the [dotnet/runtime](https://github.com/dotnet/runtime) repository. Once your PR gets merged and a new NuGet package is published to the [dotnet/runtime](https://github.com/dotnet/runtime) NuGet feed, you should remove the Reference to a `.dll` and install/update the package consumed by [MicroBenchmarks](../src/benchmarks/micro/MicroBenchmarks.csproj). You can do this by running the following script locally:
 
 ```cmd
-/home/adsitnik/projects/performance>python3 ./scripts/benchmarks_ci.py --filter $YourFilter -f netcoreapp5.0
+/home/adsitnik/projects/performance>python3 ./scripts/benchmarks_ci.py --filter $YourFilter -f net5.0
 ```
 This script will try to pull the latest .NET Core SDK from [dotnet/runtime](https://github.com/dotnet/runtime) nightly build, which should contain the new API that you just merged in your first PR, and use that to build MicroBenchmarks project and then run the benchmarks that satisfy the filter you provided. 
 

--- a/docs/blazor-scenarios.md
+++ b/docs/blazor-scenarios.md
@@ -63,7 +63,7 @@ Same instruction of [Step 4 in Scenario Tests Guide](scenarios-workflow.md#step-
 For the purpose of quick reference, the commands can be summarized into the following matrix:
 | Scenario                            | Asset Directory | Precommand                                                  | Testcommand                                                       | Postcommand | Supported Framework | Supported Platform |
 |-------------------------------------|-----------------|-------------------------------------------------------------|-------------------------------------------------------------------|-------------|---------------------|--------------------|
-| SOD - New Blazor Template - Publish | blazor          | pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" | test.py sod --scenario-name "SOD - New Blazor Template - Publish" | post.py     | netcoreapp5.0       | Windows;Linux      |
+| SOD - New Blazor Template - Publish | blazor          | pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" | test.py sod --scenario-name "SOD - New Blazor Template - Publish" | post.py     | net5.0              | Windows;Linux      |
 
 
 ## Relevant Links

--- a/docs/profiling-workflow-dotnet-runtime.md
+++ b/docs/profiling-workflow-dotnet-runtime.md
@@ -131,7 +131,7 @@ It's recommended to disable Tiered JIT (to avoid the need of warmup) and emit fu
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/docs/scenarios-workflow.md
+++ b/docs/scenarios-workflow.md
@@ -55,9 +55,9 @@ python3 pre.py <command> <options>  # run precommand
 In our **startup time of an empty console template** example, we can run
 ```
 cd emptyconsoletemplate
-python3 pre.py publish -f netcoreapp5.0 -c Release
+python3 pre.py publish -f net5.0 -c Release
 ```
-The above command creates a new dotnet console template in `emptyconsoletemplate\app\` folder, builds the project targeting netcoreapp5.0 in Release and publishs it to `emptyconsoletemplate\pub\` folder.
+The above command creates a new dotnet console template in `emptyconsoletemplate\app\` folder, builds the project targeting net5.0 in Release and publishs it to `emptyconsoletemplate\pub\` folder.
 
 Run `python3 pre.py --help` for more command options and their meanings.
 

--- a/docs/sdk-scenarios.md
+++ b/docs/sdk-scenarios.md
@@ -84,16 +84,16 @@ Same instruction of [Step 4 in Scenario Tests Guide](scenarios-workflow.md#step-
     - build_no_change
 
 
-| Scenario                  | Asset Directory      | Precommand               | Testcommand                 | Postcommand | Supported Framework                                  | Supported Platform |
-|-------------------------------|----------------------|--------------------------|-----------------------------|-------------|---------------------------------------------------------|---------------------|
-| SDK Console Template          | emptyconsoletemplate | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0 | Windows;Linux       |
-| SDK .NET 2.0 Library Template | netstandard2.0       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0 | Windows;Linux       |
-| SDK ASP.NET MVC App Template  | mvcapptemplate       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1;netcoreapp5.0               | Windows;Linux       |
-| SDK Web Large 2.0             | weblarge2.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows;Linux       |
-| SDK Web Large 3.0             | weblarge3.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows;Linux       |
-| SDK Windows Forms Large       | windowsformslarge    | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows             |
-| SDK WPF Large                 | wpflarge             | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows             |
-| SDK Windows Forms Template    | windowsforms         | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows             |
-| SDK WPF Template              | wpf                  | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                             | Windows             |
-| SDK New Console               | emptyconsoletemplate | N/A                      | test.py sdk new_console     | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0 | Windows;Linux       |
+| Scenario                      | Asset Directory      | Precommand               | Testcommand                 | Postcommand | Supported Framework                              | Supported Platform |
+|-------------------------------|----------------------|--------------------------|-----------------------------|-------------|--------------------------------------------------|---------------------|
+| SDK Console Template          | emptyconsoletemplate | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0 | Windows;Linux       |
+| SDK .NET 2.0 Library Template | netstandard2.0       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0 | Windows;Linux       |
+| SDK ASP.NET MVC App Template  | mvcapptemplate       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1;net5.0               | Windows;Linux       |
+| SDK Web Large 2.0             | weblarge2.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows;Linux       |
+| SDK Web Large 3.0             | weblarge3.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows;Linux       |
+| SDK Windows Forms Large       | windowsformslarge    | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows             |
+| SDK WPF Large                 | wpflarge             | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows             |
+| SDK Windows Forms Template    | windowsforms         | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows             |
+| SDK WPF Template              | wpf                  | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.0;netcoreapp3.1                      | Windows             |
+| SDK New Console               | emptyconsoletemplate | N/A                      | test.py sdk new_console     | post.py     | netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0 | Windows;Linux       |
 

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,15 +7,15 @@ class ChannelMap():
             'branch': 'master'
         },
         '5.0':{
-            'tfm': 'netcoreapp5.0',
+            'tfm': 'net5.0',
             'branch': 'release/5.0'
         },
         'release/5.0.1xx-rc2':{
-            'tfm': 'netcoreapp5.0',
+            'tfm': 'net5.0',
             'branch': 'release/5.0.1xx-rc2'
         },
         'release/5.0.1xx':{
-            'tfm': 'netcoreapp5.0',
+            'tfm': 'net5.0',
             'branch': 'release/5.0.1xx'
         },
         'release/3.1.3xx':{

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -81,7 +81,7 @@ class FrameworkAction(Action):
             for framework in frameworks
         ]
 
-        # ['netcoreapp5.0', 'corert'] should become ['netcoreapp5.0']
+        # ['net5.0', 'corert'] should become ['net5.0']
         return list(set(monikers))
 
 class VersionsAction(Action):

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.1;netcoreapp5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.1;netcoreapp5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -32,7 +32,7 @@
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0-rc.1.20417.14" />
-    <PackageReference Include="System.Formats.Cbor" Version="5.0.0-rc.1.20417.14" Condition="'$(TargetFramework)' == 'netcoreapp5.0' or '$(TargetFramework)' == 'net6.0'" />
+    <PackageReference Include="System.Formats.Cbor" Version="5.0.0-rc.1.20417.14" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,38 +12,38 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|netcoreapp5.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `netcoreapp5.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|net5.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net5.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0
+dotnet run -c Release -f net5.0
 ```
 
 To list all available benchmarks ([read more](../../../docs/benchmarkdotnet.md#Listing-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --list flat|tree
+dotnet run -c Release -f net5.0 --list flat|tree
 ```
 
 To filter the benchmarks using a glob pattern applied to namespace.typeName.methodName ([read more](../../../docs/benchmarkdotnet.md#Filtering-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --filter *Span*
+dotnet run -c Release -f net5.0 --filter *Span*
 ```
 
 To profile the benchmarked code and produce an ETW Trace file ([read more](../../../docs/benchmarkdotnet.md#Profiling)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp5.0 --filter $YourFilter --profiler ETW
+dotnet run -c Release -f net5.0 --filter $YourFilter --profiler ETW
 ```
 
 To run the benchmarks for multiple runtimes ([read more](../../../docs/benchmarkdotnet.md#Multiple-Runtimes)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 --filter * --runtimes netcoreapp3.1 netcoreapp5.0 corert
+dotnet run -c Release -f netcoreapp3.1 --filter * --runtimes netcoreapp3.1 net5.0 corert
 ```
 
 ## Private Runtime Builds

--- a/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
+++ b/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #1426

Today @sebastienros has hit an issue when he tried to use crank to run the micro benchmarks

```log
 Determining projects to restore...
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj (in 434 ms).
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\tools\Reporting\Reporting\Reporting.csproj (in 434 ms).
  Restored C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj (in 457 ms).
  Reporting -> C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\artifacts\bin\Reporting\Release\netstandard2.0\Reporting.dll
  BenchmarkDotNet.Extensions -> C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\artifacts\bin\BenchmarkDotNet.Extensions\Release\netstandard2.0\BenchmarkDotNet.Extensions.dll
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\Perf.CborReader.cs(37,65): error CS0246: The type or namespace name 'CborConformanceMode' could not be found (are you missing a using directive or an assembly reference?) [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\CoseKeyHelpers.cs(62,66): error CS0246: The type or namespace name 'CborWriter' could not be found (are you missing a using directive or an assembly reference?) [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\Perf.CborReader.cs(46,20): error CS0246: The type or namespace name 'CborConformanceMode' could not be found (are you missing a using directive or an assembly reference?) [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\CoseKeyHelpers.cs(157,95): error CS0246: The type or namespace name 'CborReader' could not be found (are you missing a using directive or an assembly reference?) [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\Perf.CborWriter.cs(14,17): error CS0246: The type or namespace name 'CborWriter' could not be found (are you missing a using directive or an assembly reference?) [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\libraries\System.Formats.Cbor\Perf.CborReader.cs(37,103): error CS0103: The name 'CborConformanceMode' does not exist in the current context [C:\Users\Administrator\AppData\Local\Temp\benchmarks-agent\benchmarks-server-7308\c1hsasy5.32o\performance\src\benchmarks\micro\MicroBenchmarks.csproj]
```

This happened because one of our magical MSBuild conditions uses "netcoreapp5.0":

https://github.com/dotnet/performance/blob/e8a8fc62be32783d62fabffb56d14874d92a87cc/src/benchmarks/micro/MicroBenchmarks.csproj#L35

I could add another condition to it, but I think that renaming `netcoreapp5.0` to `net5.0` is a cleaner solution. 