### PR TITLE
Change NoPGO runs to OSR runs for a short time

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -246,7 +246,8 @@ def __main(args: list) -> int:
     showenv = 'set' if sys.platform == 'win32' else 'printenv'
 
     if args.pgo_status == 'nopgo':
-        pgo_config = variable_format % ('COMPlus_JitDisablePgo', '1')
+        pgo_config = variable_format % ('COMPlus_TC_QuickJitForLoops', '1')
+        pgo_config += variable_format % ('COMPlus_TC_OnStackReplacement','1')
     elif args.pgo_status == 'dynamicpgo':
         pgo_config = variable_format % ('COMPlus_TieredPGO', '1')
     elif args.pgo_status == 'fullpgo':


### PR DESCRIPTION
This changes the NoPGO runs, which our of low importance, over to OSR runs so that we can get a weeks worth of data before this tries to go in for preview 3.
