### PR TITLE
Add support for decimals in ValuesGenerator.

### DIFF
--- a/docs/microbenchmark-design-guidelines.md
+++ b/docs/microbenchmark-design-guidelines.md
@@ -368,7 +368,7 @@ T[] Array<T>(int count);
 Dictionary<TKey, TValue> Dictionary<TKey, TValue>(int count)
 ```
 
-As of today, the `T` can be: `byte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `bool`, `decimal`, `string`, and `Guid`. Extending `T` to more types is very welcomed!
+As of today, the `T` can be: `byte`, `sbyte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `bool`, `decimal`, `string`, and `Guid`. Extending `T` to more types is very welcomed!
 
 **Note:** `ValuesGenerator` is simply always creating a new instance of `Random` with a constant seed. It's a crucial component and its correctness is verified using  [Unit Tests](https://github.com/dotnet/performance/blob/main/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs).
 

--- a/docs/microbenchmark-design-guidelines.md
+++ b/docs/microbenchmark-design-guidelines.md
@@ -368,7 +368,7 @@ T[] Array<T>(int count);
 Dictionary<TKey, TValue> Dictionary<TKey, TValue>(int count)
 ```
 
-As of today, the `T` can be: `byte`, `char`, `int`, `double`, `bool` and `string`. Extending `T` to more types is very welcomed!
+As of today, the `T` can be: `byte`, `char`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, `bool`, `decimal`, `string`, and `Guid`. Extending `T` to more types is very welcomed!
 
 **Note:** `ValuesGenerator` is simply always creating a new instance of `Random` with a constant seed. It's a crucial component and its correctness is verified using  [Unit Tests](https://github.com/dotnet/performance/blob/main/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs).
 

--- a/src/benchmarks/micro/libraries/Common/AlignedMemory.cs
+++ b/src/benchmarks/micro/libraries/Common/AlignedMemory.cs
@@ -24,7 +24,7 @@ namespace System
         }
 
         public static unsafe AlignedMemory Allocate(uint length, uint alignment)
-            => new AlignedMemory(NativeMemory.AlignedAlloc(length, alignment), (int)length);
+            => new AlignedMemory(NativeMemory.AlignedAlloc((UIntPtr)length, (UIntPtr)alignment), (int)length);
 
         public bool IsDisposed => _disposed;
 

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -14,19 +14,31 @@ namespace BenchmarkDotNet.Extensions
     {
         private const int Seed = 12345; // we always use the same seed to have repeatable results!
 
+        /// <summary>
+        /// Returns a T value that is NOT the default(T) (typically zero) value.
+        /// For bool, there's only one choice (true/1).
+        /// For byte/sbyte, will never return byte.MaxValue (256) so there are a maximum of 254 values.
+        /// </summary>
         public static T GetNonDefaultValue<T>()
         {
-            if (typeof(T) == typeof(byte)) // we can't use ArrayOfUniqueValues for byte
-                return Array<T>(byte.MaxValue).First(value => !value.Equals(default));
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)) // we can't use ArrayOfUniqueValues for byte/sbyte (but they have the same range)
+                return Array<T>(byte.MaxValue).First(value => !value.Equals(default(T)));
             else
-                return ArrayOfUniqueValues<T>(2).First(value => !value.Equals(default));
+                return ArrayOfUniqueValues<T>(2).First(value => !value.Equals(default(T)));
         }
 
         /// <summary>
-        /// does not support byte because there are only 256 unique byte values
+        /// Returns an array of the requested size where each entry is a distinct value. 
+        /// For byte and sbyte support a maximum count of 255 because there are only 256
+        /// unique byte values. For bool, there are only 2 values so throw for more requested
         /// </summary>
         public static T[] ArrayOfUniqueValues<T>(int count)
         {
+             if (count > 2 && typeof(T) == typeof(bool))
+                throw new ArgumentOutOfRangeException("count", "Cannot exceed 2 for bool values");
+             if (count > 255 && (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)))
+                throw new ArgumentOutOfRangeException("count", "Cannot exceed 255 for byte or sbyte values");
+
             // allocate the array first to try to take advantage of memory randomization
             // as it's usually the first thing called from GlobalSetup method
             // which with MemoryRandomization enabled is the first method called right after allocation
