### PR TITLE
[MAUI] Enable iOS ipa file size measurement

### DIFF
--- a/src/scenarios/helloios/pre.py
+++ b/src/scenarios/helloios/pre.py
@@ -23,6 +23,8 @@ args = parser.parse_args()
 
 name = args.name
 namezip = '%s.zip' % (name)
+if not os.path.exists(PUBDIR):
+    os.mkdir(PUBDIR)
 if not os.path.exists(name):
     getLogger().error('Cannot find %s' % (name))
     exit(-1)
@@ -46,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, PUBDIR)
+        copytree(name, os.path.join(PUBDIR, name))
     else:
-        copyfile(name, PUBDIR)
+        copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/helloios/pre.py
+++ b/src/scenarios/helloios/pre.py
@@ -48,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, os.path.join(PUBDIR, name))
+        copytree(name, PUBDIR)
     else:
         copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/helloios/pre.py
+++ b/src/scenarios/helloios/pre.py
@@ -34,17 +34,6 @@ if args.unzip:
 
     with ZipFile(namezip) as zip:
         zip.extractall(os.path.join('.', PUBDIR))
-
-    baseDir = os.path.join(PUBDIR, 'Payload')
-    appFolder = os.listdir(baseDir) # Should only be one
-    if len(appFolder) > 1:
-        getLogger.error("More than one app folder found in payload! Should only be one.")
-        exit(-1)
-
-    appFolderPath = os.path.join(baseDir, appFolder[0])
-    for subfile in os.listdir(appFolderPath):
-        move(os.path.join(appFolderPath, subfile), PUBDIR)
-    os.removedirs(appFolderPath)
     
 else:
     if(os.path.isdir(name)):

--- a/src/scenarios/helloios/pre.py
+++ b/src/scenarios/helloios/pre.py
@@ -48,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, PUBDIR)
+        copytree(name, PUBDIR, dirs_exist_ok=True)
     else:
         copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/helloios/pre.py
+++ b/src/scenarios/helloios/pre.py
@@ -1,10 +1,51 @@
 '''
 pre-command
 '''
-from performance.logger import setup_loggers
-from shutil import copytree
+import sys
+import os
+from zipfile import ZipFile
+from performance.logger import setup_loggers, getLogger
+from shutil import copyfile, copytree, move
 from shared.const import PUBDIR
+from argparse import ArgumentParser
 
 setup_loggers(True)
 
-copytree('app', PUBDIR)
+parser = ArgumentParser()
+parser.add_argument('--unzip', help='Unzip ipa file and report extracted tree', action='store_true', default=False)
+parser.add_argument(
+        '--name',
+        dest='name',
+        required=True,
+        type=str,
+        help='Name of the file/folder to setup (with .app or .ipa)')
+args = parser.parse_args()
+
+name = args.name
+namezip = '%s.zip' % (name)
+if not os.path.exists(name):
+    getLogger().error('Cannot find %s' % (name))
+    exit(-1)
+if args.unzip:
+    if not os.path.exists(namezip):
+        copyfile(name, namezip)
+
+    with ZipFile(namezip) as zip:
+        zip.extractall(os.path.join('.', PUBDIR))
+
+    baseDir = os.path.join(PUBDIR, 'Payload')
+    appFolder = os.listdir(baseDir) # Should only be one
+    if len(appFolder) > 1:
+        getLogger.error("More than one app folder found in payload! Should only be one.")
+        exit(-1)
+
+    appFolderPath = os.path.join(baseDir, appFolder[0])
+    for subfile in os.listdir(appFolderPath):
+        move(os.path.join(appFolderPath, subfile), PUBDIR)
+    os.removedirs(appFolderPath)
+    
+else:
+    if(os.path.isdir(name)):
+        copytree(name, PUBDIR)
+    else:
+        copyfile(name, PUBDIR)

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -23,6 +23,8 @@ args = parser.parse_args()
 
 name = args.name
 namezip = '%s.zip' % (name)
+if not os.path.exists(PUBDIR):
+    os.mkdir(PUBDIR)
 if not os.path.exists(name):
     getLogger().error('Cannot find %s' % (name))
     exit(-1)
@@ -46,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, PUBDIR)
+        copytree(name, f"{PUBDIR}/{name}")
     else:
-        copyfile(name, PUBDIR)
+        copyfile(name, f"{PUBDIR}/")

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -48,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, os.path.join(PUBDIR, name))
+        copytree(name, PUBDIR)
     else:
         copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -34,17 +34,6 @@ if args.unzip:
 
     with ZipFile(namezip) as zip:
         zip.extractall(os.path.join('.', PUBDIR))
-
-    baseDir = os.path.join(PUBDIR, 'Payload')
-    appFolder = os.listdir(baseDir) # Should only be one
-    if len(appFolder) > 1:
-        getLogger.error("More than one app folder found in payload! Should only be one.")
-        exit(-1)
-
-    appFolderPath = os.path.join(baseDir, appFolder[0])
-    for subfile in os.listdir(appFolderPath):
-        move(os.path.join(appFolderPath, subfile), PUBDIR)
-    os.removedirs(appFolderPath)
     
 else:
     if(os.path.isdir(name)):

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -48,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, f"{PUBDIR}/{name}")
+        copytree(name, os.path.join(PUBDIR, name))
     else:
-        copyfile(name, f"{PUBDIR}/")
+        copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -48,6 +48,6 @@ if args.unzip:
     
 else:
     if(os.path.isdir(name)):
-        copytree(name, PUBDIR)
+        copytree(name, PUBDIR, dirs_exist_ok=True)
     else:
         copyfile(name, os.path.join(PUBDIR, name))

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -1,10 +1,51 @@
 '''
 pre-command
 '''
-from performance.logger import setup_loggers
-from shutil import copytree
+import sys
+import os
+from zipfile import ZipFile
+from performance.logger import setup_loggers, getLogger
+from shutil import copyfile, copytree, move
 from shared.const import PUBDIR
+from argparse import ArgumentParser
 
 setup_loggers(True)
 
-copytree('app', PUBDIR)
+parser = ArgumentParser()
+parser.add_argument('--unzip', help='Unzip ipa file and report extracted tree', action='store_true', default=False)
+parser.add_argument(
+        '--name',
+        dest='name',
+        required=True,
+        type=str,
+        help='Name of the file/folder to setup (with .app or .ipa)')
+args = parser.parse_args()
+
+name = args.name
+namezip = '%s.zip' % (name)
+if not os.path.exists(name):
+    getLogger().error('Cannot find %s' % (name))
+    exit(-1)
+if args.unzip:
+    if not os.path.exists(namezip):
+        copyfile(name, namezip)
+
+    with ZipFile(namezip) as zip:
+        zip.extractall(os.path.join('.', PUBDIR))
+
+    baseDir = os.path.join(PUBDIR, 'Payload')
+    appFolder = os.listdir(baseDir) # Should only be one
+    if len(appFolder) > 1:
+        getLogger.error("More than one app folder found in payload! Should only be one.")
+        exit(-1)
+
+    appFolderPath = os.path.join(baseDir, appFolder[0])
+    for subfile in os.listdir(appFolderPath):
+        move(os.path.join(appFolderPath, subfile), PUBDIR)
+    os.removedirs(appFolderPath)
+    
+else:
+    if(os.path.isdir(name)):
+        copytree(name, PUBDIR)
+    else:
+        copyfile(name, PUBDIR)


### PR DESCRIPTION
Adds support for measuring ipa files to the Maui and iOS pre.py files. This also includes the addition of passing in the name of the folder/file you want to use in testing. This is a sibling commit to https://github.com/dotnet/runtime/pull/66358.