### PR TITLE
Fixup Brotli compression tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Compression/Brotli.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/Brotli.cs
@@ -13,7 +13,7 @@ namespace System.IO.Compression
         private const int Window = 22;
 
         public override Stream CreateStream(Stream stream, CompressionMode mode) => new BrotliStream(stream, mode);
-        public override Stream CreateStream(Stream stream, CompressionLevel level) => new BrotliStream(stream, level);
+        public override Stream CreateStream(Stream stream, CompressionLevel level) => new BrotliStream(stream, level, leaveOpen: true);
 
         [Benchmark]
         public Span<byte> Compress_WithState()

--- a/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -59,7 +59,7 @@ namespace System.IO.Compression
         {
             CompressedFile.CompressedDataStream.Position = 0; // all benchmarks invocation reuse the same stream, we set Postion to 0 to start at the beginning
 
-            var compressor = CreateStream(CompressedFile.CompressedDataStream, level);
+            using var compressor = CreateStream(CompressedFile.CompressedDataStream, level);
             compressor.Write(CompressedFile.UncompressedData, 0, CompressedFile.UncompressedData.Length);
         }
 


### PR DESCRIPTION
As seen here, https://github.com/dotnet/runtime/issues/73391#issuecomment-1205619431, this test had a bug where in
the work that was being done by the underlying test was not being correctly measured. This fix resolves that.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


