### PR TITLE
Adding PR template to help ensure microbenchmarks are maintained correctly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Thank you for submitting a pull request to our repo.
+
+     It's critical that our microbenchmarks remain efficient, reliable and accurate.
+
+     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:
+
+     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md
+
+     and ensure that your changes in this PR comply with its requirements.
+
+ -->
+
+

--- a/docs/microbenchmark-design-guidelines.md
+++ b/docs/microbenchmark-design-guidelines.md
@@ -34,6 +34,7 @@
       - [Params](#params)
       - [ArgumentsSource](#argumentssource)
       - [Generic benchmarks](#generic-benchmarks)
+      - [Allowed operating systems](#allowed-operating-systems)
   - [Best Practices](#best-practices)
     - [Single Responsibility Principle](#single-responsibility-principle)
     - [No Side-Effects](#no-side-effects)
@@ -41,6 +42,7 @@
     - [Loops](#loops)
     - [Method Inlining](#method-inlining)
     - [Be explicit](#be-explicit)
+    - [Add Categories](#add-categories)
 
 ## Mindset
 
@@ -489,6 +491,15 @@ public class EmptyClass { }
 public struct EmptyStruct { }
 ```
 
+#### Allowed operating systems
+
+This is possible with the `AllowedOperatingSystemsAttribute`. You need to provide a mandatory comment and OS(es) that benchmark(s) can run on.
+
+```cs
+[AllowedOperatingSystems("Hangs on non-Windows, dotnet/runtime#18290", OS.Windows)]
+public class Perf_PipeTest
+```
+
 ## Best Practices
 
 ### Single Responsibility Principle
@@ -592,3 +603,21 @@ var result = Math.Max(x, y); // we use double overload because float has implici
 ```
 
 It's our responsibility to ensure that the benchmarks do exactly what we want. This is why using explicit types over `var` is preferred.
+
+### Add categories
+
+Every micro benchmark should belong to at least either Runtime, Libraries or ThirdParty category. It allows for filtering by category.
+
+Adding given type/method to particular category requires using a `[BenchmarkCategory]` attribute:
+
+```cs
+[BenchmarkCategory(Categories.Libraries)]
+public class SomeType
+```
+
+Optionally, you can add multiple categories - see the [list here](../src/benchmarks/micro/Categories.cs):
+
+```c#
+[BenchmarkCategory(Categories.Libraries, Categories.Regex)]
+public class Perf_Regex_Common
+```

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -8,7 +8,7 @@ To run the benchmarks, you need to download dotnet cli or use the python script,
 
 We use BenchmarkDotNet as the benchmarking tool, you can read more about it in [our short summary](../../../docs/benchmarkdotnet.md) (it's recommended). The key thing that you need to remember is that **BenchmarkDotNet runs every benchmark in a dedicated process and stops the benchmarking when a specified level of precision is met**.
 
-To learn more about designing benchmarks, please read [Microbenchmark Design Guidelines](../../../docs/microbenchmark-design-guidelines.md).
+To learn more about designing benchmarks, please read [Microbenchmark Design Guidelines](../../../docs/microbenchmark-design-guidelines.md). It's essential to be familar with these guidelines before modifying or adding any micro benchmarks.
 
 ## Quick Start
 
@@ -71,25 +71,3 @@ If you **prefer to use dotnet cli** instead of CoreRun, you need to pass the pat
 BenchmarkDotNet allows you to run the benchmarks for private builds of [Full .NET Framework](../../../docs/benchmarkdotnet.md#Private-CLR-Build) and [CoreRT](../../../docs/benchmarkdotnet.md#Private-CoreRT-Build)
 
 We once again encourage you to read the [full docs about BenchmarkDotNet](../../../docs/benchmarkdotnet.md#table-of-contents).
-
----
-
-### Categories
-
-Every micro benchmark should belong to either Runtime, Libraries or ThirdParty category. It allows for filtering by category.
-
-Adding given type/method to particular category requires using a `[BenchmarkCategory]` attribute:
-
-```cs
-[BenchmarkCategory(Categories.Libraries)]
-public class SomeType
-```
-
-### Enabling given benchmark(s) for selected Operating System(s)
-
-This is possible with the `AllowedOperatingSystemsAttribute`. You need to provide a mandatory comment and OS(es) that benchmark(s) can run on.
-
-```cs
-[AllowedOperatingSystems("Hangs on non-Windows, dotnet/corefx#18290", OS.Windows)]
-public class Perf_PipeTest
-```


### PR DESCRIPTION
This appears in the form when any PR is created; it's commented, so if they don't delete it, it won't show up in the final PR.

the readme.md next to the microbenchmarks is almost all about how to run them: I moved a small part that was actually guidelines into the guidelines doc, so it's together.