### PR TITLE
Fix builds for `runtime` branch `release/7.0-rc1`

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -2,6 +2,11 @@ from argparse import ArgumentParser
 
 class ChannelMap():
     channel_map = {
+        'release/7.0-rc1': {
+            'tfm': 'net7.0',
+            'branch': '7.0.1xx',
+            'quality': 'daily'
+        },
         'release/7.0-preview8': {
             'tfm': 'net7.0',
             'branch': '7.0.1xx',


### PR DESCRIPTION
Add `7.0-rc1` to channel_map, to fix builds on `runtime release/7.0-rc1`
branch.

All the perf jobs are broken with:

`ci_setup.py: error: argument --channel: invalid choice: 'release/7.0-rc1' (choose from 'release/7.0-preview8', 'release/7.0-preview7', 'release/7.0-preview6', 'release/7.0-preview5', 'release/7.0-preview4', 'release/7.0-preview3', 'release/7.0-preview2', 'release/7.0-preview1', 'release/6.0', '6.0', 'main', 'nativeaot7.0', 'master', 'nativeaot6.0', '5.0', 'release/5.0.1xx-rc2', 'release/5.0.1xx', 'release/3.1.3xx', 'release/3.1.2xx', 'release/3.1.1xx', '3.1', '3.0', 'release/2.1.6xx', '2.1', 'LTS', 'net48')`

cc @lewing @steveisok 