### PR TITLE
Fix StringSegment benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Primitives/StringSegmentBenchmark.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Primitives/StringSegmentBenchmark.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Primitives
     public class StringSegmentBenchmark
     {
         private readonly StringSegment _segment = new StringSegment("Hello world!");
+        private readonly StringSegment _segment2 = new StringSegment("Hello world!".AsSpan().ToString()); // different backing string instance
         private readonly StringSegment _largeSegment = new StringSegment("Hello, World!, Hello people! My Car Is Cool. Your Carport is blue.");
         private readonly StringSegment _trimSegment = new StringSegment("   Hello world!    ");
         private readonly object _boxedSegment;
@@ -45,13 +46,13 @@ namespace Microsoft.Extensions.Primitives
         public bool Equals_Object_Invalid() => _segment.Equals(null as object);
 
         [Benchmark]
-        public bool Equals_Object_Valid() => _segment.Equals(_boxedSegment);
+        public bool Equals_Object_Valid() => _segment2.Equals(_boxedSegment);
 
         [Benchmark]
-        public bool Equals_Valid() => _segment.Equals(_segment);
+        public bool Equals_Valid() => _segment2.Equals(_segment);
 
         [Benchmark]
-        public bool Equals_String() => _segment.Equals("Hello world!");
+        public bool Equals_String() => _segment2.Equals("Hello world!");
 
         [Benchmark]
         public int GetSegmentHashCode() => _segment.GetHashCode();


### PR DESCRIPTION
Fix #1648 

before

|                Method |       Mean |     Error |    StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
|   Equals_Object_Valid |  6.9717 ns | 0.1589 ns | 0.1409 ns |  6.9810 ns |  6.7026 ns |  7.1886 ns |      - |     - |     - |         - |
|          Equals_Valid |  7.5355 ns | 0.9589 ns | 1.1043 ns |  6.9090 ns |  6.6869 ns |  9.7626 ns |      - |     - |     - |         - |
|         Equals_String |  6.9713 ns | 0.2155 ns | 0.2482 ns |  6.9029 ns |  6.6748 ns |  7.3508 ns |      - |     - |     - |         - |

after

|                Method |       Mean |     Error |    StdDev |     Median |        Min |       Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |-----------:|----------:|----------:|-----------:|-----------:|----------:|-------:|------:|------:|----------:|
|   Equals_Object_Valid | 22.9112 ns | 3.0579 ns | 3.5215 ns | 22.9654 ns | 17.4405 ns | 29.582 ns |      - |     - |     - |         - |
|          Equals_Valid | 16.0472 ns | 2.4490 ns | 2.8203 ns | 17.0559 ns | 11.1673 ns | 21.338 ns |      - |     - |     - |         - |
|         Equals_String | 20.1640 ns | 3.4096 ns | 3.9265 ns | 20.7891 ns | 14.1251 ns | 28.495 ns |      - |     - |     - |         - |
