### PR TITLE
Add Perf_String_Substring_* benchmarks

### DIFF
--- a/src/benchmarks/micro/Serializers/Binary_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_FromStream.cs
@@ -10,7 +10,7 @@ using MicroBenchmarks.Serializers.Helpers;
 
 namespace MicroBenchmarks.Serializers
 {
-#pragma warning disable SYSLIB0011
+#pragma warning disable SYSLIB0011 // BinaryFormatter serialization is obsolete and should not be used.
     [GenericTypeArguments(typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]

--- a/src/benchmarks/micro/Serializers/Binary_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_FromStream.cs
@@ -10,6 +10,7 @@ using MicroBenchmarks.Serializers.Helpers;
 
 namespace MicroBenchmarks.Serializers
 {
+#pragma warning disable SYSLIB0011
     [GenericTypeArguments(typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]
@@ -84,4 +85,5 @@ namespace MicroBenchmarks.Serializers
         [GlobalCleanup]
         public void Cleanup() => memoryStream.Dispose();
     }
+#pragma warning restore SYSLIB0011
 }

--- a/src/benchmarks/micro/Serializers/Binary_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_ToStream.cs
@@ -10,6 +10,7 @@ using MicroBenchmarks.Serializers.Helpers;
 
 namespace MicroBenchmarks.Serializers
 {
+#pragma warning disable SYSLIB0011
     [GenericTypeArguments(typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]
@@ -57,4 +58,5 @@ namespace MicroBenchmarks.Serializers
             MessagePack.MessagePackSerializer.Serialize<T>(memoryStream, value);
         }
     }
+#pragma warning restore SYSLIB0011
 }

--- a/src/benchmarks/micro/Serializers/Binary_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Binary_ToStream.cs
@@ -10,7 +10,7 @@ using MicroBenchmarks.Serializers.Helpers;
 
 namespace MicroBenchmarks.Serializers
 {
-#pragma warning disable SYSLIB0011
+#pragma warning disable SYSLIB0011 // BinaryFormatter serialization is obsolete and should not be used.
     [GenericTypeArguments(typeof(LoginViewModel))]
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]

--- a/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
@@ -11,7 +11,8 @@ using MicroBenchmarks;
 
 namespace System.Runtime.Serialization.Formatters.Tests
 {
-    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
+#pragma warning disable SYSLIB0011
+    [BenchmarkCategory(Categories.Libraries)]
     public class Perf_BinaryFormatter
     {
         private readonly BinaryFormatter _formatter = new BinaryFormatter();
@@ -47,4 +48,5 @@ namespace System.Runtime.Serialization.Formatters.Tests
             public string Id;
         }
     }
+#pragma warning restore SYSLIB0011
 }

