### PR TITLE
extend ResultsComparer with the possibility to decompress files produced by benchmarks_monthly.py

### DIFF
--- a/src/tools/ResultsComparer/Data.cs
+++ b/src/tools/ResultsComparer/Data.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using DataTransferContracts;
+using SharpCompress.Archives;
+using SharpCompress.Archives.GZip;
+using SharpCompress.Archives.Tar;
+using SharpCompress.Archives.Zip;
+using SharpCompress.Readers;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ResultsComparer
+{
+    internal static class Data
+    {
+        internal static void Decompress(FileInfo zip, DirectoryInfo output)
+        {
+            using Stream mainZipStream = zip.OpenRead();
+            using ZipArchive mainArchive = ZipArchive.Open(mainZipStream);
+            string folderPath;
+
+            foreach (ZipArchiveEntry mainArchiveEntry in mainArchive.Entries.Where(e => !e.IsDirectory))
+            {
+                folderPath = null;
+                using Stream zipArchiveEntryCopy = CreateCopy(mainArchiveEntry.OpenEntryStream());
+
+                if (mainArchiveEntry.Key.EndsWith(".zip")) // .zip files from interrupted runs, compressed manually by the contributors
+                {
+                    using ZipArchive zipArchive = ZipArchive.Open(zipArchiveEntryCopy);
+                    foreach (var zipEntry in zipArchive.Entries.Where(e => e.Key.EndsWith(".json")))
+                    {
+                        zipEntry.WriteToDirectory(folderPath ??= GetFolderPath(output, mainArchiveEntry.Key, zipEntry.Key, zipEntry));
+                    }
+                }
+                else if (mainArchiveEntry.Key.EndsWith(".tar.gz") // produced by benchmarks_monthly.py
+                    && !mainArchiveEntry.Key.Contains("SSE")) // temporary workaround (TODO: handle results for same config with different env vars)
+                {
+                    using GZipArchive gZipArchive = GZipArchive.Open(zipArchiveEntryCopy);
+                    using IReader extractedGzip = gZipArchive.ExtractAllEntries();
+                    while (extractedGzip.MoveToNextEntry())
+                    {
+                        if (!extractedGzip.Entry.IsDirectory)
+                        {
+                            using Stream tarCopy = CreateCopy(extractedGzip.OpenEntryStream());
+                            using TarArchive tarArchive = TarArchive.Open(tarCopy);
+                            foreach (var tarEntry in tarArchive.Entries.Where(e => e.Key.EndsWith(".json")))
+                            {
+                                tarEntry.WriteToDirectory(folderPath ??= GetFolderPath(output, mainArchiveEntry.Key, extractedGzip.Entry.Key, tarEntry));
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    Console.WriteLine($"{mainArchiveEntry.Key} was not recognized");
+                }
+            }
+        }
+
+        // most of the entry streams are non-seekable and it causes trouble, this is why we just create copies
+        private static Stream CreateCopy(Stream entryStream)
+        {
+            using (entryStream)
+            {
+                MemoryStream copy = new();
+                entryStream.CopyTo(copy);
+                copy.Position = 0;
+                return copy;
+            }
+        }
+
+        private static string GetFolderPath(DirectoryInfo output, string mainEntryKey, string currentEntryKey, IArchiveEntry archiveEntry)
+        {
+            using Stream jsonFileCopy = CreateCopy(archiveEntry.OpenEntryStream());
+            BdnResult bdnResult = Helper.ReadFromStream(jsonFileCopy);
+
+            string userName = mainEntryKey.Split('/')[2]; // sth like Performance-Runs/nativeaot6.0/adsitnik/arm64_win10-nativeaot6.0.tar.gz
+            string moniker = GetMoniker(currentEntryKey) ?? GetMoniker(mainEntryKey);
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(bdnResult.HostEnvironmentInfo.Architecture).Append('_');
+            sb.Append(Stats.GetSimplifiedOSName(bdnResult.HostEnvironmentInfo.OsVersion).Replace(" ", "")).Append('_');
+            sb.Append(GetSimplifiedProcessorName(bdnResult.HostEnvironmentInfo.ProcessorName).Replace(" ", "")).Append('_');
+            sb.Append(userName).Append('_');
+            sb.Append(moniker); // netX-previewY
+
+            string outputPath = Path.Combine(output.FullName, sb.ToString().ToLower());
+            Directory.CreateDirectory(outputPath);
+            return outputPath;
+        }
+
+        private static string GetMoniker(string key)
+        {
+            if (key.Contains("net6")) // some files are net6.0, some are missing the dot (net60)
+                return "net6.0";
+            if (key.Contains("nativeaot6"))
+                return "nativeaot6.0";
+            if (key.Contains("net7.0-preview"))
+                return "net7.0-preview" + key[key.IndexOf("net7.0-preview") + "net7.0-preview".Length];
+            if (key.Contains("nativeaot7.0-preview"))
+                return "nativeaot7.0-preview" + key[key.IndexOf("nativeaot7.0-preview") + "nativeaot7.0-preview".Length];
+
+            return null;
+        }
+
+        // This method is hacky and ugly. Don't use it anywhere else!!
+        // We could just get hash code of the processor name and be done with it,
+        // but then during actual investigation it would be harder to find the json files with original results.
+        private static string GetSimplifiedProcessorName(string processorName)
+        {
+            if (processorName.StartsWith("Unknown"))
+                return "unknown";
+
+            foreach (var segment in processorName.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (segment[0] == 'i' || segment[0] == 'E') // things like i7-8700 or E5530
+                    return segment.Replace("-", "");
+                if (segment.EndsWith("CL")
+                    || segment.EndsWith("X") // things like AMD 3945WX or 5900X 
+                    || segment.StartsWith("SQ") // things like SQ1
+                    || segment.StartsWith("M1")
+                    || segment.StartsWith("ARM")) // things like ARMv7
+                {
+                    return segment;
+                }
+            }
+
+            return processorName.Replace(" ", "");
+        }
+    }
+}

--- a/src/tools/ResultsComparer/Helper.cs
+++ b/src/tools/ResultsComparer/Helper.cs
@@ -51,5 +51,19 @@ namespace ResultsComparer
                 throw;
             }
         }
+
+        internal static BdnResult ReadFromStream(Stream stream)
+        {
+            try
+            {
+                return (BdnResult)new JsonSerializer().Deserialize(new StreamReader(stream), typeof(BdnResult));
+            }
+            catch (JsonSerializationException)
+            {
+                Console.WriteLine($"Exception while reading the JSON file.");
+
+                throw;
+            }
+        }
     }
 }

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -15,7 +15,7 @@ using System.Text.RegularExpressions;
 
 namespace ResultsComparer
 {
-    public class Program
+    public static class Program
     {
         public static int Main(string[] args)
         {
@@ -37,11 +37,9 @@ namespace ResultsComparer
             Option<bool> fullId = new Option<bool>(
                 new[] { "--full-id" }, "Display the full benchmark name id.");
 
-            threshold.IsRequired = true;
-
             RootCommand rootCommand = new RootCommand
             {
-                basePath, diffPath, threshold, noise, top, filters, fullId
+                basePath, diffPath, threshold.AsRequired(), noise, top, filters, fullId
             };
 
             rootCommand.SetHandler<string, string, string, string, int?, string[], bool>(
@@ -72,13 +70,9 @@ namespace ResultsComparer
             Option<bool> printStats = new Option<bool>(
                 new[] { "--stats" }, () => true, "Prints summary per Architecture, Namespace and Operating System.");
 
-            input.IsRequired = true;
-            basePattern.IsRequired = true;
-            diffPattern.IsRequired = true;
-
             Command matrixCommand = new Command("matrix", "Produces a matrix for all configurations found in given folder.")
             {
-                input, basePattern, diffPattern, threshold, noise, top, filters, printStats
+                input.AsRequired(), basePattern.AsRequired(), diffPattern.AsRequired(), threshold, noise, top, filters, printStats
             };
 
             rootCommand.AddCommand(matrixCommand);
@@ -163,5 +157,11 @@ namespace ResultsComparer
 
         // https://stackoverflow.com/a/6907849/5852046 not perfect but should work for all we need
         private static string WildcardToRegex(string pattern) => $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
+
+        private static Option AsRequired(this Option option)
+        {
+            option.IsRequired = true;
+            return option;
+        }
     }
 }

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -96,6 +96,20 @@ namespace ResultsComparer
                     }
                 }, input, basePattern, diffPattern, threshold, noise, top, filters, printStats);
 
