### PR TITLE
Added a fix for Win10 build break for the get_host_info

### DIFF
--- a/src/benchmarks/gc/src/exec/env/get_host_info.cpp
+++ b/src/benchmarks/gc/src/exec/env/get_host_info.cpp
@@ -189,15 +189,24 @@ static CacheStats getCacheStats()
 
                 break;
             }
+
             case RelationProcessorPackage:
             case RelationGroup:
-            case RelationProcessorModule:
                 break;
 
             default:
-                printf("Invalid relationship %d\n", info.Relationship);
-                //assert(0); // invalid relationship
-                break;
+                // RelationProcessorModule:
+                if (info.Relationship == 7)
+                {
+                    break;
+                }
+
+                else
+                {
+                    printf("Invalid relationship %d\n", info.Relationship);
+                    //assert(0); // invalid relationship
+                    break;
+                }
         }
 
         info_ptr = offset(info_ptr, info.Size);


### PR DESCRIPTION
Currently ``RelationProcessorModule`` isn't a recognized ``LOGICAL_PROCESSOR_RELATIONSHIP`` in Windows 10 and thereby, causing failures. This can be fixed by refering to the int value of the enum rather than the undefined value. 