### PR TITLE
update benchmarkdotnet version to version0.13.0.1579

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1559" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1559" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1561" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1561" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1561" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1561" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1579" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1579" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 to set WasmNativeWorkload=false in project template for wasm runs.