### PR TITLE
Change reenable regex industry tests.

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -193,7 +193,7 @@ class RunCommand:
                     stdout=PIPE if should_pipe else DEVNULL,
                     stderr=STDOUT,
                     universal_newlines=True,
-                    encoding="utf-16",
+                    encoding="utf-8",
             ) as proc:
                 if proc.stdout is not None:
                     with proc.stdout:

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -193,7 +193,7 @@ class RunCommand:
                     stdout=PIPE if should_pipe else DEVNULL,
                     stderr=STDOUT,
                     universal_newlines=True,
-                    encoding="utf-8",
+                    encoding="utf-16",
             ) as proc:
                 if proc.stdout is not None:
                     with proc.stdout:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -122,7 +122,7 @@
 
   <ItemGroup>
     <!-- Temporarily disable tests here -->
-    <Compile Remove="libraries\System.Text.RegularExpressions\Perf.Regex.Industry.cs" />
+	<!--Like <Compile Remove="libraries\System.Text.RegularExpressions\Perf.Regex.Industry.cs" /> -->
 	  
     <!-- Workaround https://github.com/dotnet/project-system/issues/935 -->
     <None Include="**/*.cs" />

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -209,7 +209,7 @@ namespace System.Text.RegularExpressions.Tests
             //"\\s[a-zA-Z]{0,12}ing\\s", // duplicates Perf_Regex_Industry_RustLang_Sherlock test
             "([A-Za-z]awyer|[A-Za-z]inn)\\s",
             //"[\"'][^\"']{0,30}[?!\\.][\"']", // Breaks benchmarkdotnet 13.1
-            //"\u221E|\u2713",
+            //"\u221E|\u2713", //Breaks encoding reader in helix
             "\\p{Sm}")]
         public string Pattern { get; set; }
 

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -209,7 +209,7 @@ namespace System.Text.RegularExpressions.Tests
             //"\\s[a-zA-Z]{0,12}ing\\s", // duplicates Perf_Regex_Industry_RustLang_Sherlock test
             "([A-Za-z]awyer|[A-Za-z]inn)\\s",
             //"[\"'][^\"']{0,30}[?!\\.][\"']", // Breaks benchmarkdotnet 13.1
-            "\u221E|\u2713",
+            //"\u221E|\u2713",
             "\\p{Sm}")]
         public string Pattern { get; set; }
 


### PR DESCRIPTION
Worked locally, but it worked locally before, look to the PR tests to see if the fix worked.