### PR TITLE
Wrap certification initialization with try-catch

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
@@ -36,7 +36,8 @@ namespace System.Net.Test.Common
                                  certificateFileName)),
                          CertificatePassword,
                          X509KeyStorageFlags.DefaultKeySet);
-                } catch (Exception)
+                }
+                catch (Exception)
                 {
                     return null;
                 }

--- a/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
@@ -24,15 +24,23 @@ namespace System.Net.Test.Common
             public static X509Certificate2 GetRSA4096Certificate() => GetCertificate("rsa4096.pfx");
 
             private static X509Certificate2 GetCertificate(string certificateFileName)
-                => new X509Certificate2(
-                    File.ReadAllBytes(
-                        Path.Combine(
-                            AppContext.BaseDirectory, 
-                            "libraries", 
-                            "System.Net.Http", 
-                            certificateFileName)),
-                    CertificatePassword,
-                    X509KeyStorageFlags.DefaultKeySet);
+            {
+                try
+                {
+                    return new X509Certificate2(
+                         File.ReadAllBytes(
+                             Path.Combine(
+                                 AppContext.BaseDirectory,
+                                 "libraries",
+                                 "System.Net.Http",
+                                 certificateFileName)),
+                         CertificatePassword,
+                         X509KeyStorageFlags.DefaultKeySet);
+                } catch (Exception)
+                {
+                    return null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
From last few weeks we are seeing issue in superpmi where the `MicroBenchmarks.dll` execution fails on startup. This is before it starts executing any test. The code does static fields initialization and few fields rely on certificates to be present on the machine. For some reason, this is not the case on the test machines where `superpmi collect` pipeline is run and because of this failure, we are unable to do any collection for benchmarks.

This PR wraps the certificate code with `try-catch` so even if it fails, it will just fail the respective benchmarks test instead of the entire `MicroBenchmark.dll`.

Related: https://github.com/dotnet/performance/issues/2454