### PR TITLE
Support an argument to resume MicroBenchmarks from a previous run

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -173,12 +173,21 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Attempts to run the benchmarks without building.',
     )
     parser.add_argument(
+        '--resume',
+        dest='resume',
+        required=False,
+        default=False,
+        action='store_true',
+        help='Resume a previous run from existing benchmark results',
+    )
+    parser.add_argument(
         '--skip-logger-setup',
         dest='skip_logger_setup',
         required=False,
         default=False,
         action='store_true',
-        help='Skips the logger setup, for cases when invoked by another script that already sets logging up')
+        help='Skips the logger setup, for cases when invoked by another script that already sets logging up',
+    )
 
     return parser
 

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -75,7 +75,13 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         '--no-clean',
         dest='no_clean',
         action='store_true',
-        help='Do not clean the SDK and results directories before execution')
+        help='Do not clean the SDK installations before execution')
+
+    parser.add_argument(
+        '--resume',
+        dest='resume',
+        action='store_true',
+        help='Resume a previous run from existing benchmark results')
 
     parser.add_argument(
         '--dry-run',
@@ -129,7 +135,7 @@ def __main(args: list) -> int:
         resultsPath = os.path.join(rootPath, 'artifacts', 'bin', 'MicroBenchmarks', 'Release', moniker, 'BenchmarkDotNet.Artifacts', 'results')
 
         if not args.no_clean:
-            # Delete any preexisting SDK and results, which allows
+            # Delete any preexisting SDK installations, which allows
             # multiple versions to be run from a single command
             if os.path.isdir(sdkPath):
                 log('rmdir -r ' + sdkPath)
@@ -137,16 +143,19 @@ def __main(args: list) -> int:
                 if not args.dry_run:
                     shutil.rmtree(sdkPath)
 
+        benchmarkArgs = ['--skip-logger-setup', '--filter', args.filter, '--architecture', args.architecture, '-f', version['tfm']]
+
+        if 'build' in version:
+            benchmarkArgs += ['--dotnet-versions', version['build']]
+
+        if args.resume:
+            benchmarkArgs += ['--resume']
+        else:
             if os.path.isdir(resultsPath):
                 log('rmdir -r ' + resultsPath)
 
                 if not args.dry_run:
                     shutil.rmtree(resultsPath)
-
-        benchmarkArgs = ['--skip-logger-setup', '--filter', args.filter, '--architecture', args.architecture, '-f', version['tfm']]
-
-        if 'build' in version:
-            benchmarkArgs += ['--dotnet-versions', version['build']]
 
         if args.bdn_arguments:
             if version['tfm'].startswith('nativeaot'):

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -243,6 +243,8 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
         ]
     if args.filter:
         run_args += ['--filter'] + args.filter
+    if args.resume:
+        run_args += ['--resume']
 
     # Extra BenchmarkDotNet cli arguments.
     if args.bdn_arguments:

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -23,15 +23,18 @@ namespace MicroBenchmarks
             List<string> categoryExclusionFilterValue;
             Dictionary<string, string> parameterFilterValue;
             bool getDiffableDisasm;
+            bool resumeRun;
 
             // Parse and remove any additional parameters that we need that aren't part of BDN
-            try {
+            try
+            {
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-count", out partitionCount);
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out partitionIndex);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out exclusionFilterValue);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--category-exclusion-filter", out categoryExclusionFilterValue);
                 argsList = CommandLineOptions.ParseAndRemovePairsParameter(argsList, "--parameter-filter", out parameterFilterValue);
                 CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--disasm-diff", out getDiffableDisasm);
+                CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--resume", out resumeRun);
 
                 CommandLineOptions.ValidatePartitionParameters(partitionCount, partitionIndex);
             }
@@ -52,7 +55,8 @@ namespace MicroBenchmarks
                         exclusionFilterValue: exclusionFilterValue,
                         categoryExclusionFilterValue: categoryExclusionFilterValue,
                         parameterFilterValue: parameterFilterValue,
-                        getDiffableDisasm: getDiffableDisasm)
+                        getDiffableDisasm: getDiffableDisasm,
+                        resumeRun: resumeRun)
                     .AddValidator(new NoWasmValidator(Categories.NoWASM)))
                 .ToExitCode();
         }

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -99,7 +99,7 @@ namespace BenchmarkDotNet.Extensions
                 return new string[0];
 
             // Get all existing report files, of any export type; order by descending filename length to avoid rename collisions
-            return artifacts.GetFiles($"*-report-*", SearchOption.AllDirectories)
+            var existingBenchmarks = artifacts.GetFiles($"*-report-*", SearchOption.AllDirectories)
                 .OrderByDescending(resultFile => resultFile.FullName.Length)
                 .SelectMany(resultFile =>
                 {
@@ -137,6 +137,18 @@ namespace BenchmarkDotNet.Extensions
 
                     return new string[0];
                 });
