### PR TITLE
Add GitHub API call backoff for getting commit date

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -622,7 +622,7 @@ def get_commit_date(
 
     build_timestamp = None
     item = None
-    retrycount = 0
+    retrycount = -1
     success = 0
     while success == 0 and retrycount <= 4:
         try:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -622,9 +622,9 @@ def get_commit_date(
 
     build_timestamp = None
     item = None
-    retrycount = -1
+    retrycount = 0
     success = 0
-    while success == 0 and retrycount <= 4:
+    while success == 0 and retrycount <= 5:
         try:
             with urlopen(url) as response:
                 getLogger().info("Commit: %s", url)
@@ -634,7 +634,7 @@ def get_commit_date(
         except URLError:
             retrycount += 1
             getLogger().warning(f"URL Error trying to get commit date from {url}, Attempt {retrycount}")
-            sleep(30)
+            sleep(60)
 
     if not build_timestamp:
         if not item:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -621,8 +621,6 @@ def get_commit_date(
         url = urlformat % (owner, repo, commit_sha)
 
     build_timestamp = None
-    item = None
-    retrycount = 0
     sleep_time = 10 # Start with 10 second sleep timer
     for retrycount in range(5):
         try:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -624,7 +624,7 @@ def get_commit_date(
     item = None
     retrycount = 0
     success = 0
-    while success == 0 and retrycount <= 3:
+    while success == 0 and retrycount <= 4:
         try:
             with urlopen(url) as response:
                 getLogger().info("Commit: %s", url)
@@ -634,7 +634,7 @@ def get_commit_date(
         except URLError:
             retrycount += 1
             getLogger().warning(f"URL Error trying to get commit date from {url}, Attempt {retrycount}")
-            sleep(2)
+            sleep(30)
 
     if not build_timestamp:
         if not item:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -621,6 +621,7 @@ def get_commit_date(
         url = urlformat % (owner, repo, commit_sha)
 
     build_timestamp = None
+    item = None
     retrycount = 0
     success = 0
     while success == 0 and retrycount <= 3:
@@ -632,10 +633,16 @@ def get_commit_date(
                 success = 1
         except URLError:
             retrycount += 1
+            getLogger().warning(f"URL Error trying to get commit date from {url}, Attempt {retrycount}")
+            sleep(2)
 
     if not build_timestamp:
-        raise RuntimeError(
-            'Could not get timestamp for commit %s' % commit_sha)
+        if not item:
+            raise RuntimeError(
+                'Could not get timestamp for commit %s' % commit_sha)
+        else:
+            raise RuntimeError(
+                'Could not get timestamp for commit %s, data retrieved:\n %s' % (commit_sha, item))
     return build_timestamp
 
 def get_project_name(csproj_file: str) -> str:


### PR DESCRIPTION
Add GitHub API call backoff for getting commit date. We are currently hitting issues where occasionally the fetch of the commit date is not occurring successfully; the goal is to give git more time to get the proper data so we don't fail because we tried to get the data to quickly. Because of the difficulty of reproducing this error, this change is set to hopefully mitigate it when it occurs, but also provide more information for debugging if it doesn't.