### PR TITLE
Add a benchmarks_monthly.py script to simplify the monthly manual runs

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -157,6 +157,14 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         action='store_true',
         help='Attempts to run the benchmarks without building.',
     )
+    parser.add_argument(
+        '--skip-logger-setup',
+        dest='skip_logger_setup',
+        required=False,
+        default=False,
+        action='store_true',
+        help='Skips the logger setup, for cases when invoked by another script that already sets logging up')
+
     return parser
 
 
@@ -174,7 +182,9 @@ def __main(args: list) -> int:
     validate_supported_runtime()
     args = __process_arguments(args)
     verbose = not args.quiet
-    setup_loggers(verbose=verbose)
+
+    if not args.skip_logger_setup:
+        setup_loggers(verbose=verbose)
 
     if not args.frameworks:
         raise Exception("Framework version (-f) must be specified.")

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -45,6 +45,21 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         default='*',
         help='Specifies the benchmark filter to pass to BenchmarkDotNet')
 
+    parser.add_argument(
+        '--architecture',
+        dest='architecture',
+        required=False,
+        choices=['x64', 'x86', 'arm64', 'arm'],
+        default='x64',
+        help='Specifies the processor architecture to pass to BenchmarkDotNet')
+
+    parser.add_argument(
+        '--bdn-arguments',
+        dest='bdn_arguments',
+        required=False,
+        help='Command line arguments to be passed to BenchmarkDotNet, wrapped in quotes',
+    )
+
     return parser
 
 def __process_arguments(args: list):
@@ -67,6 +82,12 @@ def __main(args: list) -> int:
 
     if 'build' in version:
         benchmarkArgs += ['--dotnet-versions', version['build']]
+
+    if args.architecture:
+        benchmarkArgs += ['--architecture', args.architecture]
+
+    if args.bdn_arguments:
+        benchmarkArgs += ['--bdn-arguments', args.bdn_arguments]
 
     getLogger().log(getLogger().getEffectiveLevel(), '\nExecuting: benchmarks_ci.py ' + str.join(' ', benchmarkArgs) + '\n')
     benchmarks_ci.__main(benchmarkArgs)

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -94,7 +94,7 @@ def __main(args: list) -> int:
 
     args = __process_arguments(args)
     rootPath = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
-    sdkPath = os.path.join(rootPath, 'tools', 'dotnet', args.architecture, 'sdk')
+    sdkPath = os.path.join(rootPath, 'tools', 'dotnet', args.architecture)
 
     logPrefix = ''
 

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -10,12 +10,15 @@ from argparse import ArgumentParser, ArgumentTypeError
 from logging import getLogger
 
 import benchmarks_ci
+import datetime
+import tarfile
 import sys
+import os
 
 VERSIONS = {
-    '7.0-preview2': { 'tfm': 'net7.0', 'build': '7.0.100-preview.2.22124.4' },
-    '7.0-preview1': { 'tfm': 'net7.0', 'build': '7.0.100-preview.1.22077.12' },
-    '6.0': { 'tfm': 'net6.0' }
+    'net7.0-preview2': { 'tfm': 'net7.0', 'build': '7.0.100-preview.2.22124.4' },
+    'net7.0-preview1': { 'tfm': 'net7.0', 'build': '7.0.100-preview.1.22077.12' },
+    'net6.0': { 'tfm': 'net6.0' }
 }
 
 def get_version_from_name(name: str) -> str:
@@ -36,6 +39,12 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         choices=VERSIONS,
         help='Specifies the .NET release for the benchmarks run')
 
+    parser.add_argument(
+        '--filter',
+        dest='filter',
+        default='*',
+        help='Specifies the benchmark filter to pass to BenchmarkDotNet')
+
     return parser
 
 def __process_arguments(args: list):
@@ -43,6 +52,7 @@ def __process_arguments(args: list):
         description='Tool to execute the monthly manual micro benchmark performance runs',
         allow_abbrev=False
     )
+
     add_arguments(parser)
     return parser.parse_args(args)
 
