### PR TITLE
Add initial performance tests for XmlConvert.

### DIFF
--- a/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlConvert.cs
+++ b/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlConvert.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Xml.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public class Perf_XmlConvert
+    {
+	    private DateTime _testDateTime;
+	    private TimeSpan _testTimeSpan;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+	        _testDateTime = DateTime.UtcNow;
+	        _testTimeSpan = new TimeSpan(1, 2, 3, 4, 56);
+        }
+
+        [Benchmark]
+        public string DateTime_ToString() => XmlConvert.ToString(_testDateTime, XmlDateTimeSerializationMode.Utc);
+
+        [Benchmark]
+        public string DateTime_ToString_Local() => XmlConvert.ToString(_testDateTime, XmlDateTimeSerializationMode.Local);
+
+        [Benchmark]
+        public string DateTime_ToString_Unspecified() => XmlConvert.ToString(_testDateTime, XmlDateTimeSerializationMode.Unspecified);
+
+        [Benchmark]
+        public string DateTime_ToString_RoundtripKind() => XmlConvert.ToString(_testDateTime, XmlDateTimeSerializationMode.RoundtripKind);
+
+        [Benchmark]
+        public string TimeSpan_ToString() => XmlConvert.ToString(_testTimeSpan);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlConvert.cs
+++ b/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlConvert.cs
@@ -10,15 +10,8 @@ namespace System.Xml.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_XmlConvert
     {
-	    private DateTime _testDateTime;
-	    private TimeSpan _testTimeSpan;
-
-        [GlobalSetup]
-        public void Setup()
-        {
-	        _testDateTime = DateTime.UtcNow;
-	        _testTimeSpan = new TimeSpan(1, 2, 3, 4, 56);
-        }
+        private DateTime _testDateTime = new DateTime(1996, 6, 3, 22, 15, 0);
+        private TimeSpan _testTimeSpan = new TimeSpan(1, 2, 3, 4, 56);
 
         [Benchmark]
         public string DateTime_ToString() => XmlConvert.ToString(_testDateTime, XmlDateTimeSerializationMode.Utc);


### PR DESCRIPTION
Related to improvements done in [Issue 64868](https://github.com/dotnet/runtime/pull/64868)

Results from my PC

// * Summary *

BenchmarkDotNet=v0.13.1.1689-nightly, OS=Windows 10 (10.0.19043.1466/21H1/May2021Update)
11th Gen Intel Core i9-11900K 3.50GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  Job-DJFTTG : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1

Before
|                          Method |      Mean |    Error |   StdDev |    Median |       Min |       Max |  Gen 0 | Allocated |
|-------------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|----------:|
|               DateTime_ToString |  79.56 ns | 1.238 ns | 0.967 ns |  79.64 ns |  77.60 ns |  81.20 ns | 0.0486 |     408 B |
|         DateTime_ToString_Local | 243.25 ns | 1.684 ns | 1.576 ns | 243.55 ns | 241.02 ns | 245.91 ns | 0.0541 |     456 B |
|   DateTime_ToString_Unspecified |  76.37 ns | 0.422 ns | 0.394 ns |  76.41 ns |  75.65 ns |  77.01 ns | 0.0487 |     408 B |
| DateTime_ToString_RoundtripKind |  78.79 ns | 0.868 ns | 0.769 ns |  78.70 ns |  77.46 ns |  80.15 ns | 0.0485 |     408 B |
|               TimeSpan_ToString |  62.96 ns | 0.485 ns | 0.454 ns |  62.88 ns |  62.09 ns |  63.75 ns | 0.0200 |     168 B |

After
|                          Method |      Mean |    Error |   StdDev |    Median |       Min |       Max |  Gen 0 | Allocated |
|-------------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|----------:|
|               DateTime_ToString |  54.50 ns | 0.304 ns | 0.270 ns |  54.55 ns |  53.98 ns |  54.99 ns | 0.0096 |      80 B |
|         DateTime_ToString_Local | 187.15 ns | 2.430 ns | 2.029 ns | 187.60 ns | 180.93 ns | 189.17 ns | 0.0099 |      88 B |
|   DateTime_ToString_Unspecified |  49.17 ns | 0.523 ns | 0.464 ns |  49.24 ns |  47.62 ns |  49.50 ns | 0.0095 |      80 B |
| DateTime_ToString_RoundtripKind |  53.01 ns | 0.768 ns | 0.718 ns |  53.34 ns |  51.73 ns |  53.67 ns | 0.0095 |      80 B |
|               TimeSpan_ToString |  41.16 ns | 0.206 ns | 0.192 ns |  41.22 ns |  40.55 ns |  41.31 ns | 0.0065 |      56 B |