### PR TITLE
Update Maui/Mobile pre.py's to simplify running different apps

### DIFF
--- a/src/scenarios/helloandroid/pre.py
+++ b/src/scenarios/helloandroid/pre.py
@@ -14,31 +14,36 @@ setup_loggers(True)
 
 parser = ArgumentParser()
 parser.add_argument('--unzip', help='Unzip APK and report extracted tree', action='store_true', default=False)
+parser.add_argument(
+        '--apk-name',
+        dest='apk',
+        required=True,
+        type=str,
+        help='Name of the APK to setup (with .apk)')
 args = parser.parse_args()
 
 if not os.path.exists(PUBDIR):
     os.mkdir(PUBDIR)
-apknames = ['HelloAndroid.apk', 'HelloAndroidWithDiag.apk']
-for apkname in apknames:
-    apknamezip = '%s.zip' % (apkname)
-    if not os.path.exists(apkname):
-        getLogger().error('Cannot find %s' % (apkname))
-        exit(-1)
-    if args.unzip:
-        if not os.path.exists(apknamezip):
-            copyfile(apkname, apknamezip)
+apkname = args.apk
+apknamezip = '%s.zip' % (apkname)
+if not os.path.exists(apkname):
+    getLogger().error('Cannot find %s' % (apkname))
+    exit(-1)
+if args.unzip:
+    if not os.path.exists(apknamezip):
+        copyfile(apkname, apknamezip)
 
-        with ZipFile(apknamezip) as zip:
-            zip.extractall(os.path.join('.', PUBDIR))
+    with ZipFile(apknamezip) as zip:
+        zip.extractall(os.path.join('.', PUBDIR))
 
-        assets_dir = os.path.join(PUBDIR, 'assets')
-        assets_zip = os.path.join(assets_dir, 'assets.zip')
-        with ZipFile(assets_zip) as zip:
-            zip.extractall(assets_dir)
+    assets_dir = os.path.join(PUBDIR, 'assets')
+    assets_zip = os.path.join(assets_dir, 'assets.zip')
+    with ZipFile(assets_zip) as zip:
+        zip.extractall(assets_dir)
 
-        os.remove(assets_zip)
-    else:
-        copyfile(apkname, os.path.join(PUBDIR, apkname))
+    os.remove(assets_zip)
+else:
+    copyfile(apkname, os.path.join(PUBDIR, apkname))
 
 
 

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -4,7 +4,7 @@ pre-command
 import sys
 import os
 from zipfile import ZipFile
-from performance.logger import setup_loggers
+from performance.logger import setup_loggers, getLogger
 from shutil import copyfile
 from shared.precommands import PreCommands
 from shared.const import PUBDIR
@@ -14,12 +14,20 @@ setup_loggers(True)
 
 parser = ArgumentParser()
 parser.add_argument('--unzip', help='Unzip APK and report extracted tree', action='store_true', default=False)
+parser.add_argument(
+        '--apk-name',
+        dest='apk',
+        required=True,
+        type=str,
+        help='Name of the APK to setup')
 args = parser.parse_args()
 
-apkname = 'MauiAndroidDefault.apk'
+if not os.path.exists(PUBDIR):
+    os.mkdir(PUBDIR)
+apkname = args.apk
 apknamezip = '%s.zip' % (apkname)
 if not os.path.exists(apkname):
-    print('Cannot find %s' % (apkname))
+    getLogger().error('Cannot find %s' % (apkname))
     exit(-1)
 if args.unzip:
     if not os.path.exists(apknamezip):
@@ -35,7 +43,6 @@ if args.unzip:
 
     os.remove(assets_zip)
 else:
-    os.mkdir(PUBDIR)
     copyfile(apkname, os.path.join(PUBDIR, apkname))
 
 


### PR DESCRIPTION
Update Maui/Mobile pre.py's to simplify running different apps. 

Removes the default app name for each folder and instead takes in the app folder name as an argument to run pre run functionality against. This should make it more straightforward to add and remove tests as their names will not need to be added here, instead only being set in the android_scenarios.proj file.