### PR TITLE
create the tar file even if some benchmarks have failed

### DIFF
--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -98,6 +98,8 @@ def __main(args: list) -> int:
     sdkPath = os.path.join(rootPath, 'tools', 'dotnet', args.architecture)
 
     logPrefix = ''
+    logger = getLogger()
+    logLevel = getLogger().getEffectiveLevel()
 
     if args.dry_run:
         logPrefix = '[DRY RUN] '
@@ -110,13 +112,13 @@ def __main(args: list) -> int:
             # Delete any preexisting SDK and results, which allows
             # multiple versions to be run from a single command
             if os.path.isdir(sdkPath):
-                getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'rmdir -r ' + sdkPath)
+                logger.log(logLevel, logPrefix + 'rmdir -r ' + sdkPath)
 
                 if not args.dry_run:
                     shutil.rmtree(sdkPath)
 
             if os.path.isdir(resultsPath):
-                getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'rmdir -r ' + resultsPath)
+                logger.log(logLevel, logPrefix + 'rmdir -r ' + resultsPath)
 
                 if not args.dry_run:
                     shutil.rmtree(resultsPath)
@@ -129,19 +131,19 @@ def __main(args: list) -> int:
         if args.bdn_arguments:
             benchmarkArgs += ['--bdn-arguments', args.bdn_arguments]
 
-        getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
+        logger.log(logLevel, logPrefix + 'Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
 
         if not args.dry_run:
             try:
                 benchmarks_ci.__main(benchmarkArgs)
             except CalledProcessError:
-                getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure')
+                logger.log(logLevel, logPrefix + 'benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure')
                 # don't rethrow if some results were produced, as we want to create the tar file with results anyway
                 if not os.path.isdir(resultsPath):
                     raise
 
-        getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'Results were created in the following folder:')
-        getLogger().log(getLogger().getEffectiveLevel(), logPrefix + '  ' + resultsPath)
+        logger.log(logLevel, logPrefix + 'Results were created in the following folder:')
+        logger.log(logLevel, logPrefix + '  ' + resultsPath)
 
         timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M')
 
@@ -157,8 +159,8 @@ def __main(args: list) -> int:
             resultsTar.add(resultsPath, arcname=resultsName)
             resultsTar.close()
 
-        getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'Results were collected into the following tar archive:')
-        getLogger().log(getLogger().getEffectiveLevel(), logPrefix + '  ' + resultsTarPath)
+        logger.log(logLevel, logPrefix + 'Results were collected into the following tar archive:')
+        logger.log(logLevel, logPrefix + '  ' + resultsTarPath)
 
 if __name__ == '__main__':
     __main(sys.argv[1:])

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -140,7 +140,7 @@ def __main(args: list) -> int:
             try:
                 benchmarks_ci.__main(benchmarkArgs)
             except CalledProcessError:
-                logger.log(logLevel, logPrefix + 'benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure')
+                log('benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure')
                 # don't rethrow if some results were produced, as we want to create the tar file with results anyway
                 if not os.path.isdir(resultsPath):
                     raise

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -99,7 +99,7 @@ def __main(args: list) -> int:
 
     logPrefix = ''
     logger = getLogger()
-    logLevel = getLogger().getEffectiveLevel()
+    logLevel = logger.getEffectiveLevel()
 
     def log(text: str):
         logger.log(logLevel, logPrefix + text)

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -101,6 +101,9 @@ def __main(args: list) -> int:
     logger = getLogger()
     logLevel = getLogger().getEffectiveLevel()
 
+    def log(text: str):
+        logger.log(logLevel, logPrefix + text)
+
     if args.dry_run:
         logPrefix = '[DRY RUN] '
 
@@ -112,13 +115,13 @@ def __main(args: list) -> int:
             # Delete any preexisting SDK and results, which allows
             # multiple versions to be run from a single command
             if os.path.isdir(sdkPath):
-                logger.log(logLevel, logPrefix + 'rmdir -r ' + sdkPath)
+                log('rmdir -r ' + sdkPath)
 
                 if not args.dry_run:
                     shutil.rmtree(sdkPath)
 
             if os.path.isdir(resultsPath):
-                logger.log(logLevel, logPrefix + 'rmdir -r ' + resultsPath)
+                log('rmdir -r ' + resultsPath)
 
                 if not args.dry_run:
                     shutil.rmtree(resultsPath)
@@ -131,7 +134,7 @@ def __main(args: list) -> int:
         if args.bdn_arguments:
             benchmarkArgs += ['--bdn-arguments', args.bdn_arguments]
 
-        logger.log(logLevel, logPrefix + 'Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
+        log('Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
 
         if not args.dry_run:
             try:
@@ -142,8 +145,8 @@ def __main(args: list) -> int:
                 if not os.path.isdir(resultsPath):
                     raise
 
-        logger.log(logLevel, logPrefix + 'Results were created in the following folder:')
-        logger.log(logLevel, logPrefix + '  ' + resultsPath)
+        log('Results were created in the following folder:')
+        log('  ' + resultsPath)
 
         timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M')
 
@@ -159,8 +162,8 @@ def __main(args: list) -> int:
             resultsTar.add(resultsPath, arcname=resultsName)
             resultsTar.close()
 
-        logger.log(logLevel, logPrefix + 'Results were collected into the following tar archive:')
-        logger.log(logLevel, logPrefix + '  ' + resultsTarPath)
+        log('Results were collected into the following tar archive:')
+        log('  ' + resultsTarPath)
 
 if __name__ == '__main__':
     __main(sys.argv[1:])

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -10,6 +10,7 @@ from performance.logger import setup_loggers
 from argparse import ArgumentParser, ArgumentTypeError
 from datetime import datetime
 from logging import getLogger
+from subprocess import CalledProcessError
 
 import benchmarks_ci
 import tarfile
@@ -131,7 +132,13 @@ def __main(args: list) -> int:
         getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
 
         if not args.dry_run:
-            benchmarks_ci.__main(benchmarkArgs)
+            try:
+                benchmarks_ci.__main(benchmarkArgs)
+            except CalledProcessError:
+                getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure')
+                # don't rethrow if some results were produced, as we want to create the tar file with results anyway
+                if not os.path.isdir(resultsPath):
+                    raise
 
         getLogger().log(getLogger().getEffectiveLevel(), logPrefix + 'Results were created in the following folder:')
         getLogger().log(getLogger().getEffectiveLevel(), logPrefix + '  ' + resultsPath)


### PR DESCRIPTION
fixes #2308

```log
[2022/03/16 16:11:06][INFO] Global total time: 00:00:47 (47.29 sec), executed benchmarks: 4
[2022/03/16 16:11:06][INFO] // * Artifacts cleanup *
[2022/03/16 16:11:06][INFO] $ popd
[2022/03/16 16:11:06][ERROR] Process exited with status 1
[2022/03/16 16:11:06][INFO] Run failure registered
[2022/03/16 16:11:06][INFO] benchmarks_ci exited with non zero exit code, please check the log and report benchmark failure
[2022/03/16 16:11:06][INFO] Results were created in the following folder:
[2022/03/16 16:11:06][INFO]   .\artifacts\bin\MicroBenchmarks\Release\net6.0\BenchmarkDotNet.Artifacts\results
[2022/03/16 16:11:06][INFO] Results were collected into the following tar archive:
[2022/03/16 16:11:06][INFO]   .\artifacts\2022-03-16-16-11-net6.0.tar.gz
```