### PR TITLE
make sure --buildTimeout parameter is only set once

### DIFF
--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -252,7 +252,8 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
         run_args += ['--runtimes', 'wasm']
 
     # Increase default 2 min build timeout to accommodate slow (or even very slow) hardware
-    run_args += ['--buildTimeout', '600']
+    if '--buildTimeout' not in args.bdn_arguments:
+    	run_args += ['--buildTimeout', '600']
 
     return run_args
 

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1555" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1555" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1559" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1559" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allow --buildTimeout is set outside micro_benchmarks.py as extra benchmarkdonet parameter