### PR TITLE
Fixed GCPerHeapHistories in Workstation GC's in GC Infra

### DIFF
--- a/src/benchmarks/gc/src/analysis/process_trace.py
+++ b/src/benchmarks/gc/src/analysis/process_trace.py
@@ -236,18 +236,15 @@ def _get_processed_gc(
 
 
 def _get_per_heap_histories(gc: AbstractTraceGC) -> Sequence[Result[str, AbstractGCPerHeapHistory]]:
-    if gc.HeapCount == 1:
-        return [Err("Workstation GC has no AbstractGCPerHeapHistories")]
+    n = len(gc.PerHeapHistories)
+    if n != gc.HeapCount:
+        print(
+            f"WARN: GC {gc.Number} has {gc.HeapCount} heaps, but {n} PerHeapHistories. It's a "
+            + f" It's a {get_gc_kind_for_abstract_trace_gc(gc).name}."
+        )
+        return repeat(Err("GC has wrong number of PerHeapHistories"), gc.HeapCount)
     else:
-        n = len(gc.PerHeapHistories)
-        if n != gc.HeapCount:
-            print(
-                f"WARN: GC {gc.Number} has {gc.HeapCount} heaps, but {n} PerHeapHistories. It's a "
-                + f" It's a {get_gc_kind_for_abstract_trace_gc(gc).name}."
-            )
-            return repeat(Err("GC has wrong number of PerHeapHistories"), gc.HeapCount)
-        else:
-            return [Ok(h) for h in gc.PerHeapHistories]
+        return [Ok(h) for h in gc.PerHeapHistories]
 
 
 def _get_server_gc_heap_histories(


### PR DESCRIPTION
This PR removes some code that was preventing GC Infra from fetching `GCPerHeapHistories` data when the trace in question came from an app running Workstation GC. The GC properties that were detected that required this information are the following:

* `Gen2FreeListSpaceBeforeMB`
* `Gen2FreeListSpaceAfterMB`
* `LOHFreeListSpaceBeforeMB`
* `LOHFreeListSpaceAfterMB`

When one tried to access these properties in the scenario described above, they would be greeted with the following error:

`Exception: Workstation GC has no AbstractGCPerHeapHistories.`

This behavior is wrong as if we check *GCStats* directly in PerfView, we can observe that regardless of GC Type, they do have *GCPerHeapHistories*.

With this fix, the infra now reads this information properly and can be used for charting, calculations, and any other supported functionality.