### PR TITLE
Add release7.0-preview[2,3,4] channels into the channel map.

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -2,6 +2,21 @@ from argparse import ArgumentParser
 
 class ChannelMap():
     channel_map = {
+        'release/7.0-preview4': {
+            'tfm': 'net7.0',
+            'branch': '7.0.1xx',
+            'quality': 'daily'
+        },
+        'release/7.0-preview3': {
+            'tfm': 'net7.0',
+            'branch': '7.0.1xx',
+            'quality': 'daily'
+        },
+        'release/7.0-preview2': {
+            'tfm': 'net7.0',
+            'branch': '7.0.1xx',
+            'quality': 'daily'
+        },
         'release/7.0-preview1': {
             'tfm': 'net7.0',
             'branch': '7.0.1xx',


### PR DESCRIPTION
As stated, adds release7.0-preview[2,3,4] channels into the channel map. Previews 3 and 4 are included for future proofing while we investigate potential improvements in channel map parsing.

part of https://github.com/dotnet/performance/issues/2286.