--- a/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
@@ -11,7 +11,7 @@ using MicroBenchmarks;
 
 namespace System.Runtime.Serialization.Formatters.Tests
 {
-#pragma warning disable SYSLIB0011
+#pragma warning disable SYSLIB0011 // BinaryFormatter serialization is obsolete and should not be used.
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_BinaryFormatter
     {

--- a/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Serialization.Formatters/Perf.BinaryFormatter.cs
@@ -12,7 +12,7 @@ using MicroBenchmarks;
 namespace System.Runtime.Serialization.Formatters.Tests
 {
 #pragma warning disable SYSLIB0011 // BinaryFormatter serialization is obsolete and should not be used.
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public class Perf_BinaryFormatter
     {
         private readonly BinaryFormatter _formatter = new BinaryFormatter();

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -290,22 +290,24 @@ namespace System.Tests
 
         public static IEnumerable<int> GetStarts()
         {
-            //for (int i = 0; i <= _length / 2; i++)
-            //{
-            //    yield return i;
-            //}
+            yield return 0;
+            yield return _length / 2;
             yield return _length;
         }
 
         [Benchmark]
         public void Substring() => _s.Substring(Start);
+
+        // TEMP: For comparison
+        [Benchmark]
+        public void NewString() => new string('\0', _s.Length - Start);
     }
 
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
-    //[DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
+    [DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
     public class Perf_String_Substring_IntInt
     {
-        const int _length = 30;
+        const int _length = 16;
         static readonly string _s = new string('a', _length);
 
         [ParamsSource(nameof(GetSlices))]
@@ -313,7 +315,7 @@ namespace System.Tests
 
         public static IEnumerable<Sub> GetSlices()
         {
-            for (int i = 0; i < _length / 2; i++)
+            for (int i = 0; i <= _length / 2; i++)
             {
                 yield return new() { StartIndex = i, Length = i };
             }
@@ -335,20 +337,10 @@ namespace System.Tests
             _s.Substring(slice.StartIndex, slice.Length);
         }
 
+        // TEMP: For comparison
         [Benchmark]
-        public void AllocateString() => new string('\0', Slice.Length);
+        public void NewString() => new string('\0', Slice.Length);
     }
-
-
-    //[BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
-    //public class Perf_String_Substring_IntInt
-    //{
-    //    [Benchmark]
-    //    public void Substring_Full() => "abc".Substring(0, 3);
-
-    //    [Benchmark]
-    //    public void Substring_Empty() => "abc".Substring(0, 0);
-    //}
 
     public class StringArguments
     {

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -290,10 +290,10 @@ namespace System.Tests
 
         public static IEnumerable<int> GetStarts()
         {
-            for (int i = 0; i <= _length / 2; i++)
-            {
-                yield return i;
-            }
+            //for (int i = 0; i <= _length / 2; i++)
+            //{
+            //    yield return i;
+            //}
             yield return _length;
         }
 
@@ -302,10 +302,10 @@ namespace System.Tests
     }
 
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
-    [DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
+    //[DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
     public class Perf_String_Substring_IntInt
     {
-        const int _length = 16;
+        const int _length = 30;
         static readonly string _s = new string('a', _length);
 
         [ParamsSource(nameof(GetSlices))]
@@ -313,7 +313,7 @@ namespace System.Tests
 
         public static IEnumerable<Sub> GetSlices()
         {
-            for (int i = 0; i <= _length / 2; i++)
+            for (int i = 0; i < _length / 2; i++)
             {
                 yield return new() { StartIndex = i, Length = i };
             }
@@ -329,7 +329,14 @@ namespace System.Tests
         }
 
         [Benchmark]
-        public void Substring() => _s.Substring(Slice.StartIndex, Slice.Length);
+        public void Substring()
+        {
+            var slice = Slice;
+            _s.Substring(slice.StartIndex, slice.Length);
+        }
+
+        [Benchmark]
+        public void AllocateString() => new string('\0', Slice.Length);
     }
 
 

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -297,10 +297,6 @@ namespace System.Tests
 
         [Benchmark]
         public void Substring() => _s.Substring(Start);
-
-        // TEMP: For comparison
-        [Benchmark]
-        public void NewString() => new string('\0', _s.Length - Start);
     }
 
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
@@ -336,10 +332,6 @@ namespace System.Tests
             var slice = Slice;
             _s.Substring(slice.StartIndex, slice.Length);
         }
-
-        // TEMP: For comparison
-        [Benchmark]
-        public void NewString() => new string('\0', Slice.Length);
     }
 
     public class StringArguments

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -279,6 +279,7 @@ namespace System.Tests
     }
 
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+    [DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
     public class Perf_String_Substring_Int
     {
         const int _length = 16;
@@ -301,6 +302,7 @@ namespace System.Tests
     }
 
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+    [DisassemblyDiagnoser(maxDepth: 2, printSource: true, exportHtml: true, exportDiff: true)]
     public class Perf_String_Substring_IntInt
     {
         const int _length = 16;

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -95,6 +95,7 @@ namespace System.Tests
         [Arguments("dzsdzsDDZSDZSDZSddsz", 0)]
         [Arguments("dzsdzsDDZSDZSDZSddsz", 7)]
         [Arguments("dzsdzsDDZSDZSDZSddsz", 10)]
+        [Arguments("dzsdzsDDZSDZSDZSddsz", 19)]
         public string Substring_Int(string s, int i)
             => s.Substring(i);
 
@@ -276,7 +277,70 @@ namespace System.Tests
             return str[index];
         }
     }
-    
+
+    [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+    public class Perf_String_Substring_Int
+    {
+        const int _length = 16;
+        static readonly string _s = new string('a', _length);
+
+        [ParamsSource(nameof(GetStarts))]
+        public int Start { get; set; }
+
+        public static IEnumerable<int> GetStarts()
+        {
+            for (int i = 0; i <= _length / 2; i++)
+            {
+                yield return i;
+            }
+            yield return _length;
+        }
+
+        [Benchmark]
+        public void Substring() => _s.Substring(Start);
+    }
+
+    [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+    public class Perf_String_Substring_IntInt
+    {
+        const int _length = 16;
+        static readonly string _s = new string('a', _length);
+
+        [ParamsSource(nameof(GetSlices))]
+        public Sub Slice { get; set; }
+
+        public static IEnumerable<Sub> GetSlices()
+        {
+            for (int i = 0; i <= _length / 2; i++)
+            {
+                yield return new() { StartIndex = i, Length = i };
+            }
+            yield return new() { StartIndex = 0, Length = _length };
+        }
+
+        public class Sub
+        {
+            public int StartIndex { get; set; }
+            public int Length { get; set; }
+
+            public override string ToString() => $"I:{StartIndex,2} L:{Length,2}";
+        }
+
+        [Benchmark]
+        public void Substring() => _s.Substring(Slice.StartIndex, Slice.Length);
+    }
+
+
+    //[BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+    //public class Perf_String_Substring_IntInt
+    //{
+    //    [Benchmark]
+    //    public void Substring_Full() => "abc".Substring(0, 3);
+
+    //    [Benchmark]
+    //    public void Substring_Empty() => "abc".Substring(0, 0);
+    //}
+
     public class StringArguments
     {
         public int Size { get; }


### PR DESCRIPTION
Draft benchmarks for Substring. cc @adamsitnik feel free to make any changes you like right away. For some reason I can no longer built this after updating latest main. In relation to https://github.com/dotnet/runtime/pull/62577