### PR TITLE
Error handling fixes

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -243,7 +243,8 @@ def __main(args: list) -> int:
                 reportdir = os.path.join(
                     get_artifacts_directory() if not args.bdn_artifacts else args.bdn_artifacts,
                     'FailureReporter')
-                os.makedirs(reportdir)
+                if not os.path.exists(reportdir):
+                    os.makedirs(reportdir)
                 globpath = os.path.join(
                     reportdir, 
                     'failure-report.json')
@@ -253,9 +254,10 @@ def __main(args: list) -> int:
                 ]
                 reporterpath = os.path.join(helixpayload(), 'FailureReporter')
                 if not os.path.exists(reporterpath):
-                    raise FileNotFoundError
-                getLogger().info("Generating failure results at " + globpath)
-                RunCommand(cmdline, verbose=True).run(reporterpath)
+                    getLogger().error("can't find file {0}.format(reporterpath)")
+                else:
+                    getLogger().info("Generating failure results at " + globpath)
+                    RunCommand(cmdline, verbose=True).run(reporterpath)
             else:
                 args.upload_to_perflab_container = False
 


### PR DESCRIPTION
- [ ] Check if folder exists before mkdir
- [ ] log error message when FailureReport file doesn't exist instead of raising exception, so that the remaining code in the function has chance to run  