### PR TITLE
remove setting /p:TrimmerDefaultAction=link as it's not needed anymore

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -42,7 +42,6 @@ namespace BenchmarkDotNet.Extensions
                 {
                     new MsBuildArgument("/p:DebugType=portable"), // See https://github.com/dotnet/roslyn/issues/42393
                     new MsBuildArgument("-bl:benchmarkdotnet.binlog"), // for diagnosing CI failures
-                    new MsBuildArgument("/p:TrimmerDefaultAction=link"), // to ensure that trimmer only analyzes the parts of the dependencies that are used
                 });
             }
 


### PR DESCRIPTION
it's now set by NativeAOT toolchain itself (https://github.com/dotnet/BenchmarkDotNet/pull/1972) and in theory it could also affect Mono AOT benchmarks