+            Option<FileInfo> zip = new Option<FileInfo>(
+                new[] { "--input", "-i" }, "Path to the compressed .zip file that contains results downloaded from SharePoint.");
+            Option<DirectoryInfo> output = new Option<DirectoryInfo>(
+                new[] { "--output" }, "Pattern to the output folder where decompressed results should be stored");
+
+            Command decompressCommand = new Command("decompress", "Decompresses results from provided .zip file. Pre-configuration step for the matrix command.")
+            {
+                zip.AsRequired(), output.AsRequired()
+            };
+
+            decompressCommand.SetHandler<FileInfo, DirectoryInfo>(static (zip, output) => Data.Decompress(zip, output), zip, output);
+
+            matrixCommand.AddCommand(decompressCommand);
+
             return rootCommand.Invoke(args);
         }
 

--- a/src/tools/ResultsComparer/README.md
+++ b/src/tools/ResultsComparer/README.md
@@ -45,12 +45,13 @@ If there is no difference or if there is no match (we use full benchmark names t
 
 ## Matrix
 
-The tools supports also comparing multiple result sets. For up-to-date help please run `dotnet run -- matrix --help`
+The tools supports also comparing multiple result sets. For up-to-date help please run `dotnet run -- matrix --help`.
 
 Sample usage:
 
 ```cmd
-dotnet run -c Release matrix --input D:\results\p3_all\ --base net7.0-preview2 --diff net7.0-preview3 --threshold 10% --noise 2ns --filter System.IO*
+dotnet run -c Release matrix decompress --input D:\results\Performance-Runs.zip --output D:\results\net7.0-preview3
+dotnet run -c Release matrix --input D:\results\net7.0-preview3 --base net7.0-preview2 --diff net7.0-preview3 --threshold 10% --noise 2ns --filter System.IO*
 ```
 
 Sample results:

--- a/src/tools/ResultsComparer/ResultsComparer.csproj
+++ b/src/tools/ResultsComparer/ResultsComparer.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+    <PackageReference Include="SharpCompress" Version="0.31.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
All we need to do to get the right folder structure is to download a single zip file from SharePoint:

![image](https://user-images.githubusercontent.com/6011991/163163555-a221af39-f4e2-4424-bea9-c91b1097c44e.png)

and run the command.

Sample usage:

```cmd
dotnet run -c Release matrix decompress --input D:\results\Performance-Runs.zip --output D:\results\net7.0-preview3
```

The command decompresses everything and puts in the right folders.