### PR TITLE
Disable Perf.TarFile for wasm, as the library is not supported on wasm

### DIFF
--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace System.Formats.Tar.Tests
 {
-    [BenchmarkCategory(Categories.Libraries)]
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public class Perf_TarFile
     {
         /*


### PR DESCRIPTION
Fixes https://github.com/dotnet/performance/issues/2442
