### PR TITLE
temporarily disable failing BigInteger benchmark

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime.Numerics/Perf.BigInteger.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Numerics/Perf.BigInteger.cs
@@ -91,7 +91,8 @@ namespace System.Numerics.Tests
         public IEnumerable<object> ModPowValues()
         {
             yield return new BigIntegers(new[] { 16, 16, 16 });
-            yield return new BigIntegers(new[] { 1024, 1024, 64 });
+            // currently commented out due to a bug in the product https://github.com/dotnet/performance/issues/2575
+            // yield return new BigIntegers(new[] { 1024, 1024, 64 });
             yield return new BigIntegers(new[] { 16384, 16384, 64 });
         }
 


### PR DESCRIPTION
https://github.com/dotnet/performance/issues/2575 turned out to be a product bug. Disable it before the product is fixed and the fix flows to the SDK installer.

cc @tannergooding 