### PR TITLE
Removed non-5.0.1xx jobs from pipeline.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ resources:
 trigger:
   branches:
     include:
-    - master
+    - release/5.0.1xx
   paths:
     include:
     - eng/Version.Details.xml
@@ -16,7 +16,7 @@ trigger:
 pr:
   branches:
     include:
-    - master
+    - release/5.0.1xx
   paths:
     exclude: # don't trigger the CI if only a doc file was changed
     - docs/*
@@ -28,13 +28,13 @@ pr:
     - src/tools/ResultsComparer/README.md
     - README.md
 
-schedules:
-- cron: "0 */12 * * *"
-  displayName: Every 12 hours build
-  branches:
-    include:
-    - master
-  always: true
+# schedules:
+# - cron: "0 */12 * * *"
+#   displayName: Every 12 hours build
+#   branches:
+#     include:
+#     - release/5.0.1xx
+#   always: true
 
 jobs:
 
@@ -54,8 +54,6 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: scenarios.proj
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        # - release/3.1.3xx
-        - 3.0
         - release/5.0.1xx
 
   # Ubuntu 1804 x64 scenario benchmarks
@@ -70,9 +68,7 @@ jobs:
       container: ubuntu_x64_build_container
       projectFile: scenarios.proj
       channels:
-        - master
         - release/5.0.1xx
-        # - release/3.1.3xx
   
   # Windows x64 Blazor scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -85,7 +81,6 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: blazor_scenarios.proj
       channels:
-        - master
         - release/5.0.1xx
 
   # Windows x64 SDK scenario benchmarks
@@ -99,9 +94,7 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: sdk_scenarios.proj
       channels:
-        - master
         - release/5.0.1xx
-        # - release/3.1.3xx
   
   # Ubuntu 1804 x64 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -115,9 +108,7 @@ jobs:
       container: ubuntu_x64_build_container
       projectFile: sdk_scenarios.proj
       channels:
-        - master
         - release/5.0.1xx
-        # - release/3.1.3xx
 
   # Windows x86 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -130,9 +121,7 @@ jobs:
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: sdk_scenarios.proj
       channels:
-        - master
         - release/5.0.1xx
-        # - release/3.1.3xx
   
   # Windows x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -146,24 +135,21 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries' 
       channels:
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
-        #- 2.1
 
-  # Windows x64 net461 micro benchmarks
-  - template: /eng/performance/benchmark_jobs.yml
-    parameters:
-      osName: windows
-      osVersion: RS4
-      kind: micro_net461
-      architecture: x64
-      pool: Hosted VS2017
-      queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
-      csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-      runCategories: 'runtime libraries'
-      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        - LTS # use LTS channel for net461 framework
+  # # Windows x64 net461 micro benchmarks
+  # - template: /eng/performance/benchmark_jobs.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS4
+  #     kind: micro_net461
+  #     architecture: x64
+  #     pool: Hosted VS2017
+  #     queue: Windows.10.Amd64.ClientRS4.DevEx.15.8.Open
+  #     csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+  #     runCategories: 'runtime libraries'
+  #     channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+  #       - LTS # use LTS channel for net461 framework
 
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -177,7 +163,6 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for public jobs we want to make sure that the PRs don't break x86
-        - master
         - release/5.0.1xx
 
   # Windows x64 ML.NET benchmarks
@@ -192,9 +177,7 @@ jobs:
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -208,9 +191,7 @@ jobs:
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
         
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -225,10 +206,7 @@ jobs:
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
-        #- 2.1
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -243,9 +221,7 @@ jobs:
       runCategories: 'mldotnet'
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
 
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -260,9 +236,7 @@ jobs:
       runCategories: 'roslyn'
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-        - master
         - release/5.0.1xx
-        #- release/3.1.3xx
 
 ###########################################
 # Private Jobs
@@ -281,9 +255,7 @@ jobs:
       queue: Windows.10.Amd64.19H1.Tiger.Perf
       projectFile: scenarios.proj
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported channels
-        # - release/3.1.2xx
         - release/5.0.1xx
