### PR TITLE
Bump BDN to 0.13.1.1786

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -7,8 +7,8 @@
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' == ''">
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1.1780" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1.1780" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1.1786" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1.1786" />
   </ItemGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet\BenchmarkDotNet.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />


### PR DESCRIPTION
This update contains following fixes:
* https://github.com/dotnet/BenchmarkDotNet/pull/1990 (cc @fanyang-mono @naricc)
* https://github.com/dotnet/BenchmarkDotNet/pull/1994
* https://github.com/dotnet/BenchmarkDotNet/pull/1996 (cc @stefan-sf-ibm)

@LoopedBard3 could you please upload `0.13.1.1786` to our feed? thanks!