### PR TITLE
don't run AXV benchmarks on ARM* (not supported)

### DIFF
--- a/src/benchmarks/micro/runtime/BilinearInterpol/BilinearInterpol.cs
+++ b/src/benchmarks/micro/runtime/BilinearInterpol/BilinearInterpol.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 // HW Intrinsic APIs are available only in .NET Core 3.0+
 #if !NETFRAMEWORK
@@ -312,6 +313,7 @@ public class BilinearTest
 #if !NETFRAMEWORK
     [BenchmarkCategory(Categories.Runtime)]
     [Benchmark]
+    [OperatingSystemsArchitectureFilter(allowed: true, Architecture.X64, Architecture.X86)]
     public double[] Interpol_AVX()
     {
         if (Avx2.IsSupported)


### PR DESCRIPTION
While looking at the Preview2 results I've realized that we execute this benchmark on ARM architectures which don't support AVX and report time close to zero. 

## BilinearTest.Interpol_AVX

| Result |     Base |    Diff | Ratio    | Bit   |
| ------ | --------:| -------:| -------- | ----- |
| Same   |  3401.21 | 3358.70 | 1.01     | X64   |
| Same   |  2169.49 | 2189.33 | 0.99     | X64   |
| Faster | 16859.11 | 6716.95 | 2.51     | X64   |
| Same   |     0.01 |    0.00 | Infinity | X64   |
| Same   |  2158.82 | 2175.17 | 0.99     | X64   |
| Same   |  2619.84 | 2636.92 | 0.99     | X64   |
| Same   |  3695.94 | 3402.26 | 1.09     | X64   |
| Same   |  2416.75 | 2370.45 | 1.02     | X64   |
| Same   |  2384.20 | 2486.15 | 0.96     | X64   |
| Same   |  3555.76 | 3650.63 | 0.97     | X64   |
| Same   |     0.41 |    0.25 | 1.65     | X64   |
| Same   |  3269.63 | 3064.97 | 1.07     | X64   |
| Same   |  2399.89 | 2388.55 | 1.00     | X64   |
| Same   |  2417.38 | 2355.47 | 1.03     | X64   |
| Same   |     0.01 |    0.00 | Infinity | Arm64 |
| Same   |     0.00 |    0.34 | 0.01     | Arm64 |
| Same   |     0.00 |    0.36 | 0.00     | Arm64 |
| Same   |  3943.60 | 3730.95 | 1.06     | X86   |
| Slower |  4246.34 | 9404.60 | 0.45     | X86   |
| Same   |  3480.71 | 3259.69 | 1.07     | X86   |
| Same   |     0.00 |    0.01 | 0.00     | X86   |
| Same   |     0.78 |    0.16 | 4.73     | Arm   |
| Same   |  7559.47 | 7068.27 | 1.07     | X64   |
| Slower |  5083.63 | 9262.89 | 0.55     | X64   |
| Slower |  3971.01 | 7127.62 | 0.56     | X64   |

The two rows with 0 reported for other architectures are from results provided by Dan where he disabled AVX on purpose