### PR TITLE
Allow to build with local BenchmarkDotNet sources

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -3,11 +3,16 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(BenchmarkDotNetSources)' == ''">
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0.1559" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.0.1559" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(BenchmarkDotNetSources)' != ''">
+    <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet\BenchmarkDotNet.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet.Diagnostics.Windows\BenchmarkDotNet.Diagnostics.Windows.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
 


### PR DESCRIPTION
Make it easier to use custom BenchmarkDotNet sources. Example use:

    dotnet build -bl -c Release -p:BenchmarkDotNetSources="\myPath\git\BenchmarkDotNet" src\benchmarks\micro