### PR TITLE
Change skewness and kurtosis to be nullable type

### DIFF
--- a/src/tools/ResultsComparer/DataTransferContracts.cs
+++ b/src/tools/ResultsComparer/DataTransferContracts.cs
@@ -76,8 +76,8 @@ namespace DataTransferContracts // generated with http://json2csharp.com/#
         public double StandardError { get; set; }
         public double Variance { get; set; }
         public double StandardDeviation { get; set; }
-        public double Skewness { get; set; }
-        public double Kurtosis { get; set; }
+        public double? Skewness { get; set; }
+        public double? Kurtosis { get; set; }
         public ConfidenceInterval ConfidenceInterval { get; set; }
         public Percentiles Percentiles { get; set; }
     }


### PR DESCRIPTION
* Fixes #1684
* Skewness and kurtosis can have undefined (null) values when
  the variance is zero.
* Currently when this situation arrises, an unhandled exception
  is thrown by the json deserialization.