### PR TITLE
Revise the PipeStream perf tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.AnonymousPipeStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.AnonymousPipeStream.cs
@@ -4,24 +4,13 @@
 
 namespace System.IO.Pipes.Tests
 {
-    public class Perf_AnonymousPipeStream_ServerIn_ClientOut : Perf_PipeTest
+    public class Perf_AnonymousPipeStream : Perf_PipeTest
     {
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
             ret.readablePipe = new AnonymousPipeServerStream(PipeDirection.In);
             ret.writeablePipe = new AnonymousPipeClientStream(PipeDirection.Out, ((AnonymousPipeServerStream)ret.readablePipe).ClientSafePipeHandle);
-            return ret;
-        }
-    }
-
-    public class Perf_AnonymousPipeStream_ServerOut_ClientIn : Perf_PipeTest
-    {
-        protected override ServerClientPair CreateServerClientPair()
-        {
-            ServerClientPair ret = new ServerClientPair();
-            ret.writeablePipe = new AnonymousPipeServerStream(PipeDirection.Out);
-            ret.readablePipe = new AnonymousPipeClientStream(PipeDirection.In, ((AnonymousPipeServerStream)ret.writeablePipe).ClientSafePipeHandle);
             return ret;
         }
     }

--- a/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.NamedPipeStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.NamedPipeStream.cs
@@ -2,56 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using BenchmarkDotNet.Attributes;
 using System.Threading.Tasks;
 
 namespace System.IO.Pipes.Tests
 {
-    public class Perf_NamedPipeStream_ServerOut_ClientIn : Perf_PipeTest
+    public class Perf_NamedPipeStream : Perf_PipeTest
     {
+        [Params(PipeOptions.None, PipeOptions.Asynchronous)]
+        public PipeOptions Options { get; set; }
+
         protected override ServerClientPair CreateServerClientPair()
         {
             ServerClientPair ret = new ServerClientPair();
             string pipeName = GetUniquePipeName();
-            var writeablePipe = new NamedPipeServerStream(pipeName, PipeDirection.Out, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-            var readablePipe = new NamedPipeClientStream(".", pipeName, PipeDirection.In, PipeOptions.Asynchronous);
-
-            Task clientConnect = readablePipe.ConnectAsync();
-            writeablePipe.WaitForConnection();
-            clientConnect.Wait();
-
-            ret.readablePipe = readablePipe;
-            ret.writeablePipe = writeablePipe;
-            return ret;
-        }
-    }
-
-    public class Perf_NamedPipeStream_ServerIn_ClientOut : Perf_PipeTest
-    {
-        protected override ServerClientPair CreateServerClientPair()
-        {
-            ServerClientPair ret = new ServerClientPair();
-            string pipeName = GetUniquePipeName();
-            var readablePipe = new NamedPipeServerStream(pipeName, PipeDirection.In, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-            var writeablePipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);
-
-            Task clientConnect = writeablePipe.ConnectAsync();
-            readablePipe.WaitForConnection();
-            clientConnect.Wait();
-
-            ret.readablePipe = readablePipe;
-            ret.writeablePipe = writeablePipe;
-            return ret;
-        }
-    }
-
-    public class Perf_NamedPipeStream_ServerInOut_ClientInOut : Perf_PipeTest
-    {
-        protected override ServerClientPair CreateServerClientPair()
-        {
-            ServerClientPair ret = new ServerClientPair();
-            string pipeName = GetUniquePipeName();
-            var readablePipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
-            var writeablePipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            var readablePipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, Options);
+            var writeablePipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, Options);
 
             Task clientConnect = writeablePipe.ConnectAsync();
             readablePipe.WaitForConnection();

--- a/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.PipeTest.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Pipes/Perf.PipeTest.cs
@@ -11,6 +11,8 @@ namespace System.IO.Pipes.Tests
     [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public abstract class Perf_PipeTest : PipeTestBase
     {
+        private const int Iterations = 1000;
+
         [Params(1000000)]
         public int size; 
 
@@ -32,15 +34,56 @@ namespace System.IO.Pipes.Tests
         [GlobalCleanup]
         public void Cleanup() => _serverClientPair.Dispose();
         
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public async Task ReadWrite()
         {
-            Task write = Task.Run(() => _serverClientPair.writeablePipe.Write(_sent, 0, _sent.Length));
-            int totalReadLength = 0;
-            while (totalReadLength < _sent.Length)
+            Task write = Task.Run(delegate
             {
-                int readLength = _serverClientPair.readablePipe.Read(_received, totalReadLength, size - totalReadLength);
-                totalReadLength += readLength;
+                for (int i = 0; i < Iterations; i++)
+                {
+                    _serverClientPair.writeablePipe.Write(_sent, 0, _sent.Length);
+                }
+            });
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                int totalReadLength = 0;
+                while (totalReadLength < _sent.Length)
+                {
+                    totalReadLength += _serverClientPair.readablePipe.Read(_received, totalReadLength, size - totalReadLength);
+                }
+            }
+
+            await write;
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public async Task ReadWriteAsync()
+        {
+            Task write = Task.Run(async delegate
+            {
+                for (int i = 0; i < Iterations; i++)
+                {
+#if !NETFRAMEWORK
+                    await _serverClientPair.writeablePipe.WriteAsync(_sent);
+#else
+                    await _serverClientPair.writeablePipe.WriteAsync(_sent, 0, _sent.Length);
+#endif
+                }
+            });
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                int totalReadLength = 0;
+                while (totalReadLength < _sent.Length)
+                {
+                    totalReadLength += await
+#if !NETFRAMEWORK
+                        _serverClientPair.readablePipe.ReadAsync(_received.AsMemory(totalReadLength));
+#else
+                        _serverClientPair.readablePipe.ReadAsync(_received, totalReadLength, size - totalReadLength);
+#endif
+                }
             }
 
             await write;


### PR DESCRIPTION
There's no need to run the same tests with different pipe directions.

We were missing read/write async tests.

And we were only running tests for named pipe with FileOptions.Asynchronous; we should also have None.