### PR TITLE
Added other pipeline statuses to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # .NET Performance
 
-| Public Build Status                         | Internal Build Status                           |
-| :------------------------------------------ | :---------------------------------------------: |
-| [![public_build_icon]][public_build_status] | [![internal_build_icon]][internal_build_status] |
+| Build Source Version                        | Public Build Status                                                         | Internal Build Status                                                           |
+| :------------------------------------------ | :-------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| main                                        | [![public_build_icon_main]][public_build_status_main]                       | [![internal_build_icon_main]][internal_build_status_main]                       |
+| release/5.0.1xx                             | [![public_build_icon_release_5.0.1xx]][public_build_status_release_5.0.1xx] | [![internal_build_icon_release_5.0.1xx]][internal_build_status_release_5.0.1xx] |
+| release/3.1.4xx                             | [![public_build_icon_release_3.1.4xx]][public_build_status_release_3.1.4xx] | [![internal_build_icon_release_3.1.4xx]][internal_build_status_release_3.1.4xx] |
 
 This repo contains benchmarks used for testing the performance of all .NET Runtimes: .NET Core, Full .NET Framework, Mono and CoreRT.
 
@@ -19,7 +21,17 @@ Finding these benchmarks in a separate repository might be surprising. Performan
 
 This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-[public_build_icon]:                               https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=main	
-[public_build_status]:                             https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=main	
-[internal_build_icon]:                             https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=main	
-[internal_build_status]:                           https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=main	
+[public_build_icon_main]:                        https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=main
+[public_build_status_main]:                      https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=main
+[internal_build_icon_main]:                      https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=main
+[internal_build_status_main]:                    https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=main
+
+[public_build_icon_release_5.0.1xx]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=release%2F5.0.1xx
+[public_build_status_release_5.0.1xx]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=release%2F5.0.1xx
+[internal_build_icon_release_5.0.1xx]:           https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=release%2F5.0.1xx
+[internal_build_status_release_5.0.1xx]:         https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=release%2F5.0.1xx
+
+[public_build_icon_release_3.1.4xx]:             https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/performance/performance-ci?branchName=release%2F3.1.4xx
+[public_build_status_release_3.1.4xx]:           https://dev.azure.com/dnceng/public/_build/latest?definitionId=271&branchName=release%2F3.1.4xx
+[internal_build_icon_release_3.1.4xx]:           https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=release%2F3.1.4xx
+[internal_build_status_release_3.1.4xx]:         https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=release%2F3.1.4xx


### PR DESCRIPTION
Added the release 5.0.1xx and release 3.1.4xx status tags to the README.md. The 5.0.1xx release does not seem to have any runs directly attributed to it, but this should be fixed with issue #1946.