### PR TITLE
Update channel map for net7.0 and servicing runtime branches

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -2,14 +2,19 @@ from argparse import ArgumentParser
 
 class ChannelMap():
     channel_map = {
+        'release/6.0': {
+            'tfm': 'net6.0',
+            'branch': '6.0.1xx',
+            'quality': 'daily'
+        },
         '6.0': {
             'tfm': 'net6.0',
-            'branch': 'main',
+            'branch': '6.0.1xx',
             'quality': 'daily'
         },
         'main': {
-            'tfm': 'net6.0',
-            'branch': 'main',
+            'tfm': 'net7.0',
+            'branch': '7.0.1xx',
             'quality': 'daily'
         },
         'master': {

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -770,7 +770,7 @@ def install(
     # run, we will be testing the "wrong" version, ie, not the version we specified.
     if (not versions) and channels:
         for channel in channels:
-            cmdline_args = common_cmdline_args + ['-Channel', channel if channel != "main" else "6.0.1xx"]
+            cmdline_args = common_cmdline_args + ['-Channel', ChannelMap.get_branch(channel)]
             if ChannelMap.get_quality_from_channel(channel) is not None:
                 cmdline_args += ['-Quality', ChannelMap.get_quality_from_channel(channel)]
             RunCommand(cmdline_args, verbose=verbose, retry=1).run(


### PR DESCRIPTION
These are the changes that go along with https://github.com/dotnet/runtime/pull/59070, in order to keep both main and the release branches working. Also should fix https://github.com/dotnet/performance/issues/2009.