### PR TITLE
Add OS Arch filter to remove the two tests on Arm64.

### DIFF
--- a/src/benchmarks/micro/libraries/System.Threading.Timers/Perf.Timer.cs
+++ b/src/benchmarks/micro/libraries/System.Threading.Timers/Perf.Timer.cs
@@ -5,6 +5,7 @@
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace System.Threading.Tests
 {
@@ -46,6 +47,7 @@ namespace System.Threading.Tests
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoWASM)]
+        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.Arm64)]
         public void SynchronousContention()
         {
             Task[] tasks = _tasks;
@@ -64,6 +66,7 @@ namespace System.Threading.Tests
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoWASM)]
+        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.Arm64)]
         public void AsynchronousContention()
         {
             Task[] tasks = _tasks;


### PR DESCRIPTION
Per https://github.com/dotnet/performance/issues/2420. Can't do test run do to full failures: https://github.com/dotnet/performance/issues/2421 but this will get it ready for testing and merge.
