### PR TITLE
Add StringReaderReadLineTests

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -13,8 +13,20 @@ namespace System.IO.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class StringReaderReadLineTests
     {
-        public const int LineCount = 256_000;
-        public const int ReaderCount = 10000;
+        // Benchmark is based on measuring individual `ReadLine` calls
+        // of lines of different lengths within a range defined as
+        // benchmark parameters.
+        // To fulfill BDNs requirement for an iteration time of 250ms,
+        // this means a lot of invocations, more than a single string in
+        // a `StringReader` can accommodate.
+        // Therefore, the benchmark generates of string with a certain
+        // target length and then a number of readers for the same
+        // string, since `StringReader` does not support being "reset".
+        // The trade off is we need to switch reader during the `ReadLine`
+        // call when current reader ends, which adds a bit of overhead. 
+        // This is deemed negligible and amortized constant.
+        private const int StringReaderTargetLength = 16 * 1024 * 1024;
+        private const int ReaderCount = 1000;
 
         private string _text;
         private StringReader[] _readers;
@@ -23,32 +35,33 @@ namespace System.IO.Tests
 
         public StringReaderReadLineTests()
         {
-            LineConfigs = new Config[]
+            LineLengthRanges = new Range[]
             {
-                new (){ LineLengthMin = 0, LineLengthMax = 0 },
-                new (){ LineLengthMin = 0, LineLengthMax = 64 },
-                new (){ LineLengthMin = 128, LineLengthMax = 512 },
+                new (){ Min =   0, Max =    0 },
+                new (){ Min =   1, Max =    8 },
+                new (){ Min =   9, Max =   32 },
+                new (){ Min =  33, Max =  128 },
+                new (){ Min = 129, Max = 1024 },
             };
         }
 
-        [ParamsSource(nameof(LineConfigs))]
-        public Config LineConfig { get; set; }
+        [ParamsSource(nameof(LineLengthRanges))]
+        public Range LineLengthRange { get; set; }
 
-        public IEnumerable<Config> LineConfigs { get; }
+        public IEnumerable<Range> LineLengthRanges { get; }
 
-        public class Config
+        public class Range
         {
-            public int LineLengthMin { get; set; }
-            public int LineLengthMax { get; set; }
+            public int Min { get; set; }
+            public int Max { get; set; }
 
-            public override string ToString() =>
-                $"LineLength [{LineLengthMin,4},{LineLengthMax,4}]";
+            public override string ToString() => $"[{Min,4},{Max,4}]";
         }
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _text = GenerateLinesText(LineConfig);
+            _text = GenerateLinesText(LineLengthRange, StringReaderTargetLength);
             _readers = Enumerable.Range(0, ReaderCount)
                 .Select(i => new StringReader(_text)).ToArray();
             _readerIndex = 0;
@@ -64,21 +77,23 @@ namespace System.IO.Tests
             return line;
         }
 
-        private static string GenerateLinesText(Config config)
+        private static string GenerateLinesText(Range lineLengthRange, int textTargetLength)
         {
-            var min = config.LineLengthMin;
-            var max = config.LineLengthMax;
-            var count = LineCount;
+            var min = lineLengthRange.Min;
+            var max = lineLengthRange.Max;
 
-            var newLines = Math.Min(min, max) > 0 
-                ? new[] { "\n", "\r", "\r\n" } 
-                : new[] { "\r\n" };
+            // Just to make things interesting 
+            // new line characters are randomized.
+            // Note if lines are empty not \r and \n
+            // might be "combined".
+            var newLines = new[] { "\n", "\r", "\r\n" };
 
-            var capacity = (2 + max / 2 + min / 2) * count;
+            var capacity = textTargetLength + max + 2;
             var sb = new StringBuilder(capacity);
 
             var random = new Random(42);
-            for (int l = 0; l < count; l++)
+            int lineCount = 0;
+            while(sb.Length < textTargetLength)
             {
                 var charsCount = random.Next(min, max);
                 for (int c = 0; c < charsCount; c++)
@@ -88,8 +103,13 @@ namespace System.IO.Tests
                 }
                 var newLine = newLines[random.Next(newLines.Length)];
                 sb.Append(newLine);
+                ++lineCount;
             }
             var text = sb.ToString();
+
+            Console.WriteLine($"// Generated lines {lineCount} and " +
+                $"text length {text.Length} out of capacity {capacity}");
+
             return text;
         }
     }

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -57,7 +57,7 @@ namespace System.IO.Tests
             public int Min { get; set; }
             public int Max { get; set; }
 
