### PR TITLE
Allow for uploading partial benchmark results when some runs fail

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -40,7 +40,7 @@ def info(verbose: bool) -> None:
     cmdline = ['dotnet', '--info']
     RunCommand(cmdline, verbose=verbose).run()
 
-def exec(asm_path: str, success_exit_codes: list = None, verbose: bool, *args) -> int:
+def exec(asm_path: str, success_exit_codes: list, verbose: bool, *args) -> int:
     """
     Executes `dotnet exec` which can be used to execute assemblies
     """
@@ -48,9 +48,6 @@ def exec(asm_path: str, success_exit_codes: list = None, verbose: bool, *args) -
     working_dir=path.dirname(asm_path)
     if not path.exists(asm_path):
         raise ArgumentError('Cannot find assembly {} to exec'.format(asm_path))
-
-    if success_exit_codes is None:
-        success_exit_codes = [0]
 
     cmdline = ['dotnet', 'exec', path.basename(asm_path)]
     cmdline += list(args)
@@ -472,7 +469,7 @@ class CSharpProject:
     def run(self,
             configuration: str,
             target_framework_moniker: str,
-            success_exit_codes: list = None,
+            success_exit_codes: list,
             verbose: bool,
             *args) -> int:
         '''
@@ -486,9 +483,6 @@ class CSharpProject:
             '--framework', target_framework_moniker,
             '--no-restore', '--no-build',
         ]
-
-        if success_exit_codes is None:
-            success_exit_codes = [0]
 
         if args:
             cmdline = cmdline + list(args)

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -40,7 +40,7 @@ def info(verbose: bool) -> None:
     cmdline = ['dotnet', '--info']
     RunCommand(cmdline, verbose=verbose).run()
 
-def exec(asm_path: str, verbose: bool, *args) -> None:
+def exec(asm_path: str, success_exit_codes: list = None, verbose: bool, *args) -> int:
     """
     Executes `dotnet exec` which can be used to execute assemblies
     """
@@ -49,9 +49,12 @@ def exec(asm_path: str, verbose: bool, *args) -> None:
     if not path.exists(asm_path):
         raise ArgumentError('Cannot find assembly {} to exec'.format(asm_path))
 
+    if success_exit_codes is None:
+        success_exit_codes = [0]
+
     cmdline = ['dotnet', 'exec', path.basename(asm_path)]
     cmdline += list(args)
-    RunCommand(cmdline, verbose=verbose).run(working_dir)
+    return RunCommand(cmdline, success_exit_codes, verbose=verbose).run(working_dir)
 
 def __log_script_header(message: str):
     message_length = len(message)
@@ -469,8 +472,9 @@ class CSharpProject:
     def run(self,
             configuration: str,
             target_framework_moniker: str,
+            success_exit_codes: list = None,
             verbose: bool,
-            *args) -> None:
+            *args) -> int:
         '''
         Calls dotnet to run a .NET project output.
         '''
@@ -483,9 +487,12 @@ class CSharpProject:
             '--no-restore', '--no-build',
         ]
 
+        if success_exit_codes is None:
+            success_exit_codes = [0]
+
         if args:
             cmdline = cmdline + list(args)
-        RunCommand(cmdline, verbose=verbose).run(
+        return RunCommand(cmdline, success_exit_codes, verbose=verbose).run(
             self.working_directory)
 
 

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -226,7 +226,7 @@ class RunCommand:
                 return (proc.returncode, quoted_cmdline)
 
 
-    def run(self, working_directory: str = None) -> None:
+    def run(self, working_directory: str = None) -> int:
         '''Executes specified shell command.'''
 
         retrycount = 0
@@ -240,3 +240,5 @@ class RunCommand:
                 "Process exited with status %s", returncode)
             raise CalledProcessError(
                 returncode, quoted_cmdline)
+        
+        return returncode

--- a/src/harness/BenchmarkDotNet.Extensions/Extensions.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/Extensions.cs
@@ -17,10 +17,20 @@ namespace BenchmarkDotNet.Extensions
                 return 1;
 
             // if anything has failed, it's an error
-            if (summaries.Any(summary => summary.HasCriticalValidationErrors || summary.Reports.Any(report => !report.BuildResult.IsBuildSuccess || !report.AllMeasurements.Any())))
+            if (summaries.Any(summary => summary.HasAnyErrors()))
                 return 1;
 
             return 0;
+        }
+
+        public static bool HasAnyErrors(this Summary summary)
+        {
+            return summary.HasCriticalValidationErrors || summary.Reports.Any(report => report.HasAnyErrors());
+        }
+
+        public static bool HasAnyErrors(this BenchmarkReport report)
+        {
+            return !report.BuildResult.IsBuildSuccess || !report.AllMeasurements.Any();
         }
     }
 }

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -24,12 +24,20 @@ namespace BenchmarkDotNet.Extensions
         {
             var reporter = Reporter.CreateReporter();
 
+            reporter.HasCriticalValidationErrors = summary.HasCriticalValidationErrors;
+
             DisassemblyDiagnoser disassemblyDiagnoser = summary.Reports
                 .FirstOrDefault()? // dissasembler was either enabled for all or none of them (so we use the first one)
                 .BenchmarkCase.Config.GetDiagnosers().OfType<DisassemblyDiagnoser>().FirstOrDefault();
 
             foreach (var report in summary.Reports)
             {
+                // Skip individual reports with errors
+                if (report.HasAnyErrors())
+                {
+                    continue;
+                }
+
                 var test = new Test();
                 test.Name = FullNameProvider.GetBenchmarkName(report.BenchmarkCase);
                 test.Categories = report.BenchmarkCase.Descriptor.Categories;

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -24,7 +24,7 @@ namespace BenchmarkDotNet.Extensions
         {
             var reporter = Reporter.CreateReporter();
 
-            reporter.HasCriticalValidationErrors = summary.HasCriticalValidationErrors;
+            var hasCriticalErrors = summary.HasCriticalValidationErrors;
 
             DisassemblyDiagnoser disassemblyDiagnoser = summary.Reports
                 .FirstOrDefault()? // dissasembler was either enabled for all or none of them (so we use the first one)
@@ -41,6 +41,11 @@ namespace BenchmarkDotNet.Extensions
                 var test = new Test();
                 test.Name = FullNameProvider.GetBenchmarkName(report.BenchmarkCase);
                 test.Categories = report.BenchmarkCase.Descriptor.Categories;
+                
+                if (hasCriticalErrors)
+                {
+                    test.AdditionalData["criticalErrors"] = "true";
+                }
 
                 var results = from result in report.AllMeasurements
                               where result.IterationMode == Engines.IterationMode.Workload && result.IterationStage == Engines.IterationStage.Result

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -24,6 +24,8 @@ namespace Reporting
 
         private Reporter() { }
 
+        public bool HasCriticalValidationErrors { get; set; } = false;
+
         public void AddTest(Test test)
         {
             if (tests.Any(t => t.Name.Equals(test.Name)))
@@ -108,7 +110,8 @@ namespace Reporting
                 build,
                 os,
                 run,
-                tests
+                tests,
+                criticalErrors = HasCriticalValidationErrors
             };
             var settings = new JsonSerializerSettings();
             var resolver = new DefaultContractResolver();

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -24,8 +24,6 @@ namespace Reporting
 
         private Reporter() { }
 
-        public bool HasCriticalValidationErrors { get; set; } = false;
-
         public void AddTest(Test test)
         {
             if (tests.Any(t => t.Name.Equals(test.Name)))
@@ -111,7 +109,6 @@ namespace Reporting
                 os,
                 run,
                 tests,
-                criticalErrors = HasCriticalValidationErrors
             };
             var settings = new JsonSerializerSettings();
             var resolver = new DefaultContractResolver();


### PR DESCRIPTION
This change ensures that if running the microbenchmarks returns a non-zero status code, that it will still upload any other successful results that it found. If there were any unsuccessful results, then the build pipeline will still be marked as failing so that any failures can be investigated.