### PR TITLE
ResultsComparer improvements

### DIFF
--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -10,8 +10,7 @@ namespace ResultsComparer
 {
     internal static class MultipleInputsComparer
     {
-        private static readonly string[] Headers = new[] { "Result", "Base", "Diff", "Ratio", "Alloc Delta", "Modality", "Operating System", "Bit", "Processor Name" };
-        private static readonly string[] HeadersNoModality = new[] { "Result", "Base", "Diff", "Ratio", "Alloc Delta", "Operating System", "Bit", "Processor Name" };
+        private static readonly string[] Headers = new[] { "Result", "Base", "Diff", "Ratio", "Alloc Delta", "Operating System", "Bit", "Processor Name", "Modality" };
 
         internal static void Compare(MultipleInputsOptions args)
         {
@@ -30,8 +29,6 @@ namespace ResultsComparer
             foreach (var benchmarkResults in args.BasePaths
                 .SelectMany((basePath, index) => GetResults(basePath, args.DiffPaths.ElementAt(index), args, stats))
                 .GroupBy(result => result.id, StringComparer.InvariantCulture)
-                //.Where(group => group.Any(result => result.conclusion == EquivalenceTestConclusion.Slower))
-                //.Where(group => !group.All(result => result.conclusion == EquivalenceTestConclusion.Same || result.conclusion == EquivalenceTestConclusion.Base)) // we are not interested in things that did not change
                 .Take(args.TopCount ?? int.MaxValue)
                 .OrderBy(group => group.Sum(result => Score(result.conclusion, result.baseEnv, result.baseResult, result.diffResult))))
             {
@@ -52,19 +49,14 @@ namespace ResultsComparer
                         DiffMedian = result.diffResult.Statistics.Median,
                         Ratio = GetRatio(result),
                         AllocatedDiff = GetAllocatedDiff(result.diffResult, result.baseResult),
-                        Modality = Helper.GetModalInfo(result.baseResult) ?? Helper.GetModalInfo(result.diffResult),
                         OperatingSystem = Stats.GetSimplifiedOSName(result.baseEnv.OsVersion),
                         Architecture = result.baseEnv.Architecture,
                         ProcessorName = result.baseEnv.ProcessorName,
+                        Modality = Helper.GetModalInfo(result.baseResult) ?? Helper.GetModalInfo(result.diffResult),
                     })
                     .ToArray();
 
-                bool displayModality = data.Any(row => row.Modality is not null);
-
-                Table table = displayModality 
-                    ? data.ToMarkdownTable()
-                    : data.ToMarkdownTable(i => i.Conclusion, i => i.BaseMedian.ToString("0.##"), i => i.DiffMedian.ToString("0.##"), i => i.Ratio.ToString("0.##"), i => i.AllocatedDiff, i => i.OperatingSystem, i => i.Architecture, i => i.ProcessorName);
-                table = table.WithHeaders(displayModality ? Headers : HeadersNoModality);
+                var table = data.ToMarkdownTable().WithHeaders(Headers);
 
                 foreach (var line in table.ToMarkdown().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
                     Console.WriteLine($"| {line.TrimStart()}|"); // the table starts with \t and does not end with '|' and it looks bad so we fix it

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -16,12 +16,10 @@ namespace ResultsComparer
             Console.WriteLine();
             Console.WriteLine($"* Statistical Test threshold: {args.StatisticalTestThreshold}, the noise filter: {args.NoiseThreshold}");
             Console.WriteLine("* Result is conslusion: Slower|Faster|Same");
-            Console.WriteLine("* Base is median base execution time in nanoseconds");
-            Console.WriteLine("* Diff is median diff execution time in nanoseconds");
+            Console.WriteLine($"* Base is median base execution time in nanoseconds for {args.BasePattern}");
+            Console.WriteLine($"* Diff is median diff execution time in nanoseconds {args.DiffPattern}");
             Console.WriteLine("* Ratio = Base/Diff (the higher the better)");
             Console.WriteLine("* Alloc Delta = Allocated bytes diff - Allocated bytes base (the lower the better)");
-            Console.WriteLine("* Base V = Base Runtime Version");
-            Console.WriteLine("* Diff V = Diff Runtime Version");
             Console.WriteLine();
 
             Stats stats = new Stats();
@@ -55,12 +53,10 @@ namespace ResultsComparer
                         OperatingSystem = Stats.GetSimplifiedOSName(result.baseEnv.OsVersion),
                         Architecture = result.baseEnv.Architecture,
                         ProcessorName = result.baseEnv.ProcessorName,
-                        BaseRuntimeVersion = GetSimplifiedRuntimeVersion(result.baseEnv.RuntimeVersion),
-                        DiffRuntimeVersion = GetSimplifiedRuntimeVersion(result.diffEnv.RuntimeVersion),
                     })
                     .ToArray();
 
-                var table = data.ToMarkdownTable().WithHeaders("Result", "Base", "Diff", "Ratio", "Alloc Delta", "Modality", "Operating System", "Bit", "Processor Name", "Base V", "Diff V");
+                var table = data.ToMarkdownTable().WithHeaders("Result", "Base", "Diff", "Ratio", "Alloc Delta", "Modality", "Operating System", "Bit", "Processor Name");
 
                 foreach (var line in table.ToMarkdown().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
                     Console.WriteLine($"| {line.TrimStart()}|"); // the table starts with \t and does not end with '|' and it looks bad so we fix it
@@ -196,23 +192,6 @@ namespace ResultsComparer
             else if (env.Architecture == "X86" && os == windows) return 8;
             else if (env.Architecture == "X64" && os == macos) return 9;
             else throw new NotSupportedException($"Config {env.Architecture} {env.OsVersion} was not recognized");
-        }
-
-        private static string GetSimplifiedRuntimeVersion(string text)
-        {
-            if (text.StartsWith(".NET Core 3", StringComparison.OrdinalIgnoreCase))
-            {
-                // it's something like ".NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603)"
-                // and what we care about is "3.1.6"
-                return text.Substring(".NET Core ".Length, "3.1.X".Length);
-            }
-            else
-            {
-                // it's something like ".NET 6.0.0 (6.0.21.35216)"
-                // and what we care about is "6.0.21.35216"
-                int index = text.IndexOf('(');
-                return text.Substring(index + 1, text.Length - index - 2);
-            }
         }
     }
 }

