### PR TITLE
[mauiandroid] move location of 10 second delay

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -495,6 +495,8 @@ ex: C:\repos\performance;C:\repos\runtime
             testRunStats = re.findall(runSplitRegex, testRun.stdout) # Split results saving value (List: Starting, Status, LaunchState, Activity, TotalTime, WaitTime) 
             getLogger().info(f"Test run activity: {testRunStats[3]}")
 
+            time.sleep(10) # Add delay to ensure app is fully installed and give it some time to settle
+
             stopAppCmd = [ 
                 adb.stdout.strip(),
                 'shell',
@@ -527,8 +529,6 @@ ex: C:\repos\performance;C:\repos\runtime
                 if "com.google.android.permissioncontroller" in testRunStats[3]:
                     getLogger().exception("Failed to get past permission screen, run locally to see if enough next button presses were used.")
                     exit(-1)
-
-            time.sleep(10) # Add delay to ensure app is fully installed and give it some time to settle
 
             allResults = []
             for i in range(self.startupiterations):


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/maui-profiling/blob/a2d469b1394941376a0cc0dcad557e5cefa5a24c/scripts/profile.ps1

Comparing the times I get from my `profile.ps1` script:

    dotnet new maui: Average(ms): 550.7
    .NET Podcast:    Average(ms): 832.5

To the python script in this repo:

    > python test.py devicestartup --device-type android --package-path MauiAndroidDefault.apk --package-name com.companyname.mauitesting
    ...
    [2022/03/29 16:20:02][INFO] Metric |Average |Min |Max
    [2022/03/29 16:20:02][INFO] ----------------|---------------|---------------|---------------
    [2022/03/29 16:20:02][INFO] Generic Startup |569.600 ms |559.000 ms |577.000 ms
    > python test.py devicestartup --device-type android --package-path MauiAndroidPodcast.apk --package-name com.Microsoft.NetConf2021.Maui
    ...
    [2022/03/29 16:26:14][INFO] Metric |Average |Min |Max
    [2022/03/29 16:26:14][INFO] ----------------|---------------|---------------|---------------
    [2022/03/29 16:26:14][INFO] Generic Startup |856.100 ms |844.000 ms |876.000 ms

Using the exact `.apk` files from a build:

https://dev.azure.com/dnceng/internal/_build/results?buildId=1688708&view=results

There appeared to be 20-40ms *missing*. We've been trying to figure
out this mystery for a bit.

After watching the python script run, I noticed the app is launched
for the first time, killed immediately, then the initial 10-second
delay occurs. That is different that the powershell script, which
actually leaves the app on screen for 10 seconds.

Moving the location of the delay seems to result in more appropriate
times:

    [2022/03/29 21:48:03][INFO] Metric          |Average        |Min            |Max
    [2022/03/29 21:48:03][INFO] ----------------|---------------|---------------|---------------
    [2022/03/29 21:48:03][INFO] Generic Startup |836.800 ms     |820.000 ms     |889.000 ms
    ...
    [2022/03/29 21:49:15][INFO] Metric          |Average        |Min            |Max
    [2022/03/29 21:49:15][INFO] ----------------|---------------|---------------|---------------
    [2022/03/29 21:49:15][INFO] Generic Startup |825.800 ms     |812.000 ms     |842.000 ms

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


