### PR TITLE
Update VM Images For Release 3.1.4 Branch

### DIFF
--- a/azure-pipelines-gc.yml
+++ b/azure-pipelines-gc.yml
@@ -25,6 +25,7 @@ jobs:
     osName: windows
     osVersion: RS5
     architecture: x64
-    pool: Hosted VS2017
+    pool:
+      vmImage: windows-2019
     kind: scenarios
     queue: Windows.10.Amd64.ClientRS5.Open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x64
-      pool: Hosted VS2017
+      pool:
+        vmImage: windows-2019
       kind: scenarios
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: scenarios.proj
@@ -63,7 +64,8 @@ jobs:
       osVersion: 1804
       kind: scenarios
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       projectFile: scenarios.proj
@@ -76,7 +78,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: blazor_scenarios
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: blazor_scenarios.proj
@@ -89,7 +92,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: sdk_scenarios
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: sdk_scenarios.proj
@@ -103,7 +107,8 @@ jobs:
       osVersion: 1804
       kind: sdk_scenarios
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       projectFile: sdk_scenarios.proj
@@ -116,7 +121,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x86
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: sdk_scenarios
       queue: Windows.10.Amd64.ClientRS5.Open
       projectFile: sdk_scenarios.proj
@@ -130,7 +136,8 @@ jobs:
       osVersion: RS5
       kind: micro
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries' 
@@ -144,7 +151,8 @@ jobs:
       osVersion: RS5
       kind: micro
       architecture: x86
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
@@ -158,7 +166,8 @@ jobs:
       osVersion: RS5
       kind: mlnet
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
@@ -172,7 +181,8 @@ jobs:
       osVersion: RS5
       kind: roslyn
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS5.Open
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
@@ -186,7 +196,8 @@ jobs:
       osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -201,7 +212,8 @@ jobs:
       osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'mldotnet'
@@ -216,7 +228,8 @@ jobs:
       osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'roslyn'
@@ -236,7 +249,8 @@ jobs:
       osName: windows
       osVersion: 19H1
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: scenarios
       queue: Windows.10.Amd64.19H1.Tiger.Perf
       projectFile: scenarios.proj
@@ -250,7 +264,8 @@ jobs:
       osVersion: 1804
       kind: scenarios
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       container: ubuntu_x64_build_container
       projectFile: scenarios.proj
@@ -264,7 +279,8 @@ jobs:
       osVersion: 19H1
       kind: micro
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
@@ -278,7 +294,8 @@ jobs:
       osVersion: 19H1
       kind: micro
       architecture: x86
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
@@ -292,7 +309,8 @@ jobs:
       osVersion: 19H1
       kind: mlnet
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
@@ -306,7 +324,8 @@ jobs:
       osVersion: 19H1
       kind: roslyn
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.19H1.Tiger.Perf # using a dedicated private Helix queue (perfsnakes)
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
@@ -320,7 +339,8 @@ jobs:
       osVersion: 1804
       kind: micro
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -335,7 +355,8 @@ jobs:
       osVersion: 1804
       kind: mlnet
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Microsoft.ML.Benchmarks/Microsoft.ML.Benchmarks.csproj
@@ -350,7 +371,8 @@ jobs:
       osVersion: 1804
       kind: roslyn
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       queue: Ubuntu.1804.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -371,7 +393,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: sdk_scenarios
       queue: Windows.10.Amd64.19H1.Tiger.Perf
       projectFile: sdk_scenarios.proj
@@ -384,7 +407,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x86
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: sdk_scenarios
       queue: Windows.10.Amd64.19H1.Tiger.Perf
       projectFile: sdk_scenarios.proj
@@ -397,7 +421,8 @@ jobs:
       osName: ubuntu
       osVersion: 1804
       architecture: x64
-      pool: Azure Pipelines
+      pool: 
+        vmImage: ubuntu-latest
       kind: sdk_scenarios
       queue: Ubuntu.1804.Amd64.Tiger.Perf
       container: ubuntu_x64_build_container
@@ -411,7 +436,8 @@ jobs:
       osName: windows
       osVersion: RS5
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       kind: blazor_scenarios
       queue: Windows.10.Amd64.19H1.Tiger.Perf
       projectFile: blazor_scenarios.proj

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -85,8 +85,7 @@ jobs:
           - group: dotnet-benchview
         workspace:
           clean: all
-        pool:
-          name: ${{ parameters.pool }}
+        pool: ${{ parameters.pool }}
         container: ${{ parameters.container }}
         strategy:
           matrix:

--- a/eng/performance/pr.yml
+++ b/eng/performance/pr.yml
@@ -17,7 +17,8 @@ jobs:
       osVersion: RS4
       kind: micro
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx' 
@@ -32,7 +33,8 @@ jobs:
       osVersion: RS4
       kind: micro
       architecture: x86
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'coreclr corefx'
@@ -47,7 +49,8 @@ jobs:
       osVersion: 1604
       kind: micro
       architecture: x64
-      pool: Hosted Ubuntu 1604
+      pool: 
+        vmImage: Hosted Ubuntu 1604
       queue: Ubuntu.1604.Amd64.Open
       container: ubuntu_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
@@ -63,7 +66,8 @@ jobs:
       osVersion: RS4
       kind: mlnet
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
       runCategories: 'mldotnet'
@@ -78,7 +82,8 @@ jobs:
       osVersion: 1604
       kind: mlnet
       architecture: x64
-      pool: Hosted Ubuntu 1604
+      pool: 
+        vmImage: Hosted Ubuntu 1604
       queue: Ubuntu.1604.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'mldotnet'
@@ -94,7 +99,8 @@ jobs:
       osVersion: RS4
       kind: roslyn
       architecture: x64
-      pool: Hosted VS2017
+      pool: 
+        vmImage: windows-2019
       queue: Windows.10.Amd64.ClientRS4.Open
       csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
       runCategories: 'roslyn'
@@ -109,7 +115,8 @@ jobs:
       osVersion: 1604
       kind: roslyn
       architecture: x64
-      pool: Hosted Ubuntu 1604
+      pool:
+        vmImage: Hosted Ubuntu 1604
       queue: Ubuntu.1604.Amd64.Open
       container: ubuntu_x64_build_container
       runCategories: 'roslyn'

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -66,8 +66,7 @@ jobs:
           - group: dotnet-benchview
         workspace:
           clean: all
-        pool:
-          name: ${{ parameters.pool }}
+        pool: ${{ parameters.pool }}
         container: ${{ parameters.container }}
         strategy:
           matrix:


### PR DESCRIPTION
This PR carries over the changes to the main branch that update the pipeline VM Images.  The test pipeline run
https://dev.azure.com/dnceng/public/_build/results?buildId=1512854&view=results
reached the 'Send job to Helix' phase for all jobs, indicating the VM specification in the YAML worked correctly.