--- a/src/tools/ResultsComparer/MultipleInputsOptions.cs
+++ b/src/tools/ResultsComparer/MultipleInputsOptions.cs
@@ -9,6 +9,8 @@ namespace ResultsComparer
 {
     public class MultipleInputsOptions
     {
+        public string BasePattern { get; init; }
+        public string DiffPattern { get; init; }
         public string[] BasePaths { get; init; }
         public string[] DiffPaths { get; init; }
         public Threshold StatisticalTestThreshold { get; init; }

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -91,6 +91,8 @@ namespace ResultsComparer
                     {
                         MultipleInputsComparer.Compare(new MultipleInputsOptions
                         {
+                            BasePattern = basePattern,
+                            DiffPattern = diffPattern,
                             BasePaths = basePaths.ToArray(),
                             DiffPaths = diffPaths.ToArray(),
                             StatisticalTestThreshold = testThreshold,

--- a/src/tools/ResultsComparer/Stats.cs
+++ b/src/tools/ResultsComparer/Stats.cs
@@ -9,6 +9,7 @@ namespace ResultsComparer
 {
     internal class Stats
     {
+        internal const EquivalenceTestConclusion Noise = (EquivalenceTestConclusion)123;
         private readonly Dictionary<string, PerConclusion> perArchitecture = new();
         private readonly Dictionary<string, PerConclusion> perNamespace = new();
         private readonly Dictionary<string, PerConclusion> perOS = new();
@@ -62,11 +63,12 @@ namespace ResultsComparer
                     Same = ((double)pair.Value.Same / pair.Value.Total).ToString("P2"),
                     Slower = ((double)pair.Value.Slower / pair.Value.Total).ToString("P2"),
                     Faster = ((double)pair.Value.Faster / pair.Value.Total).ToString("P2"),
+                    Noise = ((double)pair.Value.Noise / pair.Value.Total).ToString("P2"),
                     Unknown = ((double)pair.Value.Unknown / pair.Value.Total).ToString("P2"),
                 })
                 .ToArray();
 
-                var table = data.ToMarkdownTable().WithHeaders(name, "Same", "Slower", "Faster", "Unknown");
+                var table = data.ToMarkdownTable().WithHeaders(name, "Same", "Slower", "Faster", "Noise", "Unknown");
 
                 foreach (var line in table.ToMarkdown().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
                     Console.WriteLine($"| {line.TrimStart()}|"); // the table starts with \t and does not end with '|' and it looks bad so we fix it
@@ -79,7 +81,7 @@ namespace ResultsComparer
 
         private class PerConclusion
         {
-            internal long Total, Faster, Slower, Same, Unknown;
+            internal long Total, Faster, Slower, Same, Unknown, Noise;
 
             internal void Update(EquivalenceTestConclusion conclusion)
             {
@@ -100,6 +102,9 @@ namespace ResultsComparer
                     case EquivalenceTestConclusion.Unknown:
                         Unknown++;
                         break;
+                    case Stats.Noise:
+                        Noise++;
+                        break;
                     default:
                         throw new NotSupportedException($"Invalid conclusion! {conclusion}");
                 }
@@ -113,6 +118,7 @@ namespace ResultsComparer
                 Console.WriteLine($"Same:    {(double)Same / Total:P2}");
                 Console.WriteLine($"Slower:  {(double)Slower / Total:P2}");
                 Console.WriteLine($"Faster:  {(double)Faster / Total:P2}");
+                Console.WriteLine($"Noise:   {(double)Noise / Total:P2}");
                 Console.WriteLine($"Unknown: {(double)Unknown / Total:P2}");
                 Console.WriteLine();
             }


### PR DESCRIPTION
* Updated ordering (arm64 is now more important than x64)
* Stop displaying base and diff runtime versions for each benchmark, print preview number in the Legend
* For results recognized as "Noise", display them as "Noise" (not "Same" like we did so far), and use `-` in the ratio column