### PR TITLE
Setting output encoding to utf-8 to stop UnicodeDecode error in micro runs

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -193,6 +193,7 @@ class RunCommand:
                     stdout=PIPE if should_pipe else DEVNULL,
                     stderr=STDOUT,
                     universal_newlines=True,
+                    encoding="utf-8",
             ) as proc:
                 if proc.stdout is not None:
                     with proc.stdout:


### PR DESCRIPTION
Setting output encoding to utf-8 to stop UnicodeDecode error in micro runs:
```
Traceback (most recent call last):
  File "C:\h\w\B0520A04\p\scripts\benchmarks_ci.py", line 250, in <module>
    __main(sys.argv[1:])
  File "C:\h\w\B0520A04\p\scripts\benchmarks_ci.py", line 226, in __main
    micro_benchmarks.run(
  File "C:\h\w\B0520A04\p\scripts\micro_benchmarks.py", line 310, in run
    BENCHMARKS_CSPROJ.run(
  File "C:\h\w\B0520A04\p\scripts\dotnet.py", line 467, in run
    RunCommand(cmdline, verbose=verbose).run(
  File "C:\h\w\B0520A04\p\scripts\performance\common.py", line 210, in run
    (returncode, quoted_cmdline) = self.__runinternal(working_directory)
  File "C:\h\w\B0520A04\p\scripts\performance\common.py", line 199, in __runinternal
    for line in iter(proc.stdout.readline, ''):
  File "C:\python3.9.1\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1786: character maps to <undefined>
```