### PR TITLE
Remove new industry regex tests from WASM runs

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -40,8 +40,8 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://github.com/mariomka/regex-benchmark</summary>
-    [BenchmarkCategory(Categories.Libraries)]
-    public class Perf_Regex_Industry_Mariomka
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
+    public class Perf_Regex_Industry_Mariomkas
     {
         [Params(
             @"[\w\.+-]+@[\w\.-]+\.[\w\.-]+",
@@ -77,7 +77,7 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://github.com/cloudflare/sliceslice-rs/tree/a27b76c8527d44d5b3534c84b878d8289eacb7ff/data</summary>
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     [SkipTooManyTestCasesValidator]
     public class Perf_Regex_Industry_SliceSlice
     {
@@ -118,7 +118,7 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://github.com/rust-lang/regex</summary>
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     [SkipTooManyTestCasesValidator]
     public class Perf_Regex_Industry_RustLang_Sherlock
     {
@@ -189,7 +189,7 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://rust-leipzig.github.io/regex/2017/03/28/comparison-of-regex-engines/</summary>
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     [SkipTooManyTestCasesValidator]
     public class Perf_Regex_Industry_Leipzig
     {
@@ -237,7 +237,7 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://www.boost.org/doc/libs/1_41_0/libs/regex/doc/gcc-performance.html</summary>
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     [SkipTooManyTestCasesValidator]
     public class Perf_Regex_Industry_BoostDocs_Simple
     {


### PR DESCRIPTION
These tests are causing crashes in BDN on WASM runs. Below I have copied the stacktrace. I am not sure if this is a limitation in WASM that we are hitting with these tests, or a problem with the tests, but for now I am going to disable these on WASM.

@naricc @adamsitnik 

```
[2021/11/30 11:49:28][INFO] System.Reflection.TargetInvocationException: Arg_TargetInvocationException
[2021/11/30 11:49:28][INFO]  ---> System.ArgumentNullException: ArgumentNull_Generic Arg_ParamName_Name, paths
[2021/11/30 11:49:28][INFO]    at System.IO.Path.Combine(String[] paths)
[2021/11/30 11:49:28][INFO]    at System.Text.RegularExpressions.Tests.Perf_Regex_Industry.ReadInputFile(String name)
[2021/11/30 11:49:28][INFO]    at System.Text.RegularExpressions.Tests.Perf_Regex_Industry_RustLang_Sherlock.Setup()
[2021/11/30 11:49:28][INFO]    at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
[2021/11/30 11:49:28][INFO]    at BenchmarkDotNet.Autogenerated.Runnable_107.Run(IHost host, String benchmarkName)
[2021/11/30 11:49:28][INFO]    at System.Reflection.RuntimeMethodInfo.InvokeWorker(Object obj, BindingFlags invokeAttr, Span`1 parameters)
[2021/11/30 11:49:28][INFO]    Exception_EndOfInnerExceptionStack
[2021/11/30 11:49:28][INFO]    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
[2021/11/30 11:49:28][INFO]    at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
[2021/11/30 11:49:28][INFO]    at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args)
[2021/11/30 11:49:28][INFO] // AfterAll
[2021/11/30 11:49:28][INFO] // Benchmark Process 8033 has exited with code 255.
[2021/11/30 11:49:28][INFO] No more Benchmark runs will be launched as NO measurements were obtained from the previous run!
```