### PR TITLE
Fix UnsupportedOS issue

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -15,6 +15,12 @@ namespace System.Net.NetworkInformation.Tests
         public NetworkInterface[] GetAllNetworkInterfaces() => NetworkInterface.GetAllNetworkInterfaces();
 
         [Benchmark]
+    #if NET5_0_OR_GREATER
+        [System.Runtime.Versioning.UnsupportedOSPlatform("osx")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("freebsd")]
+    #endif
         public void GetAllNetworkInterfacesProperties()
         {
             foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())


### PR DESCRIPTION
This was introduced by https://github.com/dotnet/runtime/pull/68432. We need to mark the
test as not runnable on the platforms where we are missing this property