### PR TITLE
Make BTL traces compatible with GC Infra's CPU Samples Analysis

### DIFF
--- a/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
+++ b/src/benchmarks/gc/src/analysis/managed-lib/Analysis.cs
@@ -1432,7 +1432,9 @@ namespace GCPerf
         /// </returns>
         public static EtlxNS.TraceLog GetOpenedTraceLog(string tracePath)
         {
-            return EtlxNS.TraceLog.OpenOrConvert(tracePath);
+            return new EtlxNS.TraceLog(
+                EtlxNS.TraceLog.CreateFromEventTraceLogFile(tracePath)
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
When working with the CPU Samples Analysis feature of GC Infra, the API used to open trace files only supported _ETL_ and _ETLX_ traces. However, _BTL_ traces are also a common occurrence, so this PR changes to another API that supports all trace file formats.