### PR TITLE
Resolve Ubuntu Scenario Test Failures

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -52,7 +52,7 @@ namespace ScenarioMeasurement
                 RootAccess = true
             };
 
-            if (Install(logger) != Result.Success)
+            if (Install() != Result.Success)
             {
                 throw new Exception("Lttng installation failed. Please try manual install.");
             }
@@ -105,9 +105,9 @@ namespace ScenarioMeasurement
             return result;
         }
 
-        public Result Install(Logger logger)
+        public Result Install()
         {
-            if (LttngInstalled(logger))
+            if (LttngInstalled())
             {
                 Console.WriteLine("Lttng is already installed.");
                 return Result.Success;
@@ -115,10 +115,10 @@ namespace ScenarioMeasurement
             perfCollectProcess.Arguments = "install -force";
             perfCollectProcess.Run();
 
-            int retry = 1;
+            int retry = 10;
             for(int i=0; i<retry; i++)
             {
-                if (!LttngInstalled(logger))
+                if (!LttngInstalled())
                 {
                     Console.WriteLine($"Lttng not installed. Retry {i}...");
                     perfCollectProcess.Run();
@@ -146,17 +146,14 @@ namespace ScenarioMeasurement
             KernelEvents.Add(keyword);
         }
 
-        private bool LttngInstalled(Logger logger)
+        private bool LttngInstalled()
         {
             ProcessStartInfo procStartInfo = new ProcessStartInfo("modinfo", "lttng_probe_writeback");
-            logger.Log("FileName: " + procStartInfo.FileName);
-            logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.StartInfo.RedirectStandardOutput = true;
             proc.Start();
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
-            logger.Log("Result: (" + result + ")");
             return File.Exists("//usr/bin/lttng") && result != null && result.Contains("filename:");
         }
 

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -152,10 +152,10 @@ namespace ScenarioMeasurement
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.StartInfo.RedirectStandardOutput = true;
             proc.Start();
-            proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
             // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
-            return File.Exists("//usr/bin/lttng") && result != null && result.Contains("filename:");
+            return result.Contains("filename:");
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,11 +148,13 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled(Logger logger)
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "lsmod | more ");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod | more ");
             logger.Log("FileName: " + procStartInfo.FileName);
             logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
+            proc.StartInfo.RedirectStandardOutput = true;
             proc.Start();
+            proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
             return File.Exists("//usr/bin/lttng") && result.Contains("lttng_");
         }

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -115,7 +115,7 @@ namespace ScenarioMeasurement
             perfCollectProcess.Arguments = "install -force";
             perfCollectProcess.Run();
 
-            int retry = 10;
+            int retry = 1;
             for(int i=0; i<retry; i++)
             {
                 if (!LttngInstalled(logger))

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled()
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("/bin/bash", "lsmod | more ");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "lsmod | more ");
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.Start();
             string result = proc.StandardOutput.ReadToEnd();

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled()
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("", "lsmod | more ");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("/bin/bash", "lsmod | more ");
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.Start();
             string result = proc.StandardOutput.ReadToEnd();

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled(Logger logger)
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod | more ");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod | grep lttng");
             logger.Log("FileName: " + procStartInfo.FileName);
             logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
