### PR TITLE
blazor_scenarios: Fix issues caused by `dotnet` being shared by all the workitems

### DIFF
--- a/src/scenarios/blazor/post.py
+++ b/src/scenarios/blazor/post.py
@@ -5,7 +5,7 @@ post cleanup script
 import zipfile
 from os import walk, environ
 from os.path import isfile, join
-from shared.postcommands import clean_directories
+import shared.postcommands
 from shared import const
 from performance.common import runninginlab
 from test import EXENAME
@@ -19,5 +19,6 @@ if runninginlab():
                 f.append(join(dirpath, name))
         for files in f:
             publish.write(files)
-        
-clean_directories()
+
+postcommands = PostCommands()
+postcommands.clean_directories()

--- a/src/scenarios/blazor/post.py
+++ b/src/scenarios/blazor/post.py
@@ -5,7 +5,7 @@ post cleanup script
 import zipfile
 from os import walk, environ
 from os.path import isfile, join
-import shared.postcommands
+from shared.postcommands import clean_directories
 from shared import const
 from performance.common import runninginlab
 from test import EXENAME
@@ -20,5 +20,4 @@ if runninginlab():
         for files in f:
             publish.write(files)
 
-postcommands = PostCommands()
-postcommands.clean_directories()
+clean_directories()

--- a/src/scenarios/blazor/pre.py
+++ b/src/scenarios/blazor/pre.py
@@ -12,11 +12,10 @@ from test import EXENAME
 
 precommands = PreCommands()
 
