### PR TITLE
Switch to using BUILD_REPOSITORY_PROVIDER to detect internal runs

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -54,7 +54,7 @@
     <UIScenario Include="WPF SFC" Condition="'$(TargetsWindows)' == 'true'">
       <PayloadDirectory>$(ScenariosDir)wpfsfc</PayloadDirectory>
     </UIScenario>
-    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(PerfCommandUploadTokenNonEscaped) != ''">
+    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(BUILD_REPOSITORY_PROVIDER) == 'TfsGit'">
       <PayloadDirectory>$(ScenariosDir)paintdotnet</PayloadDirectory>
     </UIScenario>
   </ItemGroup>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->

This change fixes the previous check for whether we were running internal, as it did not work.