@@ -156,7 +156,7 @@ namespace ScenarioMeasurement
             proc.Start();
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
-            return File.Exists("//usr/bin/lttng") && result.Contains("lttng_");
+            return File.Exists("//usr/bin/lttng") && result != null && result.Length > 0;
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -147,7 +148,11 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled()
         {
-            return File.Exists("//usr/bin/lttng");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("", "lsmod | more ");
+            Process proc = new Process() { StartInfo = procStartInfo, };
+            proc.Start();
+            string result = proc.StandardOutput.ReadToEnd();
+            return File.Exists("//usr/bin/lttng") && result.Contains("lttng_");
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled(Logger logger)
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c modinfo lttng_probe_writeback");
             logger.Log("FileName: " + procStartInfo.FileName);
             logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
@@ -157,7 +157,7 @@ namespace ScenarioMeasurement
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
             logger.Log("Result: (" + result + ")");
-            return File.Exists("//usr/bin/lttng") && result != null;
+            return File.Exists("//usr/bin/lttng") && result != null && result.Contains("filename:");
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled(Logger logger)
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c modinfo lttng_probe_writeback");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("modinfo", "lttng_probe_writeback");
             logger.Log("FileName: " + procStartInfo.FileName);
             logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -148,7 +148,7 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled(Logger logger)
         {
-            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod | grep lttng");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "-c lsmod");
             logger.Log("FileName: " + procStartInfo.FileName);
             logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
@@ -157,7 +157,7 @@ namespace ScenarioMeasurement
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
             logger.Log("Result: (" + result + ")");
-            return File.Exists("//usr/bin/lttng") && result != null && result.Length > 0;
+            return File.Exists("//usr/bin/lttng") && result != null && result.Contains("lttng");
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -156,6 +156,7 @@ namespace ScenarioMeasurement
             proc.Start();
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
+            logger.Log("Result: (" + result + ")");
             return File.Exists("//usr/bin/lttng") && result != null && result.Length > 0;
         }
 

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -157,7 +157,7 @@ namespace ScenarioMeasurement
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
             logger.Log("Result: (" + result + ")");
-            return File.Exists("//usr/bin/lttng") && result != null && result.Contains("lttng");
+            return File.Exists("//usr/bin/lttng") && result != null;
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -52,7 +52,7 @@ namespace ScenarioMeasurement
                 RootAccess = true
             };
 
-            if (Install() != Result.Success)
+            if (Install(logger) != Result.Success)
             {
                 throw new Exception("Lttng installation failed. Please try manual install.");
             }
@@ -105,9 +105,9 @@ namespace ScenarioMeasurement
             return result;
         }
 
-        public Result Install()
+        public Result Install(Logger logger)
         {
-            if (LttngInstalled())
+            if (LttngInstalled(logger))
             {
                 Console.WriteLine("Lttng is already installed.");
                 return Result.Success;
@@ -118,7 +118,7 @@ namespace ScenarioMeasurement
             int retry = 10;
             for(int i=0; i<retry; i++)
             {
-                if (!LttngInstalled())
+                if (!LttngInstalled(logger))
                 {
                     Console.WriteLine($"Lttng not installed. Retry {i}...");
                     perfCollectProcess.Run();
@@ -146,11 +146,11 @@ namespace ScenarioMeasurement
             KernelEvents.Add(keyword);
         }
 
-        private bool LttngInstalled()
+        private bool LttngInstalled(Logger logger)
         {
             ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "lsmod | more ");
-            Console.WriteLine("FileName: " + procStartInfo.FileName);
-            Console.WriteLine("Args: " + procStartInfo.Arguments);
+            logger.Log("FileName: " + procStartInfo.FileName);
+            logger.Log("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.Start();
             string result = proc.StandardOutput.ReadToEnd();

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -154,6 +154,7 @@ namespace ScenarioMeasurement
             proc.Start();
             proc.WaitForExit();
             string result = proc.StandardOutput.ReadToEnd();
+            // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
             return File.Exists("//usr/bin/lttng") && result != null && result.Contains("filename:");
         }
 

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -149,6 +149,8 @@ namespace ScenarioMeasurement
         private bool LttngInstalled()
         {
             ProcessStartInfo procStartInfo = new ProcessStartInfo("bash", "lsmod | more ");
+            Console.WriteLine("FileName: " + procStartInfo.FileName);
+            Console.WriteLine("Args: " + procStartInfo.Arguments);
             Process proc = new Process() { StartInfo = procStartInfo, };
             proc.Start();
             string result = proc.StandardOutput.ReadToEnd();


### PR DESCRIPTION
This PR is to resolve scenario test failures in pipeline runs such as
https://dev.azure.com/dnceng/internal/_build/results?buildId=1101991&view=logs&j=9d3763e3-464f-5ce4-a590-b3a4c86731a8&t=0357c9b3-0714-5dd0-78d8-213761c0279d
The New Console Template, New VB Console Template, and Static Console Template scenario tests were failing on machines where the lttng kernel modules had not been installed because the check for whether lttng was installed was returning false positives, causing the test to proceed when the necessary modules were not present..  The  modified check has been confirmed to return false if lttng is not installed, and true once it has been installed.