### PR TITLE
System.Formats.Tar benchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -111,7 +111,6 @@
     <Compile Remove="runtime\Math\Functions\Double\Atanh.cs" />
     <Compile Remove="runtime\Math\Functions\Double\Cbrt.cs" />
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
-    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.1')">
@@ -133,7 +132,6 @@
     <Compile Remove="libraries\Common\ConnectedStreams.cs" />
     <Compile Remove="libraries\Common\StreamBuffer.cs" />
     <Compile Remove="libraries\Common\MultiArrayBuffer.cs" />
-    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '5.0')">
@@ -142,7 +140,6 @@
     <Compile Remove="libraries\System.Text.Json\Serializer\WritePreservedReferences.cs" />
     <Compile Remove="libraries\System.Net.Security\SslStreamTests.Context.cs" />
     <Compile Remove="libraries\System.Formats.Cbor\*.cs" />
-    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '6.0')">
@@ -150,6 +147,9 @@
     <Compile Remove="libraries\Common\AlignedMemory.cs" />
     <Compile Remove="libraries\System.IO.FileSystem\Perf.RandomAccess.cs" />
     <Compile Remove="libraries\System.IO.FileSystem\Perf.RandomAccess.NoBuffering.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '7.0')">
     <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -56,6 +56,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" />
     <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="System.Formats.Tar" Version="$(SystemVersion)" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
@@ -111,6 +112,7 @@
     <Compile Remove="runtime\Math\Functions\Double\Atanh.cs" />
     <Compile Remove="runtime\Math\Functions\Double\Cbrt.cs" />
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
+    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.1')">
@@ -132,6 +134,7 @@
     <Compile Remove="libraries\Common\ConnectedStreams.cs" />
     <Compile Remove="libraries\Common\StreamBuffer.cs" />
     <Compile Remove="libraries\Common\MultiArrayBuffer.cs" />
+    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '5.0')">
@@ -140,6 +143,7 @@
     <Compile Remove="libraries\System.Text.Json\Serializer\WritePreservedReferences.cs" />
     <Compile Remove="libraries\System.Net.Security\SslStreamTests.Context.cs" />
     <Compile Remove="libraries\System.Formats.Cbor\*.cs" />
+    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '6.0')">
@@ -147,6 +151,7 @@
     <Compile Remove="libraries\Common\AlignedMemory.cs" />
     <Compile Remove="libraries\System.IO.FileSystem\Perf.RandomAccess.cs" />
     <Compile Remove="libraries\System.IO.FileSystem\Perf.RandomAccess.NoBuffering.cs" />
+    <Compile Remove="libraries\System.Formats.Tar\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -56,7 +56,6 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" />
     <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" />
