### PR TITLE
Fix 3.1.4 pipeline

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,7 +10,6 @@
     <!-- 3.0.3 runtime pack/apphost packs are needed for tests, and not on nuget.org yet or other feeds below. Darc cannot see that due to nonstandard way these are pulled in to a non-3.0 branch -->
     <add key="darc-pub-dotnet-core-setup-c03f2fe" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-core-setup-c03f2fe6/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-aspnetcore-bd1e14b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-bd1e14b7/nuget/v3/index.json" />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
     - container: ubuntu_x64_build_container
-      image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-c103199-20180628134544
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20210311173856-047508b
 
 # CI Trigger on master branch
 trigger:

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -78,7 +78,7 @@ jobs:
               value: 'py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
+              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
 
           - group: DotNet-HelixApi-Access
           # perflab upload tokens still exist in this variable group

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -61,7 +61,7 @@ jobs:
               value: 'py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
+              value: 'sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
         workspace:

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ScenarioMeasurement</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="2.0.0-beta1.20074.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20158.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Util\Util.csproj" />

--- a/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
+++ b/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
@@ -53,7 +53,7 @@ namespace Startup.Tests
             string ctfFile = Path.Combine(testAssetDirectory, "test-process-time_startup.trace.zip");
             var parser = new ProcessTimeParser();
             var pids = new List<int>() { 18627, 18674, 18721, 18768, 18813 };
