### PR TITLE
Changed YML PR trigger to include only release/3.1.4xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ trigger:
 pr:
   branches:
     include:
-    - master
+    - release/3.1.4xx
   paths:
     exclude: # don't trigger the CI if only a doc file was changed
     - docs/*


### PR DESCRIPTION
Changed the PR trigger to be based off of release/3.1.4xx branch instead of master. This should cause all tests to trigger for dotnet maestro bot PR's. This is the minimum change to get maestro auto-merge working. Other main option would be to add specific tests that only run for when maestro does a PR.