@@ -50,6 +62,11 @@ namespace BenchmarkDotNet.Extensions
             return result;
         }
 
+        /// <summary>
+        /// Returns an array of the requested size where each entry is a random value and values could repeat 
+        /// For byte and sbyte values are built from Random.NextBytes, for other types GenerateValue is used
+        /// to generate a random value in the appropriate range
+        /// </summary>
         public static T[] Array<T>(int count)
         {
             var result = new T[count];
@@ -82,6 +99,10 @@ namespace BenchmarkDotNet.Extensions
             52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
         };
 
+        /// <summary>
+        /// Returns an array of bytes of the requested size where each entry is a random value 
+        /// from the legal subset of ASCII characters used in Base-64 encoded values
+        /// </summary>
         public static byte[] ArrayBase64EncodingBytes(int count)
         {
             var result = new byte[count];
@@ -97,8 +118,18 @@ namespace BenchmarkDotNet.Extensions
             return result;
         }
 
+        /// <summary>
+        /// Returns a Dictionary of the requested size where each entry is a has a distinct key value and
+        /// the stored values are randomly generated. 
+        /// GenerateValue is used to generate a random value in the appropriate range for both the key and value
+        /// </summary>
         public static Dictionary<TKey, TValue> Dictionary<TKey, TValue>(int count)
         {
+            if (count > 2 && typeof(TKey) == typeof(bool))
+                throw new ArgumentOutOfRangeException("count", "Cannot exceed 2 for Dictionary<bool, TValue>");
+            if (count > 255 && (typeof(TKey) == typeof(byte) || typeof(TKey) == typeof(sbyte)))
+                throw new ArgumentOutOfRangeException("count", "Cannot exceed 255 for Dictionary<byte, TValue> or Dictionary<sbyte, TValue>");
+
             var dictionary = new Dictionary<TKey, TValue>();
 
             var random = new Random(Seed);
@@ -114,6 +145,11 @@ namespace BenchmarkDotNet.Extensions
             return dictionary;
         }
 
+        /// <summary>
+        /// Returns an array of the requested size where each entry is a random string value.
+        /// The values are random length strings within the range requested and are composed
+        /// a random assortment of the letters a..z, A..Z, and digits 0..9
+        /// </summary>
         public static string[] ArrayOfStrings(int count, int minLength, int maxLength)
         {
             var random = new Random(Seed);
@@ -126,24 +162,32 @@ namespace BenchmarkDotNet.Extensions
             return strings;
         }
 
