### PR TITLE
Add benchmarks for log formatting

### DIFF
--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Logging/FormattingOverheadBenchmark.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Logging/FormattingOverheadBenchmark.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using MicroBenchmarks;
+
+namespace Microsoft.Extensions.Logging
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public class FormattingOverhead : LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<ILoggerProvider, LoggerProvider<FormattingLogger>>();
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+        }
+
+        [Benchmark]
+        public void TwoArguments_DefineMessage()
+        {
+            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+        }
+
+        [Benchmark]
+        public void FourArguments_DefineMessage()
+        {
+            FourArgumentErrorMessage(_logger, 1, "string", 2, "string", Exception);
+        }
+
+        [Benchmark]
+        public void NoArguments()
+        {
+            _logger.LogError(Exception, "Message");
+        }
+
+        [Benchmark]
+        public void TwoArguments()
+        {
+            _logger.LogError(Exception, "Message {Argument1} {Argument2}", 1, "string");
+        }
+
+        [Benchmark]
+        public void FourArguments_EnumerableArgument()
+        {
+            _logger.LogError(Exception, "Message {Argument1} {Argument2} {Argument3} {Argument4}", 1, "string", new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }, 1);
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Logging/LoggingBenchmarkBase.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Logging/LoggingBenchmarkBase.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Extensions.Logging
         protected static readonly Action<ILogger, int, string, Exception> TwoArgumentTraceMessage = LoggerMessage.Define<int, string>(LogLevel.Trace, 0, "Message {Argument1} {Argument2}");
         protected static readonly Action<ILogger, int, string, Exception> TwoArgumentErrorMessage = LoggerMessage.Define<int, string>(LogLevel.Error, 0, "Message {Argument1} {Argument2}");
 
+        protected static readonly Action<ILogger, int, string, int, string, Exception> FourArgumentErrorMessage = LoggerMessage.Define<int, string, int, string>(LogLevel.Error, 0, "Message {Argument1} {Argument2} {Argument3} {Argument4}");
+
         protected static Exception Exception = GetRealException();
         
         private static Exception GetRealException()
@@ -48,6 +50,24 @@ namespace Microsoft.Extensions.Logging
         {
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
+
+        public class FormattingLogger : ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                formatter(state, exception);
             }
 
             public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
Adds benchmarks for formatting in LogValuesFormatter to detect performance regression after a pull request that I intend to create for solving https://github.com/dotnet/runtime/issues/36025

Edit: Link to pull-request https://github.com/dotnet/runtime/pull/49228