### PR TITLE
Added support for KiB, MiB, and GiB notations when reading a machines specs in GC infra

### DIFF
--- a/src/benchmarks/gc/src/commonlib/util.py
+++ b/src/benchmarks/gc/src/commonlib/util.py
@@ -608,8 +608,16 @@ def kb_to_mb(kb: float) -> float:
     return bytes_to_mb(kb_to_bytes(kb))
 
 
+def mb_to_kb(mb: float) -> float:
+    return bytes_to_kb(mb_to_bytes(mb))
+
+
 def mb_to_gb(mb: float) -> float:
     return bytes_to_gb(mb_to_bytes(mb))
+
+
+def gb_to_kb(gb: float) -> float:
+    return bytes_to_kb(gb_to_bytes(gb))
 
 
 def gb_to_mb(gb: float) -> float:


### PR DESCRIPTION
Fixes #1816. When reading a Linux machine's cache memory sizes, the infra by default expected the numbers in KB, with the "K" notation. However, as of recent, it is not uncommon to work with machines that use the "KiB" notation instead.

In addition to this, it's not rare for machines to have MB of cache. This PR also adds the capability to process "M" and "MiB" for this case, and in foresight of the future, "G" and "GiB" values.

With these changes in place, `python3 . setup` should now work properly on Linux machines.