### PR TITLE
Add Information To JSON Upload For Use In Improved Alerting

### DIFF
--- a/src/tools/Reporting/Reporting/Os.cs
+++ b/src/tools/Reporting/Reporting/Os.cs
@@ -11,5 +11,7 @@ namespace Reporting
         public string Architecture { get; set; }
 
         public string Name { get; set; }
+
+        public string MachineName { get; set; }
     }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -56,6 +56,7 @@ namespace Reporting
                 PerfRepoHash = environment.GetEnvironmentVariable("PERFLAB_PERFHASH"),
                 Name = environment.GetEnvironmentVariable("PERFLAB_RUNNAME"),
                 Queue = environment.GetEnvironmentVariable("PERFLAB_QUEUE"),
+                WorkItemName = environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME"),
             };
             Boolean.TryParse(environment.GetEnvironmentVariable("PERFLAB_HIDDEN"), out bool hidden);
             run.Hidden = hidden;
@@ -72,6 +73,7 @@ namespace Reporting
             os = new Os()
             {
                 Name = $"{RuntimeEnvironment.OperatingSystem} {RuntimeEnvironment.OperatingSystemVersion}",
+                MachineName = environment.GetEnvironmentVariable("COMPUTERNAME"),
                 Architecture = RuntimeInformation.OSArchitecture.ToString(),
                 Locale = CultureInfo.CurrentUICulture.ToString()
             };

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -73,7 +73,7 @@ namespace Reporting
             os = new Os()
             {
                 Name = $"{RuntimeEnvironment.OperatingSystem} {RuntimeEnvironment.OperatingSystemVersion}",
-                MachineName = environment.GetEnvironmentVariable("COMPUTERNAME"),
+                MachineName = Environment.MachineName,
                 Architecture = RuntimeInformation.OSArchitecture.ToString(),
                 Locale = CultureInfo.CurrentUICulture.ToString()
             };

--- a/src/tools/Reporting/Reporting/Run.cs
+++ b/src/tools/Reporting/Reporting/Run.cs
@@ -19,6 +19,8 @@ namespace Reporting
         public string Name { get; set; }
 
         public string Queue { get; set; }
+
+        public string WorkItemName { get; set; }
         public IDictionary<string, string> Configurations { get; set; } = new Dictionary<string, string>();
     }
 }


### PR DESCRIPTION
This PR adds WorkItemName to the Run section of the JSON so that the logger in the TableUploader will have enough information to generate a link to the console logs for a run.  It also adds MachineName to the OS section for general use.

Used by https://nettel.visualstudio.com/perflab/_git/perflab/pullrequest/284