### PR TITLE
Remove base diff

### DIFF
--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -44,7 +44,7 @@ namespace ResultsComparer
                 Console.WriteLine($"## {benchmarkResults.Key}");
                 Console.WriteLine();
 
-                var table; 
+                var table = null;
                 if (args.RatioOnly) 
                 {
                     var data = benchmarkResults

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -44,7 +44,7 @@ namespace ResultsComparer
                 Console.WriteLine($"## {benchmarkResults.Key}");
                 Console.WriteLine();
 
-                var table = null;
+                Table table = null;
                 if (args.RatioOnly) 
                 {
                     var data = benchmarkResults

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -11,6 +11,7 @@ namespace ResultsComparer
     internal static class MultipleInputsComparer
     {
         private static readonly string[] Headers = new[] { "Result", "Base", "Diff", "Ratio", "Alloc Delta", "Operating System", "Bit", "Processor Name", "Modality" };
+        private static readonly string[] HeadersRatioOnly = new[] { "Result", "Ratio", "Alloc Delta", "Operating System", "Bit", "Processor Name", "Modality" };
 
         internal static void Compare(MultipleInputsOptions args)
         {
@@ -18,8 +19,11 @@ namespace ResultsComparer
             Console.WriteLine();
             Console.WriteLine($"* Statistical Test threshold: {args.StatisticalTestThreshold}, the noise filter: {args.NoiseThreshold}");
             Console.WriteLine($"* Result is conclusion: Slower|Faster|Same|Noise|Unknown. Noise means that the difference was larger than {args.StatisticalTestThreshold} but not {args.NoiseThreshold}.");
-            Console.WriteLine($"* Base is median base execution time in nanoseconds for {args.BasePattern}");
-            Console.WriteLine($"* Diff is median diff execution time in nanoseconds for {args.DiffPattern}");
+            if (!args.RatioOnly) 
+            {
+                Console.WriteLine($"* Base is median base execution time in nanoseconds for {args.BasePattern}");
+                Console.WriteLine($"* Diff is median diff execution time in nanoseconds for {args.DiffPattern}");
+            }
             Console.WriteLine("* Ratio = Base/Diff (the higher the better).");
             Console.WriteLine("* Alloc Delta = Allocated bytes diff - Allocated bytes base (the lower the better)");
             Console.WriteLine();
@@ -40,23 +44,43 @@ namespace ResultsComparer
                 Console.WriteLine($"## {benchmarkResults.Key}");
                 Console.WriteLine();
 
-                var data = benchmarkResults
-                    .OrderBy(result => Order(result.baseEnv))
-                    .Select(result => new
-                    {
-                        Conclusion = result.conclusion == Stats.Noise ? "Noise" : result.conclusion.ToString(),
-                        BaseMedian = result.baseResult.Statistics.Median,
-                        DiffMedian = result.diffResult.Statistics.Median,
-                        Ratio = GetRatio(result),
-                        AllocatedDiff = GetAllocatedDiff(result.diffResult, result.baseResult),
-                        OperatingSystem = Stats.GetSimplifiedOSName(result.baseEnv.OsVersion),
-                        Architecture = result.baseEnv.Architecture,
-                        ProcessorName = result.baseEnv.ProcessorName,
-                        Modality = Helper.GetModalInfo(result.baseResult) ?? Helper.GetModalInfo(result.diffResult),
-                    })
-                    .ToArray();
-
-                var table = data.ToMarkdownTable().WithHeaders(Headers);
+                var table; 
+                if (args.RatioOnly) 
+                {
+                    var data = benchmarkResults
+                        .OrderBy(result => Order(result.baseEnv))
+                        .Select(result => new
+                        {
+                            Conclusion = result.conclusion == Stats.Noise ? "Noise" : result.conclusion.ToString(),
+                            Ratio = GetRatio(result),
+                            AllocatedDiff = GetAllocatedDiff(result.diffResult, result.baseResult),
+                            OperatingSystem = Stats.GetSimplifiedOSName(result.baseEnv.OsVersion),
+                            Architecture = result.baseEnv.Architecture,
+                            ProcessorName = result.baseEnv.ProcessorName,
+                            Modality = Helper.GetModalInfo(result.baseResult) ?? Helper.GetModalInfo(result.diffResult),
+                        })
+                        .ToArray();
+                    table = data.ToMarkdownTable().WithHeaders(HeadersRatioOnly);
+                } 
+                else 
+                {
+                    var data = benchmarkResults
+                        .OrderBy(result => Order(result.baseEnv))
+                        .Select(result => new
+                        {
+                            Conclusion = result.conclusion == Stats.Noise ? "Noise" : result.conclusion.ToString(),
+                            BaseMedian = result.baseResult.Statistics.Median,
+                            DiffMedian = result.diffResult.Statistics.Median,
+                            Ratio = GetRatio(result),
+                            AllocatedDiff = GetAllocatedDiff(result.diffResult, result.baseResult),
+                            OperatingSystem = Stats.GetSimplifiedOSName(result.baseEnv.OsVersion),
+                            Architecture = result.baseEnv.Architecture,
+                            ProcessorName = result.baseEnv.ProcessorName,
+                            Modality = Helper.GetModalInfo(result.baseResult) ?? Helper.GetModalInfo(result.diffResult),
+                        })
+                        .ToArray();
+                    table = data.ToMarkdownTable().WithHeaders(Headers);
+                }
 
                 foreach (var line in table.ToMarkdown().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
                     Console.WriteLine($"| {line.TrimStart()}|"); // the table starts with \t and does not end with '|' and it looks bad so we fix it

--- a/src/tools/ResultsComparer/MultipleInputsOptions.cs
+++ b/src/tools/ResultsComparer/MultipleInputsOptions.cs
@@ -18,5 +18,6 @@ namespace ResultsComparer
         public int? TopCount { get; init; }
         public Regex[] Filters { get; init; }
         public bool PrintStats { get; init; }
+        public bool RatioOnly { get; init; }
     }
 }

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -79,7 +79,7 @@ namespace ResultsComparer
 
             rootCommand.AddCommand(matrixCommand);
 
-            matrixCommand.SetHandler<DirectoryInfo, string, string, string, string, int?, string[], bool>(
+            matrixCommand.SetHandler<DirectoryInfo, string, string, string, string, int?, string[], bool, bool>(
                 static (input, basePattern, diffPattern, threshold, noise, top, filters, printStats, ratioOnly) =>
                 {
                     if (TryParseThresholds(threshold, noise, out var testThreshold, out var noiseThreshold)

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -69,16 +69,18 @@ namespace ResultsComparer
                 new[] { "--diff" }, "Pattern used to search for diff results in Input folder. Example: net7.0-preview3");
             Option<bool> printStats = new Option<bool>(
                 new[] { "--stats" }, () => true, "Prints summary per Architecture, Namespace and Operating System.");
+            Option<bool> ratioOnly = new Option<bool>(
+                new[] { "--ratio-only" }, "Do not display the base and diff columns in the results.");
 
             Command matrixCommand = new Command("matrix", "Produces a matrix for all configurations found in given folder.")
             {
-                input.AsRequired(), basePattern.AsRequired(), diffPattern.AsRequired(), threshold, noise, top, filters, printStats
+                input.AsRequired(), basePattern.AsRequired(), diffPattern.AsRequired(), threshold, noise, top, filters, printStats, ratioOnly
             };
 
             rootCommand.AddCommand(matrixCommand);
 
             matrixCommand.SetHandler<DirectoryInfo, string, string, string, string, int?, string[], bool>(
-                static (input, basePattern, diffPattern, threshold, noise, top, filters, printStats) =>
+                static (input, basePattern, diffPattern, threshold, noise, top, filters, printStats, ratioOnly) =>
                 {
                     if (TryParseThresholds(threshold, noise, out var testThreshold, out var noiseThreshold)
                         && TryGetPaths(input, basePattern, diffPattern, out var basePaths, out var diffPaths))
@@ -93,10 +95,11 @@ namespace ResultsComparer
                             NoiseThreshold = noiseThreshold,
                             TopCount = top,
                             Filters = GetFilters(filters),
-                            PrintStats = printStats
+                            PrintStats = printStats,
+                            RatioOnly = ratioOnly
                         });
                     }
-                }, input, basePattern, diffPattern, threshold, noise, top, filters, printStats);
+                }, input, basePattern, diffPattern, threshold, noise, top, filters, printStats, ratioOnly);
 
             Option<FileInfo> zip = new Option<FileInfo>(
                 new[] { "--input", "-i" }, "Path to the compressed .zip file that contains results downloaded from SharePoint.");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->

When publishing the monthly perf report, it is necessary to generate a version of the report without the raw base and diff data, only publicly showing the ratio between them. This PR adds a `--ratio-only` flag to `benchmarks_monthly`, which generates the final report without the base and diff columns.

