### PR TITLE
Disable the compilation of the Perf.Regex.Industry.cs

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -121,6 +121,9 @@
   </ItemGroup>
 
   <ItemGroup>
+	<!-- Temporarily disable tests here -->
+	<Compile Remove="libraries\System.Text.RegularExpressions\Perf.Regex.Industry.cs" />
+	  
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />
   </ItemGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -121,8 +121,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<!-- Temporarily disable tests here -->
-	<Compile Remove="libraries\System.Text.RegularExpressions\Perf.Regex.Industry.cs" />
+    <!-- Temporarily disable tests here -->
+    <Compile Remove="libraries\System.Text.RegularExpressions\Perf.Regex.Industry.cs" />
 	  
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />


### PR DESCRIPTION
Disable the compilation of the Perf.Regex.Industry.cs file as it is causing the microbenchmark tests to fail.
First step of #2140, follow for more information

Pipeline error:
```
[2021/11/18 12:22:02][INFO] // Found 5 benchmarks:
[2021/11/18 12:22:02][INFO] //   Perf_Regex_Industry_Leipzig.Count: Job-RCHHKQ(PowerPlanMode=00000000-0000-0000-0000-000000000000, Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog, InvocationCount=1, IterationCount=1, IterationTime=250.0000 ms, MaxIterationCount=20, MinIterationCount=15, RunStrategy=ColdStart, UnrollFactor=1, WarmupCount=0) [Pattern=(?i)Tom|Sawyer|Huckleberry|Finn, Options=Compiled]
[2021/11/18 12:22:02][INFO] //   Perf_Regex_Industry_Leipzig.Count: Job-RCHHKQ(PowerPlanMode=00000000-0000-0000-0000-000000000000, Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog, InvocationCount=1, IterationCount=1, IterationTime=250.0000 ms, MaxIterationCount=20, MinIterationCount=15, RunStrategy=ColdStart, UnrollFactor=1, WarmupCount=0) [Pattern=Huck[a-zA-Z]+|Saw[a-zA-Z]+, Options=None]
[2021/11/18 12:22:02][INFO] //   Perf_Regex_Industry_Leipzig.Count: Job-RCHHKQ(PowerPlanMode=00000000-0000-0000-0000-000000000000, Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog, InvocationCount=1, IterationCount=1, IterationTime=250.0000 ms, MaxIterationCount=20, MinIterationCount=15, RunStrategy=ColdStart, UnrollFactor=1, WarmupCount=0) [Pattern=Tom.{10,25}river|river.{10,25}Tom, Options=None]
[2021/11/18 12:22:02][INFO] //   Perf_Regex_Industry_Leipzig.Count: Job-RCHHKQ(PowerPlanMode=00000000-0000-0000-0000-000000000000, Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog, InvocationCount=1, IterationCount=1, IterationTime=250.0000 ms, MaxIterationCount=20, MinIterationCount=15, RunStrategy=ColdStart, UnrollFactor=1, WarmupCount=0) [Pattern=Twain, Options=Compiled]
[2021/11/18 12:22:52][INFO] $ popd
Traceback (most recent call last):
  File "C:\h\w\AB8A099E\p\scripts\benchmarks_ci.py", line 250, in <module>
    __main(sys.argv[1:])
  File "C:\h\w\AB8A099E\p\scripts\benchmarks_ci.py", line 226, in __main
    micro_benchmarks.run(
  File "C:\h\w\AB8A099E\p\scripts\micro_benchmarks.py", line 310, in run
    BENCHMARKS_CSPROJ.run(
  File "C:\h\w\AB8A099E\p\scripts\dotnet.py", line 467, in run
    RunCommand(cmdline, verbose=verbose).run(
  File "C:\h\w\AB8A099E\p\scripts\performance\common.py", line 211, in run
    (returncode, quoted_cmdline) = self.__runinternal(working_directory)
  File "C:\h\w\AB8A099E\p\scripts\performance\common.py", line 200, in __runinternal
    for line in iter(proc.stdout.readline, ''):
  File "C:\python3.9.1\lib\codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xec in position 78: invalid continuation byte
```