-            public override string ToString() => $"[{Min,4},{Max,4}]";
+            public override string ToString() => $"[{Min,4}, {Max,4}]";
         }
 
         [GlobalSetup]

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    [InvocationCount(InvocationCount)]
+    public class StringReaderReadLineTests
+    {
+        public const int LineCount = 100_000;
+        public const int ReaderCount = 100;
+        public const int InvocationCount = LineCount * ReaderCount;
+
+        private string _text;
+        private StringReader[] _readers;
+        private int _readerIndex;
+        private StringReader _reader;
+
+        public StringReaderReadLineTests()
+        {
+            LineConfigs = new[]
+            {
+                (LineLengthMin: 0, LineLengthMax: 64, LineCount),
+                (LineLengthMin: 256, LineLengthMax: 512, LineCount),
+            };
+        }
+
+        [ParamsSource(nameof(LineConfigs))]
+        public (int LineLengthMin, int LineLengthMax, int LineCount) LineConfig { get; set; }
+
+        public IEnumerable<(int LineLengthMin, int LineLengthMax, int LineCount)> LineConfigs { get; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var (min, max, count) = LineConfig;
+            var capacity = (2 + max / 2 + min / 2) * count;
+            var newLines = new[] { "\n", "\r", "\r\n" };
+            var sb = new StringBuilder(capacity);
+            var random = new Random(42);
+            for (int l = 0; l < count; l++)
+            {
+                var charsCount = random.Next(min, max);
+                for (int c = 0; c < charsCount; c++)
+                {
+                    var ch = (char)random.Next('0', 'z');
+                    sb.Append(ch);
+                }
+                var newLine = newLines[random.Next(newLines.Length)];
+                sb.Append(newLine);
+            }
+            _text = sb.ToString();
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _readers = Enumerable.Range(0, ReaderCount + 1).Select(i =>new StringReader(_text)).ToArray();
+            _readerIndex = 0;
+            _reader = _readers[_readerIndex];
+        }
+
+        [Benchmark]
+        public string ReadLine()
+        {
+            var line = _reader.ReadLine();
+            if (line == null)
+                _reader = _readers[++_readerIndex];
+            return line;
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -19,7 +19,7 @@ namespace System.IO.Tests
         // To fulfill BDNs requirement for an iteration time of 250ms,
         // this means a lot of invocations, more than a single string in
         // a `StringReader` can accommodate.
-        // Therefore, the benchmark generates of string with a certain
+        // Therefore, the benchmark generates a string with a certain
         // target length and then a number of readers for the same
         // string, since `StringReader` does not support being "reset".
         // The trade off is we need to switch reader during the `ReadLine`
@@ -30,7 +30,6 @@ namespace System.IO.Tests
         // of new readers during benchmarking. Otherwise, it will throw.
         private const int ReaderCount = 10000;
 
-        private string _text;
         private StringReader[] _readers;
         private int _readerIndex;
         private StringReader _reader;
@@ -65,9 +64,9 @@ namespace System.IO.Tests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _text = GenerateLinesText(LineLengthRange, StringReaderTargetLength);
+            var text = GenerateLinesText(LineLengthRange, StringReaderTargetLength);
             _readers = Enumerable.Range(0, ReaderCount)
-                .Select(i => new StringReader(_text)).ToArray();
+                .Select(i => new StringReader(text)).ToArray();
             _readerIndex = 0;
             _reader = _readers[_readerIndex];
         }        

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -26,7 +26,9 @@ namespace System.IO.Tests
         // call when current reader ends, which adds a bit of overhead. 
         // This is deemed negligible and amortized constant.
         private const int StringReaderTargetLength = 16 * 1024 * 1024;
-        private const int ReaderCount = 1000;
+        // Reader count must be high enough to ensure we never run out
+        // of new readers during benchmarking. Otherwise, it will throw.
+        private const int ReaderCount = 10000;
 
         private string _text;
         private StringReader[] _readers;

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -40,10 +40,12 @@ namespace System.IO.Tests
             LineLengthRanges = new Range[]
             {
                 new (){ Min =   0, Max =    0 },
+                new (){ Min =   1, Max =    1 },
                 new (){ Min =   1, Max =    8 },
                 new (){ Min =   9, Max =   32 },
                 new (){ Min =  33, Max =  128 },
                 new (){ Min = 129, Max = 1024 },
+                new (){ Min =   0, Max = 1024 },
             };
         }
 
@@ -88,7 +90,7 @@ namespace System.IO.Tests
             // new line characters are randomized.
             // Note if lines are empty not \r and \n
             // might be "combined".
-            var newLines = new[] { "\n", "\r", "\r\n" };
+            var newLine = Environment.NewLine;
 
             var capacity = textTargetLength + max + 2;
             var sb = new StringBuilder(capacity);
@@ -103,7 +105,6 @@ namespace System.IO.Tests
                     var ch = (char)random.Next('0', 'z');
                     sb.Append(ch);
                 }
-                var newLine = newLines[random.Next(newLines.Length)];
                 sb.Append(newLine);
                 ++lineCount;
             }

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -86,10 +86,6 @@ namespace System.IO.Tests
             var min = lineLengthRange.Min;
             var max = lineLengthRange.Max;
 
-            // Just to make things interesting 
-            // new line characters are randomized.
-            // Note if lines are empty not \r and \n
-            // might be "combined".
             var newLine = Environment.NewLine;
 
             var capacity = textTargetLength + max + 2;

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -88,7 +88,7 @@ namespace System.IO.Tests
 
             var newLine = Environment.NewLine;
 
