### PR TITLE
Bump BDN version

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -8,8 +8,8 @@
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' == ''">
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1.1689" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1.1689" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1.1694" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1.1694" />
   </ItemGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet\BenchmarkDotNet.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />


### PR DESCRIPTION
The change includes:

* https://github.com/dotnet/BenchmarkDotNet/pull/1917 which effectively allows us to overcome OOM in Roslyn and benchmark x86 (cc @AndyAyersMS)
* https://github.com/dotnet/BenchmarkDotNet/pull/1916 cc @naricc 

Big thanks to @DrewScoggins for uploading new package to the MS feed