### PR TITLE
[MAUI]Update Device Startup Scenario Naming

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -564,7 +564,7 @@ ex: C:\repos\performance;C:\repos\runtime
             traceFile.close()
 
             startup = StartupWrapper()
-            self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.STARTUP_DEVICETIMETOMAIN, tracefolder='PerfTest/', tracename='runoutput.trace', scenarioname='Device Startup - Android %s' % (self.packagename))
+            self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.STARTUP_DEVICETIMETOMAIN, tracefolder='PerfTest/', tracename='runoutput.trace', scenarioname=self.scenarioname)
             startup.parsetraces(self.traits)
 
         elif self.testtype == const.SOD:


### PR DESCRIPTION
Changed startup scenario name to match normal scenario naming scheme of using the scenario name provided in the scenarios.proj file. Update

