### PR TITLE
Fixes for wasm builds

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -108,6 +108,21 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Product repository.'
     )
 
+    def __is_valid_dotnet_path(dp: str) -> str:
+        if not os.path.isdir(dp):
+            raise ArgumentTypeError('Path {} does not exist'.format(dp))
+        if not os.path.isfile(os.path.join(dp, 'dotnet')):
+            raise ArgumentTypeError('Could not find dotnet in {}'.format(dp))
+        return dp
+
+    parser.add_argument(
+        '--dotnet-path',
+        dest='dotnet_path',
+        required=False,
+        type=__is_valid_dotnet_path,
+        help='Path to a custom dotnet'
+    )
+
     def __is_valid_datetime(dt: str) -> str:
         try:
             datetime.strptime(dt, '%Y-%m-%dT%H:%M:%SZ')
@@ -193,12 +208,15 @@ def __main(args: list) -> int:
         .FrameworkAction \
         .get_target_framework_monikers(args.frameworks)
     # Acquire necessary tools (dotnet)
-    init_tools(
-        architecture=args.architecture,
-        dotnet_versions=args.dotnet_versions,
-        target_framework_monikers=target_framework_monikers,
-        verbose=verbose
-    )
+    if not args.dotnet_path:
+        init_tools(
+            architecture=args.architecture,
+            dotnet_versions=args.dotnet_versions,
+            target_framework_monikers=target_framework_monikers,
+            verbose=verbose
+        )
+    else:
+        dotnet.setup_dotnet(args.dotnet_path)
 
     # WORKAROUND
     # The MicroBenchmarks.csproj targets .NET Core 2.1, 3.0, 3.1 and 5.0

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -780,20 +780,22 @@ def install(
                 get_repo_root_path()
             )
 
+    setup_dotnet(install_dir)
+
+def setup_dotnet(dotnet_path: str):
     # Set DotNet Cli environment variables.
     environ['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
     environ['DOTNET_MULTILEVEL_LOOKUP'] = '0'
     environ['UseSharedCompilation'] = 'false'
-    environ['DOTNET_ROOT'] = install_dir
+    environ['DOTNET_ROOT'] = dotnet_path
 
     # Add installed dotnet cli to PATH
-    environ["PATH"] = install_dir + pathsep + environ["PATH"]
+    environ["PATH"] = dotnet_path + pathsep + environ["PATH"]
 
     # If we have copied dotnet from a different machine, then it may not be
     # marked as executable. Fix this.
     if platform != 'win32':
-        chmod(path.join(install_dir, 'dotnet'), S_IRWXU)
-
+        chmod(path.join(dotnet_path, 'dotnet'), S_IRWXU)
 
 def __add_arguments(parser: ArgumentParser) -> ArgumentParser:
     '''

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -1,6 +1,11 @@
 <Project>
   <PropertyGroup>
-    <WasmBuildOnlyAfterPublish Condition="'$(RunAOTCompilation)' == 'true'">false</WasmBuildOnlyAfterPublish>
+    <!-- Skip the first build -->
+    <WasmBuildOnlyAfterPublish>true</WasmBuildOnlyAfterPublish>
+
+    <!-- this will fail the build if the emcc versions don't match -->
+    <_WasmStrictVersionMatch>true</_WasmStrictVersionMatch>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <Target Name="ExtraPrepareForWasmBuild" AfterTargets="PrepareForWasmBuild">

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -9,4 +9,8 @@
       <WasmFilesToIncludeInFileSystem Include="@(_LibrariesFile)" TargetPath="libraries\%(RecursiveDir)%(FileName)%(Extension)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="Validate" BeforeTargets="Build">
+    <Error Text="Cannot find WasmMainJSPath: $(WasmMainJSPath)" Condition="'$(WasmMainJSPath)' == '' or !Exists('$(WasmMainJSPath)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
`Add --dotnet-path to the ci scripts`

For wasm builds, we use a custom dotnet populated with the bits from a
`runtime` build. And this is passed to bdn via `--cli` argument.

The project is built by `benchmarks_ci.py` first, and then run, which
then builds the project again via BDN, using the dotnet from the
`--cli` argument.

But this means that the project gets built with the "default" dotnet
first, and then the custom one next, which can result in a corrupted
build. Using `--dotnet-path`, same as `--cli` avoids this.