+        /// <summary>
+        /// Returns a random of the type requested
+        /// For strings, it will be a random assortment of the letters 'a'..'z', 'A'..'Z', or '0'..'9' that is 1 to 50 characters long
+        /// </summary>
         private static T GenerateValue<T>(Random random)
         {
+            // Note: some of these types (especially the unsigned and values larger than int) are not giving the full range of values.
+            // WE CANNOT change that now because existing performance tests are based on the values returned previously.
             if (typeof(T) == typeof(byte))
-                return (T)(object)(byte)random.Next(byte.MinValue, byte.MaxValue);
+                return (T)(object)(byte)random.Next(byte.MinValue, byte.MaxValue);      // note: will never return 256 as Random.Next max value is exclusive
+            if (typeof(T) == typeof(sbyte))
+                return (T)(object)(sbyte)random.Next(sbyte.MinValue, sbyte.MaxValue);   // note: will never return 128 as Random.Next max value is exclusive
             if (typeof(T) == typeof(char))
-                return (T)(object)(char)random.Next(char.MinValue, char.MaxValue);
+                return (T)(object)(char)random.Next(char.MinValue, char.MaxValue);      // note: will never return `\uffff` as Random.Next max value is exclusive
             if (typeof(T) == typeof(short))
-                return (T)(object)(short)random.Next(short.MaxValue);
+                return (T)(object)(short)random.Next(short.MaxValue);   // note: will never return short.MaxValue as Random.Next max value is exclusive
             if (typeof(T) == typeof(ushort))
-                return (T)(object)(ushort)random.Next(short.MaxValue);
+                return (T)(object)(ushort)random.Next(short.MaxValue);  // note: will never return short.MaxValue (right in the middle of the domain)
             if (typeof(T) == typeof(int))
-                return (T)(object)random.Next();
+                return (T)(object)random.Next();         // note: cannot call NextInt32 here, because that would change what we've returned in the past
             if (typeof(T) == typeof(uint))
-                return (T)(object)(uint)random.Next();
+                return (T)(object)(uint)random.Next();   // note: cannot call NextInt32 here, because that would change what we've returned in the past
             if (typeof(T) == typeof(long))
-                return (T)(object)(long)random.Next();
+                return (T)(object)(long)random.Next();   // note: will never return a value at or above int.MaxValue
             if (typeof(T) == typeof(ulong))
-                return (T)(object)(ulong)random.Next();
+                return (T)(object)(ulong)random.Next();  // note: will never return a value at or above int.MaxValue because Random.Next never returns negatives
             if (typeof(T) == typeof(float))
                 return (T)(object)(float)random.NextDouble();
             if (typeof(T) == typeof(double))
@@ -153,13 +197,17 @@ namespace BenchmarkDotNet.Extensions
             if (typeof(T) == typeof(decimal))
                 return (T)(object)GenerateRandomDecimal(random);
             if (typeof(T) == typeof(string))
-                return (T)(object)GenerateRandomString(random, 1, 50);
+                return (T)(object)GenerateRandomString(random, 1, 50);  // note: all strings have only the characters 'a'..'z', 'A'..'Z', or '0'..'9'
             if (typeof(T) == typeof(Guid))
-                return (T)(object)GenerateRandomGuid(random);
+                return (T)(object)GenerateRandomGuid(random);   // note: may return malformed Guids (not logically valid per RFC 4122 formatting)
 
             throw new NotImplementedException($"{typeof(T).Name} is not implemented");
         }
-
+     
+        /// <summary>
+        /// Returns a random length strings within the range requested and are composed
+        /// a random assortment of the letters a..z, A..Z, and digits 0..9
+        /// </summary>
         private static string GenerateRandomString(Random random, int minLength, int maxLength)
         {
             var length = random.Next(minLength, maxLength);
@@ -180,6 +228,11 @@ namespace BenchmarkDotNet.Extensions
             return builder.ToString();
         }
 
+        /// <summary>
+        /// Returns a randomly generated Guid.
+        /// Note: this is not guaranteed to be a reasonably formatted RFC 4122 Guid, NOR is this
+        /// necessarily a "Version 4 Random" guid. 
+        /// </summary>
         private static Guid GenerateRandomGuid(Random random)
         {
             byte[] bytes = new byte[16];
@@ -187,8 +240,14 @@ namespace BenchmarkDotNet.Extensions
             return new Guid(bytes);
         }
 
+        /// <summary>
+        /// Returns a randomly generated decimal value. 
+        /// Note: returns a value across the entire valid decimal value-space
+        /// </summary>
         private static decimal GenerateRandomDecimal(Random random)
         {
+            // Decimal values have a sign, a scale, and 96 bits of significance (lo/mid/high)
+            // generate those parts randomly and assemble a valid decimal
             byte scale = (byte)random.Next(29);
             bool sign = random.Next(2) == 0;
             return new decimal(random.NextInt32(),
@@ -197,7 +256,15 @@ namespace BenchmarkDotNet.Extensions
                                sign,
                                scale);
         }
