### PR TITLE
Remove unneeded centos yum install

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -61,9 +61,6 @@ jobs:
           - ${{ if eq(parameters.osName, 'ubuntu')}}:
             - name: InstallPrerequisites
               value: 'sudo apt-get -y install python3-venv'
-          - ${{ if eq(parameters.osName, 'centos')}}:
-            - name: InstallPrerequisites
-              value: 'sudo yum -y install clang zlib-devel krb5-libs krb5-devel'
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           # for public runs, we do not want to upload perflab data
           - name: PerfLabArguments


### PR DESCRIPTION
Some packages installed with yum for centos runs have been added to the centos image itself: https://github.com/dotnet/arcade/issues/9485. With these added, we should be able to remove the yum install command from the setup commands. 