### PR TITLE
Disable PerfFileStream while we wait for dotnet/runtime#67545 to be f…

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -13,6 +13,7 @@ using MicroBenchmarks;
 namespace System.IO.Tests
 {
     [BenchmarkCategory(Categories.Libraries)]
+    [OperatingSystemsFilter(allowed: true, OS.Windows)]
     public class Perf_FileStream
     {
         private const int OneKibibyte  = 1 << 10; // 1024


### PR DESCRIPTION
Disable PerfFileStream on Linux while we wait for dotnet/runtime#67545 to be fixed.

Should mitigate issue #2366