-if precommands.has_workload:
-    if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
-        subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
-    else:
-        subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
+if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
+    precommands.uninstall_workload("wasm-tools")
+else:
+    precommands.uninstall_workload("microsoft-net-sdk-blazorwebassembly-aot")
 
 setup_loggers(True)
 precommands.new(template='blazorwasm',

--- a/src/scenarios/blazor/pre.py
+++ b/src/scenarios/blazor/pre.py
@@ -23,4 +23,6 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-precommands.execute()
+# ensure that we don't use the workload, which would trigger native
+# relinking
+precommands.execute(['-p:WasmNativeWorkload=false'])

--- a/src/scenarios/blazoraot/post.py
+++ b/src/scenarios/blazoraot/post.py
@@ -2,9 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import PostCommands
+from shared.postcommands import PostCommands, clean_directories
 import subprocess
 
 postcommands = PostCommands()
-postcommands.clean_directories()
+clean_directories()
 postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazoraot/post.py
+++ b/src/scenarios/blazoraot/post.py
@@ -2,8 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import clean_directories
+from shared.postcommands import PostCommands
 import subprocess
 
-clean_directories()
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
+postcommands = PostCommands()
+postcommands.clean_directories()
+postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazoraot/pre.py
+++ b/src/scenarios/blazoraot/pre.py
@@ -17,8 +17,7 @@ precommands.new(template='blazorwasm',
                 exename=EXENAME,
                 working_directory=sys.path[0])
 
-if not precommands.has_workload:
-    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+precommands.install_workload('wasm-tools')
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorminapp/post.py
+++ b/src/scenarios/blazorminapp/post.py
@@ -2,9 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import PostCommands
+from shared.postcommands import PostCommands, clean_directories
 import subprocess
 
 postcommands = PostCommands()
-postcommands.clean_directories()
+clean_directories()
 postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorminapp/post.py
+++ b/src/scenarios/blazorminapp/post.py
@@ -2,8 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import clean_directories
+from shared.postcommands import PostCommands
 import subprocess
 
-clean_directories()
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
+postcommands = PostCommands()
+postcommands.clean_directories()
+postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorminapp/pre.py
+++ b/src/scenarios/blazorminapp/pre.py
@@ -17,6 +17,9 @@ precommands.new(template='blazorwasm',
                 exename=EXENAME,
                 working_directory=sys.path[0])
 
+# This project uses native relinking
+
+# We want to use native relinking which requires the workload
 precommands.install_workload('wasm-tools')
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
@@ -25,6 +28,10 @@ for line in f.readlines():
         outFileText += line
         outFileText += "    <BlazorEnableTimeZoneSupport>false</BlazorEnableTimeZoneSupport>" + os.linesep
         outFileText += "    <InvariantGlobalization>true</InvariantGlobalization>" + os.linesep
+        # this will trigger native relinking, and fail the build if the workload is not available
+        outFileText += "    <WasmBuildNative>true</WasmBuildNative>" + os.linesep
+        # skip unncessary relinking done after build
+        outFileText += "    <WasmBuildOnlyAfterPublish>true</WasmBuildOnlyAfterPublish>" + os.linesep
     else:
         outFileText += line
 f.close()

--- a/src/scenarios/blazorminapp/pre.py
+++ b/src/scenarios/blazorminapp/pre.py
@@ -16,8 +16,8 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-if not precommands.has_workload:
-    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+
+precommands.install_workload('wasm-tools')
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorminappaot/post.py
+++ b/src/scenarios/blazorminappaot/post.py
@@ -2,9 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import PostCommands
+from shared.postcommands import PostCommands, clean_directories
 import subprocess
 
 postcommands = PostCommands()
-postcommands.clean_directories()
+clean_directories()
 postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorminappaot/post.py
+++ b/src/scenarios/blazorminappaot/post.py
@@ -2,8 +2,9 @@
 post cleanup script
 '''
 
-from shared.postcommands import clean_directories
+from shared.postcommands import PostCommands
 import subprocess
 
-clean_directories()
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
+postcommands = PostCommands()
+postcommands.clean_directories()
+postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorminappaot/pre.py
+++ b/src/scenarios/blazorminappaot/pre.py
@@ -16,8 +16,8 @@ precommands.new(template='blazorwasm',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-if not precommands.has_workload:
-    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+
+precommands.install_workload('wasm-tools')
 f = open(os.path.join(os.getcwd(), "app", "emptyblazorwasmtemplate.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/blazorpizza/pre.py
+++ b/src/scenarios/blazorpizza/pre.py
@@ -11,10 +11,9 @@ setup_loggers(True)
 precommands = PreCommands()
 # For blazor3.2 the linker argument '--dump-dependencies' should be added statically to enable linker dump
 # For blazor5.0 the linker argument can be added to the command line as an msbuild property
-if precommands.has_workload:
-    if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
-        subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
-    else:
-        subprocess.run(["dotnet", "workload", "uninstall", "microsoft-net-sdk-blazorwebassembly-aot"])
+if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
+    precommands.uninstall_workload("wasm-tools")
+else:
+    precommands.uninstall_workload("microsoft-net-sdk-blazorwebassembly-aot")
 precommands.existing("src", "BlazingPizza.sln")
 precommands.execute()

--- a/src/scenarios/blazorpizza/pre.py
+++ b/src/scenarios/blazorpizza/pre.py
@@ -16,4 +16,5 @@ if precommands.framework == 'net6.0' or precommands.framework == 'net7.0':
 else:
     precommands.uninstall_workload("microsoft-net-sdk-blazorwebassembly-aot")
 precommands.existing("src", "BlazingPizza.sln")
-precommands.execute()
+# ensure that we don't use relinking
+precommands.execute(['-p:WasmNativeWorkload=false'])

--- a/src/scenarios/blazorpizzaaot/post.py
+++ b/src/scenarios/blazorpizzaaot/post.py
@@ -5,7 +5,7 @@ post cleanup script
 import zipfile
 from os import walk, environ
 from os.path import isfile, join
-from shared.postcommands import PostCommands
+from shared.postcommands import PostCommands, clean_directories
 from shared import const
 from performance.common import runninginlab
 from test import EXENAME
@@ -21,5 +21,5 @@ if runninginlab():
             publish.write(files)
 
 postcommands = PostCommands()
-postcommands.clean_directories()
+clean_directories()
 postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorpizzaaot/post.py
+++ b/src/scenarios/blazorpizzaaot/post.py
@@ -5,7 +5,7 @@ post cleanup script
 import zipfile
 from os import walk, environ
 from os.path import isfile, join
-from shared.postcommands import clean_directories
+from shared.postcommands import PostCommands
 from shared import const
 from performance.common import runninginlab
 from test import EXENAME
@@ -19,6 +19,7 @@ if runninginlab():
                 f.append(join(dirpath, name))
         for files in f:
             publish.write(files)
-        
-subprocess.run(["dotnet", "workload", "uninstall", "wasm-tools"])
-clean_directories()
+
+postcommands = PostCommands()
+postcommands.clean_directories()
+postcommands.uninstall_workload('wasm-tools')

--- a/src/scenarios/blazorpizzaaot/pre.py
+++ b/src/scenarios/blazorpizzaaot/pre.py
@@ -12,8 +12,8 @@ from test import EXENAME
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing("src", "BlazingPizza.sln")
-if not precommands.has_workload:
-    subprocess.run(["dotnet", "workload", "install", "wasm-tools", "--skip-manifest-update"])
+
+precommands.install_workload('wasm-tools')
 f = open(os.path.join(os.getcwd(), "app", "BlazingPizza.Client", "BlazingPizza.Client.csproj"), 'r')
 outFileText = ""
 for line in f.readlines():

--- a/src/scenarios/shared/postcommands.py
+++ b/src/scenarios/shared/postcommands.py
@@ -1,8 +1,31 @@
 from shared.const import APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR
 from performance.common import remove_directory
+from argparse import ArgumentParser
+import subprocess
 
-def clean_directories():
-    to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR, "emsdk")
-    print(f"Removing {','.join(to_remove)} if exist ...")
-    for dir in to_remove:
-        remove_directory(dir)
+class PostCommands:
+    '''
+    Handles any post run cleanup
+    '''
+
+    def __init__(self):
+        parser = ArgumentParser()
+
+        parser.add_argument('--readonly-dotnet',
+                            dest='readonly_dotnet',
+                            default=False,
+                            action='store_true',
+                            help='Indicates that the dotnet being used should not be modified (for example, when it is ahared with other builds)')
+
+        args = parser.parse_args()
+        self.readonly_dotnet = args.readonly_dotnet
+
+    def uninstall_workload(self, workloadid: str):
+        if not self.readonly_dotnet:
+            subprocess.run(["dotnet", "workload", "uninstall", workloadid])
+
+    def clean_directories(self):
+        to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR, "emsdk")
+        print(f"Removing {','.join(to_remove)} if exist ...")
+        for dir in to_remove:
+            remove_directory(dir)

--- a/src/scenarios/shared/postcommands.py
+++ b/src/scenarios/shared/postcommands.py
@@ -24,8 +24,8 @@ class PostCommands:
         if not self.readonly_dotnet:
             subprocess.run(["dotnet", "workload", "uninstall", workloadid])
 
-    def clean_directories(self):
-        to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR, "emsdk")
-        print(f"Removing {','.join(to_remove)} if exist ...")
-        for dir in to_remove:
-            remove_directory(dir)
+def clean_directories():
+    to_remove = (APPDIR, TMPDIR, TRACEDIR, PUBDIR, BINDIR, CROSSGENDIR, "emsdk")
+    print(f"Removing {','.join(to_remove)} if exist ...")
+    for dir in to_remove:
+        remove_directory(dir)

--- a/src/scenarios/shared/postcommands.py
+++ b/src/scenarios/shared/postcommands.py
@@ -13,7 +13,6 @@ class PostCommands:
 
         parser.add_argument('--readonly-dotnet',
                             dest='readonly_dotnet',
-                            default=False,
                             action='store_true',
                             help='Indicates that the dotnet being used should not be modified (for example, when it is ahared with other builds)')
 

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -158,7 +158,7 @@ class PreCommands:
             pass
         if self.operation == BUILD:
             self._restore()
-            self._build(configuration=self.configuration, framework=self.framework, args=build_args)
+            self._build(configuration=self.configuration, framework=self.framework, build_args=build_args)
         if self.operation == PUBLISH:
             self._restore()
             self._publish(configuration=self.configuration,

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -152,18 +152,18 @@ class PreCommands:
         self.project = CSharpProject(csproj, const.BINDIR)
         self._updateframework(csproj.file_name)
 
-    def execute(self):
+    def execute(self, build_args: list = []):
         'Parses args and runs precommands'
         if self.operation == DEFAULT:
             pass
         if self.operation == BUILD:
             self._restore()
-            self._build(configuration=self.configuration, framework=self.framework)
+            self._build(configuration=self.configuration, framework=self.framework, args=build_args)
         if self.operation == PUBLISH:
             self._restore()
             self._publish(configuration=self.configuration,
                           runtime_identifier=self.runtime_identifier,
-                          framework=self.framework)
+                          framework=self.framework, build_args=build_args)
         if self.operation == CROSSGEN:
             startup_args = [
                 os.path.join(self.crossgen_arguments.coreroot, 'crossgen%s' % extension()),
@@ -198,13 +198,15 @@ class PreCommands:
         insert_after(filepath, line, trace_statement)
 
     def install_workload(self, workloadid: str):
+        'Installs the workload, if needed'
         if not self.has_workload:
             if self.readonly_dotnet:
                 raise Exception('workload needed to build, but has_workload=false, and readonly_dotnet=true')
             subprocess.run(["dotnet", "workload", "install", workloadid, "--skip-manifest-update"])
 
     def uninstall_workload(self, workloadid: str):
-        if not self.readonly_dotnet:
+        'Uninstalls the workload, if possible'
+        if self.has_workload and not self.readonly_dotnet:
             subprocess.run(["dotnet", "workload", "uninstall", workloadid])
 
     def _addstaticmsbuildproperty(self, projectfile: str):
@@ -228,7 +230,7 @@ class PreCommands:
         if self.framework:
             replace_line(projectfile, r'<TargetFramework>.*?</TargetFramework>', f'<TargetFramework>{self.framework}</TargetFramework>')
 
-    def _publish(self, configuration: str, framework: str = None, runtime_identifier: str = None):
+    def _publish(self, configuration: str, framework: str = None, runtime_identifier: str = None, build_args: list = []):
         self.project.publish(configuration,
                              const.PUBDIR, 
                              True,
@@ -236,18 +238,20 @@ class PreCommands:
                              framework,
                              runtime_identifier,
                              self._parsemsbuildproperties(),
-                             '-bl:%s' % self.binlog if self.binlog else ""
+                             '-bl:%s' % self.binlog if self.binlog else "",
+                             *build_args
                              )
 
     def _restore(self):
         self.project.restore(packages_path=get_packages_directory(), verbose=True)
 
-    def _build(self, configuration: str, framework: str = None):
+    def _build(self, configuration: str, framework: str = None, build_args: list = []):
         self.project.build(configuration=configuration,
                                verbose=True,
                                packages_path=get_packages_directory(),
                                target_framework_monikers=[framework],
-                               output_to_bindir=True)
+                               output_to_bindir=True,
+                               *build_args)
 
     def _backup(self, projectdir:str):
         'Copy from projectdir to appdir so we do not modify the source code'


### PR DESCRIPTION
.. because of being in the helix correlation payload directory.

1. 
```
blazor_scenarios: Add new --readonly-dotnet arg to pre, and post
.. commands, when the dotnet installation is shared, and should not be
modified. Workload install/uninstall is one such modification.

This is useful for runtime runs, where the dotnet used already has the
workload installed, and is shared by all the work items via the helix
correlation payload, and thus should not be modified.
```

2. Some improvements to ensure that native relinking is used only when intended.