### PR TITLE
Update microbenchmarks readme

### DIFF
--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,58 +12,58 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|net5.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net5.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|net5.0|net6.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net6.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 
 ```cmd
-dotnet run -c Release -f net5.0
+dotnet run -c Release -f net6.0
 ```
 
 To list all available benchmarks ([read more](../../../docs/benchmarkdotnet.md#Listing-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net5.0 --list flat|tree
+dotnet run -c Release -f net6.0 --list flat|tree
 ```
 
 To filter the benchmarks using a glob pattern applied to namespace.typeName.methodName ([read more](../../../docs/benchmarkdotnet.md#Filtering-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net5.0 --filter *Span*
+dotnet run -c Release -f net6.0 --filter *Span*
 ```
 
 To profile the benchmarked code and produce an ETW Trace file ([read more](../../../docs/benchmarkdotnet.md#Profiling)):
 
 ```cmd
-dotnet run -c Release -f net5.0 --filter $YourFilter --profiler ETW
+dotnet run -c Release -f net6.0 --filter $YourFilter --profiler ETW
 ```
 
 To run the benchmarks for multiple runtimes ([read more](../../../docs/benchmarkdotnet.md#Multiple-Runtimes)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 --filter * --runtimes netcoreapp3.1 net5.0 corert
+dotnet run -c Release -f net5.0 --filter * --runtimes net5.0 net6.0
 ```
 
 ## Private Runtime Builds
 
-If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
+If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests - so a command similar to `build clr+lib+libs.tests -rc release -lc release`) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 --filter $YourFilter \
-    --corerun C:\Projects\runtime\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe
+dotnet run -c Release -f net6.0 --filter $YourFilter \
+    --corerun C:\git\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe
 ```
 
 To make sure that your changes don't introduce any regressions, you can provide paths to CoreRuns with and without your changes and use the Statistical Test feature to detect regressions/improvements ([read more](../../../docs/benchmarkdotnet.md#Regressions)):
 
 ```cmd
-dotnet run -c Release -f netcoreapp3.1 \
+dotnet run -c Release -f net6.0 \
     --filter BenchmarksGame* \
     --statisticalTest 3ms \
     --coreRun \
-        "C:\Projects\runtime_upstream\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe" \
-        "C:\Projects\runtime_fork\artifacts\bin\testhost\net5.0-Windows_NT-Release-x64\shared\Microsoft.NETCore.App\5.0.0\CoreRun.exe"
+        "C:\git\runtime_upstream\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe" \
+        "C:\git\runtime_fork\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.0\CoreRun.exe"
 ```
 
 If you **prefer to use dotnet cli** instead of CoreRun, you need to pass the path to cli via the `--cli` argument.

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -48,7 +48,7 @@ dotnet run -c Release -f net5.0 --filter * --runtimes net5.0 net6.0
 
 ## Private Runtime Builds
 
-If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests - so a command similar to `build clr+lib+libs.tests -rc release -lc release`) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
+If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests - so a command similar to `build clr+libs+libs.tests -rc release -lc release`) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
 
 ```cmd
 dotnet run -c Release -f net6.0 --filter $YourFilter \


### PR DESCRIPTION
Update to be net6.0 by default.
Move into docs as I think it's important enough to be there. Most people will come to this repo to run microbenchmarks.