### PR TITLE
Add reflection invoke benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
@@ -80,14 +80,15 @@ namespace System.Reflection
         }
 
         [Benchmark]
-        public void StaticMethod4_int_string_struct_class()
+        // Include the array allocation and population for a typical scenario.
+        public void StaticMethod4_arrayNotCached_int_string_struct_class()
         {
             object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
             s_method_int_string_struct_class.Invoke(null, args);
         }
 
         [Benchmark]
-        public void StaticMethod4_PreInstantiatedObjectArray_int_string_struct_class()
+        public void StaticMethod4_int_string_struct_class()
         {
             s_method_int_string_struct_class.Invoke(null, s_args);
         }
@@ -95,21 +96,7 @@ namespace System.Reflection
         [Benchmark]
         public void StaticMethod4_ByRefParams_int_string_struct_class()
         {
-            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
-            s_method_byref_int_string_struct_class.Invoke(null, args);
-        }
-
-        [Benchmark]
-        public void StaticMethod4_ByRefParams_PreInstantiatedObjectArray_int_string_struct_class()
-        {
             s_method_byref_int_string_struct_class.Invoke(null, s_args);
-        }
-
-        [Benchmark]
-        public void StaticMethod1_NullableInt()
-        {
-            object[] args = new object[] { 42 };
-            s_method_nullableInt.Invoke(null, args);
         }
 
         [Benchmark]
@@ -127,15 +114,13 @@ namespace System.Reflection
         [Benchmark]
         public void Ctor4_int_string_struct_class()
         {
-            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
-            s_ctor_int_string_struct_class.Invoke(args);
+            s_ctor_int_string_struct_class.Invoke(s_args);
         }
 
         [Benchmark]
         public void Ctor4_ActivatorCreateInstance()
         {
-            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
-            Activator.CreateInstance(typeof(MyClass), args);
+            Activator.CreateInstance(typeof(MyClass), s_args);
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
+    public class Invoke
+    {
+        private static MyClass s_MyClass = new MyClass();
+        private static object[] s_args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+        private static int s_dummy;
+        private static MethodInfo s_method;
+        private static MethodInfo s_method_int_string_struct_class;
+        private static MethodInfo s_method_byref_int_string_struct_class;
+        private static MethodInfo s_method_nullableInt;
+        private static ConstructorInfo s_ctor_int_string_struct_class;
+        private static ConstructorInfo s_ctor_NoParams;
+        private static PropertyInfo s_property_int;
+        private static PropertyInfo s_property_class;
+        private static FieldInfo s_field_int;
+        private static FieldInfo s_field_class;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_method = typeof(MyClass).
+                GetMethod(nameof(MyClass.MyMethod), BindingFlags.Public | BindingFlags.Instance)!;
+
+            s_method_int_string_struct_class = typeof(Invoke).
+                GetMethod(nameof(Method_int_string_struct_class), BindingFlags.Public | BindingFlags.Static)!;
+
+            s_method_byref_int_string_struct_class = typeof(Invoke).
+                GetMethod(nameof(Method_byref_int_string_struct_class), BindingFlags.Public | BindingFlags.Static)!;
+
+            s_method_nullableInt = typeof(Invoke).
+                GetMethod(nameof(Method_nullableInt), BindingFlags.Public | BindingFlags.Static)!;
+
+            s_ctor_int_string_struct_class = typeof(MyClass).
+                GetConstructor(new Type[] { typeof(int), typeof(string), typeof(MyBlittableStruct), typeof(MyClass) })!;
+
+            s_ctor_NoParams = typeof(MyClass).
+                GetConstructor(Array.Empty<Type>())!;
+
+            s_property_int = typeof(MyClass).
+                GetProperty(nameof(MyClass.I));
+
+            s_property_class = typeof(MyClass).
+                GetProperty(nameof(MyClass.O));
+
+            s_field_int = typeof(MyClass).
+                GetField(nameof(MyClass.i));
+
+            s_field_class = typeof(MyClass).
+                GetField(nameof(MyClass.o));
+        }
+
+        public static void Method_int_string_struct_class(int i, string s, MyBlittableStruct myStruct, MyClass myClass)
+        {
+            s_dummy++;
+        }
+
+        public static void Method_byref_int_string_struct_class(ref int i, ref string s, ref MyBlittableStruct myStruct, ref MyClass myClass)
+        {
+            s_dummy++;
+        }
+
+        public static void Method_nullableInt(int? i)
+        {
+            s_dummy++;
+        }
+
+        [Benchmark]
+        public void Method0_NoParms()
+        {
+            s_method.Invoke(s_MyClass, null);
+        }
+
+        [Benchmark]
+        public void StaticMethod4_int_string_struct_class()
+        {
+            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+            s_method_int_string_struct_class.Invoke(null, args);
+        }
+
+        [Benchmark]
+        public void StaticMethod4_PreInstantiatedObjectArray_int_string_struct_class()
+        {
+            s_method_int_string_struct_class.Invoke(null, s_args);
+        }
+
+        [Benchmark]
+        public void StaticMethod4_ByRefParams_int_string_struct_class()
+        {
+            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+            s_method_byref_int_string_struct_class.Invoke(null, args);
+        }
+
+        [Benchmark]
+        public void StaticMethod4_ByRefParams_PreInstantiatedObjectArray_int_string_struct_class()
+        {
+            s_method_byref_int_string_struct_class.Invoke(null, s_args);
+        }
+
+        [Benchmark]
+        public void StaticMethod1_NullableInt()
+        {
+            object[] args = new object[] { 42 };
+            s_method_nullableInt.Invoke(null, args);
+        }
+
+        [Benchmark]
+        public void Ctor0_NoParams()
+        {
+            s_ctor_NoParams.Invoke(null);
+        }
+
+        [Benchmark]
+        public void Ctor0_ActivatorCreateInstance_NoParams()
+        {
+            Activator.CreateInstance(typeof(MyClass));
+        }
+
+        [Benchmark]
+        public void Ctor4_int_string_struct_class()
+        {
+            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+            s_ctor_int_string_struct_class.Invoke(args);
+        }
+
+        [Benchmark]
+        public void Ctor4_ActivatorCreateInstance()
+        {
+            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+            Activator.CreateInstance(typeof(MyClass), args);
+        }
+
+        [Benchmark]
+        public void Property_Get_int()
+        {
+            s_property_int.GetValue(s_MyClass);
+        }
+
+        [Benchmark]
+        public void Property_Get_class()
+        {
+            s_property_class.GetValue(s_MyClass);
+        }
+
+        [Benchmark]
+        public void Property_Set_int()
+        {
+            s_property_int.SetValue(s_MyClass, 42);
+        }
+
+        [Benchmark]
+        public void Property_Set_class()
+        {
+            s_property_class.SetValue(s_MyClass, null);
+        }
+
+        [Benchmark]
+        public void Field_Get_int()
+        {
+            s_field_int.GetValue(s_MyClass);
+        }
+
+        [Benchmark]
+        public void Field_Set_int()
+        {
+            s_field_int.SetValue(s_MyClass, 42);
+        }
+
+        public struct MyBlittableStruct
+        {
+            public int i;
+            public bool b;
+        }
+
+        public class MyClass
+        {
+            public MyClass() { }
+            public MyClass(int i, string s, MyBlittableStruct myStruct, MyClass myClass) { }
+
+            public void MyMethod() { }
+
+            public int i = 0;
+            public bool b = false;
+            public string s = null;
+            public object o = null;
+
+            public int I { get; set; } = 0;
+            public object O { get; set; } = null;
+        }
+    }
+}


