### PR TITLE
Disable Failing MemoryMarshal.GetReference Test for WASM

### DIFF
--- a/src/benchmarks/micro/libraries/System.Memory/MemoryMarshal.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/MemoryMarshal.cs
@@ -13,7 +13,7 @@ namespace System.Memory
 {
     [GenericTypeArguments(typeof(byte))]
     [GenericTypeArguments(typeof(int))]
-    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span)]
+    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span, Categories.NoWASM)]
     public class MemoryMarshal<T>
         where T : struct
     {


### PR DESCRIPTION
Failures have been observed in https://github.com/dotnet/performance/issues/1948
Until a long-term fix can be applied, the failing test needs to be disabled.