### PR TITLE
Add command-line option to display full benchmark name id

### DIFF
--- a/src/tools/ResultsComparer/CommandLineOptions.cs
+++ b/src/tools/ResultsComparer/CommandLineOptions.cs
@@ -35,6 +35,9 @@ namespace ResultsComparer
         [Option('f', "filter", HelpText = "Filter the benchmarks by name using glob pattern(s). Optional.")]
         public IEnumerable<string> Filters { get; set; }
 
+        [Option("full-id", HelpText = "Display the full benchmark name id. Optional.")]
+        public bool FullId { get; set; }
+
         [Usage(ApplicationAlias = "")]
         public static IEnumerable<Example> Examples
         {

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -120,7 +120,7 @@ namespace ResultsComparer
                 .Take(args.TopCount ?? int.MaxValue)
                 .Select(result => new
                 {
-                    Id = result.id.Length > 80 ? result.id.Substring(0, 80) : result.id,
+                    Id = (result.id.Length <= 80 || args.FullId) ? result.id : result.id.Substring(0, 80),
                     DisplayValue = GetRatio(conclusion, result.baseResult, result.diffResult),
                     BaseMedian = result.baseResult.Statistics.Median,
                     DiffMedian = result.diffResult.Statistics.Median,
@@ -191,7 +191,7 @@ namespace ResultsComparer
         private static void ExportToXml((string id, Benchmark baseResult, Benchmark diffResult, EquivalenceTestConclusion conclusion)[] notSame, FileInfo xmlPath)
         {
             if (xmlPath == null)
-            {  
+            {
                 Console.WriteLine("No file given");
                 return;
             }


### PR DESCRIPTION
* Currently ResultsComparer trims all benchmark name ids to 80 characters. This option gives the ability to view the whole id.