### PR TITLE
Delete RegisterAndUnregister_Parallel cancellation test

### DIFF
--- a/src/benchmarks/micro/libraries/System.Threading/Perf.CancellationToken.cs
+++ b/src/benchmarks/micro/libraries/System.Threading/Perf.CancellationToken.cs
@@ -16,11 +16,6 @@ namespace System.Threading.Tests
         [Benchmark]
         public void RegisterAndUnregister_Serial() => _token.Register(() => { }).Dispose();
 
-        [Benchmark(OperationsPerInvoke = 1_000_000)]
-        [BenchmarkCategory(Categories.NoWASM)]
-        public void RegisterAndUnregister_Parallel() =>
-            Parallel.For(0, 1_000_000, i => _token.Register(() => { }).Dispose());
-
         [Benchmark]
         public void Cancel()
         {


### PR DESCRIPTION
We've decided this isn't a relevant scenario to track.  The type was originally optimized for this scenario at the expense of serial usage, but since then the majority use case is the serial one.

cc: @adamsitnik 