### PR TITLE
micro_benchmarks.py: Run the project from an isolated directory

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -39,6 +39,13 @@ def info(verbose: bool) -> None:
     cmdline = ['dotnet', '--info']
     RunCommand(cmdline, verbose=verbose).run()
 
+def exec(working_dir: str, verbose: bool, *args) -> None:
+    """
+    Executes `dotnet exec` which can be used to execute assemblies
+    """
+    cmdline = ['dotnet', 'exec']
+    cmdline += list(args)
+    RunCommand(cmdline, verbose=verbose).run(working_dir)
 
 def __log_script_header(message: str):
     message_length = len(message)


### PR DESCRIPTION
Problem:

When running `MicroBenchmarks.csproj` for wasm, the build does:

1. `dotnet restore /Users/radical/dev/performance/src/benchmarks/micro/MicroBenchmarks.csproj ...`
2. `dotnet build /Users/radical/dev/performance/src/benchmarks/micro/MicroBenchmarks.csproj ...`
   - which emits to `./artifacts/{obj, bin}/MicroBenchmarks/`
3. `dotnet run --project /Users/radical/dev/performance/src/benchmarks/micro/MicroBenchmarks.csproj`
   - and this runs from the artifacts dir

Then the running `MicroBenchmarks` tries to build the same project as a project reference from a generated wrapper project:

4. `// start dotnet restore`; `// start dotnet build ..`
   - And this emits warnings, and then errors:
```
warning MSB3026: Could not copy "/Users/radical/dev/performance/artifacts/obj/MicroBenchmarks/Release/net7.0/MicroBenchmarks.pdb" to "/Users/radical/dev/performance/artifacts/bin/MicroBenchmarks/Release/net7.0/MicroBenchmarks.pdb". Beginning retry 1 in 1000ms. The process cannot access the file '/Users/radical/dev/performance/artifacts/bin/MicroBenchmarks/Release/net7.0/MicroBenchmarks.pdb' because it is being used by another process.
```

- This is because the project is running from the same directory, as
  what the build in (4) tries to work with, which causes the build
  failure. If I use a different directory for (4), then there are no
  errors.

This fails the build. But BDN ignores that, and runs the build again
with `--no-dependencies`, which then skips the build of
`MicroBenchmarks.csproj`, and just builds the wrapper project, thus
succeeding.

Solution:

This commit prevents this by copying the build output to a separate
directory, and running it from there.

Fixes https://github.com/dotnet/performance/issues/2327


