### PR TITLE
Add cold start Json serialization benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using MicroBenchmarks.Serializers;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+    [GenericTypeArguments(typeof(SimpleStructWithProperties))]
+    public class ColdStartSerialization<T>
+    {
+        // Measures cold start performance for the serializer
+        // using a fresh JsonSerializerOptions instance per run.
+
+        private T _value;
+        private readonly JsonSerializerOptions _defaultOptions = new JsonSerializerOptions();
+        private readonly JsonStringEnumConverter _converter = new();
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _value = DataGenerator.Generate<T>();
+            RoundtripSerialization(_defaultOptions);
+        }
+
+        private void RoundtripSerialization(JsonSerializerOptions options)
+        {
+            string json = JsonSerializer.Serialize(_value, options);
+            JsonSerializer.Deserialize<T>(json, options);
+        }
+
+        [Benchmark]
+        public void CachedDefaultOptions() => RoundtripSerialization(_defaultOptions);
+
+        [Benchmark]
+        public void NewDefaultOptions() => RoundtripSerialization(new());
+
+        [Benchmark]
+        public void NewCustomizedOptions() => 
+            RoundtripSerialization(
+                new JsonSerializerOptions {
+                    AllowTrailingCommas = true,
+                    WriteIndented = true,
+                    MaxDepth = 1000,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                });
+
+        [Benchmark]
+        public void NewCustomConverter() =>
+            RoundtripSerialization(
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { new JsonStringEnumConverter() }
+                });
+
+        [Benchmark]
+        public void NewCachedCustomConverter() =>
+            RoundtripSerialization(
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { _converter }
+                });
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Tests
 
         private T _value;
         private readonly JsonSerializerOptions _defaultOptions = new JsonSerializerOptions();
-        private readonly JsonStringEnumConverter _converter = new();
+        private readonly JsonStringEnumConverter _converter = new JsonStringEnumConverter();
 
         [GlobalSetup]
         public void Setup()
@@ -26,20 +26,20 @@ namespace System.Text.Json.Serialization.Tests
             RoundtripSerialization(_defaultOptions);
         }
 
-        private void RoundtripSerialization(JsonSerializerOptions options)
+        private T RoundtripSerialization(JsonSerializerOptions options)
         {
             string json = JsonSerializer.Serialize(_value, options);
-            JsonSerializer.Deserialize<T>(json, options);
+            return JsonSerializer.Deserialize<T>(json, options);
         }
 
         [Benchmark]
-        public void CachedDefaultOptions() => RoundtripSerialization(_defaultOptions);
+        public T CachedDefaultOptions() => RoundtripSerialization(_defaultOptions);
 
         [Benchmark]
-        public void NewDefaultOptions() => RoundtripSerialization(new());
+        public T NewDefaultOptions() => RoundtripSerialization(new JsonSerializerOptions());
 
         [Benchmark]
-        public void NewCustomizedOptions() => 
+        public T NewCustomizedOptions() => 
             RoundtripSerialization(
                 new JsonSerializerOptions {
                     AllowTrailingCommas = true,
@@ -49,7 +49,7 @@ namespace System.Text.Json.Serialization.Tests
                 });
 
         [Benchmark]
-        public void NewCustomConverter() =>
+        public T NewCustomConverter() =>
             RoundtripSerialization(
                 new JsonSerializerOptions
                 {
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Tests
                 });
 
         [Benchmark]
-        public void NewCachedCustomConverter() =>
+        public T NewCachedCustomConverter() =>
             RoundtripSerialization(
                 new JsonSerializerOptions
                 {


### PR DESCRIPTION
Add new benchmarks to track the perf issues as described in https://github.com/dotnet/runtime/issues/40072.