-
+       
+        /// <summary>
+        /// Returns a randomly generated int value from the entire range of legal 32-bit integers
+        /// Note: using Random.Next will never return negative values so we can't use that where
+        /// we want the complete bit-space.
+        /// WARNING: Do not use this method in the GenerateValue for the various int-like types
+        /// as that would change the range and order of values returned and THAT would change the
+        /// performance benchmarks
+        /// </summary>
         private static int NextInt32(this Random random)
         {
             int firstBits = random.Next(0, 1 << 4) << 28;

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -128,6 +128,8 @@ namespace BenchmarkDotNet.Extensions
 
         private static T GenerateValue<T>(Random random)
         {
+            if (typeof(T) == typeof(byte))
+                return (T)(object)(byte)random.Next(byte.MinValue, byte.MaxValue);
             if (typeof(T) == typeof(char))
                 return (T)(object)(char)random.Next(char.MinValue, char.MaxValue);
             if (typeof(T) == typeof(short))

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -33,7 +33,7 @@ namespace BenchmarkDotNet.Extensions
             // of random-sized memory by BDN engine
             T[] result = new T[count];
 
-            var random = new Random(Seed); 
+            var random = new Random(Seed);
 
             var uniqueValues = new HashSet<T>();
 
@@ -49,12 +49,12 @@ namespace BenchmarkDotNet.Extensions
 
             return result;
         }
-        
+
         public static T[] Array<T>(int count)
         {
             var result = new T[count];
 
-            var random = new Random(Seed); 
+            var random = new Random(Seed);
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
@@ -148,6 +148,8 @@ namespace BenchmarkDotNet.Extensions
                 return (T)(object)random.NextDouble();
             if (typeof(T) == typeof(bool))
                 return (T)(object)(random.NextDouble() > 0.5);
+            if (typeof(T) == typeof(decimal))
+                return (T)(object)GenerateRandomDecimal(random);
             if (typeof(T) == typeof(string))
                 return (T)(object)GenerateRandomString(random, 1, 50);
             if (typeof(T) == typeof(Guid))
@@ -166,11 +168,11 @@ namespace BenchmarkDotNet.Extensions
                 var rangeSelector = random.Next(0, 3);
 
                 if (rangeSelector == 0)
-                    builder.Append((char) random.Next('a', 'z'));
+                    builder.Append((char)random.Next('a', 'z'));
                 else if (rangeSelector == 1)
-                    builder.Append((char) random.Next('A', 'Z'));
+                    builder.Append((char)random.Next('A', 'Z'));
                 else
-                    builder.Append((char) random.Next('0', '9'));
+                    builder.Append((char)random.Next('0', '9'));
             }
 
             return builder.ToString();
@@ -181,6 +183,24 @@ namespace BenchmarkDotNet.Extensions
             byte[] bytes = new byte[16];
             random.NextBytes(bytes);
             return new Guid(bytes);
+        }
+
+        private static decimal GenerateRandomDecimal(Random random)
+        {
+            byte scale = (byte)random.Next(29);
+            bool sign = random.Next(2) == 0;
+            return new decimal(random.NextInt32(),
+                               random.NextInt32(),
+                               random.NextInt32(),
+                               sign,
+                               scale);
+        }
+
+        private static int NextInt32(this Random random)
+        {
+            int firstBits = random.Next(0, 1 << 4) << 28;
+            int lastBits = random.Next(0, 1 << 28);
+            return firstBits | lastBits;
         }
     }
 }

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs
@@ -18,6 +18,8 @@ namespace Tests
         [Fact]
         public void GeneratedArraysContainOnlyUniqueValues()
         {
+            AssertGeneratedArraysContainOnlyUniqueValues<bool>(2);
+            AssertGeneratedArraysContainOnlyUniqueValues<byte>(255);
             AssertGeneratedArraysContainOnlyUniqueValues<int>(1024);
             AssertGeneratedArraysContainOnlyUniqueValues<string>(1024);
         }
@@ -34,6 +36,7 @@ namespace Tests
         [Fact]
         public void GeneratedArraysContainAlwaysSameValues()
         {
+            AssertGeneratedArraysContainAlwaysSameValues<byte>(255);
             AssertGeneratedArraysContainAlwaysSameValues<int>(1024);
             AssertGeneratedArraysContainAlwaysSameValues<string>(1024);
         }
