### PR TITLE
Add StreamReaderReadLineTests and base TextReaderReadLineTests

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO/StreamReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StreamReaderReadLineTests.cs
@@ -2,25 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using BenchmarkDotNet.Attributes;
-using MicroBenchmarks;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
     [BenchmarkCategory(Categories.Libraries)]
-    public class StringReaderReadLineTests : TextReaderReadLineTests
+    public class StreamReaderReadLineTests : TextReaderReadLineTests
     {
+        private MemoryStream _stream;
+
         [GlobalSetup]
-        public void GlobalSetup() => _text = GenerateLinesText(LineLengthRange, 16 * 1024);
+        public void GlobalSetup()
+        {
+            _text = GenerateLinesText(LineLengthRange, 16 * 1024);
+            _stream = new(Encoding.UTF8.GetBytes(_text));
+        }
 
         [Benchmark]
         public void ReadLine()
         {
-            using StringReader reader = new (_text);
+            _stream.Seek(0, SeekOrigin.Begin);
+            using StreamReader reader = new (_stream, null, true, 1024, leaveOpen: true);
             while (reader.ReadLine() != null) ;
         }
 
@@ -28,7 +33,8 @@ namespace System.IO.Tests
         [BenchmarkCategory(Categories.NoWASM)]
         public async Task ReadLineAsync()
         {
-            using StringReader reader = new(_text);
+            _stream.Seek(0, SeekOrigin.Begin);
+            using StreamReader reader = new(_stream, null, true, 1024, leaveOpen: true);
             while (await reader.ReadLineAsync() != null) ;
         }
     }

--- a/src/benchmarks/micro/libraries/System.IO/StreamReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/StreamReaderReadLineTests.cs
@@ -12,20 +12,19 @@ namespace System.IO.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class StreamReaderReadLineTests : TextReaderReadLineTests
     {
-        private MemoryStream _stream;
+        private byte[] _bytes;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             _text = GenerateLinesText(LineLengthRange, 16 * 1024);
-            _stream = new(Encoding.UTF8.GetBytes(_text));
+            _bytes = Encoding.UTF8.GetBytes(_text);
         }
 
         [Benchmark]
         public void ReadLine()
         {
-            _stream.Seek(0, SeekOrigin.Begin);
-            using StreamReader reader = new (_stream, null, true, 1024, leaveOpen: true);
+            using StreamReader reader = new (new MemoryStream(_bytes));
             while (reader.ReadLine() != null) ;
         }
 
@@ -33,8 +32,7 @@ namespace System.IO.Tests
         [BenchmarkCategory(Categories.NoWASM)]
         public async Task ReadLineAsync()
         {
-            _stream.Seek(0, SeekOrigin.Begin);
-            using StreamReader reader = new(_stream, null, true, 1024, leaveOpen: true);
+            using StreamReader reader = new(new MemoryStream(_bytes));
             while (await reader.ReadLineAsync() != null) ;
         }
     }

--- a/src/benchmarks/micro/libraries/System.IO/TextReaderReadLineTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/TextReaderReadLineTests.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.IO.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public abstract class TextReaderReadLineTests
+    {
+        protected string _text;
+
+        [ParamsSource(nameof(GetLineLengthRanges))]
+        public Range LineLengthRange { get; set; }
+
+        public static IEnumerable<Range> GetLineLengthRanges()
+        {
+            yield return new() { Min = 0, Max = 0 };
+            yield return new() { Min = 1, Max = 1 };
+            yield return new() { Min = 1, Max = 8 };
+            yield return new() { Min = 9, Max = 32 };
+            yield return new() { Min = 33, Max = 128 };
+            yield return new() { Min = 129, Max = 1024 };
+            yield return new() { Min = 1025, Max = 2048 };
+            yield return new() { Min = 0, Max = 1024 };
+        }
+
+        public class Range
+        {
+            public int Min { get; set; }
+            public int Max { get; set; }
+
+            public override string ToString() => $"[{Min,4}, {Max,4}]";
+        }
+
+        protected static string GenerateLinesText(Range lineLengthRange, int textTargetLength)
+        {
+            var min = lineLengthRange.Min;
+            var max = lineLengthRange.Max;
+
+            var newLine = Environment.NewLine;
+
+            var capacity = textTargetLength + max + newLine.Length;
+            var sb = new StringBuilder(capacity);
+
+            var random = new Random(42);
+            int lineCount = 0;
+            while (sb.Length < textTargetLength)
+            {
+                var charsCount = random.Next(min, max);
+                for (int c = 0; c < charsCount; c++)
+                {
+                    var ch = (char)random.Next('0', 'z');
+                    sb.Append(ch);
+                }
+                sb.Append(newLine);
+                ++lineCount;
+            }
+            var text = sb.ToString();
+
+            Console.WriteLine($"// Generated lines {lineCount} and " +
+                $"text length {text.Length} out of capacity {capacity}");
+
+            return text;
+        }
+    }
+}


### PR DESCRIPTION
Follow up to #2083 cc: @adamsitnik feel free to make whatever changes you deem necessary. Note I expanded line length range to include 1025-2048 specifically to trigger `StreamReader.ReadLine` path that allocates `StringBuilder`.