-            var capacity = textTargetLength + max + 2;
+            var capacity = textTargetLength + max + newLine.Length;
             var sb = new StringBuilder(capacity);
 
             var random = new Random(42);

--- a/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StringReaderReadLineTests.cs
@@ -48,10 +48,8 @@ namespace System.IO.Tests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            string text = GenerateLinesText(LineConfig);
-            _text = text;
-            File.WriteAllText(@$"D:\StringReaderReadLine-{LineConfig.LineLengthMin}-{LineConfig.LineLengthMax}.txt", _text);
-            _readers = Enumerable.Range(0, ReaderCount + 1)
+            _text = GenerateLinesText(LineConfig);
+            _readers = Enumerable.Range(0, ReaderCount)
                 .Select(i => new StringReader(_text)).ToArray();
             _readerIndex = 0;
             _reader = _readers[_readerIndex];


### PR DESCRIPTION
Benchmark for https://github.com/dotnet/runtime/pull/60463

cc: @danmoseley @adamsitnik 

Example run comparing main `m` to PR `pr`.
``` ini

BenchmarkDotNet=v0.13.1.1611-nightly, OS=Windows 10.0.19043.1266 (21H1/May2021Update)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100-rc.2.21505.57
  [Host]     : .NET 6.0.0 (6.0.21.48005), X64 RyuJIT
  Job-BIEWJM : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
  Job-IFXICU : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|   Method |        Job |                                                                                                    Toolchain | LineLengthRange |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD |  Gen 0 | Allocated |
|--------- |----------- |------------------------------------------------------------------------------------------------------------- |---------------- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|-------:|----------:|
| **ReadLine** | **Job-BIEWJM** |  **runtime-m** |     **[   0,   0]** |   **7.208 ns** | **0.0556 ns** | **0.0434 ns** |   **7.194 ns** |   **7.165 ns** |   **7.288 ns** |  **1.00** |    **0.00** |      **-** |         **-** |
| ReadLine | Job-IFXICU | runtime-pr |     [   0,   0] |  10.112 ns | 0.1781 ns | 0.1666 ns |  10.105 ns |   9.875 ns |  10.438 ns |  1.41 |    0.02 |      - |         - |
|          |            |                                                                                                              |                 |            |           |           |            |            |            |       |         |        |           |
| **ReadLine** | **Job-BIEWJM** |  **runtime-m** |     **[   1,   8]** |  **17.751 ns** | **0.2287 ns** | **0.2028 ns** |  **17.686 ns** |  **17.552 ns** |  **18.192 ns** |  **1.00** |    **0.00** | **0.0020** |      **33 B** |
| ReadLine | Job-IFXICU | runtime-pr |     [   1,   8] |  16.998 ns | 0.1011 ns | 0.0946 ns |  16.992 ns |  16.872 ns |  17.212 ns |  0.96 |    0.01 | 0.0020 |      33 B |
|          |            |                                                                                                              |                 |            |           |           |            |            |            |       |         |        |           |
| **ReadLine** | **Job-BIEWJM** |  **runtime-m** |     **[   9,  32]** |  **26.336 ns** | **0.1205 ns** | **0.1127 ns** |  **26.273 ns** |  **26.200 ns** |  **26.510 ns** |  **1.00** |    **0.00** | **0.0039** |      **65 B** |
| ReadLine | Job-IFXICU | runtime-pr |     [   9,  32] |  19.896 ns | 0.0740 ns | 0.0618 ns |  19.879 ns |  19.801 ns |  20.046 ns |  0.76 |    0.00 | 0.0038 |      65 B |
|          |            |                                                                                                              |                 |            |           |           |            |            |            |       |         |        |           |
| **ReadLine** | **Job-BIEWJM** |  **runtime-m** |     **[  33, 128]** |  **62.594 ns** | **0.2100 ns** | **0.1861 ns** |  **62.584 ns** |  **62.222 ns** |  **62.928 ns** |  **1.00** |    **0.00** | **0.0108** |     **185 B** |
| ReadLine | Job-IFXICU | runtime-pr |     [  33, 128] |  31.021 ns | 0.0902 ns | 0.0800 ns |  31.015 ns |  30.912 ns |  31.200 ns |  0.50 |    0.00 | 0.0110 |     185 B |
|          |            |                                                                                                              |                 |            |           |           |            |            |            |       |         |        |           |
| **ReadLine** | **Job-BIEWJM** |  **runtime-m** |     **[ 129,1024]** | **319.244 ns** | **0.6595 ns** | **0.6169 ns** | **319.302 ns** | **318.088 ns** | **320.391 ns** |  **1.00** |    **0.00** | **0.0697** |   **1,181 B** |
| ReadLine | Job-IFXICU | runtime-pr |     [ 129,1024] |  98.174 ns | 0.2733 ns | 0.2282 ns |  98.123 ns |  97.705 ns |  98.567 ns |  0.31 |    0.00 | 0.0705 |   1,181 B |
