### PR TITLE
[benchmarks_monthly.py] remove entire SDK folder when doing cleanup

### DIFF
--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -104,7 +104,7 @@ def __main(args: list) -> int:
 
     args = __process_arguments(args)
     rootPath = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
-    sdkPath = os.path.join(rootPath, 'tools', 'dotnet', args.architecture)
+    sdkPath = os.path.join(rootPath, 'tools', 'dotnet')
 
     logPrefix = ''
     logger = getLogger()


### PR DESCRIPTION
The issue was reported offline by @AndyAyersMS.

Repro:
* take arm64 machine, run benchmarks_monthly.py without specifying `--architecture arm64`
* script downloads x64 SDK and crashes
* re-run the script with `--architecture arm64`, it fails due to `./tools/dotnet/x64` containing things `./tools/dotnet/arm64` does not like ;)

The fix is to always remove entire SDK folder.


