### PR TITLE
Fix the microbenchmarks build

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -72,6 +72,9 @@ namespace System.IO.Tests
         [Arguments(OneKibibyte , FileOptions.None)]
         [Arguments(OneKibibyte , FileOptions.Asynchronous)]
         [AllowedOperatingSystems("Lock and Unlock are supported only on Windows and Linux", OS.Linux, OS.Windows)]
+#if NET6_0_OR_GREATER // the method was marked as unsupported on macOS in .NET 6.0
+        [System.Runtime.Versioning.UnsupportedOSPlatform("macos")]
+#endif
         public void LockUnlock(long fileSize, FileOptions options)
         {
             string filePath = _sourceFilePaths[fileSize];

--- a/src/benchmarks/micro/libraries/System.IO/NullWriteStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO/NullWriteStream.cs
@@ -41,7 +41,7 @@ namespace System.IO.Tests
 #if NETCOREAPP2_1_OR_GREATER // these virtual methods only exist in .NET Core 2.1+
         public override void Write(ReadOnlySpan<byte> buffer) { }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => new ValueTask(Task.CompletedTask);
 #endif
     }
 }


### PR DESCRIPTION
reported offline by @kunalspathak 

```log
[2021/02/12 01:04:06][INFO] /home/helixbot/work/9CF2092C/w/A7AC08F0/e/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs(80,17): error CA1416: This call site is reachable on all platforms. 'FileStream.Lock(long, long)' is unsupported on: 'macos'. [/home/helixbot/work/9CF2092C/w/A7AC08F0/e/src/benchmarks/micro/MicroBenchmarks.csproj]
[2021/02/12 01:04:06][INFO] /home/helixbot/work/9CF2092C/w/A7AC08F0/e/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs(82,17): error CA1416: This call site is reachable on all platforms. 'FileStream.Unlock(long, long)' is unsupported on: 'macos'. [/home/helixbot/work/9CF2092C/w/A7AC08F0/e/src/benchmarks/micro/MicroBenchmarks.csproj]
[2021/02/12 01:04:06][INFO]     0 Warning(s)
[2021/02/12 01:04:06][INFO]     2 Error(s)
```

while testing my change I've realized that the 2.1 and 3.1 builds were broken too, so I've fixed them as well