### PR TITLE
Remove scenarios broken by top level C#

### DIFF
--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -39,7 +39,7 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
-    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')">
+    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0">
       <PayloadDirectory>$(ScenariosDir)emptyconsoletemplate</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem>
@@ -86,7 +86,7 @@
       <PayloadDirectory>$(ScenariosDir)netstandard2.0</PayloadDirectory>
     </SDKWorkItem>
 
-    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1">
+    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0">
       <PayloadDirectory>$(ScenariosDir)mvcapptemplate</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem>

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -133,6 +133,8 @@ class StartupWrapper(object):
                     raise FileNotFoundError
                 getLogger().info("Generating failure results at " + reportjson)
                 RunCommand(cmdline, verbose=True).run(reporterpath)
+            # rethrow the original exception 
+            raise
 
         if runninginlab():
             copytree(TRACEDIR, os.path.join(helixuploaddir(), 'traces'))


### PR DESCRIPTION
Recent changes in the SDK templates mean that building them with previous TFMs fails. This scenario works if the older SDKs are present, but that's not the situation in our test runs.

This also contains a fix to startup.py to re-throw the previously caught exception so that CI status is correct.