### PR TITLE
Add ZLibStream benchmark

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -20,11 +20,13 @@ namespace System.IO.Compression
         public override Stream CreateStream(Stream stream, CompressionLevel level) => new DeflateStream(stream, level);
     }
 
+#if NET6_0_OR_GREATER // API introduced in .NET 6
     public class ZLib : CompressionStreamPerfTestBase
     {
         public override Stream CreateStream(Stream stream, CompressionMode mode) => new ZLibStream(stream, mode);
         public override Stream CreateStream(Stream stream, CompressionLevel level) => new ZLibStream(stream, level);
     }
+#endif
 
     // Brotli has a dedicated file with more benchmarks
 

--- a/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -13,13 +13,19 @@ namespace System.IO.Compression
         public override Stream CreateStream(Stream stream, CompressionMode mode) => new GZipStream(stream, mode);
         public override Stream CreateStream(Stream stream, CompressionLevel level) => new GZipStream(stream, level);
     }
-    
+
     public class Deflate : CompressionStreamPerfTestBase
     {
         public override Stream CreateStream(Stream stream, CompressionMode mode) => new DeflateStream(stream, mode);
         public override Stream CreateStream(Stream stream, CompressionLevel level) => new DeflateStream(stream, level);
     }
-    
+
+    public class ZLib : CompressionStreamPerfTestBase
+    {
+        public override Stream CreateStream(Stream stream, CompressionMode mode) => new ZLibStream(stream, mode);
+        public override Stream CreateStream(Stream stream, CompressionLevel level) => new ZLibStream(stream, level);
+    }
+
     // Brotli has a dedicated file with more benchmarks
 
     [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]


### PR DESCRIPTION
We had benchmarks for the other Compression streams: BrotliStream, DeflateStream, GZipStream, but we didn't have one for ZLibStream.