### PR TITLE
Maestro Update Fix

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -16,6 +16,7 @@ from stat import S_IRWXU
 from subprocess import CalledProcessError, check_output
 from sys import argv, platform
 from typing import Tuple
+from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
 from time import sleep
@@ -599,7 +600,7 @@ def get_commit_date(
                 item = loads(response.read().decode('utf-8'))
                 build_timestamp = item['commit']['committer']['date']
                 success = 1
-        except urllib.error.URLError:
+        except URLError:
             retrycount += 1
 
     if not build_timestamp:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -590,10 +590,17 @@ def get_commit_date(
         url = urlformat % (owner, repo, commit_sha)
 
     build_timestamp = None
-    with urlopen(url) as response:
-        getLogger().info("Commit: %s", url)
-        item = loads(response.read().decode('utf-8'))
-        build_timestamp = item['commit']['committer']['date']
+    retrycount = 0
+    success = 0
+    while success == 0 and retrycount <= 3:
+        try:
+            with urlopen(url) as response:
+                getLogger().info("Commit: %s", url)
+                item = loads(response.read().decode('utf-8'))
+                build_timestamp = item['commit']['committer']['date']
+                success = 1
+        except urllib.error.URLError:
+            retrycount += 1
 
     if not build_timestamp:
         raise RuntimeError(


### PR DESCRIPTION
There was an issue in the automatic maestro update pipeline for dotnet/arcade:
https://dev.azure.com/dnceng/public/_build/results?buildId=1157259&view=logs&j=a180af0e-af02-5d26-0017-a0951a9cd006&t=fa1e7e93-22f5-5c80-f187-7542438ac1cb
involving a urlopen(...) call timing out.  This PR works to resolve that issue by adding retries.