### PR TITLE
Disabling blazor hot reload

### DIFF
--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -177,13 +177,15 @@
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
+    <!--
     <HelixWorkItem Include="Hot Reload Blazor Client" Condition="'$(FrameworkVersion)' == '6.0'">
       <PayloadDirectory>$(ScenariosDir)blazorwasmdotnetwatch</PayloadDirectory>
       <PreCommands>$(Python) pre.py build -f net$(FrameworkVersion) -c Release</PreCommands>
-      <Command>$(Python) test.py dotnetwatch --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(Python) test.py dotnetwatch -(-fixme when uncommenting!!)scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py</PostCommands>
       <Timeout>4:00</Timeout>
     </HelixWorkItem>
+    -->
     <HelixWorkItem Include="Hot Reload MVC" Condition="'$(FrameworkVersion)' == '6.0'">
       <PayloadDirectory>$(ScenariosDir)mvcdotnetwatch</PayloadDirectory>
       <PreCommands>$(Python) pre.py build -f net$(FrameworkVersion) -c Release</PreCommands>


### PR DESCRIPTION
Disabling blazor hot reload as we fix its running errors, especially in prep for the long weekend. An exact copy of the last time we disabled blazor hot reload.