### PR TITLE
Fix Nuget Security Analysis Failure in release/5.0.1xx

### DIFF
--- a/src/benchmarks/other/dmlib/Nuget.config
+++ b/src/benchmarks/other/dmlib/Nuget.config
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <configuration>
 <packageSources>
+    <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
 </packageSources>


### PR DESCRIPTION
I observed a failure in the dotnet performance pipeline for release 5.0:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1334156&view=results

This PR is to resolve the observed issue.