### PR TITLE
Fix python script retry behavior

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -202,7 +202,7 @@ class RunCommand:
 
         retrycount = 0
         (returncode, quoted_cmdline) = self.__runinternal(working_directory)
-        while returncode not in self.success_exit_codes and retrycount <= self.__retry:
+        while returncode not in self.success_exit_codes and retrycount < self.__retry:
             (returncode, _) = self.__runinternal(working_directory)
             retrycount += 1
 


### PR DESCRIPTION
- Don't retry running when self.__retry is set to 0
- Before this change: If an exception occurs in any single benchmark, it causes a return code of 1. This results in the script retrying the original run command again (only once more).
- After this change: No retry attempts are made (if self.__retry=0)

Example (before change) (using the unmodified python script with self.__retry=0) :

1. py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter "A" "B" "C"
2. benchmark "A" runs
3. benchmark "B" runs but with an exception
4. benchmark "C" runs
5. At this point, the script retries the original command in (1)
6. py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter "A" "B" "C"
7. benchmark "A" runs
8. benchmark "B" runs but with an exception
9. benchmark "C" runs
10. At this point, the script does not do any further retries
11. Exits

Example (after change) (using the unmodified python script with self.__retry=0):

1. py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter "A" "B" "C"
2. benchmark "A" runs
3. benchmark "B" runs but with an exception
4. benchmark "C" runs
10. At this point, the script does not do any further retries
11. Exits

Prior to this change, it was especially problematic in situations where the filter is set to "*" (full set of benchmarks). Any single exception would cause them all to run again at the end in another retry attempt.