### PR TITLE
Rethrow the caught exception so that it is bobbled up correctly

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -260,6 +260,8 @@ def __main(args: list) -> int:
                     RunCommand(cmdline, verbose=True).run(reporterpath)
             else:
                 args.upload_to_perflab_container = False
+            # rethrow the caught CalledProcessError exception so that the exception being bobbled up correctly.
+            raise
 
         dotnet.shutdown_server(verbose)
 

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -260,7 +260,7 @@ def __main(args: list) -> int:
                     RunCommand(cmdline, verbose=True).run(reporterpath)
             else:
                 args.upload_to_perflab_container = False
-            # rethrow the caught CalledProcessError exception so that the exception being bobbled up correctly.
+            # rethrow the caught CalledProcessError exception so that the exception being bubbled up correctly.
             raise
 
         dotnet.shutdown_server(verbose)


### PR DESCRIPTION
This is for fixing a regression introduced by PR https://github.com/dotnet/performance/pull/1703.  CalledProcessError exception was caught to do failure report handling, however, it was not rethrew. Because of that, the job reports pass even when  micro_benchmarks.run() failed with exception.

