### PR TITLE
Multiple improvements, to help with blazor scenarios

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -161,6 +161,15 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Directory to install dotnet to'
     )
 
+    parser.add_argument(
+        '--not-in-lab',
+        dest='in_lab',
+        required=False,
+        action='store_false',
+        default=True,
+        help='Indicates that this is not running in perflab'
+    )
+
     def __is_valid_dotnet_path(dp: str) -> str:
         if not os.path.isdir(dp):
             raise ArgumentTypeError('Path {} does not exist'.format(dp))
@@ -304,7 +313,7 @@ def __main(args: list) -> int:
         with open(args.output_file, 'w') as out_file:
             out_file.write(which)
             out_file.write(pgo_config)
-            out_file.write(variable_format % ('PERFLAB_INLAB', '1'))
+            out_file.write(variable_format % ('PERFLAB_INLAB', '1' if args.in_lab else '0'))
             out_file.write(variable_format % ('PERFLAB_REPO', '/'.join([owner, repo])))
             out_file.write(variable_format % ('PERFLAB_BRANCH', branch))
             out_file.write(variable_format % ('PERFLAB_PERFHASH', perfHash))
@@ -324,8 +333,6 @@ def __main(args: list) -> int:
             out_file.write(variable_format % ('MAUI_VERSION', args.maui_version))
             out_file.write(path_variable % dotnet_path)
             out_file.write(showenv)
-            
-
     else:
         with open(args.output_file, 'w') as out_file:
             out_file.write(variable_format % ('PERFLAB_INLAB', '0'))

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -297,6 +297,9 @@ def __main(args: list) -> int:
         branch = ChannelMap.get_branch(args.channel) if not args.branch else args.branch
 
         getLogger().info("Writing script to %s" % args.output_file)
+        dir_path = os.path.dirname(args.output_file)
+        if not os.path.isdir(dir_path):
+            os.mkdir(dir_path)
 
         with open(args.output_file, 'w') as out_file:
             out_file.write(which)

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -163,10 +163,10 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
 
     parser.add_argument(
         '--not-in-lab',
-        dest='in_lab',
+        dest='not_in_lab',
         required=False,
-        action='store_false',
-        default=True,
+        action='store_true',
+        default=False,
         help='Indicates that this is not running in perflab'
     )
 
@@ -313,7 +313,7 @@ def __main(args: list) -> int:
         with open(args.output_file, 'w') as out_file:
             out_file.write(which)
             out_file.write(pgo_config)
-            out_file.write(variable_format % ('PERFLAB_INLAB', '1' if args.in_lab else '0'))
+            out_file.write(variable_format % ('PERFLAB_INLAB', '0' if args.not_in_lab else '1'))
             out_file.write(variable_format % ('PERFLAB_REPO', '/'.join([owner, repo])))
             out_file.write(variable_format % ('PERFLAB_BRANCH', branch))
             out_file.write(variable_format % ('PERFLAB_PERFHASH', perfHash))

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -88,7 +88,7 @@ def helixuploadroot():
     return environ.get('HELIX_WORKITEM_UPLOAD_ROOT')
 
 def runninginlab():
-    return environ.get('PERFLAB_INLAB') is not None
+    return environ.get('PERFLAB_INLAB') == '1'
 
 def get_script_path() -> str:
     '''Gets this script directory.'''

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -8,6 +8,11 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
+  <ItemGroup>
+    <_AOT_InternalForceInterpretAssemblies Include="Microsoft.CodeAnalysis.CSharp.dll" />
+    <_AOT_InternalForceInterpretAssemblies Include="Microsoft.CodeAnalysis.dll" />
+  </ItemGroup>
+
   <Target Name="ExtraPrepareForWasmBuild" AfterTargets="PrepareForWasmBuild">
     <ItemGroup>
       <_LibrariesFile Include="$(TargetDir)publish\libraries\**\*" />

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -40,8 +40,7 @@ namespace BenchmarkDotNet.Extensions
 
                 job = job.WithArguments(new Argument[]
                 {
-                    new MsBuildArgument("/p:DebugType=portable"), // See https://github.com/dotnet/roslyn/issues/42393
-                    new MsBuildArgument("-bl:benchmarkdotnet.binlog"), // for diagnosing CI failures
+                    new MsBuildArgument("/p:DebugType=portable") // See https://github.com/dotnet/roslyn/issues/42393
                 });
             }
 

