### PR TITLE
Fix Append_Span benchmark

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text/Perf.StringBuilder.cs
+++ b/src/benchmarks/micro/libraries/System.Text/Perf.StringBuilder.cs
@@ -213,8 +213,11 @@ namespace System.Text.Tests
         }
 
 #if !NETFRAMEWORK
+        [GlobalSetup(Target = nameof(Append_NonEmptySpan))]
+        public void Setup_Append_NonEmptySpan() => _string100 = new string('a', 100);
+
         [Benchmark]
-        public StringBuilder Append_Span()
+        public StringBuilder Append_NonEmptySpan()
         {
             ReadOnlySpan<char> span = _string100.AsSpan();
             StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
* add missing setup method so the benchmark does not measure appending an empty string
* rename the benchmark so ReportingSystem does not detect the fix as a regression

related to https://github.com/dotnet/runtime/issues/64751