### PR TITLE
removed SDK Web Large 2.0 for netcoreapp2.1

### DIFF
--- a/docs/sdk-scenarios.md
+++ b/docs/sdk-scenarios.md
@@ -89,7 +89,6 @@ Same instruction of [Step 4 in Scenario Tests Guide](scenarios-workflow.md#step-
 | SDK Console Template          | emptyconsoletemplate | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.1;net5.0;net6.0 | Windows;Linux      |
 | SDK .NET 2.0 Library Template | netstandard2.0       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp2.1;netcoreapp3.1;net5.0;net6.0 | Windows;Linux      |
 | SDK ASP.NET MVC App Template  | mvcapptemplate       | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.1;net5.0;net6.0               | Windows;Linux      |
-| SDK Web Large 2.0             | weblarge2.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.1                             | Windows;Linux      |
 | SDK Web Large 3.0             | weblarge3.0          | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.1                             | Windows;Linux      |
 | SDK Windows Forms Large       | windowsformslarge    | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.1                             | Windows            |
 | SDK WPF Large                 | wpflarge             | pre.py default -f \<tfm> | test.py sdk \<build option> | post.py     | netcoreapp3.1                             | Windows            |

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -91,11 +91,6 @@
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem>
 
-    <!-- WebLarge2.0 asset is specific to netcoreapp2.1 -->
-    <SDKWorkItem Include="SDK Web Large 2.0 Clean Build netcoreapp2.1">
-      <PayloadDirectory>$(ScenariosDir)weblarge2.0</PayloadDirectory>
-    </SDKWorkItem>
-
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1
     <SDKWorkItem Include="@(Framework -> 'SDK Web Large 3.0 %(Identity)')" Exclude="*2.1;*5.0">
       <PayloadDirectory>$(ScenariosDir)weblarge3.0</PayloadDirectory>


### PR DESCRIPTION
 Since [.NET2.1 is out of life support ](https://devblogs.microsoft.com/dotnet/net-core-2-1-will-reach-end-of-support-on-august-21-2021/)