### PR TITLE
fix NativeAOT benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Security.Cryptography/Perf.CryptoConfig.cs
+++ b/src/benchmarks/micro/libraries/System.Security.Cryptography/Perf.CryptoConfig.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography.X509Certificates;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
 
@@ -14,6 +16,13 @@ namespace System.Security.Cryptography.Tests
         [Arguments("SHA512")]
         [Arguments("RSA")]
         [Arguments("X509Chain")]
+#if NET5_0_OR_GREATER
+#pragma warning disable SYSLIB0021 // Type or member is obsolete
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(SHA512Managed))]
+#pragma warning restore SYSLIB0021 // Type or member is obsolete
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(X509Chain))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(RSACryptoServiceProvider))]
+#endif
         public object CreateFromName(string name) => CryptoConfig.CreateFromName(name);
     }
 }


### PR DESCRIPTION
annotate CryptoConfig.CreateFromName benchmarks with DynamicDependency attribute to fix NativeAOT benchmarks

@MichalStrehovsky it used to work, I am just letting you know in case there was so unintentional breaking change (which I doubt)