### PR TITLE
Mark these as NoAOT to allow for an AOT Arm64 run from Nov 2021

### DIFF
--- a/src/benchmarks/micro/libraries/System.Buffers/BinaryReadAndWriteTests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/BinaryReadAndWriteTests.cs
@@ -12,7 +12,7 @@ using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace System.Buffers.Binary.Tests
 {
-    [BenchmarkCategory(Categories.Libraries, Categories.Runtime)]
+    [BenchmarkCategory(Categories.Libraries, Categories.Runtime, Categories.NoAOT)]
     public class BinaryReadAndWriteTests
     {
         private readonly static byte[] _arrayLE = GetSpanLE().ToArray();

--- a/src/benchmarks/micro/libraries/System.Memory/Constructors.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/Constructors.cs
@@ -99,7 +99,7 @@ namespace System.Memory
 
     [GenericTypeArguments(typeof(byte))]
     [GenericTypeArguments(typeof(int))]
-    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span)]
+    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span, Categories.NoAOT)]
     public class Constructors_ValueTypesOnly<T>
     {
         private const int Size = 10;

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/GenericVectorConstructorTests.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/GenericVectorConstructorTests.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace System.Numerics.Tests
 {
-    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT, Categories.NoAOT)]
     public partial class Constructor
     {
         Byte[] _arrValues_Byte = GenerateRandomValuesForVector<Byte>(Byte.MinValue, Byte.MaxValue);

--- a/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorConvert.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Vectors/Perf_VectorConvert.cs
@@ -9,7 +9,7 @@ using MicroBenchmarks;
 
 namespace System.Numerics.Tests
 {
-    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT, Categories.NoAOT)]
     public class Perf_VectorConvert
     {
         private const int Iterations = 1000;

--- a/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Path.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.Path.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace System.IO.Tests
 {
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoAOT)]
     public class Perf_Path
     {
         private readonly string _testPath = FileUtils.GetTestFilePath();

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.Industry.cs
@@ -77,6 +77,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
         public int Count() => Perf_Regex_Industry.Count(_regex, _input);
     }
 
@@ -110,6 +111,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Benchmark]
         [MinIterationCount(3)] // each iteration takes several seconds
+        [BenchmarkCategory(Categories.NoAOT)]
         public int Count()
         {
             int found = 0;
@@ -189,6 +191,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
         public int Count() => Perf_Regex_Industry.Count(_regex, _sherlock);
     }
 
@@ -237,6 +240,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
         public int Count() => Perf_Regex_Industry.Count(_regex, _3200);
     }
 

--- a/src/benchmarks/micro/runtime/Span/Indexer.cs
+++ b/src/benchmarks/micro/runtime/Span/Indexer.cs
@@ -33,7 +33,7 @@ namespace Span
         public void Setup() => a = GetData(length);
 
         [Benchmark]
-        [BenchmarkCategory("Indexer in-loop bounds check elimination")]
+        [BenchmarkCategory("Indexer in-loop bounds check elimination", Categories.NoAOT)]
         public byte Ref() => TestRef(a);
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/benchmarks/micro/runtime/StoreBlock/StoreBlock.cs
+++ b/src/benchmarks/micro/runtime/StoreBlock/StoreBlock.cs
@@ -11,7 +11,7 @@ using MicroBenchmarks;
 
 namespace StoreBlock
 {
-    [BenchmarkCategory(Categories.Runtime, Categories.JIT)]
+    [BenchmarkCategory(Categories.Runtime, Categories.JIT, Categories.NoAOT)]
     public class AnyLocation
     {
         const int Size = 4096;
@@ -162,7 +162,7 @@ namespace StoreBlock
         }
     }
 
-    [BenchmarkCategory(Categories.Runtime, Categories.JIT)]
+    [BenchmarkCategory(Categories.Runtime, Categories.JIT, Categories.NoAOT)]
     public class LocalAddress
     {
         const int OperationsPerInvoke = 100;


### PR DESCRIPTION
This change is temporary and should be reverted once the run is under way.