@@ -68,119 +71,100 @@ namespace Tests
         [Fact]
         public void GetNonDefaultValueReturnsNonDefaultValue()
         {
+            Assert.True(ValuesGenerator.GetNonDefaultValue<bool>());
             Assert.NotEqual(default(byte), ValuesGenerator.GetNonDefaultValue<byte>());
             Assert.NotEqual(default(int), ValuesGenerator.GetNonDefaultValue<int>());
             Assert.NotEqual(default(string), ValuesGenerator.GetNonDefaultValue<string>());
         }
 
         [Fact]
-        public void SupportsByte()
-        {
-            Supports<byte>();
-        }
+        public void SupportsByte() => Supports<byte>(255);  // note: testing to a maximum of 255 because byte.MaxValue is never generated
 
         [Fact]
-        public void SupportsChar()
-        {
-            Supports<char>();
-        }
+        public void ThrowsOnTooManyBytes() => Assert.Throws<ArgumentOutOfRangeException>(() => Supports<byte>(256));
 
         [Fact]
-        public void SupportsShort()
-        {
-            Supports<short>();
-        }
+        public void SupportsSignedByte() => Supports<sbyte>(127);  // note: testing to a maximum of 127 because sbyte.MaxValue is never generated
 
         [Fact]
-        public void SupportsUnsignedShort()
-        {
-            Supports<ushort>();
-        }
+        public void ThrowsOnTooManySignedBytes() => Assert.Throws<ArgumentOutOfRangeException>(() => Supports<sbyte>(256));
 
         [Fact]
-        public void SupportsInteger()
-        {
-            Supports<int>();
-        }
+        public void SupportsChar() => Supports<char>();
 
         [Fact]
-        public void SupportsUnsignedInteger()
-        {
-            Supports<uint>();
-        }
+        public void SupportsShort() => Supports<short>();
 
         [Fact]
-        public void SupportsLong()
-        {
-            Supports<long>();
-        }
- 
-        [Fact]
-        public void SupportsUnsignedLong()
-        {
-            Supports<ulong>();
-        }
+        public void SupportsUnsignedShort() => Supports<ushort>();
 
         [Fact]
-        public void SupportsFloat()
-        {
-            Supports<float>();
-        }
+        public void SupportsInteger() => Supports<int>();
 
         [Fact]
-        public void SupportsDouble()
-        {
-            Supports<double>();
-        }
+        public void SupportsUnsignedInteger() => Supports<uint>();
 
         [Fact]
-        public void SupportsBool()
-        {
-            SupportsArray<bool>();
-        }
+        public void SupportsLong() => Supports<long>();
 
         [Fact]
-        public void SupportsDecimal()
-        {
-            Supports<decimal>();
-        }
+        public void SupportsUnsignedLong() => Supports<ulong>();
 
         [Fact]
-        public void SupportsString()
-        {
-            Supports<string>();
-        }
+        public void SupportsFloat() => Supports<float>();
 
         [Fact]
-        public void SupportsGuid()
-        {
-            Supports<Guid>();
-        }
+        public void SupportsDouble() => Supports<double>();
 
-        private static void SupportsArray<T>()
+        [Fact]
+        public void SupportsBool() => Supports<bool>(2);
+
+        [Fact]
+        public void ThrowsOnTooManyBools() => Assert.Throws<ArgumentOutOfRangeException>(() => Supports<bool>(3));
+
+        [Fact]
+        public void SupportsDecimal() => Supports<decimal>();
+
+        [Fact]
+        public void SupportsString() => Supports<string>();
+
+        [Fact]
+        public void SupportsGuid() => Supports<Guid>();
+
+        private static void SupportsArray<T>(int count)
         {
-            var array = ValuesGenerator.Array<T>(10);
+            var array = ValuesGenerator.Array<T>(count);
             Assert.NotNull(array);
-            Assert.Equal(10, array.Length);
+            Assert.Equal(count, array.Length);
         }
