### PR TITLE
Update tag references to dotnet-buildtools/prereqs

### DIFF
--- a/azure-pipelines-gc.yml
+++ b/azure-pipelines-gc.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
     - container: ubuntu_x64_build_container
-      image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-c103199-20180628134544
 
 # Trigger builds for PR's targeting main
 pr:

--- a/eng/performance/pr.yml
+++ b/eng/performance/pr.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
     - container: ubuntu_x64_build_container
-      image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-c103199-20180628134544
 
 trigger: none
 


### PR DESCRIPTION
Updating Docker image tag references that are obsolete and replaced by references to mcr.microsoft.com/dotnet-buildtools/prereqs. See dotnet/dotnet-docker#2848.