### PR TITLE
Add C# multi-dimension array versions of the Benchstones microbenchmarks

### DIFF
--- a/src/benchmarks/micro/Categories.cs
+++ b/src/benchmarks/micro/Categories.cs
@@ -25,6 +25,8 @@ namespace MicroBenchmarks
         public const string Benchstones = "Benchstones";
         public const string BenchF = "BenchF";
         public const string BenchI = "BenchI";
+        public const string MDBenchF = "MDBenchF";
+        public const string MDBenchI = "MDBenchI";
         public const string Inlining = "Inlining";
         public const string V8 = "V8";
         public const string Perflab = "Perflab";

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInProd.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInProd.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchF
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+public class MDInProd
+{
+    public const int Iterations = 70;
+
+    private const int RowSize = 10 * Iterations;
+
+    private static int s_seed;
+
+    [Benchmark(Description = nameof(MDInProd))]
+    public bool Test()
+    {
+        double[,] rma = new double[RowSize, RowSize];
+        double[,] rmb = new double[RowSize, RowSize];
+        double[,] rmr = new double[RowSize, RowSize];
+
+        double sum;
+
+        Inner(rma, rmb, rmr);
+
+        for (int i = 1; i < RowSize; i++)
+        {
+            for (int j = 1; j < RowSize; j++)
+            {
+                sum = 0;
+                for (int k = 1; k < RowSize; k++)
+                {
+                    sum = sum + rma[i,k] * rmb[k,j];
+                }
+                if (rmr[i,j] != sum)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static void InitRand()
+    {
+        s_seed = 7774755;
+    }
+
+    private static int Rand()
+    {
+        s_seed = (s_seed * 77 + 13218009) % 3687091;
+        return s_seed;
+    }
+
+    private static void InitMatrix(double[,] m)
+    {
+        for (int i = 1; i < RowSize; i++)
+        {
+            for (int j = 1; j < RowSize; j++)
+            {
+                m[i,j] = (Rand() % 120 - 60) / 3;
+            }
+        }
+    }
+
+    private static void InnerProduct(out double result, double[,] a, double[,] b, int row, int col)
+    {
+        result = 0.0;
+        for (int i = 1; i < RowSize; i++)
+        {
+            result = result + a[row,i] * b[i,col];
+        }
+    }
+
+    private static void Inner(double[,] rma, double[,] rmb, double[,] rmr)
+    {
+        InitRand();
+        InitMatrix(rma);
+        InitMatrix(rmb);
+        for (int i = 1; i < RowSize; i++)
+        {
+            for (int j = 1; j < RowSize; j++)
+            {
+                InnerProduct(out rmr[i,j], rma, rmb, i, j);
+            }
+        }
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInvMt.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInvMt.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Solution of linear algebraic equations and matrix inversion.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchF
+{
+[BenchmarkCategory(Categories.Runtime, Categories.MDBenchF)]
+public class MDInvMt
+{
+    public const int Iterations = 80;
+
+    private const int MatSize = Iterations;
+
+    [Benchmark(Description = nameof(MDInvMt))]
+    public bool Test()
+    {
+        double[,] t = new double[MatSize + 1, (MatSize + 1) * 2];
+
+        double det, detinv, ber, p;
+        int n, i, j;
+
+        n = MatSize;
+        for (i = 1; i <= n; i++)
+        {
+            for (j = 1; j <= n; j++)
+            {
+                if (i == j)
+                {
+                    t[i,j] = 2.0001;
+                    t[i,n + 1 + j] = 1.0;
+                }
+                else
+                {
+                    t[i,j] = 1.0001;
+                    t[i,n + 1 + j] = 0.0;
+                }
+            }
+            t[i,n + 1] = System.Math.Sqrt((float)i);
+        }
+
+        Inner(t, out det, ref n);
+
+        for (i = 1; i <= n; i++)
+        {
+            for (j = 1; j <= n; j++)
+            {
+                p = t[i,j];
+                t[i,j] = t[i,n + 1 + j];
+                t[i,n + 1 + j] = p;
+            }
+        }
+
+        Inner(t, out detinv, ref n);
+
+        ber = 0.0;
+        for (i = 1; i <= n; i++)
+        {
+            ber = ber + System.Math.Abs(System.Math.Sqrt((double)i) - t[i,n + 1]);
+        }
+
+        return true;
+    }
+
+    private static void Inner(double[,] t, out double det, ref int n)
+    {
+        double tik, tkk;
+
+        det = 1.0;
+        for (int k = 1; k <= n; k++)
+        {
+            tkk = t[k,k];
+            det = det * tkk;
+
+            for (int j = 1; j <= (2 * n + 1); j++)
+            {
+                t[k,j] = t[k,j] / tkk;
+            }
+
+            for (int i = 1; i <= n; i++)
+            {
+                if (i != k)
+                {
+                    tik = t[i,k];
+                    for (int j = 1; j <= (2 * n + 1); j++)
+                    {
+                        t[i,j] = t[i,j] - t[k,j] * tik;
+                    }
+                }
+            }
+        }
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDLLoops.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDLLoops.cs
@@ -1,0 +1,592 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// C# adaptation of C implementation of Livermore Loops Fortran benchmark.
+
+/* Livermore Loops coded in C        Latest File Modification  20 Oct 92,
+ *  by Tim Peters, Kendall Square Res. Corp. tim@ksr.com, ksr!tim@uunet.uu.net
+ *     SUBROUTINE KERNEL( TK)  replaces the Fortran routine in LFK Test program.
+ ************************************************************************
+ *                                                                      *
+ *            KERNEL     executes 24 samples of "C" computation         *
+ *                                                                      *
+ *                TK(1) - total cpu time to execute only the 24 kernels.*
+ *                TK(2) - total Flops executed by the 24 Kernels        *
+ *                                                                      *
+ ************************************************************************
+ *                                                                      *
+ *     L. L. N. L.   " C "   K E R N E L S:   M F L O P S               *
+ *                                                                      *
+ *     These kernels measure   " C "   numerical computation            *
+ *     rates for  a  spectrum  of  cpu-limited computational            *
+ *     structures or benchmarks.   Mathematical  through-put            *
+ *     is measured  in  units  of millions of floating-point            *
+ *     operations executed per second, called Megaflops/sec.            *
+ *                                                                      *
+ *     Fonzi's Law: There is not now and there never will be a language *
+ *                  in which it is the least bit difficult to write     *
+ *                  bad programs.                                       *
+ *                                                    F.H.MCMAHON  1972 *
+ ************************************************************************
+ *Originally from  Greg Astfalk, AT&T, P.O.Box 900, Princeton, NJ. 08540*
+ *               by way of Frank McMahon (LLNL).                        *
+ *                                                                      *
+ *                               REFERENCE                              *
+ *                                                                      *
+ *              F.H.McMahon,   The Livermore Fortran Kernels:           *
+ *              A Computer Test Of The Numerical Performance Range,     *
+ *              Lawrence Livermore National Laboratory,                 *
+ *              Livermore, California, UCRL-53745, December 1986.       *
+ *                                                                      *
+ *       from:  National Technical Information Service                  *
+ *              U.S. Department of Commerce                             *
+ *              5285 Port Royal Road                                    *
+ *              Springfield, VA.  22161                                 *
+ *                                                                      *
+ *    Changes made to correct many array subscripting problems,         *
+ *      make more readable (added #define's), include the original      *
+ *      FORTRAN versions of the runs as comments, and make more         *
+ *      portable by Kelly O'Hair (LLNL) and Chuck Rasbold (LLNL).       *
+ *                                                                      *
+ ************************************************************************
+ */
+
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Runtime.CompilerServices;
+using MicroBenchmarks;
+
+
+namespace Benchstone.MDBenchF
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+public class MDLLoops
+{
+    public const int Iterations = 4000;
+
+    private const double MaxErr = 1.0e-6;
+
+    private double[] _x = new double[1002];
+    private double[] _y = new double[1002];
+    private double[] _z = new double[1002];
+    private double[] _u = new double[501];
+    private double[,] _px;
+    private double[,] _cx;
+    private double[,,] _u1;
+    private double[,,] _u2;
+    private double[,,] _u3;
+    private double[,] _b;
+    private double[] _bnk1 = new double[6];
+    private double[,] _c;
+    private double[] _bnk2 = new double[6];
+    private double[,] _p;
+    private double[] _bnk3 = new double[6];
+    private double[,] _h;
+    private double[] _bnk4 = new double[6];
+    private double[] _bnk5 = new double[6];
+    private double[] _ex = new double[68];
+    private double[] _rh = new double[68];
+    private double[] _dex = new double[68];
+    private double[] _vx = new double[151];
+    private double[] _xx = new double[151];
+    private double[] _grd = new double[151];
+    private int[] _e = new int[193];
+    private int[] _f = new int[193];
+    private int[] _nrops = { 0, 5, 10, 2, 2, 2, 2, 16, 36, 17, 9, 1, 1, 7, 11 };
+    private int[] _loops = { 0, 400, 200, 1000, 510, 1000, 1000, 120, 40, 100, 100, 1000, 1000, 128, 150 };
+    private double[] _checks = {
+        0, 0.811986948148e+07, 0.356310000000e+03, 0.356310000000e+03, -0.402412007078e+05,
+        0.136579037764e+06, 0.419716278716e+06,
+        0.429449847526e+07, 0.314064400000e+06,
+        0.182709000000e+07, -0.140415250000e+09,
+        0.374895020500e+09, 0.000000000000e+00,
+        0.171449024000e+06, -0.510829560800e+07
+    };
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Escape(object _) { }
+
+    [Benchmark(Description = nameof(MDLLoops))]
+    public bool Test()
+    {
+        _px = new double[16, 101];
+        _cx = new double[16, 101];
+
+        _u1 = new double[6, 23, 3];
+        _u2 = new double[6, 23, 3];
+        _u3 = new double[6, 23, 3];
+
+        _b = new double[65, 9];
+        _c = new double[65, 9];
+        _h = new double[65, 9];
+
+        _p = new double[5, 513];
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            Main1(i < Iterations - 1 ? 0 : 1);
+        }
+
+        return true;
+    }
+
+    private static int Clock()
+    {
+        return 0;
+    }
+
+    private void Main1(int output)
+    {
+        int nt, lw, nl1, nl2;
+        int i, i1, i2, ip, ir, ix, j, j1, j2, k, kx, ky, l, m;
+        double[] ts = new double[21];
+        double[] rt = new double[21];
+        double[] rpm = new double[21];
+        double[] cksum = new double[21];
+        double r, t, a11, a12, a13, sig, a21, a22, a23, a31, a32, a33;
+        double b28, b27, b26, b25, b24, b23, b22, c0, flx, rx1;
+        double q, s, scale, uu, du1, du2, du3, ar, br, cr, xi, ri;
+        int[] mops = new int[20];
+
+        for (i = 1; i <= 20; i++)
+        {
+            cksum[i] = 0.0;
+        }
+
+        r = 4.86;
+        t = 276.0;
+        a11 = 0.5;
+        a12 = 0.33;
+        a13 = 0.25;
+        sig = 0.8;
+        a21 = 0.20;
+        a22 = 0.167;
+        a23 = 0.141;
+        a31 = 0.125;
+        a32 = 0.111;
+        a33 = 0.10;
+        b28 = 0.1;
+        b27 = 0.2;
+        b26 = 0.3;
+        b25 = 0.4;
+        b24 = 0.5;
+        b23 = 0.6;
+        b22 = 0.7;
+        c0 = 0.8;
+        flx = 4.689;
+        rx1 = 64.0;
+
+        /*
+         *     end of initialization -- begin timing
+         */
+
+        /* loop 1      hydro excerpt */
+
+        Init();
+        ts[1] = (double)Clock();
+        q = 0.0;
+        for (k = 1; k <= 400; k++)
+        {
+            _x[k] = q + _y[k] * (r * _z[k + 10] + t * _z[k + 11]);
+        }
+        ts[1] = (double)Clock() - ts[1];
+        for (k = 1; k <= 400; k++)
+        {
+            cksum[1] += (double)k * _x[k];
+        }
+
+        /* loop 2      mlr, inner product */
+
+        Init();
+        ts[2] = (double)Clock();
+        q = 0.0;
+        for (k = 1; k <= 996; k += 5)
+        {
+            q += _z[k] * _x[k] + _z[k + 1] * _x[k + 1] + _z[k + 2] * _x[k + 2] + _z[k + 3] * _x[k + 3] + _z[k + 4] * _x[k + 4];
+        }
+        ts[2] = (double)Clock() - ts[2];
+        cksum[2] = q;
+
+        /* loop 3      inner prod */
+
+        Init();
+        ts[3] = (double)Clock();
+        q = 0.0;
+        for (k = 1; k <= 1000; k++)
+        {
+            q += _z[k] * _x[k];
+        }
+        ts[3] = (double)Clock() - ts[3];
+        cksum[3] = q;
+
+        /* loop 4      banded linear equarions */
+
+        Init();
+        ts[4] = (double)Clock();
+        for (l = 7; l <= 107; l += 50)
+        {
+            lw = l;
+            for (j = 30; j <= 870; j += 5)
+            {
+                _x[l - 1] -= _x[lw++] * _y[j];
+            }
+            _x[l - 1] = _y[5] * _x[l - 1];
+        }
+        ts[4] = (double)Clock() - ts[4];
+        for (l = 7; l <= 107; l += 50)
+        {
+            cksum[4] += (double)l * _x[l - 1];
+        }
+
+        /* loop 5      tri-diagonal elimination, below diagonal */
+
+        Init();
+        ts[5] = (double)Clock();
+        for (i = 2; i <= 998; i += 3)
+        {
+            _x[i] = _z[i] * (_y[i] - _x[i - 1]);
+            _x[i + 1] = _z[i + 1] * (_y[i + 1] - _x[i]);
+            _x[i + 2] = _z[i + 2] * (_y[i + 2] - _x[i + 1]);
+        }
+        ts[5] = (double)Clock() - ts[5];
+        for (i = 2; i <= 1000; i++)
+        {
+            cksum[5] += (double)i * _x[i];
+        }
+
+        /* loop 6      tri-diagonal elimination, above diagonal */
+
+        Init();
+        ts[6] = (double)Clock();
+        for (j = 3; j <= 999; j += 3)
+        {
+            i = 1003 - j;
+            _x[i] = _x[i] - _z[i] * _x[i + 1];
+            _x[i - 1] = _x[i - 1] - _z[i - 1] * _x[i];
+            _x[i - 2] = _x[i - 2] - _z[i - 2] * _x[i - 1];
+        }
+        ts[6] = (double)Clock() - ts[6];
+        for (j = 1; j <= 999; j++)
+        {
+            l = 1001 - j;
+            cksum[6] += (double)j * _x[l];
+        }
+
+        /* loop 7      equation of state excerpt */
+
+        Init();
+        ts[7] = (double)Clock();
+        for (m = 1; m <= 120; m++)
+        {
+            _x[m] = _u[m] + r * (_z[m] + r * _y[m]) + t * (_u[m + 3] + r * (_u[m + 2] + r * _u[m + 1]) + t * (_u[m + 6] + r * (_u[m + 5] + r * _u[m + 4])));
+        }
+        ts[7] = (double)Clock() - ts[7];
+        for (m = 1; m <= 120; m++)
+        {
+            cksum[7] += (double)m * _x[m];
+        }
+
+        /* loop 8      p.d.e. integration */
+
+        Init();
+        ts[8] = (double)Clock();
+        nl1 = 1;
+        nl2 = 2;
+        for (kx = 2; kx <= 3; kx++)
+        {
+            for (ky = 2; ky <= 21; ky++)
+            {
+                du1 = _u1[kx,ky + 1,nl1] - _u1[kx,ky - 1,nl1];
+                du2 = _u2[kx,ky + 1,nl1] - _u2[kx,ky - 1,nl1];
+                du3 = _u3[kx,ky + 1,nl1] - _u3[kx,ky - 1,nl1];
+                _u1[kx,ky,nl2] = _u1[kx,ky,nl1] + a11 * du1 + a12 * du2 + a13 * du3 + sig * (_u1[kx + 1,ky,nl1]
+                   - 2.0 * _u1[kx,ky,nl1] + _u1[kx - 1,ky,nl1]);
+                _u2[kx,ky,nl2] = _u2[kx,ky,nl1] + a21 * du1 + a22 * du2 + a23 * du3 + sig * (_u2[kx + 1,ky,nl1]
+                   - 2.0 * _u2[kx,ky,nl1] + _u2[kx - 1,ky,nl1]);
+                _u3[kx,ky,nl2] = _u3[kx,ky,nl1] + a31 * du1 + a32 * du2 + a33 * du3 + sig * (_u3[kx + 1,ky,nl1]
+                   - 2.0 * _u3[kx,ky,nl1] + _u3[kx - 1,ky,nl1]);
+            }
+        }
+        ts[8] = (double)Clock() - ts[8];
+        for (i = 1; i <= 2; i++)
+        {
+            for (kx = 2; kx <= 3; kx++)
+            {
+                for (ky = 2; ky <= 21; ky++)
+                {
+                    cksum[8] += (double)kx * (double)ky * (double)i * (_u1[kx,ky,i] + _u2[kx,ky,i] + _u3[kx,ky,i]);
+                }
+            }
+        }
+
+        /* loop 9      integrate predictors */
+
+        Init();
+        ts[9] = (double)Clock();
+        for (i = 1; i <= 100; i++)
+        {
+            _px[1,i] = b28 * _px[13,i] + b27 * _px[12,i] + b26 * _px[11,i] + b25 * _px[10,i] + b24 * _px[9,i] +
+               b23 * _px[8,i] + b22 * _px[7,i] + c0 * (_px[5,i] + _px[6,i]) + _px[3,i];
+        }
+        ts[9] = (double)Clock() - ts[9];
+        for (i = 1; i <= 100; i++)
+        {
+            cksum[9] += (double)i * _px[1,i];
+        }
+
+        /* loop 10     difference predictors */
+
+        Init();
+        ts[10] = (double)Clock();
+        for (i = 1; i <= 100; i++)
+        {
+            ar = _cx[5,i];
+            br = ar - _px[5,i];
+            _px[5,i] = ar;
+            cr = br - _px[6,i];
+            _px[6,i] = br;
+            ar = cr - _px[7,i];
+            _px[7,i] = cr;
+            br = ar - _px[8,i];
+            _px[8,i] = ar;
+            cr = br - _px[9,i];
+            _px[9,i] = br;
+            ar = cr - _px[10,i];
+            _px[10,i] = cr;
+            br = ar - _px[11,i];
+            _px[11,i] = ar;
+            cr = br - _px[12,i];
+            _px[12,i] = br;
+            _px[14,i] = cr - _px[13,i];
+            _px[13,i] = cr;
+        }
+        ts[10] = (double)Clock() - ts[10];
+        for (i = 1; i <= 100; i++)
+        {
+            for (k = 5; k <= 14; k++)
+            {
+                cksum[10] += (double)k * (double)i * _px[k,i];
+            }
+        }
+
+        /* loop 11     first sum. */
+
+        Init();
+        ts[11] = (double)Clock();
+        _x[1] = _y[1];
+        for (k = 2; k <= 1000; k++)
+        {
+            _x[k] = _x[k - 1] + _y[k];
+        }
+        ts[11] = (double)Clock() - ts[11];
+        for (k = 1; k <= 1000; k++)
+        {
+            cksum[11] += (double)k * _x[k];
+        }
+
+        /* loop 12     first diff. */
+
+        Init();
+        ts[12] = (double)Clock();
+        for (k = 1; k <= 999; k++)
+        {
+            _x[k] = _y[k + 1] - _y[k];
+        }
+        ts[12] = (double)Clock() - ts[12];
+        for (k = 1; k <= 999; k++)
+        {
+            cksum[12] += (double)k * _x[k];
+        }
+
+        /* loop 13      2-d particle pusher */
+
+        Init();
+        ts[13] = (double)Clock();
+        for (ip = 1; ip <= 128; ip++)
+        {
+            i1 = (int)_p[1,ip];
+            j1 = (int)_p[2,ip];
+            _p[3,ip] += _b[i1,j1];
+            _p[4,ip] += _c[i1,j1];
+            _p[1,ip] += _p[3,ip];
+            _p[2,ip] += _p[4,ip];
+            // Each element of m_p, m_b and m_c is initialized to 1.00025 in Init().
+            // From the assignments above,
+            // i2 = m_p[1,ip] = m_p[1,ip] + m_p[3,ip] = m_p[1,ip] + m_p[3,ip] + m_b[i1,j1] = 1 + 1 + 1 = 3
+            // j2 = m_p[2,ip] = m_p[2,ip] + m_p[4,ip] = m_p[2,ip] + m_p[4,ip] + m_c[i1,j1] = 1 + 1 + 1 = 3
+            i2 = (int)_p[1,ip];
+            j2 = (int)_p[2,ip];
+            // Accessing m_y, m_z upto 35
+            _p[1,ip] += _y[i2 + 32];
+            _p[2,ip] += _z[j2 + 32];
+
+            i2 += _e[i2 + 32];
+            j2 += _f[j2 + 32];
+            _h[i2,j2] += 1.0;
+        }
+        ts[13] = (double)Clock() - ts[13];
+        for (ip = 1; ip <= 128; ip++)
+        {
+            cksum[13] += (double)ip * (_p[3,ip] + _p[4,ip] + _p[1,ip] + _p[2,ip]);
+        }
+        for (k = 1; k <= 64; k++)
+        {
+            for (ix = 1; ix <= 8; ix++)
+            {
+                cksum[13] += (double)k * (double)ix * _h[k,ix];
+            }
+        }
+
+        /* loop 14      1-d particle pusher */
+
+        Init();
+        ts[14] = (double)Clock();
+        for (k = 1; k <= 150; k++)
+        {
+            // m_grd[150] = 13.636
+            // Therefore ix <= 13
+            ix = (int)_grd[k];
+            xi = (double)ix;
+            _vx[k] += _ex[ix] + (_xx[k] - xi) * _dex[ix];
+            _xx[k] += _vx[k] + flx;
+            ir = (int)_xx[k];
+            ri = (double)ir;
+            rx1 = _xx[k] - ri;
+            ir = System.Math.Abs(ir % 64);
+            _xx[k] = ri + rx1;
+            // ir < 64 since ir = ir % 64
+            // So m_rh is accessed upto 64
+            _rh[ir] += 1.0 - rx1;
+            _rh[ir + 1] += rx1;
+        }
+        ts[14] = (double)Clock() - ts[14];
+        for (k = 1; k <= 150; k++)
+        {
+            cksum[14] += (double)k * (_vx[k] + _xx[k]);
+        }
+        for (k = 1; k <= 67; k++)
+        {
+            cksum[14] += (double)k * _rh[k];
+        }
+
+        /* time the clock call */
+
+        ts[15] = (double)Clock();
+        ts[15] = (double)Clock() - ts[15];
+
+        /* scale= set to convert time to micro-seconds */
+
+        scale = 1.0;
+        rt[15] = ts[15] * scale;
+
+        nt = 14;
+        t = s = uu = 0.0;
+        for (k = 1; k <= nt; k++)
+        {
+            rt[k] = (ts[k] - ts[15]) * scale;
+            t += rt[k];
+            mops[k] = _nrops[k] * _loops[k];
+            s += (double)mops[k];
+            rpm[k] = 0.0;
+            if (rt[k] != 0.0)
+            {
+                rpm[k] = (double)mops[k] / rt[k];
+            }
+            uu += rpm[k];
+        }
+        uu /= (double)nt;
+        s /= t;
+
+        // Ensure that the array elements are live-out
+        Escape(ts);
+        Escape(rt);
+        Escape(rpm);
+        Escape(cksum);
+        Escape(mops);
+    }
+
+    private void Init()
+    {
+        int j, k, l;
+
+        for (k = 1; k <= 1000; k++)
+        {
+            _x[k] = 1.11;
+            _y[k] = 1.123;
+            _z[k] = 0.321;
+        }
+
+        for (k = 1; k <= 500; k++)
+        {
+            _u[k] = 0.00025;
+        }
+
+        for (k = 1; k <= 15; k++)
+        {
+            for (l = 1; l <= 100; l++)
+            {
+                _px[k,l] = l;
+                _cx[k,l] = l;
+            }
+        }
+
+        for (j = 1; j < 6; j++)
+        {
+            for (k = 1; k < 23; k++)
+            {
+                for (l = 1; l < 3; l++)
+                {
+                    _u1[j,k,l] = k;
+                    _u2[j,k,l] = k + k;
+                    _u3[j,k,l] = k + k + k;
+                }
+            }
+        }
+
+        for (j = 1; j < 65; j++)
+        {
+            for (k = 1; k < 9; k++)
+            {
+                _b[j,k] = 1.00025;
+                _c[j,k] = 1.00025;
+                _h[j,k] = 1.00025;
+            }
+        }
+
+        for (j = 1; j < 6; j++)
+        {
+            _bnk1[j] = j * 100;
+            _bnk2[j] = j * 110;
+            _bnk3[j] = j * 120;
+            _bnk4[j] = j * 130;
+            _bnk5[j] = j * 140;
+        }
+
+        for (j = 1; j < 5; j++)
+        {
+            for (k = 1; k < 513; k++)
+            {
+                _p[j,k] = 1.00025;
+            }
+        }
+
+        for (j = 1; j < 193; j++)
+        {
+            _e[j] = _f[j] = 1;
+        }
+
+        for (j = 1; j < 68; j++)
+        {
+            _ex[j] = _rh[j] = _dex[j] = (double)j;
+        }
+
+        for (j = 1; j < 151; j++)
+        {
+            _vx[j] = 0.001;
+            _xx[j] = 0.001;
+            _grd[j] = (double)(j / 8 + 3);
+        }
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDRomber.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDRomber.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Integration by romberg method adapted from Conte and de Boor
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchF
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+public class MDRomber
+{
+    public const int Iterations = 640000;
+
+    [Benchmark(Description = nameof(MDRomber))]
+    public bool Test()
+    {
+        double[,] r = new double[11, 11];
+        double[,] t = new double[11, 11];
+
+        int idbg, m, n, i, kmax, fourj, j, kmaxm2, l, k, mm1;
+        double sum, ratio, t1, h, a, b;
+
+        for (l = 1; l <= Iterations; l++)
+        {
+            idbg = 0;
+            m = 2;
+            kmax = 6;
+            a = 0;
+            b = 1;
+            h = (b - a) / (m);
+            sum = (F(a) + F(b)) / 2;
+
+            mm1 = m - 1;
+            if (mm1 < 0)
+            {
+                goto L40;
+            }
+            if (mm1 == 0)
+            {
+                goto L10;
+            }
+            for (i = 1; i <= mm1; i++)
+            {
+                t1 = a + i * h;
+                sum = sum + F(t1);
+            }
+
+        L10:
+            t[1,1] = sum * h;
+            if (idbg != 0)
+            {
+                System.Console.WriteLine(" romberg t-table \n");
+                System.Console.WriteLine("{0}\n", t[1,1]);
+            }
+
+            for (k = 2; k <= kmax; k++)
+            {
+                h = h / 2;
+                n = m * 2;
+                sum = 0;
+                for (i = 1; i <= n / 2; i++)
+                {
+                    r[k,1] = r[k - 1,1] * System.Math.Sqrt(b * mm1);
+                    t1 = a + i * h;
+                    sum = sum + F(t1);
+                }
+
+                t[k,1] = t[k - 1,1] / 2 + sum * h;
+                fourj = 1;
+                for (j = 2; j <= k; j++)
+                {
+                    fourj = fourj * 4;
+                    t[k - 1,j - 1] = t[k,j - 1] - t[k - 1,j - 1];
+                    t[k,j] = t[k,j - 1] + t[k - 1,j - 1] / (fourj - 1);
+                }
+
+                if (idbg != 0)
+                {
+                    j = 1;
+                    System.Console.WriteLine("{0} {1} {2}d\n", t[k,j], j, k);
+                }
+            }
+
+            kmaxm2 = kmax - 2;
+            if (kmaxm2 <= 0)
+            {
+                goto L40;
+            }
+
+            if (idbg != 0)
+            {
+                System.Console.WriteLine(" table of ratios \n");
+            }
+
+            for (k = 1; k <= kmaxm2; k++)
+            {
+                for (j = 1; j <= k; j++)
+                {
+                    ratio = 0;
+                    if (System.Math.Abs(t[k + 1,j]) > 0)
+                    {
+                        ratio = t[k,j] / t[k + 1,j];
+                    }
+                    t[k,j] = ratio;
+                }
+            }
+
+            if (idbg != 0)
+            {
+                j = 1;
+                System.Console.WriteLine("{0} {1} {2}\n", t[k,j], j, k);
+            }
+
+        L40:
+            {
+            }
+        }
+
+        return true;
+    }
+
+    private static double F(double x)
+    {
+        return (System.Math.Exp((-(x)) * (x)));
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDSqMtx.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDSqMtx.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchF
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+public class MDSqMtx
+{
+    public const int Iterations = 4000;
+
+    private const int MatrixSize = 40;
+
+    [Benchmark(Description = nameof(MDSqMtx))]
+    public bool Test()
+    {
+        double[,] a = new double[41, 41];
+        double[,] c = new double[41, 41];
+
+        int i, j;
+
+        for (i = 1; i <= MatrixSize; i++)
+        {
+            for (j = 1; j <= MatrixSize; j++)
+            {
+                a[i,j] = i + j;
+            }
+        }
+
+        for (i = 1; i <= Iterations; i++)
+        {
+            Inner(a, c, MatrixSize);
+        }
+
+        if (c[1,1] == 23820.0)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private static void Inner(double[,] a, double[,] c, int n)
+    {
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = 1; j <= n; j++)
+            {
+                c[i,j] = 0.0;
+                for (int k = 1; k <= n; k++)
+                {
+                    c[i,j] = c[i,j] + a[i,k] * a[k,j];
+                }
+            }
+        }
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDAddArray2.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDAddArray2.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDAddArray2
+{
+    private const int Dim = 200;
+    
+    int[,] array = new int[Dim + 1, Dim + 1];
+
+    private static
+    void BenchInner1(int[,] a, ref int nn)
+    {
+        int n;
+        int l, m;
+        n = nn;
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = (i + 1); j <= n; j++)
+            {
+                for (int k = 1; k <= n; k++)
+                {
+                    l = a[i,k];
+                    m = a[j,k];
+                    unchecked
+                    {
+                        a[j,k] = l + m;
+                    }
+                }
+            }
+        }
+    }
+
+    private static
+    void BenchInner2(int[,] a, ref int nn)
+    {
+        int n;
+        int l, m;
+        n = nn;
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = (i + 1); j <= n; j++)
+            {
+                for (int k = 1; k <= n; k++)
+                {
+                    l = a[k,i];
+                    m = a[k,j];
+                    unchecked
+                    {
+                        a[k,j] = l + m;
+                    }
+                }
+            }
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Bench(int[,] a)
+    {
+        int n = Dim;
+        for (int i = 1; i <= n; i++)
+        {
+            for (int j = 1; j <= n; j++)
+            {
+                a[i,j] = i + j;
+            }
+        }
+
+        BenchInner1(a, ref n);
+        n = Dim;
+        BenchInner2(a, ref n);
+
+        return true;
+    }
+
+    [Benchmark(Description = nameof(MDAddArray2))]
+    public bool Test() => Bench(array);
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDArray2.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDArray2.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDArray2
+{
+    public const int Iterations = 500000;
+
+    static void Initialize(int[,,] s) {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) {
+                    s[i,j,k] = (2 * i) - (3 * j) + (5 * k);
+                }
+            }
+        }
+    }
+
+    static bool VerifyCopy(int[,,] s, int[,,] d) {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) {
+                    if (s[i,j,k] != d[i,j,k]) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Bench(int loop) {
+
+        int[,,] s = new int[10, 10, 10];
+        int[,,] d = new int[10, 10, 10];
+
+        Initialize(s);
+
+        for (; loop != 0; loop--) {
+            for (int i = 0; i < 10; i++) {
+                for (int j = 0; j < 10; j++) {
+                    for (int k = 0; k < 10; k++) {
+                        d[i,j,k] = s[i,j,k];
+                    }
+                }
+            }
+        }
+
+        bool result = VerifyCopy(s, d);
+
+        return result;
+    }
+
+    [Benchmark(Description = nameof(MDArray2))]
+    public bool Test() => Bench(Iterations);
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDLogicArray.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDLogicArray.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDLogicArray
+{
+    public const int Iterations = 3000;
+
+    struct Workarea
+    {
+        public int X;
+        public int[,] A;
+    }
+
+    static bool Inner(ref Workarea cmn) {
+        int i, j, k;
+        cmn.X = 0;
+        for (i = 1; i <= 50; i++) {
+            for (j = 1; j <= 50; j++) {
+                cmn.A[i,j] = 1;
+            }
+        }
+        for (k = 1; k <= 50; k++) {
+            for (j = 1; j <= 50; j++) {
+                i = 1;
+                do {
+                    cmn.X = cmn.X | cmn.A[i,j] & cmn.A[i + 1,k];
+                    i = i + 2;
+                } while (i <= 50);
+            }
+        }
+        if (cmn.X != 1) {
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+
+    [Benchmark(Description = nameof(MDLogicArray))]
+    public bool Test() {
+        Workarea cmn = new Workarea();
+        cmn.X = 0;
+        cmn.A = new int[51, 51];
+        for (int n = 1; n <= Iterations; n++) {
+            bool result = Inner(ref cmn);
+            if (!result) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMidpoint.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMidpoint.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDMidpoint
+{
+    public const int Iterations = 70000;
+
+    static int Inner(ref int x, ref int y, ref int z) {
+        int mid;
+
+        if (x < y) {
+            if (y < z) {
+                mid = y;
+            }
+            else {
+                if (x < z) {
+                    mid = z;
+                }
+                else {
+                    mid = x;
+                }
+            }
+        }
+        else {
+            if (x < z) {
+                mid = x;
+            }
+            else {
+                if (y < z) {
+                    mid = z;
+                }
+                else {
+                    mid = y;
+                }
+            }
+        }
+
+        return (mid);
+    }
+
+    [Benchmark(Description = nameof(MDMidpoint))]
+    public bool Test() {
+        int[,] a = new int[2001, 4];
+        int[] mid = new int[2001];
+        int j = 99999;
+
+        for (int i = 1; i <= 2000; i++) {
+            a[i,1] = j & 32767;
+            a[i,2] = (j + 11111) & 32767;
+            a[i,3] = (j + 22222) & 32767;
+            j = j + 33333;
+        }
+
+        for (int k = 1; k <= Iterations; k++) {
+            for (int l = 1; l <= 2000; l++) {
+                mid[l] = Inner(ref a[l,1], ref a[l,2], ref a[l,3]);
+            }
+        }
+
+        return (mid[2000] == 17018);
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMulMatrix.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMulMatrix.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDMulMatrix
+{
+    public const int Iterations = 100;
+
+    const int Size = 75;
+
+    static void Inner(int[,] a, int[,] b, int[,] c) {
+
+        int i, j, k, l;
+
+        // setup
+        for (j = 0; j < Size; j++) {
+            for (i = 0; i < Size; i++) {
+                a[i,j] = i;
+                b[i,j] = 2 * j;
+                c[i,j] = a[i,j] + b[i,j];
+            }
+        }
+
+        // jkl
+        for (j = 0; j < Size; j++) {
+            for (k = 0; k < Size; k++) {
+                for (l = 0; l < Size; l++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        // jlk
+        for (j = 0; j < Size; j++) {
+            for (l = 0; l < Size; l++) {
+                for (k = 0; k < Size; k++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        // kjl
+        for (k = 0; k < Size; k++) {
+            for (j = 0; j < Size; j++) {
+                for (l = 0; l < Size; l++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        // klj
+        for (k = 0; k < Size; k++) {
+            for (l = 0; l < Size; l++) {
+                for (j = 0; j < Size; j++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        // ljk
+        for (l = 0; l < Size; l++) {
+            for (j = 0; j < Size; j++) {
+                for (k = 0; k < Size; k++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        // lkj
+        for (l = 0; l < Size; l++) {
+            for (k = 0; k < Size; k++) {
+                for (j = 0; j < Size; j++) {
+                    c[j,k] += a[j,l] * b[l,k];
+                }
+            }
+        }
+
+        return;
+    }
+
+    [Benchmark(Description = nameof(MDMulMatrix))]
+    public int[,] Test() {
+        int[,] a = new int[Size, Size];
+        int[,] b = new int[Size, Size];
+        int[,] c = new int[Size, Size];
+
+        for (int i = 0; i < Iterations; ++i) {
+            Inner(a, b, c);
+        }
+        
+        return c;
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDNDhrystone.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDNDhrystone.cs
@@ -1,0 +1,253 @@
+ // Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// Adapted from
+//
+// Dhrystone: a synthetic systems programming benchmark
+// Reinhold P. Weicker
+// Communications of the ACM, Volume 27 Issue 10, Oct 1984, Pages 1013-1030
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDNDhrystone
+{
+    public const int Iterations = 7000000;
+
+    enum Enumeration
+    {
+        Ident1 = 1, Ident2, Ident3, Ident4, Ident5
+    }
+
+    sealed class Record
+    {
+        public Record PtrComp;
+        public Enumeration Discr;
+        public Enumeration EnumComp;
+        public int IntComp;
+        public char[] StringComp;
+    }
+
+    static int s_intGlob;
+    static bool s_boolGlob;
+    static char s_char1Glob;
+    static char s_char2Glob;
+    static int[] m_array1Glob = new int[51];
+    static int[,] m_array2Glob;
+    static Record m_ptrGlb = new Record();
+    static Record m_ptrGlbNext = new Record();
+    static char[] m_string1Loc;
+    static char[] m_string2Loc;
+
+    static void Proc0() {
+        int intLoc1;
+        int intLoc2;
+        int intLoc3 = 0;
+        Enumeration enumLoc;
+
+        int i;   /* modification */
+
+        m_ptrGlb.PtrComp = m_ptrGlbNext;
+        m_ptrGlb.Discr = Enumeration.Ident1;
+        m_ptrGlb.EnumComp = Enumeration.Ident3;
+        m_ptrGlb.IntComp = 40;
+        m_ptrGlb.StringComp = "DHRYSTONE PROGRAM, SOME STRING".ToCharArray();
+        m_string1Loc = "DHRYSTONE PROGRAM, 1'ST STRING".ToCharArray();
+        m_array2Glob[8,7] = 10;  /* Was missing in published program */
+
+        for (i = 0; i < Iterations; ++i) {
+            Proc5();
+            Proc4();
+            intLoc1 = 2;
+            intLoc2 = 3;
+            m_string2Loc = "DHRYSTONE PROGRAM, 2'ND STRING".ToCharArray();
+            enumLoc = Enumeration.Ident2;
+            s_boolGlob = !Func2(m_string1Loc, m_string2Loc);
+            while (intLoc1 < intLoc2) {
+                intLoc3 = 5 * intLoc1 - intLoc2;
+                Proc7(intLoc1, intLoc2, ref intLoc3);
+                ++intLoc1;
+            }
+            Proc8(m_array1Glob, m_array2Glob, intLoc1, intLoc3);
+            Proc1(ref m_ptrGlb);
+            for (char charIndex = 'A'; charIndex <= s_char2Glob; ++charIndex) {
+                if (enumLoc == Func1(charIndex, 'C')) {
+                    Proc6(Enumeration.Ident1, ref enumLoc);
+                }
+            }
+            intLoc3 = intLoc2 * intLoc1;
+            intLoc2 = intLoc3 / intLoc1;
+            intLoc2 = 7 * (intLoc3 - intLoc2) - intLoc1;
+            Proc2(ref intLoc1);
+        }
+    }
+
+    static void Proc1(ref Record ptrParIn) {
+        ptrParIn.PtrComp = m_ptrGlb;
+        ptrParIn.IntComp = 5;
+        ptrParIn.PtrComp.IntComp = ptrParIn.IntComp;
+        ptrParIn.PtrComp.PtrComp = ptrParIn.PtrComp;
+        Proc3(ref ptrParIn.PtrComp.PtrComp);
+        if (ptrParIn.PtrComp.Discr == Enumeration.Ident1) {
+            ptrParIn.PtrComp.IntComp = 6;
+            Proc6(ptrParIn.EnumComp, ref ptrParIn.PtrComp.EnumComp);
+            ptrParIn.PtrComp.PtrComp = m_ptrGlb.PtrComp;
+            Proc7(ptrParIn.PtrComp.IntComp, 10, ref ptrParIn.PtrComp.IntComp);
+        }
+        else {
+            ptrParIn = ptrParIn.PtrComp;
+        }
+    }
+
+    static void Proc2(ref int intParIO) {
+        int intLoc;
+        Enumeration enumLoc = Enumeration.Ident2;
+        intLoc = intParIO + 10;
+
+        for (;;) {
+            if (s_char1Glob == 'A') {
+                --intLoc;
+                intParIO = intLoc - s_intGlob;
+                enumLoc = Enumeration.Ident1;
+            }
+            if (enumLoc == Enumeration.Ident1) {
+                break;
+            }
+        }
+    }
+
+    static void Proc3(ref Record ptrParOut) {
+        if (m_ptrGlb != null) {
+            ptrParOut = m_ptrGlb.PtrComp;
+        }
+        else {
+            s_intGlob = 100;
+        }
+
+        Proc7(10, s_intGlob, ref m_ptrGlb.IntComp);
+    }
+
+    static void Proc4() {
+        bool boolLoc;
+        boolLoc = s_char1Glob == 'A';
+        boolLoc |= s_boolGlob;
+        s_char2Glob = 'B';
+    }
+
+    static void Proc5() {
+        s_char1Glob = 'A';
+        s_boolGlob = false;
+    }
+
+    static void Proc6(Enumeration enumParIn, ref Enumeration enumParOut) {
+        enumParOut = enumParIn;
+        if (!Func3(enumParIn)) {
+            enumParOut = Enumeration.Ident4;
+        }
+
+        switch (enumParIn) {
+            case Enumeration.Ident1:
+                enumParOut = Enumeration.Ident1;
+                break;
+            case Enumeration.Ident2:
+                if (s_intGlob > 100) {
+                    enumParOut = Enumeration.Ident1;
+                }
+                else {
+                    enumParOut = Enumeration.Ident4;
+                }
+                break;
+            case Enumeration.Ident3:
+                enumParOut = Enumeration.Ident2;
+                break;
+            case Enumeration.Ident4:
+                break;
+            case Enumeration.Ident5:
+                enumParOut = Enumeration.Ident3;
+                break;
+        }
+    }
+
+    static void Proc7(int intParI1, int intParI2, ref int intParOut) {
+        int intLoc;
+        intLoc = intParI1 + 2;
+        intParOut = intParI2 + intLoc;
+    }
+
+    static void Proc8(int[] array1Par, int[,] array2Par, int intParI1, int intParI2) {
+        int intLoc;
+        intLoc = intParI1 + 5;
+        array1Par[intLoc] = intParI2;
+        array1Par[intLoc + 1] = array1Par[intLoc];
+        array1Par[intLoc + 30] = intLoc;
+        for (int intIndex = intLoc; intIndex <= (intLoc + 1); ++intIndex) {
+            array2Par[intLoc,intIndex] = intLoc;
+        }
+        ++array2Par[intLoc,intLoc - 1];
+        array2Par[intLoc + 20,intLoc] = array1Par[intLoc];
+        s_intGlob = 5;
+    }
+
+    static Enumeration Func1(char charPar1, char charPar2) {
+        char charLoc1;
+        char charLoc2;
+        charLoc1 = charPar1;
+        charLoc2 = charLoc1;
+        if (charLoc2 != charPar2) {
+            return (Enumeration.Ident1);
+        }
+        else {
+            return (Enumeration.Ident2);
+        }
+    }
+
+    static bool Func2(char[] strParI1, char[] strParI2) {
+        int intLoc;
+        char charLoc = '\0';
+        intLoc = 1;
+        while (intLoc <= 1) {
+            if (Func1(strParI1[intLoc], strParI2[intLoc + 1]) == Enumeration.Ident1) {
+                charLoc = 'A';
+                ++intLoc;
+            }
+        }
+        if (charLoc >= 'W' && charLoc <= 'Z') {
+            intLoc = 7;
+        }
+        if (charLoc == 'X') {
+            return true;
+        }
+        else {
+            for (int i = 0; i < 30; i++) {
+                if (strParI1[i] > strParI2[i]) {
+                    intLoc += 7;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    static bool Func3(Enumeration enumParIn) {
+        Enumeration enumLoc;
+        enumLoc = enumParIn;
+        if (enumLoc == Enumeration.Ident3) {
+            return true;
+        }
+
+        return false;
+    }
+
+    [Benchmark(Description = nameof(MDNDhrystone))]
+    public bool Test() {
+        m_array2Glob = new int[51, 51];
+        Proc0();
+        return true;
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDPuzzle.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDPuzzle.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDPuzzle
+{
+    public const int Iterations = 400;
+    
+    private const int PuzzleSize = 511;
+    private const int ClassMax = 3;
+    private const int TypeMax = 12;
+    private const int D = 8;
+
+    private int[] _pieceCount = new int[ClassMax + 1];
+    private int[] _class = new int[TypeMax + 1];
+    private int[] _pieceMax = new int[TypeMax + 1];
+    private bool[] _puzzle = new bool[PuzzleSize + 1];
+    private bool[,] _p;
+    private int _count;
+
+    private bool Fit(int i, int j)
+    {
+        for (int k = 0; k <= _pieceMax[i]; k++)
+        {
+            if (_p[i,k])
+            {
+                if (_puzzle[j + k])
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private int Place(int i, int j)
+    {
+        int k;
+        for (k = 0; k <= _pieceMax[i]; k++)
+        {
+            if (_p[i,k])
+            {
+                _puzzle[j + k] = true;
+            }
+        }
+
+        _pieceCount[_class[i]] = _pieceCount[_class[i]] - 1;
+
+        for (k = j; k <= PuzzleSize; k++)
+        {
+            if (!_puzzle[k])
+            {
+                return k;
+            }
+        }
+
+        return 0;
+    }
+
+    private void RemoveLocal(int i, int j)
+    {
+        for (int k = 0; k <= _pieceMax[i]; k++)
+        {
+            if (_p[i,k])
+            {
+                _puzzle[j + k] = false;
+            }
+        }
+
+        _pieceCount[_class[i]] = _pieceCount[_class[i]] + 1;
+    }
+
+    private bool Trial(int j)
+    {
+        for (int i = 0; i <= TypeMax; i++)
+        {
+            if (_pieceCount[_class[i]] != 0)
+            {
+                if (Fit(i, j))
+                {
+                    int k = Place(i, j);
+                    if (Trial(k) || (k == 0))
+                    {
+                        _count = _count + 1;
+                        return true;
+                    }
+                    else
+                    {
+                        RemoveLocal(i, j);
+                    }
+                }
+            }
+        }
+
+        _count = _count + 1;
+        return false;
+    }
+
+    private bool DoIt()
+    {
+        int i, j, k, m, n;
+
+        for (m = 0; m <= PuzzleSize; m++)
+        {
+            _puzzle[m] = true;
+        }
+
+        for (i = 1; i <= 5; i++)
+        {
+            for (j = 1; j <= 5; j++)
+            {
+                for (k = 1; k <= 5; k++)
+                {
+                    _puzzle[i + D * (j + D * k)] = false;
+                }
+            }
+        }
+
+        for (i = 0; i <= TypeMax; i++)
+        {
+            for (m = 0; m <= PuzzleSize; m++)
+            {
+                _p[i,m] = false;
+            }
+        }
+
+        for (i = 0; i <= 3; i++)
+        {
+            for (j = 0; j <= 1; j++)
+            {
+                for (k = 0; k <= 0; k++)
+                {
+                    _p[0,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[0] = 0;
+        _pieceMax[0] = 3 + D * 1 + D * D * 0;
+
+        for (i = 0; i <= 1; i++)
+        {
+            for (j = 0; j <= 0; j++)
+            {
+                for (k = 0; k <= 3; k++)
+                {
+                    _p[1,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[1] = 0;
+        _pieceMax[1] = 1 + D * 0 + D * D * 3;
+
+        for (i = 0; i <= 0; i++)
+        {
+            for (j = 0; j <= 3; j++)
+            {
+                for (k = 0; k <= 1; k++)
+                {
+                    _p[2,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+        _class[2] = 0;
+        _pieceMax[2] = 0 + D * 3 + D * D * 1;
+
+        for (i = 0; i <= 1; i++)
+        {
+            for (j = 0; j <= 3; j++)
+            {
+                for (k = 0; k <= 0; k++)
+                {
+                    _p[3,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[3] = 0;
+        _pieceMax[3] = 1 + D * 3 + D * D * 0;
+
+        for (i = 0; i <= 3; i++)
+        {
+            for (j = 0; j <= 0; j++)
+            {
+                for (k = 0; k <= 1; k++)
+                {
+                    _p[4,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[4] = 0;
+        _pieceMax[4] = 3 + D * 0 + D * D * 1;
+
+        for (i = 0; i <= 0; i++)
+        {
+            for (j = 0; j <= 1; j++)
+            {
+                for (k = 0; k <= 3; k++)
+                {
+                    _p[5,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[5] = 0;
+        _pieceMax[5] = 0 + D * 1 + D * D * 3;
+
+        for (i = 0; i <= 2; i++)
+        {
+            for (j = 0; j <= 0; j++)
+            {
+                for (k = 0; k <= 0; k++)
+                {
+                    _p[6,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[6] = 1;
+        _pieceMax[6] = 2 + D * 0 + D * D * 0;
+
+        for (i = 0; i <= 0; i++)
+        {
+            for (j = 0; j <= 2; j++)
+            {
+                for (k = 0; k <= 0; k++)
+                {
+                    _p[7,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[7] = 1;
+        _pieceMax[7] = 0 + D * 2 + D * D * 0;
+
+        for (i = 0; i <= 0; i++)
+        {
+            for (j = 0; j <= 0; j++)
+            {
+                for (k = 0; k <= 2; k++)
+                {
+                    _p[8,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[8] = 1;
+        _pieceMax[8] = 0 + D * 0 + D * D * 2;
+
+        for (i = 0; i <= 1; i++)
+        {
+            for (j = 0; j <= 1; j++)
+            {
+                for (k = 0; k <= 0; k++)
+                {
+                    _p[9,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+        _class[9] = 2;
+        _pieceMax[9] = 1 + D * 1 + D * D * 0;
+
+        for (i = 0; i <= 1; i++)
+        {
+            for (j = 0; j <= 0; j++)
+            {
+                for (k = 0; k <= 1; k++)
+                {
+                    _p[10,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[10] = 2;
+        _pieceMax[10] = 1 + D * 0 + D * D * 1;
+
+        for (i = 0; i <= 0; i++)
+        {
+            for (j = 0; j <= 1; j++)
+            {
+                for (k = 0; k <= 1; k++)
+                {
+                    _p[11,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[11] = 2;
+        _pieceMax[11] = 0 + D * 1 + D * D * 1;
+
+        for (i = 0; i <= 1; i++)
+        {
+            for (j = 0; j <= 1; j++)
+            {
+                for (k = 0; k <= 1; k++)
+                {
+                    _p[12,i + D * (j + D * k)] = true;
+                }
+            }
+        }
+
+        _class[12] = 3;
+        _pieceMax[12] = 1 + D * 1 + D * D * 1;
+        _pieceCount[0] = 13;
+        _pieceCount[1] = 3;
+        _pieceCount[2] = 1;
+        _pieceCount[3] = 1;
+        m = 1 + D * (1 + D * 1);
+        _count = 0;
+
+        bool result = true;
+
+        if (Fit(0, m))
+        {
+            n = Place(0, m);
+            result = Trial(n);
+        }
+        else
+        {
+            result = false;
+        }
+
+        return result;
+    }
+
+    [Benchmark(Description = nameof(MDPuzzle))]
+    public bool Test()
+    {
+        _p = new bool[TypeMax + 1, PuzzleSize + 1];
+
+        bool result = true;
+
+        for (int i = 0; i < Iterations; ++i)
+        {
+            result &= DoIt();
+        }
+
+        return result;
+    }
+}
+}

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDXposMatrix.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDXposMatrix.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace Benchstone.MDBenchI
+{
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+public class MDXposMatrix
+{
+    public const int ArraySize = 100;
+    
+    int[,] matrixField = new int[ArraySize + 1, ArraySize + 1];
+
+    static void Inner(int[,] x, int n) {
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                int t = x[i,j];
+                x[i,j] = x[j,i];
+                x[j,i] = t;
+            }
+        }
+    }
+
+    [Benchmark(Description = nameof(MDXposMatrix))]
+    public bool Test() {
+        int[,] matrix = matrixField;
+        
+        int n = ArraySize;
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                matrix[i,j] = 1;
+            }
+        }
+
+        if (matrix[n,n] != 1) {
+            return false;
+        }
+
+        Inner(matrix, n);
+
+        if (matrix[n,n] != 1) {
+            return false;
+        }
+
+        return true;
+    }
+}
+}


### PR DESCRIPTION
The current versions of the Benchstones microbenchmarks use C#
"jagged" arrays for multi-dimension arrays. This adds a set of all the
BenchF/BenchI benchmarks that use multi-dimensions arrays, using C#
true multi-dimension array access. The code is exactly the same as the
non-multi-dimension versions except for array creation and indexing
expressions.

This will help track and compare multi-dimension versus jagged array
performance.