### PR TITLE
Add System.Text.Json SerializeToWriter/DeserializeFromReader benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
@@ -57,6 +57,14 @@ namespace System.Text.Json.Serialization.Tests
         [Benchmark]
         public T DeserializeFromUtf8Bytes() => JsonSerializer.Deserialize<T>(_utf8Serialized);
 
+        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
+        [Benchmark]
+        public T DeserializeFromReader()
+        {
+            Utf8JsonReader reader = new Utf8JsonReader(_utf8Serialized);
+            return JsonSerializer.Deserialize<T>(ref reader);
+        }
+
         [BenchmarkCategory(Categories.Libraries, Categories.JSON, Categories.NoWASM)]
         [Benchmark]
         public async Task<T> DeserializeFromStream()

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Filters;
 using MicroBenchmarks;
 using MicroBenchmarks.Serializers;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -37,6 +38,9 @@ namespace System.Text.Json.Serialization.Tests
         private MemoryStream _memoryStream;
         private object _objectWithObjectProperty;
 
+        private ArrayBufferWriter _bufferWriter;
+        private Utf8JsonWriter _writer;
+
         [GlobalSetup]
         public async Task Setup()
         {
@@ -46,6 +50,9 @@ namespace System.Text.Json.Serialization.Tests
             await JsonSerializer.SerializeAsync(_memoryStream, _value);
 
             _objectWithObjectProperty = new { Prop = (object)_value };
+
+            _bufferWriter = new ArrayBufferWriter();
+            _writer = new Utf8JsonWriter(_bufferWriter);
         }
 
         [GlobalCleanup]
@@ -58,6 +65,14 @@ namespace System.Text.Json.Serialization.Tests
         public byte[] SerializeToUtf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(_value);
 
         [Benchmark]
+        public void SerializeToWriter()
+        {
+            JsonSerializer.Serialize(_writer, _value);
+            _bufferWriter.Reset();
+            _writer.Reset();
+        }
+
+        [Benchmark]
         [BenchmarkCategory(Categories.NoWASM)]
         public async Task SerializeToStream()
         {
@@ -67,5 +82,42 @@ namespace System.Text.Json.Serialization.Tests
 
         [Benchmark]
         public string SerializeObjectProperty() => JsonSerializer.Serialize(_objectWithObjectProperty);
+
+        private sealed class ArrayBufferWriter : IBufferWriter<byte>
+        {
+            private int _offset = 0;
+            private byte[] _buffer = new byte[128];
+
+            // Clearing buffers not necessary in this benchmark.
+            public void Reset() => _offset = 0;
+
+            public void Advance(int count) => _offset += count;
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                int size = EnsureSize(sizeHint);
+                return _buffer.AsMemory(_offset, size);
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                int size = EnsureSize(sizeHint);
+                return _buffer.AsSpan(_offset, size);
+            }
+
+            private int EnsureSize(int sizeHint)
+            {
+                int totalSize = _buffer.Length;
+                int size = sizeHint == 0 ? 128 : sizeHint;
+
+                if ((uint)(_offset + size) > (uint)totalSize)
+                {
+                    int newSize = Math.Max(2 * totalSize, _offset + size);
+                    Array.Resize(ref _buffer, newSize);
+                }
+
+                return size;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a couple of System.Text.Json serialization benchmarks for writing directly to a `Utf8JsonWriter` targeting a prepopulated `IBufferWriter<byte>` and reading directly from `Utf8JsonReader`. Existing serialization benchmarks spend a substantial part of their time/allocations in buffer copying/UTF-8 transcoding, so this should provide clearer visibility in the performance of the raw serialization loop.