### PR TITLE
Perf update framework var name

### DIFF
--- a/eng/performance/blazor_scenarios.proj
+++ b/eng/performance/blazor_scenarios.proj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <FrameworkVersion>$(_Framework.Substring($([MSBuild]::Subtract($(_Framework.Length), 3))))</FrameworkVersion>
+    <FrameworkVersion>$(PERFLAB_Framework.Substring($([MSBuild]::Subtract($(PERFLAB_Framework.Length), 3))))</FrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/performance/helix.proj
+++ b/eng/performance/helix.proj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">
-    <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(_Framework) $(_PerfLabArguments)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(PERFLAB_Framework) $(_PerfLabArguments)</WorkItemCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(_Framework)' != 'net461'">
+  <PropertyGroup Condition="'$(PERFLAB_Framework)' != 'net461'">
     <WorkItemCommand>$(WorkItemCommand) $(CliArguments)</WorkItemCommand>
   </PropertyGroup>
 

--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -36,7 +36,7 @@
     <Scenario Include="Static F# Console Template">
       <PayloadDirectory>$(ScenariosDir)staticfsconsoletemplate</PayloadDirectory>
     </Scenario>
-    <!-- <Scenario Include="Static Winforms Template" Condition="'$(_Framework)' != 'netcoreapp5.0'">
+    <!-- <Scenario Include="Static Winforms Template" Condition="'$(PERFLAB_Framework)' != 'netcoreapp5.0'">
       <PayloadDirectory>$(ScenariosDir)staticwinformstemplate</PayloadDirectory>
     </Scenario> -->
     <Scenario Include="New Console Template">
@@ -60,7 +60,7 @@
   <!-- UI Startup FDD publish -->
   <ItemGroup>
     <HelixWorkItem Include="@(UIScenario -> 'Startup - %(Identity) - FDD Publish')">
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release --windowsui</PreCommands>
+      <PreCommands>$(Python) pre.py publish -f $(PERFLAB_Framework) -c Release --windowsui</PreCommands>
       <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>
@@ -68,7 +68,7 @@
   <!-- Startup FDD publish -->
   <ItemGroup>
     <HelixWorkItem Include="@(Scenario -> 'Startup - %(Identity) - FDD Publish')">
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
+      <PreCommands>$(Python) pre.py publish -f $(PERFLAB_Framework) -c Release</PreCommands>
       <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>
@@ -76,7 +76,7 @@
   <!-- SOD FDD publish -->
   <ItemGroup>
     <HelixWorkItem Include="@(Scenario -> 'SOD - %(Identity) - FDD Publish')">
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release</PreCommands>
+      <PreCommands>$(Python) pre.py publish -f $(PERFLAB_Framework) -c Release</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>
@@ -84,7 +84,7 @@
   <!-- SOD SCD publish w/ RID -->
   <ItemGroup>
     <HelixWorkItem Include="@(Scenario -> 'SOD - %(Identity) - SCD Publish')">
-      <PreCommands>$(Python) pre.py publish -f $(_Framework) -c Release -r $(RID)</PreCommands>
+      <PreCommands>$(Python) pre.py publish -f $(PERFLAB_Framework) -c Release -r $(RID)</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>
@@ -92,7 +92,7 @@
   <!-- SOD build -->
   <ItemGroup>
     <HelixWorkItem Include="@(Scenario -> 'SOD - %(Identity) - Build')">
-      <PreCommands>$(Python) pre.py build -c Release -f $(_Framework)</PreCommands>
+      <PreCommands>$(Python) pre.py build -c Release -f $(PERFLAB_Framework)</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -94,25 +94,25 @@ jobs:
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config
-          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r win-${{parameters.architecture}} $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj
+          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj
             displayName: Build startup tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
-          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(_Framework) -r win-${{parameters.architecture}} $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj
             displayName: Build SOD tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
         - ${{ if ne(parameters.osName, 'windows') }}:
           - script: cp ./NuGet.config $(CorrelationStaging);cp -r ./scripts $(CorrelationStaging)scripts;cp -r ./src/scenarios/shared $(CorrelationStaging)shared;cp -r ./src/scenarios/staticdeps $(CorrelationStaging)staticdeps
             displayName: Copy python libraries and NuGet.config
-          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
             displayName: Build startup tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
-          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
             displayName: Build SOD tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
         - template: /eng/performance/send-to-helix.yml
           parameters:
             HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -18,7 +18,7 @@
   </PropertyGroup>  
 
   <PropertyGroup>
-    <FrameworkVersion>$(_Framework.Substring($([MSBuild]::Subtract($(_Framework.Length), 3))))</FrameworkVersion>
+    <FrameworkVersion>$(PERFLAB_Framework.Substring($([MSBuild]::Subtract($(PERFLAB_Framework.Length), 3))))</FrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -340,7 +340,7 @@ def __main(args: list) -> int:
             out_file.write(path_variable % dotnet_path)
     
     # The '_Framework' is needed for specifying frameworks in proj files and for building tools later in the pipeline
-    __write_pipeline_variable('_Framework', framework)
+    __write_pipeline_variable('PERFLAB_Framework', framework)
 
 
 


### PR DESCRIPTION
We are seeing warnings about _Framework being a read-only variable in the pipelines. Currently they still allow overwriting, but it may change in the future. This is an initial attempt to get ahead of that.
