### PR TITLE
[wasm] Fix `dotnet-runtime-perf` build for wasm

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -42,7 +42,9 @@ namespace System.Net.NetworkInformation.Tests
                 try { _ = ips.BytesSent; } catch { }
                 try { _ = ips.IncomingPacketsDiscarded;} catch { }
                 try { _ = ips.IncomingPacketsWithErrors;} catch { }
+#if NET5_0_OR_GREATER
                 if (!OperatingSystem.IsLinux())
+#endif
                 {
                     try { _ = ips.IncomingUnknownProtocolPackets;} catch { }
                     try { _ = ips.NonUnicastPacketsSent; } catch { }
@@ -59,7 +61,9 @@ namespace System.Net.NetworkInformation.Tests
                 try { _ = ipp.DnsSuffix; } catch { };
                 try { _ = ipp.UnicastAddresses; } catch { };
                 try { _ = ipp.MulticastAddresses; } catch { };
+#if NET5_0_OR_GREATER
                 if (OperatingSystem.IsWindows())
+#endif
                 {
                     try { _ = ipp.IsDynamicDnsEnabled; } catch { };
                     try { _ = ipp.AnycastAddresses; } catch { };

--- a/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.NetworkInformation/NetworkInterfaceTests.cs
@@ -42,9 +42,12 @@ namespace System.Net.NetworkInformation.Tests
                 try { _ = ips.BytesSent; } catch { }
                 try { _ = ips.IncomingPacketsDiscarded;} catch { }
                 try { _ = ips.IncomingPacketsWithErrors;} catch { }
-                try { _ = ips.IncomingUnknownProtocolPackets;} catch { }
+                if (!OperatingSystem.IsLinux())
+                {
+                    try { _ = ips.IncomingUnknownProtocolPackets;} catch { }
+                    try { _ = ips.NonUnicastPacketsSent; } catch { }
+                }
                 try { _ = ips.NonUnicastPacketsReceived; } catch { }
-                try { _ = ips.NonUnicastPacketsSent; } catch { }
                 try { _ = ips.OutgoingPacketsDiscarded; } catch { }
                 try { _ = ips.OutgoingPacketsWithErrors; } catch { }
                 try { _ = ips.OutputQueueLength; } catch { }
@@ -54,10 +57,13 @@ namespace System.Net.NetworkInformation.Tests
                 // IP Properties
                 try { _ = ipp.IsDnsEnabled; } catch { };
                 try { _ = ipp.DnsSuffix; } catch { };
-                try { _ = ipp.IsDynamicDnsEnabled; } catch { };
                 try { _ = ipp.UnicastAddresses; } catch { };
                 try { _ = ipp.MulticastAddresses; } catch { };
-                try { _ = ipp.AnycastAddresses; } catch { };
+                if (OperatingSystem.IsWindows())
+                {
+                    try { _ = ipp.IsDynamicDnsEnabled; } catch { };
+                    try { _ = ipp.AnycastAddresses; } catch { };
+                }
                 try { _ = ipp.DnsAddresses; } catch { };
                 try { _ = ipp.GatewayAddresses; } catch { };
                 try { _ = ipp.DhcpServerAddresses; } catch { };


### PR DESCRIPTION
The wasm builds on `dotnet-runtime-perf` started breaking after `Fix
UnsupportedOSPlatformAttribute usage in
System.Net.NetworkInformation.cs`
(https://github.com/dotnet/runtime/pull/72792) was merged, with:

```
error CA1416: This call site is reachable on all platforms. 'IPInterfaceStatistics.IncomingUnknownProtocolPackets' is unsupported on: 'linux'. [/home/helixbot/work/AFE009B6/w/B4280986/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net7.0]
error CA1416: This call site is reachable on all platforms. 'IPInterfaceProperties.IsDynamicDnsEnabled' is supported on: 'windows'. [/home/helixbot/work/AFE009B6/w/B4280986/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net7.0]
error CA1416: This call site is reachable on all platforms. 'IPInterfaceStatistics.NonUnicastPacketsSent' is unsupported on: 'linux'. [/home/helixbot/work/AFE009B6/w/B4280986/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net7.0]
error CA1416: This call site is reachable on all platforms. 'IPInterfaceProperties.AnycastAddresses' is supported on: 'windows'. [/home/helixbot/work/AFE009B6/w/B4280986/e/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net7.0]
```

This commit adds guards around these calls.