### PR TITLE
handle incomplete reads in DeflateStream benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -61,7 +61,18 @@ namespace System.IO.Compression
             CompressedFile.CompressedDataStream.Position = 0;
 
             var compressor = CreateStream(CompressedFile.CompressedDataStream, CompressionMode.Decompress);
-            return compressor.Read(CompressedFile.UncompressedData, 0, CompressedFile.UncompressedData.Length);
+
+            byte[] buffer = CompressedFile.UncompressedData;
+
+            int totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                int bytesRead = compressor.Read(buffer, totalRead, buffer.Length - totalRead);
+                if (bytesRead == 0) break;
+                totalRead += bytesRead;
+            }
+
+            return totalRead;
         }
     }
 }


### PR DESCRIPTION
I saw https://github.com/DrewScoggins/performance-2/issues/6594 and realized that it was not an improvement ;)

|     Method |   level |             file |   Before |    After |
|----------- |-------- |----------------- |---------:|---------:|
| Decompress | Optimal | TestDocument.pdf | 34.13 us | 307.8 us |
| Decompress | Optimal |      alice29.txt | 61.43 us | 393.4 us |
| Decompress | Optimal |              sum | 64.63 us | 117.1 us |
| Decompress | Fastest | TestDocument.pdf | 34.03 us | 303.2 us |
| Decompress | Fastest |      alice29.txt | 63.68 us | 449.3 us |
| Decompress | Fastest |              sum | 65.12 us | 122.5 us |

cc @DrewScoggins https://github.com/dotnet/docs/issues/24649