### PR TITLE
Add `mauiblazordesktop` scenario

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -76,6 +76,7 @@
     </HelixWorkItem>
   </ItemGroup>
 
+  <!-- SOD & Device Startup for Windows Desktop MAUI -->
   <ItemGroup>
     <HelixWorkItem Include="SOD - Desktop Maui Unpackaged" Condition="'$(TargetsWindows)' == 'true'">
       <PayloadDirectory>$(ScenariosDir)mauidesktop</PayloadDirectory>
@@ -84,6 +85,20 @@
     </HelixWorkItem>
     <HelixWorkItem Include="Device Startup - Desktop Maui Default" Condition="'$(TargetsWindows)' == 'true'">
       <PayloadDirectory>$(ScenariosDir)mauidesktop</PayloadDirectory>
+      <PreCommands>$(Python) pre.py publish -c Release -f $(_Framework)-windows10.0.19041.0</PreCommands>
+      <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+  </ItemGroup>
+
+  <!-- SOD & Device Startup for Windows Desktop MAUI Blazor -->
+  <ItemGroup>
+    <HelixWorkItem Include="SOD - Desktop Maui Blazor Unpackaged" Condition="'$(TargetsWindows)' == 'true'">
+      <PayloadDirectory>$(ScenariosDir)mauiblazordesktop</PayloadDirectory>
+      <PreCommands>$(Python) pre.py publish -c Release -f $(_Framework)-windows10.0.19041.0</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <HelixWorkItem Include="Device Startup - Desktop Maui Blazor Default" Condition="'$(TargetsWindows)' == 'true'">
+      <PayloadDirectory>$(ScenariosDir)mauiblazordesktop</PayloadDirectory>
       <PreCommands>$(Python) pre.py publish -c Release -f $(_Framework)-windows10.0.19041.0</PreCommands>
       <Command>$(Python) test.py startup --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>

--- a/src/scenarios/mauiblazordesktop/post.py
+++ b/src/scenarios/mauiblazordesktop/post.py
@@ -1,0 +1,9 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import PostCommands, clean_directories
+
+postcommands = PostCommands()
+clean_directories()
+postcommands.uninstall_workload('maui')

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -26,4 +26,6 @@ precommands.new(template='maui-blazor',
                 no_restore=False)
 
 subprocess.run(["dotnet", "add", "./app", "package", "Microsoft.WindowsAppSDK"]) # Add the package reference for the Microsoft.WindowsAppSDK for self-contained running
