### PR TITLE
Add MicroBenchmark on foreach on list.

### DIFF
--- a/src/benchmarks/micro/libraries/System.Collections/List/ForeachOnList.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/List/ForeachOnList.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+
+namespace MicroBenchmarks.libraries.System.Collections.List
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.Collections, Categories.GenericCollections)]
+    public class Perf_ForeachOnList
+    {
+        private int[] _array;
+
+        private List<int> _list;
+
+        private IEnumerable<int> _listAsIEnumerable;
+
+        [GlobalSetup]
+        public void InitializeValue()
+        {
+            _array = ValuesGenerator.Array<int>(3_000);
+            _list = _array.ToList();
+            _listAsIEnumerable = _list;
+        }
+
+        [Benchmark(Baseline = true)]
+        public int ForeachOnArray()
+        {
+            var sum = 0;
+
+            foreach (var i in _array)
+            {
+                sum += i;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ForeachOnList()
+        {
+            var sum = 0;
+
+            foreach (var i in _list)
+            {
+                sum += i;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ForeachOnListAsIEnumerable()
+        {
+            var sum = 0;
+
+            foreach (var i in _listAsIEnumerable)
+            {
+                sum += i;
+            }
+
+            return sum;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I add a benchmark on foreach on list.

Result on my machine are:
``` ini

BenchmarkDotNet=v0.12.1.1466-nightly, OS=Windows 10.0.19042
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.101
  [Host]     : .NET 5.0.1 (5.0.120.57516), X64 RyuJIT
  Job-JPDUOU : .NET 5.0.1 (5.0.120.57516), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                     Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
|             ForeachOnArray |  1.535 μs | 0.0078 μs | 0.0065 μs |  1.533 μs |  1.526 μs |  1.547 μs |  1.00 |    0.00 |     - |     - |     - |         - |
|              ForeachOnList |  6.117 μs | 0.0222 μs | 0.0208 μs |  6.111 μs |  6.090 μs |  6.154 μs |  3.98 |    0.02 |     - |     - |     - |         - |
| ForeachOnListAsIEnumerable | 19.073 μs | 0.0488 μs | 0.0433 μs | 19.080 μs | 19.009 μs | 19.133 μs | 12.43 |    0.05 |     - |     - |     - |      40 B |

close #1696 