### PR TITLE
Increase build timeout in micro_benchmarks.py

### DIFF
--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -251,6 +251,9 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
     if args.wasm:
         run_args += ['--runtimes', 'wasm']
 
+    # Increase default 2 min build timeout to accommodate slow (or even very slow) hardware
+    run_args += ['--buildTimeout', '600']
+
     return run_args
 
 


### PR DESCRIPTION
On my old Intel Atom based Surface, the build of microbenchmarks.csproj takes nearly 4 minutes. The default build timeout is 2 minutes. 

Since we're asking folks to run micro_benchmarks.py on all kinds of hardware, we should update the timeout. I picked 600 seconds because who knows how long it takes on a Raspberry Pi (?)

Note that this will not take effect until https://github.com/dotnet/BenchmarkDotNet/issues/1669 is fixed. It is fine to merge before then though. I verified it does pass the flag through.

