### PR TITLE
Fix "The process cannot access the file" error after a failed build

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -277,7 +277,11 @@ class CSharpProject:
         project.
 
         Keyword arguments:
-        packages_path -- The directory to restore packages to.
+            packages_path -- The directory to restore packages to.
+        MSBuild arguments used to avoid "process cannot access the file":
+            /p:UseSharedCompilation=false -- disable shared compilation
+            /p:BuildInParallel=false -- disable parallel builds
+            /m:1 -- don't spawn more than a single process
         '''
         if not packages_path:
             raise TypeError('Unspecified packages directory.')

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -284,7 +284,8 @@ class CSharpProject:
         cmdline = [
             'dotnet', 'restore',
             self.csproj_file,
-            '--packages', packages_path
+            '--packages', packages_path,
+            '/p:UseSharedCompilation=false', '/p:BuildInParallel=false', '/m:1',
         ]
 
         if runtime_identifier:
@@ -309,6 +310,7 @@ class CSharpProject:
                 '--configuration', configuration,
                 '--no-restore',
                 "/p:NuGetPackageRoot={}".format(packages_path),
+                '/p:UseSharedCompilation=false', '/p:BuildInParallel=false', '/m:1',
             ]
 
             if output_to_bindir:
@@ -332,6 +334,7 @@ class CSharpProject:
                     '--framework', target_framework_moniker,
                     '--no-restore',
                     "/p:NuGetPackageRoot={}".format(packages_path),
+                    '/p:UseSharedCompilation=false', '/p:BuildInParallel=false', '/m:1',
                 ]
 
                 if output_to_bindir:
@@ -402,7 +405,8 @@ class CSharpProject:
             self.csproj_file,
             '--configuration', configuration,
             '--output', output_dir,
-            "/p:NuGetPackageRoot={}".format(packages_path)
+            "/p:NuGetPackageRoot={}".format(packages_path),
+            '/p:UseSharedCompilation=false', '/p:BuildInParallel=false', '/m:1'
         ]
         if runtime_identifier:
             cmdline += ['--runtime', runtime_identifier]


### PR DESCRIPTION
While working on #1662 I've hit the following issue:

* run `benchmarks_ci.py` against `Microbenchmarks.csproj` that does not compile
* the script fails
* fix the build, re-run the  `benchmarks_ci.py` script
* get the file in use error

```log
PS C:\Projects\performance> py .\scripts\benchmarks_ci.py -f netcoreapp3.1 --filter *LockUnlock                                                                                                                                                                                 [2021/02/12 10:50:30][INFO] ----------------------------------------------
[2021/02/12 10:50:30][INFO] Initializing logger 2021-02-12 10:50:30.329528
[2021/02/12 10:50:30][INFO] ----------------------------------------------
[2021/02/12 10:50:30][INFO] Installing tools.
[2021/02/12 10:50:30][INFO] ----------------------
[2021/02/12 10:50:30][INFO] Downloading DotNet Cli
[2021/02/12 10:50:30][INFO] ----------------------
[2021/02/12 10:50:30][INFO] DotNet Install Path: 'C:\Projects\performance\tools\dotnet\x64'
[2021/02/12 10:50:30][INFO] Downloading https://dot.net/v1/dotnet-install.ps1
[2021/02/12 10:50:31][INFO] $ pushd "C:\Projects\performance"
[2021/02/12 10:50:31][INFO] $ powershell.exe -NoProfile -ExecutionPolicy Bypass C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 -InstallDir C:\Projects\performance\tools\dotnet\x64 -Architecture x64 -Channel release/3.1.3xx
[2021/02/12 10:50:31][INFO] dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
[2021/02/12 10:50:31][INFO] dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
[2021/02/12 10:50:31][INFO] dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
[2021/02/12 10:50:31][INFO] dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
[2021/02/12 10:50:31][INFO]
[2021/02/12 10:50:36][INFO] dotnet-install: Downloading primary link https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.303-servicing-015192/dotnet-sdk-3.1.303-servicing-015192-win-x64.zip
[2021/02/12 10:50:39][INFO] dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.303-servicing-015192/dotnet-sdk-3.1.303-servicing-015192-win-x64.zip
[2021/02/12 10:50:41][INFO] C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 : Exception calling "ExtractToFile" with "3" argument(s): "The process cannot access the file 'C:\Projects\performance\tools\dotnet\x64\dotnet.exe' because it is being used by another process."
[2021/02/12 10:50:41][INFO] At line:1 char:1
[2021/02/12 10:50:41][INFO] + C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 -InstallD ...
[2021/02/12 10:50:41][INFO] + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2021/02/12 10:50:41][INFO]     + CategoryInfo          : NotSpecified: (:) [dotnet-install.ps1], MethodInvocationException
[2021/02/12 10:50:41][INFO]     + FullyQualifiedErrorId : IOException,dotnet-install.ps1
[2021/02/12 10:50:41][INFO]
[2021/02/12 10:50:41][INFO] $ popd
[2021/02/12 10:50:41][INFO] $ pushd "C:\Projects\performance"
[2021/02/12 10:50:41][INFO] $ powershell.exe -NoProfile -ExecutionPolicy Bypass C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 -InstallDir C:\Projects\performance\tools\dotnet\x64 -Architecture x64 -Channel release/3.1.3xx
[2021/02/12 10:50:42][INFO] dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
[2021/02/12 10:50:42][INFO] dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
[2021/02/12 10:50:42][INFO] dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
[2021/02/12 10:50:42][INFO] dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
[2021/02/12 10:50:42][INFO]
[2021/02/12 10:50:47][INFO] dotnet-install: Downloading primary link https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.303-servicing-015192/dotnet-sdk-3.1.303-servicing-015192-win-x64.zip
[2021/02/12 10:50:49][INFO] dotnet-install: Extracting zip from https://dotnetcli.azureedge.net/dotnet/Sdk/3.1.303-servicing-015192/dotnet-sdk-3.1.303-servicing-015192-win-x64.zip
[2021/02/12 10:50:50][INFO] C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 : Exception calling "ExtractToFile" with "3" argument(s): "The process cannot access the file 'C:\Projects\performance\tools\dotnet\x64\dotnet.exe' because it is being used by another process."
[2021/02/12 10:50:50][INFO] At line:1 char:1
[2021/02/12 10:50:50][INFO] + C:\Projects\performance\tools\dotnet\x64\dotnet-install.ps1 -InstallD ...
[2021/02/12 10:50:50][INFO] + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2021/02/12 10:50:50][INFO]     + CategoryInfo          : NotSpecified: (:) [dotnet-install.ps1], MethodInvocationException
[2021/02/12 10:50:50][INFO]     + FullyQualifiedErrorId : IOException,dotnet-install.ps1
[2021/02/12 10:50:50][INFO]
[2021/02/12 10:50:50][INFO] $ popd
[2021/02/12 10:50:50][ERROR] Process exited with status 1
```

We had exactly the same problem in BenchmarkDotNet. I was hoping that setting `UseSharedCompilation` to `false` is enough, but MSBuild was still spawning some child processes and they were keeping some resources locked.

The only solution that I've found working was to enforce MSBuild to not perform a parallel build and don't start more than a single process. 

I've tested it against all TFMs that we support (`netcoreapp2.1 netcoreapp3.1 netcoreapp5.0 net6.0 net461`) and it works.