### PR DESCRIPTION
Adds the first invoke-based reflection benchmarks. In 7.0 there was various refactoring and support for generated IL for the invoke, which significantly improved performance of most scenarios.

Here's the 6.0 vs 7.0 results:
```
|                                               Method |        Job |                                                                                                   Toolchain |       Mean |     Error |     StdDev |     Median |        Min |        Max | Ratio | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|----------------------------------------------------- |----------- |------------------------------------------------------------------------------------------------------------ |-----------:|----------:|-----------:|-----------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
|                                      Method0_NoParms | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  35.989 ns | 0.7340 ns |  0.7209 ns |  35.797 ns |  35.229 ns |  37.316 ns |  4.57 |    0.09 |      - |         - |          NA |
|                                      Method0_NoParms | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |   7.926 ns | 0.0546 ns |  0.0427 ns |   7.926 ns |   7.868 ns |   7.991 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe | 150.434 ns | 1.1955 ns |  1.1183 ns | 150.566 ns | 148.512 ns | 151.906 ns |  2.43 |    0.05 | 0.0096 |     104 B |        1.00 |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  62.006 ns | 1.0492 ns |  0.9814 ns |  62.344 ns |  60.016 ns |  63.263 ns |  1.00 |    0.00 | 0.0097 |     104 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                StaticMethod4_int_string_struct_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe | 128.163 ns | 1.3783 ns |  1.2893 ns | 127.733 ns | 126.911 ns | 130.640 ns |  3.11 |    0.05 |      - |         - |          NA |
|                StaticMethod4_int_string_struct_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  41.238 ns | 0.6350 ns |  0.5940 ns |  41.190 ns |  40.473 ns |  42.205 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe | 283.771 ns | 1.2647 ns |  1.1830 ns | 283.549 ns | 282.303 ns | 285.694 ns |  1.71 |    0.02 | 0.0045 |      48 B |        1.00 |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe | 166.303 ns | 2.4653 ns |  2.3060 ns | 166.612 ns | 163.781 ns | 171.514 ns |  1.00 |    0.00 | 0.0040 |      48 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                       Ctor0_NoParams | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  50.415 ns | 0.2689 ns |  0.2384 ns |  50.431 ns |  49.987 ns |  50.924 ns |  4.93 |    0.04 | 0.0052 |      56 B |        1.00 |
|                                       Ctor0_NoParams | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  10.234 ns | 0.0610 ns |  0.0541 ns |  10.243 ns |  10.115 ns |  10.322 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |   7.929 ns | 0.1021 ns |  0.0905 ns |   7.905 ns |   7.847 ns |   8.139 ns |  1.04 |    0.02 | 0.0053 |      56 B |        1.00 |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |   7.600 ns | 0.1369 ns |  0.1280 ns |   7.585 ns |   7.428 ns |   7.816 ns |  1.00 |    0.00 | 0.0054 |      56 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                        Ctor4_int_string_struct_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe | 148.155 ns | 1.5491 ns |  1.3732 ns | 147.567 ns | 146.829 ns | 150.935 ns |  3.32 |    0.05 | 0.0048 |      56 B |        1.00 |
|                        Ctor4_int_string_struct_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  44.622 ns | 0.4233 ns |  0.3960 ns |  44.672 ns |  43.530 ns |  45.130 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                        Ctor4_ActivatorCreateInstance | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe | 409.933 ns | 9.0823 ns | 10.4592 ns | 414.259 ns | 386.667 ns | 420.944 ns |  1.54 |    0.04 | 0.0418 |     448 B |        1.08 |
|                        Ctor4_ActivatorCreateInstance | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe | 264.523 ns | 2.1209 ns |  1.9839 ns | 264.031 ns | 262.430 ns | 268.461 ns |  1.00 |    0.00 | 0.0389 |     416 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                     Property_Get_int | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  54.411 ns | 0.2750 ns |  0.2438 ns |  54.313 ns |  54.140 ns |  54.868 ns |  4.91 |    0.05 | 0.0022 |      24 B |        1.00 |
|                                     Property_Get_int | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  11.078 ns | 0.1349 ns |  0.1196 ns |  11.041 ns |  10.919 ns |  11.338 ns |  1.00 |    0.00 | 0.0023 |      24 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                   Property_Get_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  37.038 ns | 0.1706 ns |  0.1425 ns |  36.992 ns |  36.859 ns |  37.319 ns |  4.52 |    0.04 |      - |         - |          NA |
|                                   Property_Get_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |   8.186 ns | 0.0767 ns |  0.0680 ns |   8.160 ns |   8.114 ns |   8.355 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                     Property_Set_int | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  68.409 ns | 1.3855 ns |  1.2960 ns |  68.015 ns |  67.161 ns |  71.427 ns |  2.41 |    0.07 | 0.0022 |      24 B |        1.00 |
|                                     Property_Set_int | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  28.171 ns | 0.5965 ns |  0.6630 ns |  28.334 ns |  27.322 ns |  29.424 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                   Property_Set_class | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  61.589 ns | 0.2841 ns |  0.2519 ns |  61.550 ns |  61.272 ns |  61.920 ns |  2.82 |    0.02 |      - |         - |          NA |
|                                   Property_Set_class | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  21.806 ns | 0.1523 ns |  0.1425 ns |  21.765 ns |  21.660 ns |  22.062 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                        Field_Get_int | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  30.993 ns | 0.1622 ns |  0.1438 ns |  30.972 ns |  30.768 ns |  31.259 ns |  0.87 |    0.01 | 0.0022 |      24 B |        1.00 |
|                                        Field_Get_int | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  35.749 ns | 0.2806 ns |  0.2487 ns |  35.752 ns |  35.461 ns |  36.344 ns |  1.00 |    0.00 | 0.0021 |      24 B |        1.00 |
|                                                      |            |                                                                                                             |            |           |            |            |            |            |       |         |        |           |             |
|                                        Field_Set_int | Job-BQDNCA | \runtime60\artifacts\bin\testhost\net6.0-windows-Release-x64\shared\Microsoft.NETCore.App\6.0.9\corerun.exe |  36.037 ns | 0.2146 ns |  0.1903 ns |  36.018 ns |  35.744 ns |  36.418 ns |  0.98 |    0.01 | 0.0023 |      24 B |        1.00 |
|                                        Field_Set_int | Job-RQCXYM |   \runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe |  36.766 ns | 0.2736 ns |  0.2425 ns |  36.666 ns |  36.378 ns |  37.268 ns |  1.00 |    0.00 | 0.0023 |      24 B |        1.00 |
```


