### PR TITLE
use machine architecture as default SDK architecture

### DIFF
--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -6,6 +6,7 @@ for a .NET preview release, making it easier to contribute to our
 monthly manual performance runs.
 '''
 
+from performance.common import get_machine_architecture
 from performance.logger import setup_loggers
 from argparse import ArgumentParser, ArgumentTypeError
 from datetime import datetime
@@ -61,7 +62,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--architecture',
         dest='architecture',
         choices=['x64', 'x86', 'arm64', 'arm'],
-        default='x64',
+        default=get_machine_architecture(),
         help='Specifies the SDK processor architecture')
 
     parser.add_argument(

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 from time import sleep
 
+from performance.common import get_machine_architecture
 from performance.common import get_repo_root_path
 from performance.common import get_tools_directory
 from performance.common import push_dir
@@ -845,7 +846,7 @@ def __add_arguments(parser: ArgumentParser) -> ArgumentParser:
         raise TypeError('Invalid parser.')
 
     SUPPORTED_ARCHITECTURES = [
-        'x64',  # Default architecture
+        'x64',
         'x86',
         'arm',
         'arm64',
@@ -854,7 +855,7 @@ def __add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--architecture',
         dest='architecture',
         required=False,
-        default=SUPPORTED_ARCHITECTURES[0],
+        default=get_machine_architecture(),
         choices=SUPPORTED_ARCHITECTURES,
         help='Architecture of DotNet Cli binaries to be installed.'
     )

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -13,10 +13,25 @@ from subprocess import PIPE, DEVNULL
 from subprocess import Popen
 from subprocess import STDOUT
 from io import StringIO
+from platform import machine
 
 import os
 import sys
 
+
+def get_machine_architecture():
+    machineArch = machine().lower()
+    # values taken from https://stackoverflow.com/a/45125525/5852046
+    if machineArch == 'amd64' or machineArch == 'x86_64' or machineArch == 'x64':
+        return 'x64'
+    elif machineArch == 'arm64' or machineArch == 'aarch64' or machineArch == 'aarch64_be' or machineArch == 'armv8b' or machineArch == 'armv8l':
+        return 'arm64'
+    elif machineArch == 'arm32' or machineArch == 'aarch32' or machineArch == 'arm':
+        return 'arm'
+    elif machineArch == 'i386' or machineArch == 'i486' or machineArch == 'i686':
+        return 'x86'
+    else:
+        return 'x64' # Default architecture
 
 def iswin():
     return sys.platform == 'win32'


### PR DESCRIPTION
we can use [platform.machine()](https://docs.python.org/3/library/platform.html) to get default architecture and don't require the users to specify architectures other than `x64` (current default) in explicit way.

cc @AndyAyersMS 

Tested on:

- [x] Windows 10 arm64
- [x] Windows 11 AMD x64
- [x] Windows 10 Intel x64
- [x] Ubuntu 1804 Intel x64
- [x] macOS 12.2.1 x64
- [x] ubuntu 16.04 arm64
- [x] ubuntu 18.04 arm64