### PR TITLE
Add NoWasm flag for async tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
@@ -143,6 +143,7 @@ namespace System.IO.Tests
         }
 
 #if !NETFRAMEWORK
+        [BenchmarkCategory(Categories.NoWASM)]
         [Benchmark(OperationsPerInvoke = 1000)]
         public async Task AppendAllLinesAsync()
         {
@@ -154,6 +155,7 @@ namespace System.IO.Tests
             File.Delete(_testFilePath); // see the comment in AppendAllLines
         }
 
+        [BenchmarkCategory(Categories.NoWASM)]
         [Benchmark(OperationsPerInvoke = 1000)]
         [Arguments(10)]
         [Arguments(100)]


### PR DESCRIPTION
When we add new tests, if they have async in them we need to make sure they are marked with the NoWASM tag, as that construct is not supported on WASM. I will try and keep a closer eye going forward on perf test PRs, also @adamsitnik for visibility.