### PR TITLE
Use newer packages to avoid AOT errors

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jil" Version="2.17.0" />
+    <PackageReference Include="Jil" Version="3.0.0-alpha2" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0-rc.1.20417.14" />
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0-rc.1.20417.14" />
-    <PackageReference Include="protobuf-net" Version="2.4.0" />
+    <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0-rc.1.20417.14" />
     <PackageReference Include="System.Formats.Cbor" Version="5.0.0-rc.1.20417.14" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'" />


### PR DESCRIPTION
This gets rid of AOT crosscompiler errors like:

    error : Can't find custom attr constructor image: .../performance/artifacts/bin/MicroBenchmarks/Release/net6.0/Job-XNXFKF/bin/net6.0/browser-wasm/publish/Sigil.dll mtoken: 0x0a00000b due to: Could not load file or assembly 'System.Runtime.InteropServices.PInvoke, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.