### PR TITLE
Few workarounds for the next manual perf run

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -15,6 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableXlfLocalization>false</EnableXlfLocalization>
+    <DefineConstants Condition=" '$(MSBuildFileVersion)' > '17.2.0.10401' AND $(NETCoreSdkVersion.StartsWith(7.0.100-preview))">$(DefineConstants);NET7_0_PREVIEW2_OR_GREATER</DefineConstants>
   </PropertyGroup>
   <!-- out-of-band packages that are not included in NetCoreApp have TFM-specific versions -->
   <Choose>

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -21,6 +21,9 @@ namespace MicroBenchmarks.Serializers
 
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
+#if NET7_0 // https://github.com/dotnet/runtime/issues/64657
+        [OperatingSystemsArchitectureFilter(false, Architecture.Arm64)]
+#endif
         public T Jil_() => Jil.JSON.Deserialize<T>(serialized, Jil.Options.ISO8601);
 
         [GlobalSetup(Target = nameof(JsonNet_))]

--- a/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromDifferentThreads.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromDifferentThreads.cs
@@ -104,6 +104,9 @@ namespace System.Collections.Concurrent
         }
 
         [Benchmark]
+#if NET7_0 // https://github.com/dotnet/runtime/issues/64980
+        [OperatingSystemsArchitectureFilter(false, Architecture.Arm64)]
+#endif
         public void ConcurrentStack() => SignalAndWaitForAllTasks();
 
         [IterationSetup(Target = nameof(ConcurrentQueue))]

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -26,7 +26,7 @@ namespace System.Text.RegularExpressions.Tests
 
         public static int Count(Regex r, string input)
         {
-#if NET7_0_OR_GREATER
+#if NET7_0_PREVIEW2_OR_GREATER
             return r.Count(input);
 #else
             int count = 0;


### PR DESCRIPTION
In the previous manual perf run we have discovered two ARM specific bugs: https://github.com/dotnet/runtime/issues/64980 and https://github.com/dotnet/runtime/issues/64657.

They got already fixed, but they are not part of .NET 7 Preview 2, so we need to disable them until the fixes flow to the SDK.

The `NET7_0_PREVIEW2_OR_GREATER` condition allows us to not use `Regex.Count` API which was introduced in Preview 2.
