### PR TITLE
Disable export to HTML and CSV

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -9,6 +9,9 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using System.Collections.Generic;
 using Reporting;
+using BenchmarkDotNet.Loggers;
+using System.Linq;
+using BenchmarkDotNet.Exporters;
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -37,7 +40,11 @@ namespace BenchmarkDotNet.Extensions
                 job = job.WithArguments(new Argument[] { new MsBuildArgument("/p:DebugType=portable") });
             }
 
-            var config = DefaultConfig.Instance
+            var config = ManualConfig.CreateEmpty()
+                .AddLogger(ConsoleLogger.Default) // log output to console
+                .AddValidator(DefaultConfig.Instance.GetValidators().ToArray()) // copy default validators
+                .AddAnalyser(DefaultConfig.Instance.GetAnalysers().ToArray()) // copy default analysers
+                .AddExporter(MarkdownExporter.GitHub) // export to GitHub markdown
                 .AddJob(job.AsDefault()) // tell BDN that this are our default settings
                 .WithArtifactsPath(artifactsPath.FullName)
                 .AddDiagnoser(MemoryDiagnoser.Default) // MemoryDiagnoser is enabled by default


### PR DESCRIPTION
By default, BDN exports the results to HTML, CSV, and GH Markdown:

https://github.com/dotnet/BenchmarkDotNet/blob/4a917dcb05bb1a04d0eb60a610936d15079e55fe/src/BenchmarkDotNet/Configs/DefaultConfig.cs#L30-L37

When running a lot of benchmarks many times it's a little bit annoying to get all the HTML and CSV files produced, especially when you copy the artifacts from one machine to the other.

Since BDN does not expose a way to disable exporters, we have to use an empty config and add everything that we want on our own.