-        private static void SupportsArrayOfUniques<T>()
+
+        private static void SupportsArrayOfUniques<T>(int count)
         {
-            var array = ValuesGenerator.ArrayOfUniqueValues<T>(5);
+            var array = ValuesGenerator.ArrayOfUniqueValues<T>(count);
             Assert.NotNull(array);
-            Assert.Equal(5, array.Length);
+            Assert.Equal(count, array.Length);
         }
 
         private static void SupportsNonDefaultValue<T>()
         {
             var value = ValuesGenerator.GetNonDefaultValue<T>();
-            Assert.NotEqual(default(T), value);
+            Assert.NotEqual(default, value);
         }
 
-        private static void Supports<T>()
+        private static void SupportsDictionary<TKey, TValue>(int count)
         {
-            SupportsArray<T>();
+            var dictionary = ValuesGenerator.Dictionary<TKey, TValue>(count);
+            Assert.NotNull(dictionary);
+            Assert.Equal(count, dictionary.Count);
+        }
+
+        private static void Supports<T>(int count = 10)
+        {
+            SupportsArray<T>(count);
             SupportsNonDefaultValue<T>();
-            SupportsArrayOfUniques<T>();
+            SupportsArrayOfUniques<T>(count);
+            SupportsDictionary<T, T>(count);
+            SupportsDictionary<T, string>(count);
         }
     }
 }

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/UniqueValuesGeneratorTests.cs
@@ -72,5 +72,115 @@ namespace Tests
             Assert.NotEqual(default(int), ValuesGenerator.GetNonDefaultValue<int>());
             Assert.NotEqual(default(string), ValuesGenerator.GetNonDefaultValue<string>());
         }
+
+        [Fact]
+        public void SupportsByte()
+        {
+            Supports<byte>();
+        }
+
+        [Fact]
+        public void SupportsChar()
+        {
+            Supports<char>();
+        }
+
+        [Fact]
+        public void SupportsShort()
+        {
+            Supports<short>();
+        }
+
+        [Fact]
+        public void SupportsUnsignedShort()
+        {
+            Supports<ushort>();
+        }
+
+        [Fact]
+        public void SupportsInteger()
+        {
+            Supports<int>();
+        }
+
+        [Fact]
+        public void SupportsUnsignedInteger()
+        {
+            Supports<uint>();
+        }
+
+        [Fact]
+        public void SupportsLong()
+        {
+            Supports<long>();
+        }
+ 
+        [Fact]
+        public void SupportsUnsignedLong()
+        {
+            Supports<ulong>();
+        }
+
+        [Fact]
+        public void SupportsFloat()
+        {
+            Supports<float>();
+        }
+
+        [Fact]
+        public void SupportsDouble()
+        {
+            Supports<double>();
+        }
+
+        [Fact]
+        public void SupportsBool()
+        {
+            SupportsArray<bool>();
+        }
+
+        [Fact]
+        public void SupportsDecimal()
+        {
+            Supports<decimal>();
+        }
+
+        [Fact]
+        public void SupportsString()
+        {
+            Supports<string>();
+        }
+
+        [Fact]
+        public void SupportsGuid()
+        {
+            Supports<Guid>();
+        }
+
+        private static void SupportsArray<T>()
+        {
+            var array = ValuesGenerator.Array<T>(10);
+            Assert.NotNull(array);
+            Assert.Equal(10, array.Length);
+        }
+        private static void SupportsArrayOfUniques<T>()
+        {
+            var array = ValuesGenerator.ArrayOfUniqueValues<T>(5);
+            Assert.NotNull(array);
+            Assert.Equal(5, array.Length);
+        }
+
+        private static void SupportsNonDefaultValue<T>()
+        {
+            var value = ValuesGenerator.GetNonDefaultValue<T>();
+            Assert.NotEqual(default(T), value);
+        }
+
+        private static void Supports<T>()
+        {
+            SupportsArray<T>();
+            SupportsNonDefaultValue<T>();
+            SupportsArrayOfUniques<T>();
+        }
     }
 }


### PR DESCRIPTION
As suggested in the documentation, added support for the decimal type.
Also corrected the documentation to properly enumerate the supported types.
Fixes #2546