### PR TITLE
prefix produced tar file name with architecture

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ pr:
     - src/benchmarks/real-world/JitBench/README.md
     - src/benchmarks/real-world/Microsoft.ML.Benchmarks/Input/README.md
     - src/tools/ResultsComparer/README.md
+    - scripts/benchmarks_monthly.py
     - README.md
 
 schedules:

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -176,6 +176,8 @@ def __main(args: list) -> int:
         else:
             resultsName = timestamp + '-' + versionName
 
+        resultsName = args.architecture + '-' + resultsName
+
         resultsTarPath = os.path.join(rootPath, 'artifacts', resultsName + '.tar.gz')
 
         if not args.dry_run:


### PR DESCRIPTION
It's useful to be able to determine the arch without needing to extract the files first.

Sample output:

```log
 Results were created in the following folder:                                      
   .\artifacts\bin\MicroBenchmarks\Release\net7.0\BenchmarkDotNet.Artifacts\results 
 Results were collected into the following tar archive:                             
   .\artifacts\x86-2022-04-04-09-57-net7.0-preview3.tar.gz                          
```