### PR TITLE
Revert "Disable PerfFileStream while we wait for dotnet/runtime#67545 to be fixed. (#2371)

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.FileStream.cs
@@ -13,7 +13,6 @@ using MicroBenchmarks;
 namespace System.IO.Tests
 {
     [BenchmarkCategory(Categories.Libraries)]
-    [OperatingSystemsFilter(allowed: true, OS.Windows)]
     public class Perf_FileStream
     {
         private const int OneKibibyte  = 1 << 10; // 1024


### PR DESCRIPTION
- Depends on https://github.com/dotnet/runtime/pull/68171
- This reverts commit d8f1c477ec00c47a5989f4e7b4225512958039e5 from PR https://github.com/dotnet/performance/pull/2371