### PR TITLE
MicroBenchmarks: Fix wasm/interpreter failures

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.props
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
+    <WasmMainJSPath>$(WasmDataDir)\test-main.js</WasmMainJSPath>
+  </PropertyGroup>
+</Project>

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <WasmBuildOnlyAfterPublish Condition="'$(RunAOTCompilation)' == 'true'">false</WasmBuildOnlyAfterPublish>
+  </PropertyGroup>
+
+  <Target Name="ExtraPrepareForWasmBuild" AfterTargets="PrepareForWasmBuild">
+    <ItemGroup>
+      <_LibrariesFile Include="$(TargetDir)publish\libraries\**\*" />
+      <WasmFilesToIncludeInFileSystem Include="@(_LibrariesFile)" TargetPath="libraries\%(RecursiveDir)%(FileName)%(Extension)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Some of the benchmarks fail with:

```
[INFO] System.Reflection.TargetInvocationException: Arg_TargetInvocationException
[INFO]  ---> System.IO.DirectoryNotFoundException: IO_PathNotFound_Path, /libraries/Microsoft.Extensions.Configuration.Xml/TestFiles/repeated.xml
[INFO]    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
[INFO]    at Interop.CheckIo(Error error, String path, Boolean isDirectory, Func`2 errorRewriter)
[INFO]    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Func`4 createOpenException)
[INFO]    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Permissions openPermissions, Int64& fileLength, Permissions& filePermission
[INFO]    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Permissions openPermissions, Func`4 createOpenException)
[INFO]    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
[INFO]    at System.IO.Strategies.UnixFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
[INFO]    at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
[INFO]    at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
[INFO]    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
[INFO]    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
[INFO]    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)
[INFO]    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
[INFO]    at Microsoft.Extensions.Configuration.Xml.XmlConfigurationProviderBenchmarks.GlobalSetup()
[INFO]    at BenchmarkDotNet.Engines.EngineFactory.CreateReadyToRun(EngineParameters engineParameters)
[INFO]    at BenchmarkDotNet.Autogenerated.Runnable_9.Run(IHost host, String benchmarkName)
[INFO]    at System.Reflection.RuntimeMethodInfo.InvokeWorker(Object obj, BindingFlags invokeAttr, Span`1 parameters)
[INFO]    Exception_EndOfInnerExceptionStack
[INFO]    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
[INFO]    at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
[INFO]    at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args)
```

The project adds `libraries/*` to `@(None)`, and they get copied to the
bin dir. The program can access these files when it's running.

In case of wasm though, such files need to be surfaced in its vfs, which
is not being done here, and thus the failure.

Due to the way bdn uses the project via its generated project, wasm
targets can't add this automatically. Instead, we add new props/targets
files which are imported by the generated project. And we the
`libraries/*` files can be added to the vfs in the targets file.

Also, note that the props/targets files can be used to customize the
build of the bdn generated project.

Partially fixes https://github.com/dotnet/performance/issues/2250