### PR TITLE
Revert commenting out of new 6.0 API

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
@@ -59,7 +59,6 @@ namespace System.Tests
         public void NextBytes_span_unseeded() => _randomUnseeded.NextBytes(_bytes.AsSpan());
 #endif
 
-#if false // https://github.com/dotnet/performance/issues/1642
 #if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP3_1 && !NET5_0 // New API in .NET 6.0
         [Benchmark]
         public long Next_long() => _random.NextInt64(2^20);
@@ -78,7 +77,6 @@ namespace System.Tests
 
         [Benchmark]
         public float NextSingle_unseeded() => _randomUnseeded.NextSingle();
-#endif
 #endif
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/performance/issues/1642

@billwert it appears you added support for the 6.0 SDK, because I saw PriorityQueue tests.