-            IEnumerable<Counter> counters = parser.Parse(ctfFile, "dotnet", pids, "\"dotnet\" build");
+            IEnumerable<Counter> counters = parser.Parse(null, ctfFile, "dotnet", pids, "\"dotnet\" build");
             int count = 0;
             foreach (var counter in counters)
             {
@@ -69,7 +69,7 @@ namespace Startup.Tests
             string etlFile = Path.Combine(testAssetDirectory, "test-process-time_startup.etl");
             var parser = new ProcessTimeParser();
             var pids = new List<int>() { 32752, 6352, 16876, 10500, 17784 };
-            IEnumerable<Counter> counters = parser.Parse(etlFile, "dotnet", pids, "\"dotnet\" build");
+            IEnumerable<Counter> counters = parser.Parse(null, etlFile, "dotnet", pids, "\"dotnet\" build");
             int count = 0;
             foreach (var counter in counters)
             {
@@ -85,7 +85,7 @@ namespace Startup.Tests
             string ctfFile = Path.Combine(testAssetDirectory, "test-time-to-main_startup.trace.zip");
             var parser = new TimeToMainParser();
             var pids = new List<int>() { 24352, 24362, 24371, 24380, 24389 };
-            IEnumerable<Counter> counters = parser.Parse(ctfFile, "emptycsconsoletemplate", pids, "\"pub\\emptycsconsoletemplate.exe\"");
+            IEnumerable<Counter> counters = parser.Parse(null, ctfFile, "emptycsconsoletemplate", pids, "\"pub\\emptycsconsoletemplate.exe\"");
             int count = 0;
             foreach (var counter in counters)
             {
@@ -102,7 +102,7 @@ namespace Startup.Tests
             string etlFile = Path.Combine(testAssetDirectory, "test-time-to-main_startup.etl");
             var parser = new TimeToMainParser();
             var pids = new List<int>() { 17036, 21640, 12912, 19764, 11624 };
-            IEnumerable<Counter> counters = parser.Parse(etlFile, "emptycsconsoletemplate", pids, "\"pub\\emptycsconsoletemplate.exe\"");
+            IEnumerable<Counter> counters = parser.Parse(null, etlFile, "emptycsconsoletemplate", pids, "\"pub\\emptycsconsoletemplate.exe\"");
             int count = 0;
             foreach (var counter in counters)
             {

--- a/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Crossgen2Parser.cs
@@ -19,7 +19,7 @@ namespace ScenarioMeasurement
             user.EnableUserProvider(ProviderName, TraceEventLevel.Verbose);
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             var loadingParser = new EventParser("Loading", (1, 2));
             var emittingParser = new EventParser("Emitting", (3, 4));
@@ -47,7 +47,7 @@ namespace ScenarioMeasurement
             {
                 processName = "corerun"; 
             }
-            foreach (var counter in processTimeParser.Parse(mergeTraceFile, processName, pids, commandLine))
+            foreach (var counter in processTimeParser.Parse(null, mergeTraceFile, processName, pids, commandLine))
             {
                 if (counter.Name == "Process Time")
                 {

--- a/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
@@ -24,7 +24,7 @@ namespace ScenarioMeasurement
             user.EnableUserProvider("PerfLabGenericEventSource", TraceEventLevel.Verbose);
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             var results = new List<double>();
             var threadTimes = new List<double>();

--- a/src/tools/ScenarioMeasurement/Startup/IParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/IParser.cs
@@ -7,6 +7,6 @@ namespace ScenarioMeasurement
     {
         void EnableUserProviders(ITraceSession user);
         void EnableKernelProvider(ITraceSession kernel);
-        IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine);
+        IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine);
     }
 }

--- a/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfCollect.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -147,7 +148,14 @@ namespace ScenarioMeasurement
 
         private bool LttngInstalled()
         {
-            return File.Exists("//usr/bin/lttng");
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("modinfo", "lttng_probe_writeback");
+            Process proc = new Process() { StartInfo = procStartInfo, };
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.Start();
+            string result = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
+            return result.Contains("filename:");
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/ProcessTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProcessTimeParser.cs
@@ -16,7 +16,7 @@ namespace ScenarioMeasurement
         {
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             var results = new List<double>();
             double threadTime = 0;

--- a/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/ProfileParser.cs
@@ -54,7 +54,7 @@ namespace ScenarioMeasurement
                                    stacksEnabled);
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             throw new NotImplementedException("Parsing is not supported on ProfileParser");
         }

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -186,7 +186,7 @@ namespace ScenarioMeasurement
                 {
                     commandLine = commandLine + " " + appArgs;
                 }
-                var counters = parser.Parse(traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
+                var counters = parser.Parse(logger, traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
 
 
                 CreateTestReport(scenarioName, counters, reportJsonPath, logger);

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -64,17 +64,18 @@ namespace ScenarioMeasurement
                 }
 
                 logger.Log("Reached Result Adding");
+                System.Console.WriteLine("Reached Result Adding");
                 ClrPrivateTraceEventParser clrpriv = new ClrPrivateTraceEventParser(source.Source);
                 clrpriv.StartupMainStart += evt =>
                 {
-                    logger.Log("Result Adding Event Triggered");
+                    System.Console.WriteLine("Result Adding Event Triggered");
                     if (pid.HasValue && ParserUtility.MatchSingleProcessID(evt, source, (int)pid))
                     {
-                        logger.Log($"Adding Result {pid}...");
+                        System.Console.WriteLine($"Adding Result {pid}...");
                         results.Add(evt.TimeStampRelativeMSec - start);
                         pid = null;
                         start = 0;
-                        logger.Log("Result Added");
+                        System.Console.WriteLine("Result Added");
                         if (source.IsWindows)
                         {
                             threadTimes.Add(threadTime);

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -31,6 +31,7 @@ namespace ScenarioMeasurement
 
                 source.Kernel.ProcessStart += evt =>
                 {
+                    System.Console.WriteLine("Console: Process Start");
                     if (!pid.HasValue && ParserUtility.MatchProcessStart(evt, source, processName, pids, commandLine))
                     {
                         pid = evt.ProcessID;

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -64,18 +64,18 @@ namespace ScenarioMeasurement
                 }
 
                 logger.Log("Reached Result Adding");
-                System.Console.WriteLine("Reached Result Adding");
+                System.Console.WriteLine("Console: Reached Result Adding");
                 ClrPrivateTraceEventParser clrpriv = new ClrPrivateTraceEventParser(source.Source);
                 clrpriv.StartupMainStart += evt =>
                 {
-                    System.Console.WriteLine("Result Adding Event Triggered");
+                    System.Console.WriteLine("Console: Result Adding Event Triggered");
                     if (pid.HasValue && ParserUtility.MatchSingleProcessID(evt, source, (int)pid))
                     {
-                        System.Console.WriteLine($"Adding Result {pid}...");
+                        System.Console.WriteLine($"Console: Adding Result {pid}...");
                         results.Add(evt.TimeStampRelativeMSec - start);
                         pid = null;
                         start = 0;
-                        System.Console.WriteLine("Result Added");
+                        System.Console.WriteLine("Console: Result Added");
                         if (source.IsWindows)
                         {
                             threadTimes.Add(threadTime);

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -67,7 +67,7 @@ namespace ScenarioMeasurement
                 logger.Log("Reached Result Adding");
                 System.Console.WriteLine("Console: Reached Result Adding");
                 ClrPrivateTraceEventParser clrpriv = new ClrPrivateTraceEventParser(source.Source);
-                clrpriv.StartupMainStart += evt =>
+                clrpriv.StartupSecurityCatchCallStart += evt =>
                 {
                     System.Console.WriteLine("Console: Result Adding Event Triggered");
                     if (pid.HasValue && ParserUtility.MatchSingleProcessID(evt, source, (int)pid))

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMainParser.cs
@@ -18,7 +18,7 @@ namespace ScenarioMeasurement
             user.EnableUserProvider(TraceSessionManager.ClrKeyword.Startup);
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             var results = new List<double>();
             double threadTime = 0;
@@ -63,14 +63,18 @@ namespace ScenarioMeasurement
                     };
                 }
 
+                logger.Log("Reached Result Adding");
                 ClrPrivateTraceEventParser clrpriv = new ClrPrivateTraceEventParser(source.Source);
                 clrpriv.StartupMainStart += evt =>
                 {
-                    if(pid.HasValue && ParserUtility.MatchSingleProcessID(evt, source, (int)pid))
+                    logger.Log("Result Adding Event Triggered");
+                    if (pid.HasValue && ParserUtility.MatchSingleProcessID(evt, source, (int)pid))
                     {
+                        logger.Log($"Adding Result {pid}...");
                         results.Add(evt.TimeStampRelativeMSec - start);
                         pid = null;
                         start = 0;
+                        logger.Log("Result Added");
                         if (source.IsWindows)
                         {
                             threadTimes.Add(threadTime);

--- a/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WPFParser.cs
@@ -15,7 +15,7 @@ namespace ScenarioMeasurement
             throw new System.NotImplementedException();
         }
 
-        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        public IEnumerable<Counter> Parse(Logger logger, string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             throw new System.NotImplementedException();
         }

--- a/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WindowsTraceSession.cs
@@ -154,11 +154,13 @@ namespace ScenarioMeasurement
 
         public static bool IsAdministrator()
         {
+#pragma warning disable CA1416 // WindowsTraceSession only called from TraceSessionManager if platform is windows
             using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
             {
                 WindowsPrincipal principal = new WindowsPrincipal(identity);
                 return principal.IsInRole(WindowsBuiltInRole.Administrator);
             }
         }
+#pragma warning restore CA1416
     }
 }


### PR DESCRIPTION
There have been several failures in 3.1.4 pipeline runs in need of resolution.  These associated fixes (mostly brought over from main) have been applied to resolve them:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1268896&view=logs&j=af9039db-3a09-5652-d42f-cc95d30eed70&t=6c7bba33-6b7e-5a1e-47e8-024cc8538e18
The fix for the lttng issue that remained in the test pipeline run (ported from https://github.com/dotnet/performance/pull/1802/files) needs to be compiled post-merge in order to take effect.