### PR TITLE
Update deprecated getLogger().warn to getLogger().warning.

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -273,7 +273,7 @@ def __main(args: list) -> int:
                 )
 
                 if not is_success:
-                    getLogger().warn(f"Benchmark run for framework '{framework}' contains errors")
+                    getLogger().warning(f"Benchmark run for framework '{framework}' contains errors")
                     run_contains_errors = True
 
             globpath = os.path.join(


### PR DESCRIPTION
Fixes #2472, updating getLogger's deprecated warn to warning.

This appears to be the only instance that needed to be updated.
