### PR TITLE
[Release/3.1.4] Remove blazor scenario r3.1.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,19 +72,19 @@ jobs:
       channels:
         - release/3.1.4xx
   
-  # Windows x64 Blazor scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x64
-      pool: 
-        vmImage: windows-2019
-      kind: blazor_scenarios
-      queue: Windows.10.Amd64.ClientRS5.Open
-      projectFile: blazor_scenarios.proj
-      channels:
-        - release/3.1.4xx
+  ## Windows x64 Blazor scenario benchmarks
+  #- template: /eng/performance/scenarios.yml
+  #  parameters:
+  #    osName: windows
+  #    osVersion: RS5
+  #    architecture: x64
+  #    pool: 
+  #      vmImage: windows-2019
+  #    kind: blazor_scenarios
+  #    queue: Windows.10.Amd64.ClientRS5.Open
+  #    projectFile: blazor_scenarios.proj
+  #    channels:
+  #      - release/3.1.4xx
 
   # Windows x64 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -430,16 +430,16 @@ jobs:
       channels:
         - release/3.1.4xx
 
-  # Windows x64 Blazor 3.2 scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x64
-      pool: 
-        vmImage: windows-2019
-      kind: blazor_scenarios
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: blazor_scenarios.proj
-      channels:
-        - release/3.1.4xx
+  ## Windows x64 Blazor 3.2 scenario benchmarks
+  #- template: /eng/performance/scenarios.yml
+  #  parameters:
+  #    osName: windows
+  #    osVersion: RS5
+  #    architecture: x64
+  #    pool: 
+  #      vmImage: windows-2019
+  #    kind: blazor_scenarios
+  #    queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #    projectFile: blazor_scenarios.proj
+  #    channels:
+  #      - release/3.1.4xx

--- a/eng/performance/blazor_scenarios.proj
+++ b/eng/performance/blazor_scenarios.proj
@@ -1,3 +1,9 @@
+<!-- 
+
+    Blazorwasm has been removed from the available dotnet new scenarios for 3.1.4 https://github.com/dotnet/installer/pull/13120. 
+    Leaving this project here incase it is added back in the future, but removing it from any potential yml uses.
+	
+-->
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
 
   <ItemGroup>


### PR DESCRIPTION
The Blazor Scenario job in branch release/3.1.4xx is failing. This seems to be due to it no longer being shipped with the product: https://github.com/dotnet/installer/pull/13120. This PR disables the pipeline runs of the scenario and adds a comment to the blazor scenarios proj file denoting that it is currently disabled.  