### PR TITLE
Failure reporting doesn't run outside of lab

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -31,6 +31,7 @@ from performance.common import helixpayload, validate_supported_runtime, get_art
 from performance.logger import setup_loggers
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from channel_map import ChannelMap
+from shared.util import runninginlab
 from subprocess import Popen, CalledProcessError
 
 import dotnet
@@ -237,18 +238,20 @@ def __main(args: list) -> int:
                 '**',
                 '*perf-lab-report.json')
         except CalledProcessError:
-            upload_container = 'failedresults'
-            globpath = os.path.join(
-                get_artifacts_directory() if not args.bdn_artifacts else args.bdn_artifacts,
-                'FailureReporter', 
-                'failure-report.json')
-            cmdline = [
-                'FailureReporting.exe', globpath
-            ]
-            reporterpath = os.path.join(helixpayload(), 'FailureReporter')
-            if not os.path.exists(reporterpath):
-                raise FileNotFoundError
-            RunCommand(cmdline, verbose=True).run(reporterpath)
+            if runninginlab():
+                args.upload_to_perflab_container = False
+                upload_container = 'failedresults'
+                globpath = os.path.join(
+                    get_artifacts_directory() if not args.bdn_artifacts else args.bdn_artifacts,
+                    'FailureReporter', 
+                    'failure-report.json')
+                cmdline = [
+                    'FailureReporting.exe', globpath
+                ]
+                reporterpath = os.path.join(helixpayload(), 'FailureReporter')
+                if not os.path.exists(reporterpath):
+                    raise FileNotFoundError
+                RunCommand(cmdline, verbose=True).run(reporterpath)
             
         dotnet.shutdown_server(verbose)
 

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -27,11 +27,10 @@ from logging import getLogger
 import os
 import sys
 
-from performance.common import helixpayload, validate_supported_runtime, get_artifacts_directory, RunCommand
+from performance.common import helixpayload, runninginlab, validate_supported_runtime, get_artifacts_directory, RunCommand
 from performance.logger import setup_loggers
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from channel_map import ChannelMap
-from shared.util import runninginlab
 from subprocess import Popen, CalledProcessError
 
 import dotnet

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -73,6 +73,9 @@ def helixpayload():
     '''
     return environ.get('HELIX_CORRELATION_PAYLOAD')
 
+def runninginlab():
+    return environ.get('PERFLAB_INLAB') is not None
+
 def get_script_path() -> str:
     '''Gets this script directory.'''
     return os.path.dirname(os.path.realpath(__file__))

--- a/src/scenarios/shared/sod.py
+++ b/src/scenarios/shared/sod.py
@@ -6,10 +6,10 @@ import os
 import platform
 from shutil import copytree, copy
 from performance.logger import setup_loggers
-from performance.common import helixpayload, get_artifacts_directory, get_packages_directory, RunCommand
+from performance.common import helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
-from shared.util import helixworkitempayload, helixuploaddir, builtexe, publishedexe, runninginlab, uploadtokenpresent, getruntimeidentifier, extension
+from shared.util import helixworkitempayload, helixuploaddir, builtexe, publishedexe, uploadtokenpresent, getruntimeidentifier, extension
 from shared.const import *
 class SODWrapper(object):
     '''

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -6,10 +6,10 @@ import os
 import platform
 from shutil import copytree
 from performance.logger import setup_loggers
-from performance.common import helixpayload, get_artifacts_directory, get_packages_directory, RunCommand
+from performance.common import helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
-from shared.util import extension, helixworkitempayload, helixuploaddir, builtexe, publishedexe, runninginlab, uploadtokenpresent, getruntimeidentifier, iswin
+from shared.util import extension, helixworkitempayload, helixuploaddir, builtexe, publishedexe, uploadtokenpresent, getruntimeidentifier, iswin
 from shared.const import *
 from shared.testtraits import TestTraits
 from subprocess import CalledProcessError

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -113,18 +113,19 @@ class StartupWrapper(object):
         try:
             RunCommand(startup_args, verbose=True).run()
         except CalledProcessError:
-            upload_container = 'failedresults'
-            reportjson = os.path.join(
-                TRACEDIR,
-                'FailureReporter', 
-                'failure-report.json')
-            cmdline = [
-                'FailureReporting.exe', reportjson
-            ]
-            reporterpath = os.path.join(helixpayload(), 'FailureReporter')
-            if not os.path.exists(reporterpath):
-                raise FileNotFoundError
-            RunCommand(cmdline, verbose=True).run(reporterpath)
+            if runninginlab():
+                upload_container = 'failedresults'
+                reportjson = os.path.join(
+                    TRACEDIR,
+                    'FailureReporter', 
+                    'failure-report.json')
+                cmdline = [
+                    'FailureReporting.exe', reportjson
+                ]
+                reporterpath = os.path.join(helixpayload(), 'FailureReporter')
+                if not os.path.exists(reporterpath):
+                    raise FileNotFoundError
+                RunCommand(cmdline, verbose=True).run(reporterpath)
 
         if runninginlab():
             copytree(TRACEDIR, os.path.join(helixuploaddir(), 'traces'))

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -39,9 +39,6 @@ def publishedexe(exename: str):
 def uploadtokenpresent():
     return environ.get(UPLOAD_TOKEN_VAR) is not None
 
-def runninginlab():
-    return environ.get('PERFLAB_INLAB') is not None
-
 def getruntimeidentifier():
     rid = None
     if iswin():


### PR DESCRIPTION
This PR is to fix an issue where failure reporting tries to run outside of the lab and causes unintended startup test failure.