### PR TITLE
Fix Nuget Security Analysis Failure

### DIFF
--- a/src/benchmarks/other/dmlib/Nuget.config
+++ b/src/benchmarks/other/dmlib/Nuget.config
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <configuration>
 <packageSources>
+    <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
 </packageSources>


### PR DESCRIPTION
Pipeline runs such as
https://dev.azure.com/dnceng/internal/_build/results?buildId=1185862&view=logs&j=29d8e88d-11c4-5181-c9c6-ef9b781e53ff&t=425f389a-db5b-57be-b0bc-7a8785f394fb
are failing at the Nuget Security Analysis stage, apparently due to a missing <clear /> statement.  This PR adds that statement.