### PR TITLE
Update Maui Desktop Rollback Link

### DIFF
--- a/src/scenarios/mauidesktop/pre.py
+++ b/src/scenarios/mauidesktop/pre.py
@@ -17,7 +17,7 @@ NugetFile = requests.get(NugetURL)
 open('./Nuget.config', 'wb').write(NugetFile.content)
 
 precommands = PreCommands()
-precommands.install_workload('maui', ['--from-rollback-file', 'https://aka.ms/dotnet/maui/main.json', '--configfile', './Nuget.config'])
+precommands.install_workload('maui', ['--from-rollback-file', 'https://aka.ms/dotnet/maui/net6.0.json', '--configfile', './Nuget.config'])
 precommands.new(template='maui',
                 output_dir=const.APPDIR,
                 bin_dir=const.BINDIR,


### PR DESCRIPTION
This updates the Maui Desktop Rollback file to pull from the latest net6.0 workload instead of main, which is behind as main is for contributers.