### PR TITLE
Add TAR async benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
@@ -51,7 +52,17 @@ namespace System.Formats.Tar.Tests
         }
 
         [Benchmark]
+        public async Task CreateFromDirectory_Path_Async()
+        {
+            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destinationFileName: _outputTarFilePath, includeBaseDirectory: false);
+            File.Delete(_outputTarFilePath);
+        }
+
+        [Benchmark]
         public void ExtractToDirectory_Path() => TarFile.ExtractToDirectory(sourceFileName: _inputTarFilePath, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
+
+        [Benchmark]
+        public Task ExtractToDirectory_Path_Async() => TarFile.ExtractToDirectoryAsync(sourceFileName: _inputTarFilePath, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
 
         [Benchmark]
         public void CreateFromDirectory_Stream()
@@ -61,10 +72,28 @@ namespace System.Formats.Tar.Tests
         }
 
         [Benchmark]
+        public async Task CreateFromDirectory_Stream_Async()
+        {
+            await using (MemoryStream ms = new MemoryStream())
+            {
+                await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
+            }
+        }
+
+        [Benchmark]
         public void ExtractToDirectory_Stream()
         {
             using FileStream fs = File.OpenRead(_inputTarFilePath);
             TarFile.ExtractToDirectory(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
+        }
+
+        [Benchmark]
+        public async Task ExtractToDirectory_Stream_Async()
+        {
+            await using (FileStream fs = File.OpenRead(_inputTarFilePath))
+            {
+                await TarFile.ExtractToDirectoryAsync(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
+            }
         }
     }
 }

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -74,10 +74,8 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public async Task CreateFromDirectory_Stream_Async()
         {
-            await using (MemoryStream ms = new MemoryStream())
-            {
-                await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
-            }
+            await using MemoryStream ms = new MemoryStream();
+            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]
@@ -90,10 +88,8 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public async Task ExtractToDirectory_Stream_Async()
         {
-            await using (FileStream fs = File.OpenRead(_inputTarFilePath))
-            {
-                await TarFile.ExtractToDirectoryAsync(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
-            }
+            await using FileStream fs = File.OpenRead(_inputTarFilePath);
+            await TarFile.ExtractToDirectoryAsync(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
         }
     }
 }

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -88,7 +88,7 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public async Task ExtractToDirectory_Stream_Async()
         {
-            await using FileStream fs = File.OpenRead(_inputTarFilePath);
+            await using FileStream fs = new FileStream(_inputTarFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
             await TarFile.ExtractToDirectoryAsync(source: fs, destinationDirectoryName: _outputDirPath, overwriteFiles: true);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->

@adamsitnik @dakersnar I'm copying the existing _sync_ benchmarks and making them _async_.

### Important!

Do not merge yet! This change depends on moving the performance microbenchmarks project to consume [preview7](https://github.com/dotnet/runtime/blob/release/7.0-preview7/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs). These async APIs did not exist in [preview6](https://github.com/dotnet/runtime/blob/release/7.0-preview6/src/libraries/System.Formats.Tar/ref/System.Formats.Tar.cs).

