### PR TITLE
Add the release 6.0 mapping to the channel mapping list

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -16,6 +16,10 @@ class ChannelMap():
             'tfm': 'net6.0',
             'branch': 'master'
         },
+        'release/6.0':{
+            'tfm': 'net6.0',
+            'branch': 'release/6.0'
+        },
         '5.0':{
             'tfm': 'net5.0',
             'branch': 'release/5.0'


### PR DESCRIPTION
Add the release 6.0 mapping to the channel mapping list to fix release 6.0 runtime perf issue.