### PR TITLE
Update Android Scenario Startup Flow

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -318,22 +318,22 @@ ex: C:\repos\performance;C:\repos\runtime
             adb = RunCommand(cmdline, verbose=True)
             adb.run()
 
-            #cmdline = xharnesscommand() + [
-            #    self.devicetype,
-            #    'install',
-            #    '--app', self.packagepath,
-            #    '--package-name',
-            #    self.packagename,
-            #    '-o',
-            #    const.TRACEDIR,
-            #    '-v'
-            #]
-            cmdline = [
-                adb.stdout.strip(),
+            cmdline = xharnesscommand() + [
+                self.devicetype,
                 'install',
-                '-r',
-                self.packagepath
+                '--app', self.packagepath,
+                '--package-name',
+                self.packagename,
+                '-o',
+                const.TRACEDIR,
+                '-v'
             ]
+            #cmdline = [
+            #    adb.stdout.strip(),
+            #    'install',
+            #    '-r',
+            #    self.packagepath
+            #]
 
             RunCommand(cmdline, verbose=True).run()
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -343,6 +343,38 @@ ex: C:\repos\performance;C:\repos\runtime
             getActivity.run()
             getLogger().info(getActivity.stdout)
 
+            # More setup stuff
+            cmdline = [ 
+                adb.stdout.strip(),
+                'shell',
+                f'dumpsys input_method | grep mInteractive'
+            ]
+            checkScreen = RunCommand(cmdline, verbose=True)
+            checkScreen.run()
+
+            if("mInteractive=false" in checkScreen.stdout):
+                # Turn on the screen to make interactive and see if it worked
+                getLogger().warning("Screen was off, turning on.")
+                cmdline = [
+                    adb.stdout.strip(),
+                    'shell',
+                    'input',
+                    'keyevent',
+                    '26'
+                    ]
+                RunCommand(cmdline, verbose=True).run()
+
+                cmdline = [ 
+                    adb.stdout.strip(),
+                    'shell',
+                    f'dumpsys input_method | grep mInteractive'
+                ]
+                checkScreen = RunCommand(cmdline, verbose=True)
+                checkScreen.run()
+                if("mInteractive=false" in checkScreen.stdout):
+                    getLogger().exception("Failed to make interactive.")
+
+            # Actual testing some run stuff
             getLogger().info("Test run")
             activityname = getActivity.stdout
             cmdline = [ 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -61,7 +61,6 @@ class Runner:
         parseonlyparser.add_argument('--device-type', choices=['android','ios'],type=str.lower,help='Device type for testing', dest='devicetype')
         parseonlyparser.add_argument('--package-path', help='Location of test application', dest='packagepath')
         parseonlyparser.add_argument('--package-name', help='Classname of application', dest='packagename')
-        parseonlyparser.add_argument('--exit-code', help='Success exit code', dest='expectedexitcode')
         parseonlyparser.add_argument('--startup-iterations', help='Startups to run (1+)', type=int, default=5, dest='startupiterations')
         self.add_common_arguments(parseonlyparser)
 
@@ -144,7 +143,6 @@ ex: C:\repos\performance;C:\repos\runtime
             self.packagepath = args.packagepath
             self.packagename = args.packagename
             self.devicetype = args.devicetype
-            self.expectedexitcode = args.expectedexitcode
             self.startupiterations = args.startupiterations
 
         if args.scenarioname:

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -318,22 +318,22 @@ ex: C:\repos\performance;C:\repos\runtime
             adb = RunCommand(cmdline, verbose=True)
             adb.run()
 
-            cmdline = xharnesscommand() + [
-                self.devicetype,
-                'install',
-                '--app', self.packagepath,
-                '--package-name',
-                self.packagename,
-                '-o',
-                const.TRACEDIR,
-                '-v'
-            ]
-            #cmdline = [
-            #    adb.stdout.strip(),
+            #cmdline = xharnesscommand() + [
+            #    self.devicetype,
             #    'install',
-            #    '-r',
-            #    self.packagepath
+            #    '--app', self.packagepath,
+            #    '--package-name',
+            #    self.packagename,
+            #    '-o',
+            #    const.TRACEDIR,
+            #    '-v'
             #]
+            cmdline = [
+                adb.stdout.strip(),
+                'install',
+                '-r',
+                self.packagepath
+            ]
 
             RunCommand(cmdline, verbose=True).run()
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -400,6 +400,25 @@ ex: C:\repos\performance;C:\repos\runtime
             testRunStats = re.findall(runRegex, testRun.stdout)
             getLogger().info(testRunStats[3])
 
+            if "com.google.android.permissioncontroller" in testRunStats[3]:
+                # On perm screen, use the buttons to close it. it will stay away until the app is reinstalled
+                keycommand = [
+                    adb.stdout.strip(),
+                    'shell',
+                    'input',
+                    'keyevent'
+                    ]
+                RunCommand(keycommand + ['22'], verbose=True).run() # Select next button
+                time.sleep(1)
+                RunCommand(keycommand + ['22'], verbose=True).run() # Select next button
+                time.sleep(1)
+                RunCommand(keycommand + ['66'], verbose=True).run() # Press enter to close main perm screen
+                time.sleep(1)
+                RunCommand(keycommand + ['22'], verbose=True).run() # Select next button
+                time.sleep(1)
+                RunCommand(keycommand + ['66'], verbose=True).run() # Press enter to close out of second screen
+                time.sleep(1)
+
             stopApp = [ 
                 adb.stdout.strip(),
                 'shell',
@@ -465,8 +484,8 @@ ex: C:\repos\performance;C:\repos\runtime
 
 
             #startup = StartupWrapper()
-            #self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.STARTUP_DEVICETIMETOMAIN, tracefolder='PerfTest/', tracename='trace*.nettrace', scenarioname='Device Startup - Android %s' % (self.packagename))
-            #startup.parsetraces(self.traits)
+            #self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.STARTUP_DEVICETIMETOMAIN, scenarioname='Device Startup - Android %s' % (self.packagename), dataarray=totalTimes)
+            #startup.parsearray(self.traits)
 
         elif self.testtype == const.SOD:
             sod = SODWrapper()

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -306,7 +306,18 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.DEVICESTARTUP:
             # ADB Key Event corresponding numbers: https://gist.github.com/arjunv/2bbcca9a1a1c127749f8dcb6d36fb0bc
-            runSplitRegex = ":\s(.+)"
+            # Regex used to split the response from starting the activity and saving each value
+            #Example:
+            #    Starting: Intent { cmp=net.dot.HelloAndroid/net.dot.MainActivity }
+            #    Status: ok
+            #    LaunchState: COLD
+            #    Activity: net.dot.HelloAndroid/net.dot.MainActivity
+            #    TotalTime: 241
+            #    WaitTime: 242
+            #    Complete
+            # Saves: [Intent { cmp=net.dot.HelloAndroid/net.dot.MainActivity }, ok, COLD, net.dot.HelloAndroid/net.dot.MainActivity, 241, 242]
+            # Split results (start at 0) (List is Starting (Intent activity), Status (ok...), LaunchState ([HOT, COLD, WARM]), Activity (started activity name), TotalTime(toFrameOne), WaitTime(toFullLoad)) 
+            runSplitRegex = ":\s(.+)" 
             screenWasOff = False
             getLogger().info("Clearing potential previous run nettraces")
             for file in glob.glob(os.path.join(const.TRACEDIR, 'PerfTest', 'runoutput.trace')):
@@ -393,7 +404,7 @@ ex: C:\repos\performance;C:\repos\runtime
             ]
             testRun = RunCommand(startAppCmd, verbose=True)
             testRun.run()
-            testRunStats = re.findall(runSplitRegex, testRun.stdout) 
+            testRunStats = re.findall(runSplitRegex, testRun.stdout) # Split results saving value (List: Starting, Status, LaunchState, Activity, TotalTime, WaitTime) 
             getLogger().info(f"Test run activity: {testRunStats[3]}")
 
             stopAppCmd = [ 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -363,6 +363,15 @@ ex: C:\repos\performance;C:\repos\runtime
                     '26'
                     ]
                 RunCommand(cmdline, verbose=True).run()
+                
+                cmdline = [
+                    adb.stdout.strip(),
+                    'shell',
+                    'input',
+                    'keyevent',
+                    '82'
+                    ]
+                RunCommand(cmdline, verbose=True).run() # Unlock the screen
 
                 cmdline = [ 
                     adb.stdout.strip(),

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -318,15 +318,21 @@ ex: C:\repos\performance;C:\repos\runtime
             adb = RunCommand(cmdline, verbose=True)
             adb.run()
 
-            cmdline = xharnesscommand() + [
-                self.devicetype,
+            #cmdline = xharnesscommand() + [
+            #    self.devicetype,
+            #    'install',
+            #    '--app', self.packagepath,
+            #    '--package-name',
+            #    self.packagename,
+            #    '-o',
+            #    const.TRACEDIR,
+            #    '-v'
+            #]
+            cmdline = [
+                adb.stdout.strip(),
                 'install',
-                '--app', self.packagepath,
-                '--package-name',
-                self.packagename,
-                '-o',
-                const.TRACEDIR,
-                '-v'
+                '-r',
+                self.packagepath
             ]
 
             RunCommand(cmdline, verbose=True).run()

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -318,6 +318,17 @@ ex: C:\repos\performance;C:\repos\runtime
             adb = RunCommand(cmdline, verbose=True)
             adb.run()
 
+            getLogger().info("Trying ADB workaround")
+            cmdline = xharnesscommand() + [
+                'android',
+                'adb',
+                '--',
+                'shell',
+                'wm',
+                'size'
+            ]
+            RunCommand(cmdline, verbose=True).run()
+
             cmdline = xharnesscommand() + [
                 self.devicetype,
                 'install',

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -319,10 +319,8 @@ ex: C:\repos\performance;C:\repos\runtime
             adb.run()
 
             getLogger().info("Trying ADB workaround")
-            cmdline = xharnesscommand() + [
-                'android',
-                'adb',
-                '--',
+            cmdline = [
+                adb.stdout.strip(),
                 'shell',
                 'wm',
                 'size'

--- a/src/tools/ScenarioMeasurement/Startup/DeviceTimeToMain.cs
+++ b/src/tools/ScenarioMeasurement/Startup/DeviceTimeToMain.cs
@@ -27,33 +27,23 @@ namespace ScenarioMeasurement
 
         public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerable<Counter> Parse(string mergeTraceDirectory, string mergeTraceFilter, string processName, IList<int> pids, string commandLine)
-        {
             var times = new List<double>();
-            var files = new HashSet<string>();
-            Console.WriteLine($"Finding files from {mergeTraceDirectory} with filter: {mergeTraceFilter}");
-            foreach (var file in Directory.GetFiles(mergeTraceDirectory, mergeTraceFilter))
-            {
-                Console.WriteLine($"Found {file}");
-                files.Add(file);
-            }
+            Console.WriteLine($"In the parser!!! File: {mergeTraceFile}");
+            Regex totalTimePattern = new Regex(@"TotalTime:\s(?<totalTime>.+)");
 
-            foreach (var trace in files)
+            if (File.Exists(mergeTraceFile))
             {
-                Console.WriteLine($"Parsing {trace}");
-                using (var source = new EventPipeEventSource(trace))
+                using(StreamReader sr = new StreamReader(mergeTraceFile))
                 {
-                    source.Clr.MethodLoadVerbose += evt =>
+                    string line = sr.ReadToEnd();
+                    MatchCollection finds = totalTimePattern.Matches(line);
+                    Console.WriteLine($"Finds: {finds.Count}");
+                    foreach (Match match in finds)
                     {
-                        if (evt.MethodName == "Main")
-                        {
-                            times.Add(evt.TimeStampRelativeMSec);
-                        }
-                    };
-                    source.Process();
+                        GroupCollection groups = match.Groups;
+                        Console.WriteLine(groups["totalTime"].Value);
+                        times.Add(Double.Parse(groups["totalTime"].Value));
+                    }
                 }
             }
 

--- a/src/tools/ScenarioMeasurement/Startup/DeviceTimeToMain.cs
+++ b/src/tools/ScenarioMeasurement/Startup/DeviceTimeToMain.cs
@@ -28,7 +28,6 @@ namespace ScenarioMeasurement
         public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
         {
             var times = new List<double>();
-            Console.WriteLine($"In the parser!!! File: {mergeTraceFile}");
             Regex totalTimePattern = new Regex(@"TotalTime:\s(?<totalTime>.+)");
 
             if (File.Exists(mergeTraceFile))
@@ -37,11 +36,11 @@ namespace ScenarioMeasurement
                 {
                     string line = sr.ReadToEnd();
                     MatchCollection finds = totalTimePattern.Matches(line);
-                    Console.WriteLine($"Finds: {finds.Count}");
+                    Console.WriteLine($"Found Startup Times: {finds.Count}");
                     foreach (Match match in finds)
                     {
                         GroupCollection groups = match.Groups;
-                        Console.WriteLine(groups["totalTime"].Value);
+                        Console.WriteLine($"Found Value (ms): {groups["totalTime"].Value}");
                         times.Add(Double.Parse(groups["totalTime"].Value));
                     }
                 }

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -305,38 +305,20 @@ namespace ScenarioMeasurement
             // Parse trace files
             if (!failed && !string.IsNullOrEmpty(traceFilePath))
             {
-                if (parseOnly)
+                logger.Log($"Parsing {traceFilePath}");
+
+                if (guiApp)
                 {
-                    logger.Log($"Parsing glob: {traceName}");
-
-                    if (guiApp)
-                    {
-                        appExe = Path.Join(workingDir, appExe);
-                    }
-                    string commandLine = $"\"{appExe}\"";
-                    if (!String.IsNullOrEmpty(appArgs))
-                    {
-                        commandLine = commandLine + " " + appArgs;
-                    }
-                    var counters = parser.Parse(traceDirectory, traceName, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
-
-                    CreateTestReport(scenarioName, counters, reportJsonPath, logger);
-                } else {
-                    logger.Log($"Parsing {traceFilePath}");
-
-                    if (guiApp)
-                    {
-                        appExe = Path.Join(workingDir, appExe);
-                    }
-                    string commandLine = $"\"{appExe}\"";
-                    if (!String.IsNullOrEmpty(appArgs))
-                    {
-                        commandLine = commandLine + " " + appArgs;
-                    }
-                    var counters = parser.Parse(traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
-
-                    CreateTestReport(scenarioName, counters, reportJsonPath, logger);
+                    appExe = Path.Join(workingDir, appExe);
                 }
+                string commandLine = $"\"{appExe}\"";
+                if (!String.IsNullOrEmpty(appArgs))
+                {
+                    commandLine = commandLine + " " + appArgs;
+                }
+                var counters = parser.Parse(traceFilePath, Path.GetFileNameWithoutExtension(appExe), pids, commandLine);
+
+                CreateTestReport(scenarioName, counters, reportJsonPath, logger);
             }
 
             // Skip unimplemented Linux profiling


### PR DESCRIPTION
Update the Android Scenario Startup Flow to use adb instead of test runners for more accurate startup times and the ability to test start up to first drawn frame on any apk. This effort is part of #2075 as it more easily enables the ability for Maui app testing.