### PR TITLE
Resolve Platform-Check Failure for Windows-Only Code

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
@@ -154,11 +154,13 @@ namespace ScenarioMeasurement
 
         public static bool IsAdministrator()
         {
+#pragma warning disable CA1416 // WindowsTraceSession only called from TraceSessionManager if platform is windows
             using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
             {
                 WindowsPrincipal principal = new WindowsPrincipal(identity);
                 return principal.IsInRole(WindowsBuiltInRole.Administrator);
             }
+#pragma warning restore CA1416
         }
     }
 }


### PR DESCRIPTION
Pipeline runs such as
https://dev.azure.com/dnceng/public/_build/results?buildId=1208271&view=logs&j=dd08f2bf-bf1a-5191-3568-3765002a3be7&t=f0bfaf78-669e-5ef4-30a6-ab237e128918
are failing due to a platform check throwing an error for code that only executes when the platform is windows.  This fix disables that check for the specific windows-only code.