+
+                if (existingBenchmarks.Any())
+                {
+                    Console.WriteLine($"// Found {existingBenchmarks.Count()} existing result(s) to be skipped:");
+
+                    foreach (var benchmark in existingBenchmarks.OrderBy(b => b))
+                    {
+                        Console.WriteLine($"// ***** {benchmark}");
+                    }
+                }
+
+                return existingBenchmarks;
         }
 
         private class Benchmark

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -1,18 +1,20 @@
-﻿using System.Collections.Immutable;
-using System.IO;
-using BenchmarkDotNet.Columns;
+﻿using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Exporters.Json;
-using Perfolizer.Horology;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Reports;
-using System.Collections.Generic;
-using Reporting;
-using BenchmarkDotNet.Loggers;
-using System.Linq;
 using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using Newtonsoft.Json;
+using Perfolizer.Horology;
+using Reporting;
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 
 namespace BenchmarkDotNet.Extensions
 {
@@ -27,7 +29,8 @@ namespace BenchmarkDotNet.Extensions
             List<string> categoryExclusionFilterValue = null,
             Dictionary<string, string> parameterFilterValue = null,
             Job job = null,
-            bool getDiffableDisasm = false)
+            bool getDiffableDisasm = false,
+            bool resumeRun = false)
         {
             if (job is null)
             {
@@ -37,6 +40,12 @@ namespace BenchmarkDotNet.Extensions
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
+            }
+
+            if (resumeRun)
+            {
+                exclusionFilterValue ??= new List<string>();
+                exclusionFilterValue.AddRange(GetBenchmarksToResume(artifactsPath));
             }
 
             var config = ManualConfig.CreateEmpty()
@@ -83,5 +92,63 @@ namespace BenchmarkDotNet.Extensions
                 exportHtml: false,
                 exportCombinedDisassemblyReport: false,
                 exportDiff: false));
+
+        private static IEnumerable<string> GetBenchmarksToResume(DirectoryInfo artifacts)
+        {
+            if (!artifacts.Exists)
+                return new string[0];
+
+            // Get all existing report files, of any export type; order by descending filename length to avoid rename collisions
+            return artifacts.GetFiles($"*-report-*", SearchOption.AllDirectories)
+                .OrderByDescending(resultFile => resultFile.FullName.Length)
+                .SelectMany(resultFile =>
+                {
+                    var reportFileName = resultFile.FullName;
+
+                    // Prepend the report name with -resume, potentially multiple times if multiple reports for the same
+                    // benchmarks exist, so that they don't collide with one another. But don't unnecessarily prepend
+                    // -resume multiple times.
+                    if (!reportFileName.Contains("-resume-report-") || File.Exists(reportFileName.Replace("-resume-report-", "-report-")))
+                    {
+                        var resumeFileName = reportFileName.Replace("-report-", "-resume-report-");
+                        File.Move(reportFileName, resumeFileName);
+
+                        reportFileName = resumeFileName;
+                    }
+
+                    // For JSON reports, load the data to get the benchmarks that have already been reported
+                    if (reportFileName.EndsWith(".json"))
+                    {
+                        try
+                        {
+                            var result = JsonConvert.DeserializeObject<BdnResult>(File.ReadAllText(reportFileName));
+                            var benchmarks = result.Benchmarks.Select(benchmark =>
+                            {
+                                var nameParts = new[] { benchmark.Namespace, benchmark.Type, benchmark.Method };
+                                return string.Join(".", nameParts.Where(part => !string.IsNullOrEmpty(part)));
+                            }).Distinct();
+
+                            return benchmarks;
+                        }
+                        catch (JsonSerializationException)
+                        {
+                        }
+                    }
+
+                    return new string[0];
+                });
+        }
+
+        private class Benchmark
+        {
+            public string Namespace { get; set; }
+            public string Type { get; set; }
+            public string Method { get; set; }
+        }
+
+        private class BdnResult
+        {
+            public List<Benchmark> Benchmarks { get; set; }
+        }
     }
 }


### PR DESCRIPTION
I've long wanted to be able to interrupt a microbenchmarks run and then run it again to resume from where it left off. This will be especially useful for running manual runs, enabling folks to start a run at night, and if it's not complete before the next morning, the run can be resumed the next night.

To achieve this:

1. The MicroBenchmarks console application recognizes a `--resume` argument
    * When specified, all existing report files are iterated
    * For each report file, the file is renamed to have `-resume` added into the file name, avoiding potential collisions while doing so
    * Then for each JSON report, the benchmarks are deserialized from the report file, and the distinct set of completed benchmarks is collected
    * That list of completed benchmarks is turned into a series of `--exclusion-filter` arguments to exclude those benchmarks from the run
2. The `micro_benchmarks.py` script recognizes and relays the `--resume` argument to `dotnet run`
3. The `benchmarks_ci.py` script recognizes the `--resume` argument so it can be relayed to `micro_benchmarks.py`
4. The `benchmarks_monthly.py` script recognizes the `--resume` argument
    * When specified, the existing results are not deleted before the run
    * And then the argument is relayed to `benchmarks_ci.py`

I've contemplated a few different ways to achieve this. This approach is my first working attempt. I'm open to alternative approaches if others have different ideas for how to accomplish this.