### PR TITLE
Disable ResultTable for Scenario Testing

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -44,14 +44,6 @@
     </Scenario>
   </ItemGroup>
 
-  <!-- Startup FDD publish -->
-  <ItemGroup>
-    <HelixWorkItem Include="@(Scenario -> 'Startup - %(Identity) - FDD Publish')">
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
-      <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
-    </HelixWorkItem>
-  </ItemGroup>
-
   <!-- SOD FDD publish -->
   <ItemGroup>
     <HelixWorkItem Include="@(Scenario -> 'SOD - %(Identity) - FDD Publish')">

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -119,12 +119,12 @@ namespace Reporting
                 var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
                 var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
                 ret.AppendLine(test.Name);
-                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
+                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min",resultWidth)}|{LeftJustify("Max", resultWidth)}");
                 ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
 
 
                 ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
-                foreach (var counter in topCounters)
+                foreach(var counter in topCounters)
                 {
                     ret.AppendLine(Print(counter, counterWidth, resultWidth));
                 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -119,10 +119,10 @@ namespace Reporting
                 var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
                 var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
                 ret.AppendLine(test.Name);
-                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min",resultWidth)}|{LeftJustify("Max", resultWidth)}");
+                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average",resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
                 ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
 
-
+        
                 ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
                 foreach(var counter in topCounters)
                 {

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -113,24 +113,36 @@ namespace Reporting
             StringBuilder ret = new StringBuilder();
             foreach (var test in tests)
             {
-                var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
-                var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
-                var restCounters = test.Counters.Where(c => !(c.TopCounter || c.DefaultCounter));
-                var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
-                var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
-                ret.AppendLine(test.Name);
-                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average",resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max",resultWidth)}");
-                ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
-
-           
-                ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
-                foreach(var counter in topCounters)
+                bool resultsValid = true;
+                foreach (Counter c in test.Counters)
                 {
-                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                    if (c.Results.Count == 0)
+                    {
+                        resultsValid = false;
+                        break;
+                    }
                 }
-                foreach (var counter in restCounters)
+                if (resultsValid)
                 {
-                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                    var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
+                    var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
+                    var restCounters = test.Counters.Where(c => !(c.TopCounter || c.DefaultCounter));
+                    var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
+                    var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
+                    ret.AppendLine(test.Name);
+                    ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
+                    ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
+
+
+                    ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
+                    foreach (var counter in topCounters)
+                    {
+                        ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                    }
+                    foreach (var counter in restCounters)
+                    {
+                        ret.AppendLine(Print(counter, counterWidth, resultWidth));
+                    }
                 }
             }
             return ret.ToString();

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -119,10 +119,10 @@ namespace Reporting
                 var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
                 var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
                 ret.AppendLine(test.Name);
-                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average",resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
+                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average",resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max",resultWidth)}");
                 ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
 
-        
+           
                 ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
                 foreach(var counter in topCounters)
                 {

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -113,36 +113,24 @@ namespace Reporting
             StringBuilder ret = new StringBuilder();
             foreach (var test in tests)
             {
-                bool resultsValid = true;
-                foreach (Counter c in test.Counters)
+                var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
+                var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
+                var restCounters = test.Counters.Where(c => !(c.TopCounter || c.DefaultCounter));
+                var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
+                var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
+                ret.AppendLine(test.Name);
+                ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
+                ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
+
+
+                ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
+                foreach (var counter in topCounters)
                 {
-                    if (c.Results.Count == 0)
-                    {
-                        resultsValid = false;
-                        break;
-                    }
+                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
                 }
-                if (resultsValid)
+                foreach (var counter in restCounters)
                 {
-                    var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
-                    var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
-                    var restCounters = test.Counters.Where(c => !(c.TopCounter || c.DefaultCounter));
-                    var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
-                    var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3").Length + c.MetricName.Length) + 2, 15);
-                    ret.AppendLine(test.Name);
-                    ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
-                    ret.AppendLine($"{new String('-', counterWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}|{new String('-', resultWidth)}");
-
-
-                    ret.AppendLine(Print(defaultCounter, counterWidth, resultWidth));
-                    foreach (var counter in topCounters)
-                    {
-                        ret.AppendLine(Print(counter, counterWidth, resultWidth));
-                    }
-                    foreach (var counter in restCounters)
-                    {
-                        ret.AppendLine(Print(counter, counterWidth, resultWidth));
-                    }
+                    ret.AppendLine(Print(counter, counterWidth, resultWidth));
                 }
             }
             return ret.ToString();


### PR DESCRIPTION
This change skips generation of the result table if the current issues with the 3.1 runtime lead to necessary events not occurring.