### PR TITLE
Add Perf_Guid::EqualsNotSame benchmark

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
@@ -10,7 +10,7 @@ namespace System.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_Guid
     {
-        const string guid1Str = "a8a110d5-fc49-43c5-bf46-802db8f843ff";
+        const string guidStr = "a8a110d5-fc49-43c5-bf46-802db8f843ff";
         const string guid2Str = "86A96B5D-F9B2-4CB5-B531-FC7021FA99D7";
         
         private readonly Guid _guid;

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
@@ -15,6 +15,7 @@ namespace System.Tests
         
         private readonly Guid _guid;
         private readonly Guid _same;
+        private readonly Guid _guid2;
         private readonly byte[] _buffer;
 
         public Perf_Guid()

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Guid.cs
@@ -10,7 +10,8 @@ namespace System.Tests
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_Guid
     {
-        const string guidStr = "a8a110d5-fc49-43c5-bf46-802db8f843ff";
+        const string guid1Str = "a8a110d5-fc49-43c5-bf46-802db8f843ff";
+        const string guid2Str = "86A96B5D-F9B2-4CB5-B531-FC7021FA99D7";
         
         private readonly Guid _guid;
         private readonly Guid _same;
@@ -20,6 +21,7 @@ namespace System.Tests
         {
             _guid = new Guid(guidStr);
             _same = new Guid(guidStr);
+            _guid2 = new Guid(guid2Str);
             _buffer = _guid.ToByteArray();
         }
 
@@ -34,6 +36,9 @@ namespace System.Tests
 
         [Benchmark]
         public bool EqualsSame() => _guid.Equals(_same);
+
+        [Benchmark]
+        public bool EqualsNotSame() => _guid.Equals(_guid2);
 
         [Benchmark]
         public bool EqualsOperator() => _guid == _same;


### PR DESCRIPTION
I noticed that we don't have a benchmark for a fairly common case - when we compare two unequal guids

For reference https://github.com/dotnet/runtime/pull/66889