### PR TITLE
Add JSON benchmarks for nullable types

### DIFF
--- a/src/benchmarks/micro/Serializers/DataGenerator.cs
+++ b/src/benchmarks/micro/Serializers/DataGenerator.cs
@@ -53,6 +53,8 @@ namespace MicroBenchmarks.Serializers
                 return (T)(object)new Hashtable(ValuesGenerator.ArrayOfUniqueValues<string>(100).ToDictionary(value => value));
             if (typeof(T) == typeof(LargeStructWithProperties))
                 return (T)(object)CreateLargeStructWithProperties();
+            if (typeof(T) == typeof(DateTimeOffset?))
+                return (T)(object)new DateTimeOffset(2021, 08, 13, 11, 11, 05, TimeSpan.Zero);
             if (typeof(T) == typeof(int))
                 return (T)(object)42;
 

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json.Serialization.Tests
     [GenericTypeArguments(typeof(Hashtable))]
     [GenericTypeArguments(typeof(SimpleStructWithProperties))]
     [GenericTypeArguments(typeof(LargeStructWithProperties))]
+    [GenericTypeArguments(typeof(DateTimeOffset?))]
     [GenericTypeArguments(typeof(int))]
     public class ReadJson<T>
     {

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
@@ -27,6 +27,7 @@ namespace System.Text.Json.Serialization.Tests
     [GenericTypeArguments(typeof(Hashtable))]
     [GenericTypeArguments(typeof(SimpleStructWithProperties))]
     [GenericTypeArguments(typeof(LargeStructWithProperties))]
+    [GenericTypeArguments(typeof(DateTimeOffset?))]
     [GenericTypeArguments(typeof(int))]
     public class WriteJson<T>
     {


### PR DESCRIPTION
Adding a benchmark measuring a codegen-related performance regression that we've had to deal with a few times. See also https://github.com/dotnet/runtime/pull/46788, https://github.com/dotnet/runtime/pull/57327 and https://github.com/dotnet/runtime/issues/50915

cc @steveharter @EgorBo 