### PR TITLE
Warning Fix: -p is deprecated.

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -142,7 +142,7 @@ ex: C:\repos\performance;C:\repos\runtime
             startup = StartupWrapper()
             self.traits.add_traits(scenarioname=self.scenarioname,
             scenariotypename=const.SCENARIO_NAMES[const.INNERLOOP],
-            apptorun='dotnet', appargs='run -p %s' % appfolder(self.traits.exename, self.traits.projext),
+            apptorun='dotnet', appargs='run --project %s' % appfolder(self.traits.exename, self.traits.projext),
             innerloopcommand=pythoncommand(),
             iterationsetup=pythoncommand(),
             setupargs='%s %s setup_build' % ('-3' if iswin() else '', const.ITERATION_SETUP_FILE),
@@ -154,7 +154,7 @@ ex: C:\repos\performance;C:\repos\runtime
             startup = StartupWrapper()
             self.traits.add_traits(scenarioname=self.scenarioname,
             scenariotypename=const.SCENARIO_NAMES[const.INNERLOOPMSBUILD],
-            apptorun='dotnet', appargs='run -p %s' % appfolder(self.traits.exename, self.traits.projext),
+            apptorun='dotnet', appargs='run --project %s' % appfolder(self.traits.exename, self.traits.projext),
             innerloopcommand=pythoncommand(),
             iterationsetup=pythoncommand(),
             setupargs='%s %s setup_build' % ('-3' if iswin() else '', const.ITERATION_SETUP_FILE),


### PR DESCRIPTION
Updated 'dotnet run -p' instances to use --project fixing warning about -p being deprecated.