-        - 3.0
 
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/scenarios.yml
@@ -297,7 +269,6 @@ jobs:
       container: ubuntu_x64_build_container
       projectFile: scenarios.proj
       channels:
-        #- master
         - release/5.0.1xx
 
   # Windows x64 micro benchmarks
@@ -312,9 +283,24 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
+
+  # # Windows AMD64 specific micro benchmarks
+  # - template: /eng/performance/benchmark_jobs.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: 20H2
+  #     kind: micro
+  #     architecture: x64
+  #     pool: Hosted VS2017
+  #     machinePool: Owl
+  #     queue: Windows.10.Amd64.20H2.Owl.Perf # using a dedicated private Helix queue (perfowls)
+  #     csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+  #     runCategories: 'runtime libraries'
+  #     channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
+  #       #- main
+  #       - release/5.0.1xx
+  #       #- release/3.1.2xx
       
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -328,9 +314,7 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
 
   # Windows x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -344,9 +328,7 @@ jobs:
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
 
   # Windows x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -360,9 +342,7 @@ jobs:
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
 
   # Ubuntu 1804 x64 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -377,9 +357,7 @@ jobs:
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -394,9 +372,7 @@ jobs:
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
   
   # Ubuntu 1804 x64 Roslyn benchmarks
   - template: /eng/performance/benchmark_jobs.yml
@@ -411,9 +387,7 @@ jobs:
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
       runCategories: 'roslyn'
       channels: # for private jobs we want to benchmark .NET Core 3.1 and 5.0 only
-        #- master
         - release/5.0.1xx
-        #- release/3.1.2xx
 
 ################################################
 # Scheduled Private jobs
@@ -422,63 +396,62 @@ jobs:
 # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
 
-  # Windows x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x64
-      pool: Hosted VS2017
-      kind: sdk_scenarios
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: sdk_scenarios.proj
-      channels:
-        - master
-        #- release/5.0.1xx
+  # # Windows x64 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS5
+  #     architecture: x64
+  #     pool: Hosted VS2017
+  #     kind: sdk_scenarios
+  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - main
+  #       #- release/5.0.1xx
   
-  # Windows x86 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x86
-      pool: Hosted VS2017
-      kind: sdk_scenarios
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: sdk_scenarios.proj
-      channels:
-        - master
-        #- release/5.0.1xx
+  # # Windows x86 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS5
+  #     architecture: x86
+  #     pool: Hosted VS2017
+  #     kind: sdk_scenarios
+  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - master
+  #       #- release/5.0.1xx
 
-  # Ubuntu 1804 x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: ubuntu
-      osVersion: 1804
-      architecture: x64
-      pool: Hosted Ubuntu 1604
-      kind: sdk_scenarios
-      queue: Ubuntu.1804.Amd64.Tiger.Perf
-      container: ubuntu_x64_build_container
-      projectFile: sdk_scenarios.proj
-      channels:
-        - master
-        #- release/5.0.1xx
-        # - release/3.1.2xx
+  # # Ubuntu 1804 x64 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: ubuntu
+  #     osVersion: 1804
+  #     architecture: x64
+  #     pool: Hosted Ubuntu 1604
+  #     kind: sdk_scenarios
+  #     queue: Ubuntu.1804.Amd64.Tiger.Perf
+  #     container: ubuntu_x64_build_container
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - 5.0
 
-  # Windows x64 Blazor 3.2 scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x64
-      pool: Hosted VS2017
-      kind: blazor_scenarios
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: blazor_scenarios.proj
-      channels:
-        - master
-        #- release/5.0.1xx
+  # # Windows x64 Blazor 3.2 scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS5
+  #     architecture: x64
+  #     pool: Hosted VS2017
+  #     kind: blazor_scenarios
+  #     machinePool: Tiger
+  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #     projectFile: blazor_scenarios.proj
+  #     channels:
+  #       - main
+  #       #- release/5.0.1xx
 
 ################################################
 # Manually Triggered Job


### PR DESCRIPTION
Segmented 5.0.1xx channel from the other channels so only release/5.0.1xx will run in this repo. This is a part of a trifecta of PRs on this branch, 3.1.4, and the main branch.