### PR TITLE
Fixes https://github.com/dotnet/performance/issues/2444

### DIFF
--- a/src/benchmarks/gc/src/exec/env/get_host_info.cpp
+++ b/src/benchmarks/gc/src/exec/env/get_host_info.cpp
@@ -191,6 +191,7 @@ static CacheStats getCacheStats()
             }
             case RelationProcessorPackage:
             case RelationGroup:
+            case RelationProcessorModule:
                 break;
 
             default:


### PR DESCRIPTION
Fixes #2444 by accounting for the ``RelationProcessorModule`` case prevalent in Windows 11. 