### PR TITLE
add boolean parsing variations

### DIFF
--- a/src/benchmarks/micro/libraries/System.Buffers/Utf8ParserTests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/Utf8ParserTests.cs
@@ -85,7 +85,7 @@ namespace System.Buffers.Text.Tests
         public bool TryParseSByte(Utf8TestCase value) => Utf8Parser.TryParse(value.Utf8Bytes, out sbyte _, out int _);
 
         public IEnumerable<object> BooleanValues
-            => Perf_Boolean.StringValues.OfType<string>().Select(formatted => new Utf8TestCase(formatted));
+            => Perf_Boolean.ValidStringValues.OfType<string>().Select(formatted => new Utf8TestCase(formatted));
 
         [Benchmark]
         [ArgumentsSource(nameof(BooleanValues))]

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
@@ -12,8 +12,18 @@ namespace System.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_Boolean
     {
-        public static IEnumerable<object> StringValues => Values.Select(value => value.ToString()).ToArray();
-
+        public static IEnumerable<object> StringValues => new string[]{
+            "true", // strings, not bools, as otherwise strings in the logs have casing "True"
+            "false"
+        };
+        public static IEnumerable<object> AllStringValues => StringValues.Concat(new string[]
+        {
+            "TrUe",
+            "fAlSe",
+            "falss",
+            " tRuu ",
+            "tru"
+        });
         public static IEnumerable<object> Values => new object[]
         {
             true,
@@ -25,7 +35,7 @@ namespace System.Tests
         public bool Parse(string value) => bool.Parse(value);
 
         [Benchmark]
-        [ArgumentsSource(nameof(StringValues))]
+        [ArgumentsSource(nameof(AllStringValues))]
         public bool TryParse(string value) => bool.TryParse(value, out _);
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
@@ -13,17 +13,15 @@ namespace System.Tests
     public class Perf_Boolean
     {
         public static IEnumerable<object> StringValues => new string[]{
-            "true", // strings, not bools, as otherwise strings in the logs have casing "True"
-            "false"
+            "true",
+            "false",
+            "TRUE",
+            "False"
         };
         public static IEnumerable<object> AllStringValues => StringValues.Concat(new string[]
         {
-            "TrUe",
-            "fAlSe",
-            "falss",
-            " tRuu ",
-            "tru",
-            "bogus" // presumably common case of something random that's not a boolean
+            "0",
+            "Bogus"
         });
         public static IEnumerable<object> Values => new object[]
         {

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
@@ -22,7 +22,8 @@ namespace System.Tests
             "fAlSe",
             "falss",
             " tRuu ",
-            "tru"
+            "tru",
+            "bogus" // presumably common case of something random that's not a boolean
         });
         public static IEnumerable<object> Values => new object[]
         {

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Boolean.cs
@@ -12,13 +12,14 @@ namespace System.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_Boolean
     {
-        public static IEnumerable<object> StringValues => new string[]{
+        public static IEnumerable<object> ValidStringValues => new string[]{
             "true",
             "false",
             "TRUE",
-            "False"
+            "False",
+            " True "
         };
-        public static IEnumerable<object> AllStringValues => StringValues.Concat(new string[]
+        public static IEnumerable<object> ValidAndInvalidStringValues => ValidStringValues.Concat(new string[]
         {
             "0",
             "Bogus"
@@ -30,11 +31,11 @@ namespace System.Tests
         };
 
         [Benchmark]
-        [ArgumentsSource(nameof(StringValues))]
+        [ArgumentsSource(nameof(ValidStringValues))]
         public bool Parse(string value) => bool.Parse(value);
 
         [Benchmark]
-        [ArgumentsSource(nameof(AllStringValues))]
+        [ArgumentsSource(nameof(ValidAndInvalidStringValues))]
         public bool TryParse(string value) => bool.TryParse(value, out _);
 
         [Benchmark]


### PR DESCRIPTION
What I get on my machine, without https://github.com/dotnet/runtime/pull/64782

|   Method |  value |      Mean |     Error |    StdDev |    Median |       Min |      Max | Allocated |
|--------- |------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
| TryParse |   true |  9.877 ns | 0.3212 ns | 0.3700 ns |  9.807 ns |  9.161 ns | 10.60 ns |         - |
| TryParse |  false | 11.404 ns | 0.4224 ns | 0.4865 ns | 11.344 ns | 10.722 ns | 12.22 ns |         - |
| TryParse |  fAlSe | 11.179 ns | 0.2641 ns | 0.2936 ns | 11.167 ns | 10.733 ns | 11.84 ns |         - |
| TryParse |   TrUe | 12.215 ns | 1.7123 ns | 1.9032 ns | 11.467 ns | 10.127 ns | 15.41 ns |         - |
| TryParse |    tru | 23.106 ns | 0.6177 ns | 0.6866 ns | 22.909 ns | 22.116 ns | 24.61 ns |         - |
| TryParse |  tRuu  | 25.520 ns | 0.5347 ns | 0.5722 ns | 25.542 ns | 24.739 ns | 26.64 ns |         - |
| TryParse |  falss | 26.871 ns | 0.5399 ns | 0.5302 ns | 27.117 ns | 25.552 ns | 27.44 ns |         - |
| TryParse |  bogus | 34.17 ns | 6.021 ns | 6.934 ns | 30.54 ns | 27.177 ns | 48.57 ns |         - |
|    Parse |   true | 16.222 ns | 0.7374 ns | 0.8492 ns | 16.208 ns | 14.751 ns | 18.18 ns |         - |
|    Parse |  false | 17.495 ns | 1.1390 ns | 1.3117 ns | 16.919 ns | 16.059 ns | 20.40 ns |         - |

