### PR TITLE
add binary xml version to xml benchmarks

### DIFF
--- a/src/benchmarks/micro/Serializers/Xml_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_FromStream.cs
@@ -91,7 +91,7 @@ namespace MicroBenchmarks.Serializers
 
         [GlobalCleanup]
         public void Cleanup()
-		  {
+        {
             xmlDictionaryReader.Dispose();
             memoryStream.Dispose();
         }

--- a/src/benchmarks/micro/Serializers/Xml_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_FromStream.cs
@@ -92,8 +92,8 @@ namespace MicroBenchmarks.Serializers
         [GlobalCleanup]
         public void Cleanup()
         {
-            xmlDictionaryReader.Dispose();
-            memoryStream.Dispose();
+            xmlDictionaryReader?.Dispose();
+            memoryStream?.Dispose();
         }
     }
 }

--- a/src/benchmarks/micro/Serializers/Xml_FromStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_FromStream.cs
@@ -26,6 +26,8 @@ namespace MicroBenchmarks.Serializers
         private XmlSerializer xmlSerializer;
         private DataContractSerializer dataContractSerializer;
         private MemoryStream memoryStream;
+        private byte[] memoryBytes;
+        private XmlDictionaryReader xmlDictionaryReader;
 
         [GlobalSetup(Target = nameof(XmlSerializer_))]
         public void SetupXmlSerializer()
@@ -63,9 +65,35 @@ namespace MicroBenchmarks.Serializers
             return (T)dataContractSerializer.ReadObject(memoryStream);
         }
 
-        // YAXSerializer is not included in the benchmarks because it does not allow to deserialize from stream (only from file and string)
+        [GlobalSetup(Target = nameof(DataContractSerializer_BinaryXml_))]
+        public void SetupDataContractSerializer_BinaryXml_()
+        {
+            value = DataGenerator.Generate<T>();
+            memoryStream = new MemoryStream(capacity: short.MaxValue);
+            memoryStream.Position = 0;
+            dataContractSerializer = new DataContractSerializer(typeof(T));
+            using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(memoryStream, null, null, ownsStream: false))
+               dataContractSerializer.WriteObject(writer, value);
+
+            memoryBytes = memoryStream.ToArray();
+            xmlDictionaryReader = XmlDictionaryReader.CreateBinaryReader(memoryBytes, XmlDictionaryReaderQuotas.Max);
+        }
+
+        [BenchmarkCategory(Categories.Libraries)]
+        [Benchmark(Description = nameof(XmlDictionaryReader))]
+        public T DataContractSerializer_BinaryXml_()
+        {
+            ((IXmlBinaryReaderInitializer)xmlDictionaryReader).SetInput(memoryBytes, 0, memoryBytes.Length, null, XmlDictionaryReaderQuotas.Max, null, null);
+            return (T)dataContractSerializer.ReadObject(xmlDictionaryReader);
+        }
+
+      // YAXSerializer is not included in the benchmarks because it does not allow to deserialize from stream (only from file and string)
 
         [GlobalCleanup]
-        public void Cleanup() => memoryStream.Dispose();
+        public void Cleanup()
+		  {
+            xmlDictionaryReader.Dispose();
+            memoryStream.Dispose();
+        }
     }
 }

--- a/src/benchmarks/micro/Serializers/Xml_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_ToStream.cs
@@ -69,8 +69,8 @@ namespace MicroBenchmarks.Serializers
         [GlobalCleanup]
         public void Dispose()
         {
-            xmlDictionaryWriter.Dispose();
-            memoryStream.Dispose();
+            xmlDictionaryWriter?.Dispose();
+            memoryStream?.Dispose();
         }
     }
 }

--- a/src/benchmarks/micro/Serializers/Xml_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Xml_ToStream.cs
@@ -25,6 +25,7 @@ namespace MicroBenchmarks.Serializers
         private T value;
         private XmlSerializer xmlSerializer;
         private DataContractSerializer dataContractSerializer;
+        private XmlDictionaryWriter xmlDictionaryWriter;
         private MemoryStream memoryStream;
 
         [GlobalSetup]
@@ -34,6 +35,7 @@ namespace MicroBenchmarks.Serializers
             memoryStream = new MemoryStream(capacity: short.MaxValue);
             xmlSerializer = new XmlSerializer(typeof(T));
             dataContractSerializer = new DataContractSerializer(typeof(T));
+            xmlDictionaryWriter = XmlDictionaryWriter.CreateBinaryWriter(memoryStream, null, null, ownsStream: false);
         }
 
         [BenchmarkCategory(Categories.Libraries, Categories.Runtime)]
@@ -52,9 +54,23 @@ namespace MicroBenchmarks.Serializers
             dataContractSerializer.WriteObject(memoryStream, value);
         }
 
+        [BenchmarkCategory(Categories.Libraries)]
+        [Benchmark(Description = nameof(XmlDictionaryWriter))]
+        public void DataContractSerializer_BinaryXml_()
+        {
+            memoryStream.Position = 0;
+            ((IXmlBinaryWriterInitializer)xmlDictionaryWriter).SetOutput(memoryStream, null, null, ownsStream: false);
+
+            dataContractSerializer.WriteObject(xmlDictionaryWriter, value);
+        }
+
         // YAXSerializer is not included in the benchmarks because it does not allow to serialize to stream (only to file and string)
 
         [GlobalCleanup]
-        public void Dispose() => memoryStream.Dispose();
+        public void Dispose()
+        {
+            xmlDictionaryWriter.Dispose();
+            memoryStream.Dispose();
+        }
     }
 }


### PR DESCRIPTION
As suggested by @danmoseley in https://github.com/dotnet/runtime/pull/73336#issuecomment-1214465324

This should help protect performance for binary xml scenarios such as corewcf.

Apart from [PR mentioned above](https://github.com/dotnet/runtime/pull/73336) this should also cover the changes in
- https://github.com/dotnet/runtime/pull/73332
- https://github.com/dotnet/runtime/pull/71478

And generally make Datacontractserializer changes easier to spot since binary xml has lower overhead than text based version