+shutil.copy(os.path.join('src', 'Replacement.Index.razor.cs'), os.path.join(const.APPDIR, 'Pages', 'Index.razor.cs'))
+
 precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False'])

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -28,4 +28,4 @@ precommands.new(template='maui-blazor',
 subprocess.run(["dotnet", "add", "./app", "package", "Microsoft.WindowsAppSDK"]) # Add the package reference for the Microsoft.WindowsAppSDK for self-contained running
 shutil.copy(os.path.join('src', 'Replacement.Index.razor.cs'), os.path.join(const.APPDIR, 'Pages', 'Index.razor.cs'))
 
-precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False'])
+precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False','/p:PublishReadyToRun=true'])

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -18,7 +18,7 @@ open('./Nuget.config', 'wb').write(NugetFile.content)
 
 precommands = PreCommands()
 precommands.install_workload('maui', ['--from-rollback-file', 'https://aka.ms/dotnet/maui/net6.0.json', '--configfile', './Nuget.config'])
-precommands.new(template='maui',
+precommands.new(template='maui-blazor',
                 output_dir=const.APPDIR,
                 bin_dir=const.BINDIR,
                 exename=EXENAME,

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -1,0 +1,29 @@
+'''
+pre-command: Example call 'python .\pre.py publish -f net6.0-windows10.0.19041.0 -c Release'
+'''
+import shutil
+import subprocess
+import sys
+import os
+from performance.logger import setup_loggers
+from shared.precommands import PreCommands
+from shared import const
+from test import EXENAME
+import requests
+
+setup_loggers(True)
+NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
+NugetFile = requests.get(NugetURL)
+open('./Nuget.config', 'wb').write(NugetFile.content)
+
+precommands = PreCommands()
+precommands.install_workload('maui', ['--from-rollback-file', 'https://aka.ms/dotnet/maui/net6.0.json', '--configfile', './Nuget.config'])
+precommands.new(template='maui',
+                output_dir=const.APPDIR,
+                bin_dir=const.BINDIR,
+                exename=EXENAME,
+                working_directory=sys.path[0],
+                no_restore=False)
+
+subprocess.run(["dotnet", "add", "./app", "package", "Microsoft.WindowsAppSDK"]) # Add the package reference for the Microsoft.WindowsAppSDK for self-contained running
+precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False'])

--- a/src/scenarios/mauiblazordesktop/src/Replacement.Index.razor.cs
+++ b/src/scenarios/mauiblazordesktop/src/Replacement.Index.razor.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components;
+using System.Diagnostics.Tracing;
+namespace MauiBlazorDesktopTesting.Pages
+{
+    public partial class Index
+    {
+        private static EventSource log = new EventSource(
+            "Perf-Custom-Event",
+            EventSourceSettings.EtwSelfDescribingEventFormat);
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (firstRender)
+            {
+                log.Write("FirstRender", new EventSourceOptions {Level=EventLevel.Verbose, Opcode=EventOpcode.Info });
+            }
+        }
+    }
+}

--- a/src/scenarios/mauiblazordesktop/test.py
+++ b/src/scenarios/mauiblazordesktop/test.py
@@ -7,7 +7,7 @@ EXENAME = 'MauiBlazorDesktopTesting'
 def main():
     traits = TestTraits(exename=EXENAME,
                         guiapp='true',
-                        startupmetric='WinUI',
+                        startupmetric='WinUICustom',
                         timeout=30,
                         measurementdelay='6',
                         runwithoutexit='false',

--- a/src/scenarios/mauiblazordesktop/test.py
+++ b/src/scenarios/mauiblazordesktop/test.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+from shared.runner import TestTraits, Runner
+
+EXENAME = 'MauiBlazorDesktopTesting'
+
+def main():
+    traits = TestTraits(exename=EXENAME,
+                        guiapp='true',
+                        startupmetric='WinUI',
+                        timeout=30,
+                        measurementdelay='6',
+                        runwithoutexit='false',
+                        processwillexit="false",
+                        )
+    runner = Runner(traits)
+    runner.run()
+
+
+if __name__ == "__main__":
+    result = subprocess.run(['powershell', '-Command', r'Get-ChildItem .\pub\Microsoft.Maui.dll | Select-Object -ExpandProperty VersionInfo | Select-Object ProductVersion | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    os.environ["MAUI_VERSION"] = result.stdout.decode('utf-8').strip()
+    print(f'Env: MAUI_VERSION: {os.environ["MAUI_VERSION"]}')
+    if("sha" not in os.environ["MAUI_VERSION"] and "azdo" not in os.environ["MAUI_VERSION"]):
+        raise ValueError(f"MAUI_VERSION does not contain sha and azdo indicating failure to retrieve or set the value. MAUI_VERSION: {os.environ['MAUI_VERSION']}")
+    main()

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -21,7 +21,8 @@ namespace ScenarioMeasurement
         InnerLoopMsBuild,
         DotnetWatch,
         DeviceTimeToMain,
-        WinUI
+        WinUI,
+        WinUICustom
     }
 
     public class InnerLoopMarkerEventSource : EventSource
@@ -276,6 +277,9 @@ namespace ScenarioMeasurement
                 //     break;
                 case MetricType.WinUI:
                     parser = new WinUIParser();
+                    break;
+                case MetricType.WinUICustom:    
+                    parser = new WinUICustomParser();
                     break;
             }
 

--- a/src/tools/ScenarioMeasurement/Startup/WinUICustomParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WinUICustomParser.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Reporting;
+using System;
+using System.Collections.Generic;
+
+namespace ScenarioMeasurement
+{
+    public class WinUICustomParser : IParser
+    {
+        const String WinUIProvider = "Microsoft-Windows-XAML";
+        const String PerfProvider = "Perf-Custom-Event";
+
+        public void EnableKernelProvider(ITraceSession kernel)
+        {
+            kernel.EnableKernelProvider(TraceSessionManager.KernelKeyword.Process, TraceSessionManager.KernelKeyword.Thread, TraceSessionManager.KernelKeyword.ContextSwitch);
+        }
+
+        public void EnableUserProviders(ITraceSession user)
+        {
+            user.EnableUserProvider(WinUIProvider, TraceEventLevel.Verbose);
+            user.EnableUserProvider(PerfProvider, TraceEventLevel.Verbose);
+        }
+
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        {
+            var baseStartup = new List<double>();
+            var delayedStartup = new List<double>();
+            var threadTimes = new List<double>();
+            double threadTime = 0;
+            var ins = new Dictionary<int, double>();
+            double start = -1;
+            int? pid = null;
+            using (var source = new ETWTraceEventSource(mergeTraceFile))
+            {
+                source.Kernel.ProcessStart += evt =>
+                {
+                    if (processName.Equals(evt.ProcessName, StringComparison.OrdinalIgnoreCase) && pids.Contains(evt.ProcessID) && evt.CommandLine.Trim() == commandLine.Trim())
+                    {
+                        if (pid.HasValue)
+                        {
+                            // Processes might be reentrant. For now this traces the first (outermost) process of a given name.
+                            return;
+                        }
+                        pid = evt.ProcessID;
+                        start = evt.TimeStampRelativeMSec;
+                    }
+                };
+
+                source.Kernel.ThreadCSwitch += evt =>
+                {
+                    if (!pid.HasValue) // we're currently in a measurement interval
+                        return;
+
+                    if (evt.NewProcessID != pid && evt.OldProcessID != pid)
+                        return; // but this isn't our process
+
+                    if (evt.OldProcessID == pid) // this is a switch out from our process
+                    {
+                        if (ins.TryGetValue(evt.OldThreadID, out var value)) // had we ever recorded a switch in for this thread? 
+                        {
+                            threadTime += evt.TimeStampRelativeMSec - value;
+                            ins.Remove(evt.OldThreadID);
+                        }
+                    }
+                    else // this is a switch in to our process
+                    {
+                        ins[evt.NewThreadID] = evt.TimeStampRelativeMSec;
+                    }
+                };
+
+                source.Dynamic.AddCallbackForProviderEvent(WinUIProvider, "Frame/Stop", evt =>
+                {
+                    if (pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        baseStartup.Add(evt.TimeStampRelativeMSec - start);
+                    }
+                });
+
+                source.Dynamic.AddCallbackForProviderEvent(PerfProvider, "FirstRender", evt =>
+                {
+                    if (pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        delayedStartup.Add(evt.TimeStampRelativeMSec - start);
+                        threadTimes.Add(threadTime);
+                        pid = null;
+                        threadTime = 0;
+                        start = 0;
+                    }
+                });
+
+                source.Process();
+            }
+            return new[] {
+                new Counter() { Name = "WinUI Inner Blazor Startup", MetricName = "ms", DefaultCounter=true, TopCounter=true, Results = delayedStartup.ToArray() },
+                new Counter() { Name = "WinUI Startup", MetricName = "ms", DefaultCounter=false, TopCounter=true, Results = baseStartup.ToArray() },
+                new Counter() { Name = "Time on Thread", MetricName = "ms", TopCounter=true, Results = threadTimes.ToArray() }
+            };
+        }
+    }
+}


### PR DESCRIPTION
~~Adds the `mauiblazordesktop` scenario. How can we integrate with the `__MAUI_Blazor_WebView_OnAfterRender__` console "magic string", as we're doing on [other platforms](https://github.com/dotnet/runtime/pull/68685/files#diff-58d65effbc166c8c040b8e44f90ce3504a61b52916dca244c60b91ed8b547a41R239)?~~

~~We can probably update `pre.py` to actually write out the `__MAUI_Blazor_WebView_OnAfterRender__` ([this is how we do it for other platforms](https://github.com/dotnet/runtime/blob/dcb62e3d07fe29629abd63721002824e9d3fa7e2/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml#L222-L244)) ([we'll probably have to do something Windows compatible](https://stackoverflow.com/a/23530712)). We'll need to update the collection logic to ensure it only considers the app started once that string is printed to the console.~~