### PR TITLE
Add --fully-drawn-magic-string option to startup scenario

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -806,7 +806,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     timeToMagicStringEventDateTime = datetime.strptime(magicStringEvent['timestamp'], '%Y-%m-%d %H:%M:%S.%f%z')
 
                     # startup time is time to the magic string event
-                    totalTimeMilliseconds = timeToMagicStringEventDateTime - timeToMainEventStartDateTime
+                    totalTimeMilliseconds = (timeToMagicStringEventDateTime - timeToMainEventStartDateTime).total_seconds() * 1000
                 else:
                     # startup time is time to first draw
                     totalTimeMilliseconds = timeToMainMilliseconds + timeToFirstDrawMilliseconds

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -67,7 +67,7 @@ class Runner:
         parseonlyparser.add_argument('--disable-animations', help='Disable Android device animations, does nothing on iOS.', action='store_true', dest='animationsdisabled')
         parseonlyparser.add_argument('--use-fully-drawn-time', help='Use the startup time from reportFullyDrawn for android, the equivalent for iOS is handled via logging a magic string and passing it to --fully-drawn-magic-string', action='store_true', dest='usefullydrawntime')
         parseonlyparser.add_argument('--fully-drawn-extra-delay', help='Set an additional delay time for an Android app to reportFullyDrawn (seconds), not on iOS. This should be greater than the greatest amount of extra time expected between first frame draw and reportFullyDrawn being called. Default = 3 seconds', type=int, default=3, dest='fullyDrawnDelaySecMax')
-        parseonlyparser.add_argument('--fully-drawn-magic-string', help='Set an additional delay time for an Android app to reportFullyDrawn (seconds), not on iOS. This should be greater than the greatest amount of extra time expected between first frame draw and reportFullyDrawn being called. Default = 3 seconds', type=str, dest='fullyDrawnMagicString')
+        parseonlyparser.add_argument('--fully-drawn-magic-string', help='Set the magic string that is logged by the app to indicate when the app is fully drawn. Required when using --use-fully-drawn-time on iOS.', type=str, dest='fullyDrawnMagicString')
         self.add_common_arguments(parseonlyparser)
 
         # inner loop command


### PR DESCRIPTION
It can be used on iOS to pass in a magic string that the App is expected to log when it is "fully drawn" and we report the time to that event instead of the normal startup events.
