### PR TITLE
Base64Tests: Use valid input data

### DIFF
--- a/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
@@ -52,22 +52,22 @@ namespace System.Buffers.Text.Tests
         [GlobalSetup(Target = nameof(Base64Decode))]
         public void SetupBase64Decode()
         {
-            _encodedBytes = ValuesGenerator.Array<byte>(NumberOfBytes);
+            _encodedBytes = ValuesGenerator.ArrayBase64EncodingBytes(NumberOfBytes);
             _decodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(NumberOfBytes)];
         }
 
         [Benchmark]
         public OperationStatus Base64Decode() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
 
-        [GlobalSetup(Target = nameof(Base64DecodeDetinationTooSmall))]
-        public void SetupBase64DecodeDetinationTooSmall()
+        [GlobalSetup(Target = nameof(Base64DecodeDestinationTooSmall))]
+        public void SetupBase64DecodeDestinationTooSmall()
         {
-            _encodedBytes = ValuesGenerator.Array<byte>(NumberOfBytes);
+            _encodedBytes = ValuesGenerator.ArrayBase64EncodingBytes(NumberOfBytes);
             _decodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(NumberOfBytes) - 1];
         }
 
         [Benchmark]
-        public OperationStatus Base64DecodeDetinationTooSmall() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
+        public OperationStatus Base64DecodeDestinationTooSmall() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
 
 #if !NETFRAMEWORK // API added in .NET Core 2.1
         [GlobalSetup(Target = nameof(ConvertTryFromBase64Chars))]

--- a/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
@@ -69,6 +69,16 @@ namespace System.Buffers.Text.Tests
         [Benchmark]
         public OperationStatus Base64DecodeDestinationTooSmall() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
 
+        [GlobalSetup(Target = nameof(Base64DecodeInvalidData))]
+        public void SetupBase64DecodeInvalidData()
+        {
+            _encodedBytes = ValuesGenerator.Array<byte>(NumberOfBytes);
+            _decodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(NumberOfBytes)];
+        }
+
+        [Benchmark]
+        public OperationStatus Base64DecodeInvalidData() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
+
 #if !NETFRAMEWORK // API added in .NET Core 2.1
         [GlobalSetup(Target = nameof(ConvertTryFromBase64Chars))]
         public void SetupConvertTryFromBase64Chars()

--- a/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
@@ -69,16 +69,6 @@ namespace System.Buffers.Text.Tests
         [Benchmark]
         public OperationStatus Base64DecodeDestinationTooSmall() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
 
-        [GlobalSetup(Target = nameof(Base64DecodeInvalidData))]
-        public void SetupBase64DecodeInvalidData()
-        {
-            _encodedBytes = ValuesGenerator.Array<byte>(NumberOfBytes);
-            _decodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(NumberOfBytes)];
-        }
-
-        [Benchmark]
-        public OperationStatus Base64DecodeInvalidData() => Base64.DecodeFromUtf8(_encodedBytes, _decodedBytes, out _, out _);
-
 #if !NETFRAMEWORK // API added in .NET Core 2.1
         [GlobalSetup(Target = nameof(ConvertTryFromBase64Chars))]
         public void SetupConvertTryFromBase64Chars()

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -71,6 +71,32 @@ namespace BenchmarkDotNet.Extensions
             return result;
         }
 
+        public static readonly byte[] s_encodingMap = {
+            65, 66, 67, 68, 69, 70, 71, 72,         //A..H
+            73, 74, 75, 76, 77, 78, 79, 80,         //I..P
+            81, 82, 83, 84, 85, 86, 87, 88,         //Q..X
+            89, 90, 97, 98, 99, 100, 101, 102,      //Y..Z, a..f
+            103, 104, 105, 106, 107, 108, 109, 110, //g..n
+            111, 112, 113, 114, 115, 116, 117, 118, //o..v
+            119, 120, 121, 122, 48, 49, 50, 51,     //w..z, 0..3
+            52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
+        };
+
+        public static byte[] ArrayBase64EncodingBytes(int count)
+        {
+            var result = new byte[count];
+
+            var random = new Random(Seed);
+
+            for (int i = 0; i < result.Length; i++)
+            {
+                int index = (byte)random.Next(0, s_encodingMap.Length - 1);    // Do not pick '='
+                result[i] = s_encodingMap[index];
+            }
+
+            return result;
+        }
+
         public static Dictionary<TKey, TValue> Dictionary<TKey, TValue>(int count)
         {
             var dictionary = new Dictionary<TKey, TValue>();

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -90,7 +90,7 @@ namespace BenchmarkDotNet.Extensions
 
             for (int i = 0; i < result.Length; i++)
             {
-                int index = (byte)random.Next(0, s_encodingMap.Length);
+                int index = random.Next(0, s_encodingMap.Length);
                 result[i] = s_encodingMap[index];
             }
 

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -90,7 +90,7 @@ namespace BenchmarkDotNet.Extensions
 
             for (int i = 0; i < result.Length; i++)
             {
-                int index = (byte)random.Next(0, s_encodingMap.Length - 1);    // Do not pick '='
+                int index = (byte)random.Next(0, s_encodingMap.Length);
                 result[i] = s_encodingMap[index];
             }
 


### PR DESCRIPTION
The tests were using random generated chars. This would cause the Decode
functions to exit early (usually after a single iteration).
