### PR TITLE
Remove netcoreapp2.1 from Microbenchmarks

### DIFF
--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -70,7 +70,7 @@ dotnet build -c Release
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [MicroBenchmarks.csproj](../src/benchmarks/micro/MicroBenchmarks.csproj) file.
 
 ```diff
--<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+-<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 +<TargetFrameworks>net6.0</TargetFrameworks>
 ```
 
@@ -285,7 +285,7 @@ M00_L00:
 
 The `--runtimes` or just `-r` allows you to run the benchmarks for **multiple Runtimes**.
 
-Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp2.1, netcoreapp3.1, net5.0 and net6.0.
+Available options are: Mono, CoreRT, net461, net462, net47, net471, net472, netcoreapp3.1, net5.0 and net6.0.
 
 Example: run the benchmarks for .NET 5.0 and 6.0:
 
@@ -377,5 +377,5 @@ More info can be found [here](https://github.com/dotnet/BenchmarkDotNet/issues/7
 To run benchmarks with private CoreRT build you need to provide the `IlcPath`. Example:
 
 ```cmd
-dotnet run -c Release -f netcoreapp2.1 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release
+dotnet run -c Release -f net6.0 -- --ilcPath C:\Projects\corert\bin\Windows_NT.x64.Release
 ```

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,7 +12,7 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp2.1|netcoreapp3.1|net5.0|net6.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net6.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net5.0|net6.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net6.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 

--- a/src/benchmarks/micro/libraries/Common/StreamBuffer.cs
+++ b/src/benchmarks/micro/libraries/Common/StreamBuffer.cs
@@ -338,7 +338,9 @@ namespace System.IO
                 if (Interlocked.Exchange(ref _hasWaiter, 0) == 1)
                 {
                     Debug.Assert(_waitSourceCancellationToken != default);
-		    _waitSource.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new OperationCanceledException(_waitSourceCancellationToken)));
+#if NET5_0_OR_GREATER // API introduced in .NET 5
+                    _waitSource.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(new OperationCanceledException(_waitSourceCancellationToken)));
+#endif
                 }
             }
 

--- a/src/benchmarks/micro/libraries/System.Buffers/ReadOnlySequenceTests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/ReadOnlySequenceTests.cs
@@ -52,7 +52,7 @@ namespace System.Buffers.Tests
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstArray() => First(new ReadOnlySequence<T>(_array));
 
-#if !NETFRAMEWORK && !NETCOREAPP2_1
+#if !NETFRAMEWORK
         [Benchmark(OperationsPerInvoke = 16)]
         public int FirstSpanArray() => FirstSpan(new ReadOnlySequence<T>(_array));
 

--- a/src/benchmarks/micro/libraries/System.Collections/Contains/ContainsFalse.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Contains/ContainsFalse.cs
@@ -48,7 +48,7 @@ namespace System.Collections
             return result;
         }
 
-#if !NETFRAMEWORK && !NETCOREAPP2_1
+#if !NETFRAMEWORK
         [BenchmarkCategory(Categories.Span)]
         [Benchmark]
         public bool Span()

--- a/src/benchmarks/micro/libraries/System.Collections/Contains/ContainsTrue.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Contains/ContainsTrue.cs
@@ -53,7 +53,7 @@ namespace System.Collections
             return result;
         }
 
-#if !NETFRAMEWORK && !NETCOREAPP2_1
+#if !NETFRAMEWORK
         [BenchmarkCategory(Categories.Span)]
         [Benchmark]
         public bool Span()

--- a/src/benchmarks/micro/libraries/System.IO/NullWriteStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO/NullWriteStream.cs
@@ -38,7 +38,7 @@ namespace System.IO.Tests
 
         public override void WriteByte(byte value) { }
 
-#if NETCOREAPP2_1_OR_GREATER // these virtual methods only exist in .NET Core 2.1+
+#if !NETFRAMEWORK // these virtual methods only exist in .NET Core 2.1+
         public override void Write(ReadOnlySpan<byte> buffer) { }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => new ValueTask(Task.CompletedTask);

--- a/src/benchmarks/micro/libraries/System.Linq/Perf.Enumerable.cs
+++ b/src/benchmarks/micro/libraries/System.Linq/Perf.Enumerable.cs
@@ -402,7 +402,7 @@ namespace System.Linq.Tests
         [Benchmark]
         public void EmptyTakeSelectToArray() => Enumerable.Empty<int>().Take(10).Select(i => i).ToArray();
 
-#if !NETFRAMEWORK && !NETCOREAPP2_1 // API Available in .NET Core 3.0+
+#if !NETFRAMEWORK // API Available in .NET Core 3.0+
         // Append() has two execution paths: AppendPrependIterator (a result of another Append or Prepend) and IEnumerable, this benchmark tests both
         // https://github.com/dotnet/corefx/blob/dcf1c8f51bcdbd79e08cc672e327d50612690a25/src/System.Linq/src/System/Linq/AppendPrepend.cs
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Random.cs
@@ -59,7 +59,7 @@ namespace System.Tests
         public void NextBytes_span_unseeded() => _randomUnseeded.NextBytes(_bytes.AsSpan());
 #endif
 
-#if !NETFRAMEWORK && !NETCOREAPP2_1 && !NETCOREAPP3_1 && !NET5_0 // New API in .NET 6.0
+#if NET6_0_OR_GREATER // New API in .NET 6.0
         [Benchmark]
         public long Next_long() => _random.NextInt64(2^20);
 

--- a/src/benchmarks/micro/runtime/BilinearInterpol/BilinearInterpol.cs
+++ b/src/benchmarks/micro/runtime/BilinearInterpol/BilinearInterpol.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Numerics;
 
 // HW Intrinsic APIs are available only in .NET Core 3.0+
-#if !NETCOREAPP2_1 && !NETFRAMEWORK
+#if !NETFRAMEWORK
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -193,7 +193,7 @@ public class BilinearTest
         return z;
     }
 
-#if !NETCOREAPP2_1 && !NETFRAMEWORK
+#if !NETFRAMEWORK
     private static unsafe double[] BilinearInterpol_AVX(
                                             double[] x,
                                             double[] A,
@@ -273,7 +273,7 @@ public class BilinearTest
         }
         return z;
     }
-#endif // !NETCOREAPP2_1 && !NETFRAMEWORK
+#endif // !NETFRAMEWORK
 
     // This method is currently unused. It is useful, when generating a new vectorized version
     // of the benchmark (e.g. with a different set of HW intrinsics), to ensure that it is
@@ -309,7 +309,7 @@ public class BilinearTest
         return vectorOutput;
     }
 
-#if !NETCOREAPP2_1 && !NETFRAMEWORK
+#if !NETFRAMEWORK
     [BenchmarkCategory(Categories.Runtime)]
     [Benchmark]
     public double[] Interpol_AVX()

--- a/src/benchmarks/micro/runtime/System.Reflection/Activator.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/Activator.cs
@@ -21,10 +21,8 @@ namespace System.Reflection
         [Benchmark]
         public object CreateInstanceType() => System.Activator.CreateInstance(typeof(T));
 
-#if !NETCOREAPP2_1 // API available in Full .NET Framework and .NET Core 3.0+
         [Benchmark]
         public object CreateInstanceNames() => System.Activator.CreateInstance(_assemblyName, _typeName);
-#endif
     }
 
     public class EmptyClass { }


### PR DESCRIPTION
Contributes to #1990

I've created `2.1` branch in case we ever want to benchmark 2.1 again: https://github.com/dotnet/performance/tree/2.1