--- a/src/scenarios/blazor/pre.py
+++ b/src/scenarios/blazor/pre.py
@@ -10,10 +10,15 @@ from test import EXENAME
 # For blazor3.2 the linker argument '--dump-dependencies' should be added statically to enable linker dump
 # For blazor5.0 the linker argument can be added to the command line as an msbuild property
 
-subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
-setup_loggers(True)
 precommands = PreCommands()
+
+if precommands.has_workload:
+    if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
+        subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
+    else:
+        subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
+
+setup_loggers(True)
 precommands.new(template='blazorwasm',
                 output_dir=const.APPDIR,
                 bin_dir=const.BINDIR,

--- a/src/scenarios/blazoraot/pre.py
+++ b/src/scenarios/blazoraot/pre.py
@@ -16,7 +16,9 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+
+if not precommands.has_workload:
+    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorminapp/pre.py
+++ b/src/scenarios/blazorminapp/pre.py
@@ -16,7 +16,8 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+if not precommands.has_workload:
+    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorminappaot/pre.py
+++ b/src/scenarios/blazorminappaot/pre.py
@@ -16,7 +16,8 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+if not precommands.has_workload:
+    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorpizza/pre.py
+++ b/src/scenarios/blazorpizza/pre.py
@@ -7,11 +7,14 @@ from shared import const
 from shared.precommands import PreCommands
 from test import EXENAME
 
-# For blazor3.2 the linker argument '--dump-dependencies' should be added statically to enable linker dump
-# For blazor5.0 the linker argument can be added to the command line as an msbuild property
-subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
 setup_loggers(True)
 precommands = PreCommands()
+# For blazor3.2 the linker argument '--dump-dependencies' should be added statically to enable linker dump
+# For blazor5.0 the linker argument can be added to the command line as an msbuild property
+if precommands.has_workload:
+    if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
+        subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
+    else:
+        subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
 precommands.existing("src", "BlazingPizza.sln")
 precommands.execute()

--- a/src/scenarios/blazorpizzaaot/pre.py
+++ b/src/scenarios/blazorpizzaaot/pre.py
@@ -12,7 +12,8 @@ from test import EXENAME
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing("src", "BlazingPizza.sln")
-subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+if not precommands.has_workload:
+    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
 f = open(os.path.join(os.getcwd(), "app", "BlazingPizza.Client", "BlazingPizza.Client.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -74,6 +74,7 @@ class PreCommands:
         print(self.msbuild)
         self.msbuildstatic = args.msbuildstatic
         self.binlog = args.binlog
+        self.has_workload = args.has_workload
 
         if self.operation == CROSSGEN:
             self.crossgen_arguments.parse_crossgen_args(args)
@@ -130,6 +131,11 @@ class PreCommands:
                             dest='binlog',
                             metavar='<file-name>.binlog',
                             help='flag to turn on binlog for build or publish; ex: <file-name>.binlog')
+        parser.add_argument('--has-workload',
+                            dest='has_workload',
+                            default=False,
+                            action='store_true',
+                            help='Indicates that the dotnet being used has workload already installed')
         parser.set_defaults(configuration=RELEASE)
 
     def existing(self, projectdir: str, projectfile: str):


### PR DESCRIPTION
1. improve blazor scenarios' `pre.py` scripts to install, or uninstall workloads only when needed
2. Skip AOT'ing assemblies which get oomkill'ed on CI while compiling with `emcc`
3. Add a new `--not-in-lab` param to help with supporting perf runs for public pull requests