### PR TITLE
SOD Precommand msbuild split revert

### DIFF
--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -195,7 +195,7 @@ class PreCommands:
     def _parsemsbuildproperties(self) -> list:
         if self.msbuild:
             proplist = list()
-            for propertyarg in self.msbuild.split('\n'):
+            for propertyarg in self.msbuild.split(';'):
                 proplist.append(propertyarg)
             return proplist
         return None


### PR DESCRIPTION
Updated the new line to be a semi-colon reverting the semi-colon to new line fix. Fixes #2070, reverts #2069. The blazor_scenarios.proj file needs to be updated at the same time in the runtime repo to use the two semi-colons instead of %3b.