@@ -53,13 +63,29 @@ def __main(args: list) -> int:
         raise Exception('Version must be specified.')
 
     version = get_version_from_name(args.version)
-    benchmarkArgs = ['--filter', '*', '-f', version['tfm']]
+    benchmarkArgs = ['--filter', args.filter, '-f', version['tfm']]
 
     if 'build' in version:
         benchmarkArgs += ['--dotnet-versions', version['build']]
 
-    getLogger().critical('\nExecuting: benchmarks_ci.py ' + str.join(' ', benchmarkArgs) + '\n')
+    getLogger().log(getLogger().getEffectiveLevel(), '\nExecuting: benchmarks_ci.py ' + str.join(' ', benchmarkArgs) + '\n')
     benchmarks_ci.__main(benchmarkArgs)
+
+    rootPath = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+    resultsPath = os.path.join(rootPath, 'artifacts', 'bin', 'MicroBenchmarks', 'Release', version['tfm'], 'BenchmarkDotNet.Artifacts', 'results')
+
+    getLogger().log(getLogger().getEffectiveLevel(), 'Results were created in the following folder:')
+    getLogger().log(getLogger().getEffectiveLevel(), '  ' + resultsPath)
+
+    today = str(datetime.date.today())
+    resultsName = today + '-' + args.version
+    resultsTarPath = os.path.join(rootPath, 'artifacts', resultsName + '.tar.gz')
+    resultsTar = tarfile.open(resultsTarPath, 'w:gz')
+    resultsTar.add(resultsPath, arcname=resultsName)
+    resultsTar.close()
+
+    getLogger().log(getLogger().getEffectiveLevel(), 'Results were collected into the following tar archive:')
+    getLogger().log(getLogger().getEffectiveLevel(), '  ' + resultsTarPath)
 
 if __name__ == '__main__':
     __main(sys.argv[1:])

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -7,10 +7,10 @@ monthly manual performance runs.
 '''
 
 from argparse import ArgumentParser, ArgumentTypeError
+from datetime import datetime
 from logging import getLogger
 
 import benchmarks_ci
-import datetime
 import tarfile
 import sys
 import os
@@ -98,8 +98,8 @@ def __main(args: list) -> int:
     getLogger().log(getLogger().getEffectiveLevel(), 'Results were created in the following folder:')
     getLogger().log(getLogger().getEffectiveLevel(), '  ' + resultsPath)
 
-    today = str(datetime.date.today())
-    resultsName = today + '-' + args.version
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M')
+    resultsName = timestamp + '-' + args.version
     resultsTarPath = os.path.join(rootPath, 'artifacts', resultsName + '.tar.gz')
     resultsTar = tarfile.open(resultsTarPath, 'w:gz')
     resultsTar.add(resultsPath, arcname=resultsName)

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -42,6 +42,11 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Specifies the .NET version(s) for the benchmarks run')
 
     parser.add_argument(
+        '--device-name',
+        dest='device_name',
+        help='The name of this device, to be included in the .tar.gz file name')
+
+    parser.add_argument(
         '--filter',
         dest='filter',
         default='*',
@@ -50,7 +55,6 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         '--architecture',
         dest='architecture',
-        required=False,
         choices=['x64', 'x86', 'arm64', 'arm'],
         default='x64',
         help='Specifies the SDK processor architecture')
@@ -58,7 +62,6 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         '--bdn-arguments',
         dest='bdn_arguments',
-        required=False,
         help='Command line arguments to be passed to BenchmarkDotNet, wrapped in quotes',
     )
 
@@ -108,7 +111,12 @@ def __main(args: list) -> int:
         getLogger().log(getLogger().getEffectiveLevel(), '  ' + resultsPath)
 
         timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M')
-        resultsName = timestamp + '-' + versionName
+
+        if args.device_name:
+            resultsName = timestamp + '-' + args.device_name + '-' + versionName
+        else:
+            resultsName = timestamp + '-' + versionName
+
         resultsTarPath = os.path.join(rootPath, 'artifacts', resultsName + '.tar.gz')
 
         resultsTar = tarfile.open(resultsTarPath, 'w:gz')

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+'''
+This script provides simple execution of the .NET micro benchmarks
+for a .NET preview release, making it easier to contribute to our
+monthly manual performance runs.
+'''
+
+from argparse import ArgumentParser, ArgumentTypeError
+from logging import getLogger
+
+import benchmarks_ci
+import sys
+
+VERSIONS = {
+    '7.0-preview2': { 'tfm': 'net7.0', 'build': '7.0.100-preview.2.22124.4' },
+    '7.0-preview1': { 'tfm': 'net7.0', 'build': '7.0.100-preview.1.22077.12' },
+    '6.0': { 'tfm': 'net6.0' }
+}
+
+def get_version_from_name(name: str) -> str:
+    for version in VERSIONS:
+        if version == name:
+            return VERSIONS[version]
+
+    raise Exception('The version specified is not supported', name)
+
+def add_arguments(parser: ArgumentParser) -> ArgumentParser:
+    '''Adds new arguments to the specified ArgumentParser object.'''
+
+    if not isinstance(parser, ArgumentParser):
+        raise TypeError('Invalid parser.')
+
+    parser.add_argument(
+        'version',
+        choices=VERSIONS,
+        help='Specifies the .NET release for the benchmarks run')
+
+    return parser
+
+def __process_arguments(args: list):
+    parser = ArgumentParser(
+        description='Tool to execute the monthly manual micro benchmark performance runs',
+        allow_abbrev=False
+    )
+    add_arguments(parser)
+    return parser.parse_args(args)
+
+def __main(args: list) -> int:
+    args = __process_arguments(args)
+
+    if not args.version:
+        raise Exception('Version must be specified.')
+
+    version = get_version_from_name(args.version)
+    benchmarkArgs = ['--filter', '*', '-f', version['tfm']]
+
+    if 'build' in version:
+        benchmarkArgs += ['--dotnet-versions', version['build']]
+
+    getLogger().critical('\nExecuting: benchmarks_ci.py ' + str.join(' ', benchmarkArgs) + '\n')
+    benchmarks_ci.__main(benchmarkArgs)
+
+if __name__ == '__main__':
+    __main(sys.argv[1:])

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -40,7 +40,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         'versions',
         nargs='+',
         choices=VERSIONS,
-        help='Specifies the .NET version for the benchmarks run')
+        help='Specifies the .NET version(s) for the benchmarks run')
 
     parser.add_argument(
         '--device-name',

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -67,10 +67,10 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     )
 
     parser.add_argument(
-        '--clean',
-        dest='clean',
+        '--no-clean',
+        dest='no_clean',
         action='store_true',
-        help='Clean the SDK and results directories before execution')
+        help='Do not clean the SDK and results directories before execution')
 
     parser.add_argument(
         '--dry-run',
@@ -105,7 +105,7 @@ def __main(args: list) -> int:
         version = get_version_from_name(versionName)
         resultsPath = os.path.join(rootPath, 'artifacts', 'bin', 'MicroBenchmarks', 'Release', version['tfm'], 'BenchmarkDotNet.Artifacts', 'results')
 
-        if args.clean:
+        if not args.no_clean:
             # Delete any preexisting SDK and results, which allows
             # multiple versions to be run from a single command
             if os.path.isdir(sdkPath):


### PR DESCRIPTION
We will update the script to capture the build number used for each monthly run. Along with the build number, this script also applies a default filter of '*'. With those two features, the command-line to execute is much simpler.

Instead of: `py(thon3) scripts\benchmarks_ci.py --filter '*' -f net7.0 --dotnet-versions 7.0.100-preview.1.22077.12`
This enables: `py(thon3) scripts\benchmarks_monthly.py net7.0-preview1`

When the run completes, the results are collected into a `.tar.gz` file at the root of the `artifacts` folder. The path to the tar file is logged into the console.