### PR TITLE
Fix Path String for SDK Web Large 2.0 and 3.0 Scenarios

### DIFF
--- a/src/scenarios/weblarge2.0/pre.py
+++ b/src/scenarios/weblarge2.0/pre.py
@@ -9,5 +9,5 @@ from shared import const
 
 setup_loggers(True)
 precommands = PreCommands()
-precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc/mvc.csproj')
+precommands.existing(os.path.join(sys.path[0], const.SRCDIR, 'mvc'), 'mvc.csproj')
 precommands.execute()

--- a/src/scenarios/weblarge2.0/pre.py
+++ b/src/scenarios/weblarge2.0/pre.py
@@ -9,5 +9,5 @@ from shared import const
 
 setup_loggers(True)
 precommands = PreCommands()
-precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc\\mvc.csproj')
+precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc/mvc.csproj')
 precommands.execute()

--- a/src/scenarios/weblarge3.0/pre.py
+++ b/src/scenarios/weblarge3.0/pre.py
@@ -9,5 +9,5 @@ from shared import const
 
 setup_loggers(True)
 precommands = PreCommands()
-precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc/mvc.csproj')
+precommands.existing(os.path.join(sys.path[0], const.SRCDIR, 'mvc'), 'mvc.csproj')
 precommands.execute()

--- a/src/scenarios/weblarge3.0/pre.py
+++ b/src/scenarios/weblarge3.0/pre.py
@@ -9,5 +9,5 @@ from shared import const
 
 setup_loggers(True)
 precommands = PreCommands()
-precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc\\mvc.csproj')
+precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'mvc/mvc.csproj')
 precommands.execute()


### PR DESCRIPTION
Use of the backslash in the path to mvc.csproj was causing failures for Ubuntu channels in https://dev.azure.com/dnceng/public/_build/results?buildId=1337564&view=logs&j=a180af0e-af02-5d26-0017-a0951a9cd006&t=4380d35f-bbd6-5381-ae67-81a3fcdf177f
This PR fixes the issue by moving 'mvc' inside the path.join.