-    <PackageReference Include="System.Formats.Tar" Version="$(SystemVersion)" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -1,0 +1,132 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Formats.Tar.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public class Perf_Tar
+    {
+        /*
+        Always exist:
+            root/
+                inputdir/
+                        testdir/
+                        file.txt
+
+        Created on demand:
+                outputdir/
+                output.tar
+        */
+        private readonly string _rootDirPath = FileUtils.GetTestFilePath();
+        private readonly string _tarOutputPath = Path.Combine(_rootDirPath, "output.tar");
+        private readonly string _inputDirPath = Path.Combine(_rootDirPath, "inputdir");
+        private readonly string _testFilePath = Path.Combine(_inputDirPath, "file.txt");
+        private readonly string _testDirPath = Path.Combine(_inputDirPath, "testdir");
+        private readonly string _outputDirPath = Path.Combine(_rootDirPath, "outputdir");
+        private MemoryStream _memoryStream;
+
+
+        // Global setup and cleanup
+
+        [GlobalSetup]
+        public void SetupPaths()
+        {
+            _memoryStream = null;
+            Directory.CreateDirectory(_rootTestPath);
+            Directory.CreateDirectory(_inputDirPath);
+            Directory.CreateDirectory(_testDirPath);
+            File.Create(_testFilePath).Dispose();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            Directory.Delete(_rootTestPath, recursive: true);
+            CleanupMemoryStream();
+        }
+
+
+        // TarFile.CreateFromDirectory(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory)
+
+        [GlobalSetup(Target = nameof(TarFile_CreateFromDirectory_Path))]
+        public void Setup_TarFile_CreateFromDirectory_Path() => File.Delete(_tarOutputPath);
+
+        [GlobalCleanup(Target = nameof(TarFile_CreateFromDirectory_Path))]
+        public void Cleanup_TarFile_CreateFromDirectory_Path() => File.Delete(_tarOutputPath);
+
+        [Benchmark]
+        public void TarFile_CreateFromDirectory_Path() => TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destinationFileName: _tarOutputPath, includeBaseDirectory: false);
+
+
+        // TarFile.CreateFromDirectory(string sourceDirectoryName, Stream destination, bool includeBaseDirectory)
+
+        [GlobalSetup(Target = nameof(TarFile_CreateFromDirectory_Stream))]
+        public void Setup_TarFile_CreateFromDirectory_Stream()
+        {
+            CleanupMemoryStream();
+            _memoryStream = new MemoryStream();
+        }
+
+        [GlobalCleanup(Target = nameof(TarFile_CreateFromDirectory_Stream))]
+        public void Cleanup_TarFile_CreateFromDirectory_Stream() => CleanupMemoryStream();
+
+        [Benchmark]
+        public void TarFile_CreateFromDirectory_Stream() => TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destination: _memoryStream, includeBaseDirectory: false);
+
+
+        // TarFile.ExtractToDirectory(string sourceFileName, string destinationDirectoryName, bool overwrite)
+
+        [GlobalSetup(Target = nameof(TarFile_ExtractToDirectory_Path))]
+        public void Setup_TarFile_ExtractToDirectory_Path()
+        {
+            File.Delete(_tarOutputPath);
+            Directory.Delete(_outputDirPath);
+            Directory.CreateDirectory(_outputDirPath);
+            TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destinationFileName: _tarOutputPath, includeBaseDirectory: false);
+        }
+        
+        [GlobalCleanup(Target = nameof(TarFile_ExtractToDirectory_Path))]
+        public void Cleanup_TarFile_ExtractToDirectory_Path()
+        {
+            File.Delete(_tarOutputPath);
+            Directory.Delete(_outputDirPath);
+        }
+
+        [Benchmark]
+        public void TarFile_ExtractToDirectory_Path() => TarFile.ExtractToDirectory(sourceFileName: _tarOutputPath, destinationDirectoryName: _outputDirPath, overwrite: false);
+
+
+        // TarFile.ExtractToDirectory(Stream source, string destinationDirectoryName, bool overwrite)
+
+        [GlobalSetup(Target = nameof(TarFile_ExtractToDirectory_Stream))]
+        public void Setup_TarFile_ExtractToDirectory_Stream()
+        {
+            CleanupMemoryStream();
+            TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destination: _memoryStream, includeBaseDirectory: false);
+        }
+
+        [GlobalCleanup(Target = nameof(TarFile_ExtractToDirectory_Stream))]
+        public void Cleanup_TarFile_ExtractToDirectory_Stream() => CleanupMemoryStream();
+
+        [Benchmark]
+        public void TarFile_ExtractToDirectory_Stream() => TarFile.ExtractToDirectory(source: _memoryStream, destinationDirectoryName: _outputDirPath, overwrite: false);
+
+
+        // Helpers
+
+        private void CleanupMemoryStream()
+        {
+            if (_memoryStream != null)
+            {
+                _memoryStream.Dispose();
+                _memoryStream = null;
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -43,24 +43,24 @@ namespace System.Formats.Tar.Tests
         public void Cleanup() => Directory.Delete(_rootDirPath, recursive: true);
 
         [Benchmark]
-        public void TarFile_CreateFromDirectory_Path()
+        public void CreateFromDirectory_Path()
         {
             File.Delete(_outputTarFilePath);
             TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destinationFileName: _outputTarFilePath, includeBaseDirectory: false);
         }
 
         [Benchmark]
-        public void TarFile_ExtractToDirectory_Path() => TarFile.ExtractToDirectory(sourceFileName: _inputTarFilePath, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
+        public void ExtractToDirectory_Path() => TarFile.ExtractToDirectory(sourceFileName: _inputTarFilePath, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
 
         [Benchmark]
-        public void TarFile_CreateFromDirectory_Stream()
+        public void CreateFromDirectory_Stream()
         {
             using MemoryStream ms = new MemoryStream();
             TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]
-        public void TarFile_ExtractToDirectory_Stream()
+        public void ExtractToDirectory_Stream()
         {
             using FileStream fs = File.OpenRead(_inputTarFilePath);
             TarFile.ExtractToDirectory(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -17,6 +17,7 @@ namespace System.Formats.Tar.Tests
                 inputdir/
                         testdir/
                         file.txt
+                input.tar
 
         Created on demand:
                 outputdir/

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -45,8 +45,8 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public void CreateFromDirectory_Path()
         {
-            File.Delete(_outputTarFilePath);
             TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destinationFileName: _outputTarFilePath, includeBaseDirectory: false);
+            File.Delete(_outputTarFilePath);
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -10,7 +10,7 @@ using MicroBenchmarks;
 namespace System.Formats.Tar.Tests
 {
     [BenchmarkCategory(Categories.Libraries)]
-    public class Perf_Tar
+    public class Perf_TarFile
     {
         /*
         Always exist:


### PR DESCRIPTION
System.Formats.Tar was added in net7.0-preview4 so it's time to add benchmarks.

These benchmarks call `TarFile` methods. They internally call `TarReader` and `TarWriter`, so I didn't think it would be necessary to create benchmarks exclusive for those types.

@adamsitnik @dakersnar @jeffhandley 