### PR TITLE
Read console output as utf8

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -170,7 +170,6 @@ class RunCommand:
                     stdout=PIPE if should_pipe else DEVNULL,
                     stderr=STDOUT,
                     universal_newlines=True,
-                    encoding='utf-8',
                     errors='ignore'
             ) as proc:
                 if proc.stdout is not None:

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -170,6 +170,8 @@ class RunCommand:
                     stdout=PIPE if should_pipe else DEVNULL,
                     stderr=STDOUT,
                     universal_newlines=True,
+                    encoding='utf-8',
+                    errors='ignore'
             ) as proc:
                 if proc.stdout is not None:
                     with proc.stdout:


### PR DESCRIPTION
Fix #1742

Python is apparently using the OEM codepage to decode the bytes it reads from console output pipe of the spawned dotnet process. If the dotnet process emits a sequence of bytes that is not represented in the OEM codepage, it will cause this error. System.Console.Write() will emit strings in the encoding returned by GetConsoleOutputCP(). I am guessing in this repro the console output encoding is set to UTF-8, and something in the output ends up encoding to 0x81.

E.g, if I do `chcp 65001` to change console codepage to UTF-8 and replace the top of microbenchmark.csproj with:
```xml
<Project Sdk="Microsoft.NET.Sdk" InitialTargets="echo">
<Target Name="echo">
<Warning Text="&#x81;"/>
</Target>
```
then run the benchmark script, it will fail in this way when trying to build that project. In this case the MSBuild console logger is using Console.Write(). I guess that dotnet.exe itself does so as well.

I am not sure why Python is decoding using the OEM codepage in this case. Grepping the Python code, I see a call GetConsoleOutputCP() but I didn't debug to see what is going on.

The fix is to add `errors='ignore'` to tell Python to ignore decoding errors. I considered also adding `encoding='utf-8'` but this could be equally wrong if the spawned process isn't using that encoding. If we see garbled text when folks have their console CP set to UTF-8 we would need to investigate further to figure out how to have Python properly read the console CP.