### PR TITLE
Update skip labels for certain tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -193,7 +193,7 @@ namespace System.Text.RegularExpressions.Tests
     }
 
     /// <summary>Performance tests adapted from https://rust-leipzig.github.io/regex/2017/03/28/comparison-of-regex-engines/</summary>
-    [BenchmarkCategory(Categories.Libraries, Categories.Regex, Categories.NoWASM)]
+    [BenchmarkCategory(Categories.Libraries, Categories.Regex, Categories.NoWASM, Categories.NoInterpreter)]
     [SkipTooManyTestCasesValidator]
     public class Perf_Regex_Industry_Leipzig
     {

--- a/src/benchmarks/micro/runtime/BenchmarksGame/mandelbrot-7.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/mandelbrot-7.cs
@@ -29,7 +29,7 @@ using MicroBenchmarks;
 
 namespace BenchmarksGame
 {
-    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame, Categories.JIT)]
+    [BenchmarkCategory(Categories.Runtime, Categories.BenchmarksGame, Categories.JIT, Categories.NoAOT)]
     public class MandelBrot_7
     {
         // Vector<double>.Count is treated as a constant by the JIT, don't bother

--- a/src/benchmarks/micro/runtime/Burgers/Burgers.cs
+++ b/src/benchmarks/micro/runtime/Burgers/Burgers.cs
@@ -192,7 +192,7 @@ public class Burgers
     public double[] Test2() => GetCalculated2(nt, nx, dx, dt, nu, initial);
 
     [Benchmark(Description = "Burgers_3")]
-    [BenchmarkCategory(Categories.NoInterpreter)]
+    [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
     public double[] Test3() => GetCalculated3(nt * 2, nx, dx, dt, nu, initial);
 }
 

--- a/src/benchmarks/micro/runtime/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/benchmarks/micro/runtime/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -54,30 +54,30 @@ namespace SIMD
         public void ScalarFloatSinglethreadRaw() => XBench(10, 0);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void ScalarFloatSinglethreadADT() => XBench(10, 1);
 
         [Benchmark]
         public void ScalarDoubleSinglethreadRaw() => XBench(10, 4);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void ScalarDoubleSinglethreadADT() => XBench(10, 5);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void VectorFloatSinglethreadRaw() => XBench(10, 16);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void VectorFloatSinglethreadADT() => XBench(10, 17);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void VectorDoubleSinglethreadRaw() => XBench(10, 20);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
         public void VectorDoubleSinglethreadADT() => XBench(10, 21);
     }
 }


### PR DESCRIPTION
These tests are taking over 600 seconds to complete one operation. This is
causing the entire job to timeout and fail. Removing these tests from
rotation until we figure out what is going on.


