### PR TITLE
Issue841 remove file stream construction

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -24,6 +24,7 @@ namespace System.IO.Tests
 
         private Dictionary<long, string> _sourceFilePaths, _destinationFilePaths;
         private Dictionary<int, byte[]> _userBuffers;
+        private FileStream fileStreamHolder;
 
         private void Setup(params long[] fileSizes)
         {
@@ -141,14 +142,14 @@ namespace System.IO.Tests
         public int ReadByte(long fileSize, FileOptions options)
         {
             int result = default;
-            using (FileStream fileStream = new FileStream(_sourceFilePaths[fileSize], FileMode.Open, FileAccess.Read, FileShare.Read, FourKibibytes, options))
-            {
-                for (long i = 0; i < fileSize; i++)
-                {
-                    result += fileStream.ReadByte();
-                }
+            if(fileStreamHolder == default(FileStream)){
+                fileStreamHolder = new FileStream(_sourceFilePaths[fileSize], FileMode.Open, FileAccess.Read, FileShare.Read, FourKibibytes, options);
             }
-
+            fileStreamHolder.Position = 0;
+            for (long i = 0; i < fileSize; i++)
+            {
+                result += fileStreamHolder.ReadByte();
+            }
             return result;
         }
 

--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -46,6 +46,12 @@ namespace System.IO.Tests
             }
         }
 
+        [GlobalCleanup(Targets = new[] {nameof(ReadByte)})]
+        public void FileStreamCleanup() {
+            fileStreamHolder.Dispose();
+        }
+
+
         [GlobalCleanup]
         public void Cleanup()
         {


### PR DESCRIPTION
Initial testing for #841. Focused specifically on the ReadByte case to figure out the pattern we want to use before trying to apply it to all of the tests. 