### PR TITLE
Raise error when SOD scenario does not have any files sized

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -621,7 +621,6 @@ def get_commit_date(
         url = urlformat % (owner, repo, commit_sha)
 
     build_timestamp = None
-    item = None
     retrycount = 0
     success = 0
     while success == 0 and retrycount <= 3:
@@ -633,16 +632,10 @@ def get_commit_date(
                 success = 1
         except URLError:
             retrycount += 1
-            getLogger().warning(f"URL Error trying to get commit date from {url}, Attempt {retrycount}")
-            sleep(2)
 
     if not build_timestamp:
-        if not item:
-            raise RuntimeError(
-                'Could not get timestamp for commit %s' % commit_sha)
-        else:
-            raise RuntimeError(
-                'Could not get timestamp for commit %s, data retrieved:\n %s' % (commit_sha, item))
+        raise RuntimeError(
+            'Could not get timestamp for commit %s' % commit_sha)
     return build_timestamp
 
 def get_project_name(csproj_file: str) -> str:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -621,6 +621,7 @@ def get_commit_date(
         url = urlformat % (owner, repo, commit_sha)
 
     build_timestamp = None
+    item = None
     retrycount = 0
     success = 0
     while success == 0 and retrycount <= 3:
@@ -632,10 +633,16 @@ def get_commit_date(
                 success = 1
         except URLError:
             retrycount += 1
+            getLogger().warning(f"URL Error trying to get commit date from {url}, Attempt {retrycount}")
+            sleep(2)
 
     if not build_timestamp:
-        raise RuntimeError(
-            'Could not get timestamp for commit %s' % commit_sha)
+        if not item:
+            raise RuntimeError(
+                'Could not get timestamp for commit %s' % commit_sha)
+        else:
+            raise RuntimeError(
+                'Could not get timestamp for commit %s, data retrieved:\n %s' % (commit_sha, item))
     return build_timestamp
 
 def get_project_name(csproj_file: str) -> str:

--- a/src/scenarios/shared/sod.py
+++ b/src/scenarios/shared/sod.py
@@ -70,8 +70,9 @@ class SODWrapper(object):
 
         sod_command = RunCommand(sod_args, verbose=True)
         sod_command.run()
-        zero_size_regex = f"{scenarioname} - Count\s*\|\s*0.000 count" # Checks if the overall count is zero
-        if re.match(zero_size_regex, sod_command.stdout) != None:
+        
+        zero_size_regex = rf"({(scenarioname or 'Empty Scenario Name')}\s*-\s*Count\s*\|\s*0\.000\s*count)" # Checks if the overall count is zero    
+        if re.search(zero_size_regex, sod_command.stdout) != None:
             raise ValueError(f'No files found for sizing in scenario {scenarioname}')
  
         if artifact:

--- a/src/scenarios/shared/sod.py
+++ b/src/scenarios/shared/sod.py
@@ -71,7 +71,7 @@ class SODWrapper(object):
         sod_command = RunCommand(sod_args, verbose=True)
         sod_command.run()
         zero_size_regex = f"{scenarioname} - Count\s*\|\s*0.000 count" # Checks if the overall count is zero
-        if re.match(zero_size_regex, sod_command.stdout) == None:
+        if re.match(zero_size_regex, sod_command.stdout) != None:
             raise ValueError(f'No files found for sizing in scenario {scenarioname}')
  
         if artifact:

--- a/src/scenarios/shared/sod.py
+++ b/src/scenarios/shared/sod.py
@@ -2,6 +2,7 @@
 Wrapper around startup tool.
 '''
 from logging import getLogger
+import re
 import sys
 import os
 import platform
@@ -67,7 +68,11 @@ class SODWrapper(object):
         ]
         sod_args += dirs.split(';')
 
-        RunCommand(sod_args, verbose=True).run()
+        sod_command = RunCommand(sod_args, verbose=True)
+        sod_command.run()
+        zero_size_regex = f"{scenarioname} - Count\s*\|\s*0.000 count" # Checks if the overall count is zero
+        if re.match(zero_size_regex, sod_command.stdout) == None:
+            raise ValueError(f'No files found for sizing in scenario {scenarioname}')
  
         if artifact:
           if not os.path.exists(artifact):


### PR DESCRIPTION
Raise error when SOD scenario does not have any files sized. In this case, it raises a ValueError as the count of the files found is 0 where we can expect at least 1 file. To accomplish this, I kept the change in the python script side of the code as it allows for uses of the SOD tool where no files may be expected, while catching the 0 files case for our testing. This also ensures that the error gets raised properly through the python.