### PR TITLE
Add support for the s390x architecture

### DIFF
--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -47,6 +47,8 @@ def getruntimeidentifier():
 
     if 'aarch64' in platform.machine() or os.environ.get('PERFLAB_BUILDARCH') == 'arm64':
         rid += 'arm64'
+    elif platform.machine() == 's390x':
+        rid += 's390x'
     elif platform.machine().endswith('64'):
         rid += 'x64'
     elif platform.machine().endswith('86'):


### PR DESCRIPTION
Since .NET 6 architecture s390x is officially supported. Thus, adding support for s390x here, too.