### PR TITLE
Add NoneType check before iterating args.bdn_arguments

### DIFF
--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -252,7 +252,7 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
         run_args += ['--runtimes', 'wasm']
 
     # Increase default 2 min build timeout to accommodate slow (or even very slow) hardware
-    if '--buildTimeout' not in args.bdn_arguments:
+    if not args.bdn_arguments or '--buildTimeout' not in args.bdn_arguments:
     	run_args += ['--buildTimeout', '600']
 
     return run_args


### PR DESCRIPTION
- Fixes a crash with running benchmarks_ci.py due to args.bdn_arguments being iterated over even when it's of NoneType value (the bdn_arguments flag was not given, so the variable is left uninitialized).