### PR TITLE
Target newer dotnet versions

### DIFF
--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- For a desktop build, you could add e.g. `net472;` here. -->
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0;net6.0;net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>gcperfsim_core</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
This change allows us to use GCPerfSim under .NET 6 and 7.

@kunalspathak, @dotnet/gc 