### PR TITLE
[MAUI] Add temp nuget url to the scenarios maui that use it.

### DIFF
--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -14,7 +14,8 @@ import requests
 import winreg
 
 setup_loggers(True)
-NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
+#NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config' TODO: Remove below
+NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/b3747563c1fe5b6321ca3bc852ea6a998f91ae9a/NuGet.config'
 WebViewURL = 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' # Obtained from https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section
 WebViewInstalled = False
 NugetFile = requests.get(NugetURL)

--- a/src/scenarios/mauidesktop/pre.py
+++ b/src/scenarios/mauidesktop/pre.py
@@ -12,7 +12,8 @@ from test import EXENAME
 import requests
 
 setup_loggers(True)
-NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
+#NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config' TODO: Remove Below
+NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/b3747563c1fe5b6321ca3bc852ea6a998f91ae9a/NuGet.config'
 NugetFile = requests.get(NugetURL)
 open('./Nuget.config', 'wb').write(NugetFile.content)
 


### PR DESCRIPTION
There is a new format for the rollback files, but it is not fully supported by the current nuget repos, so setup usage of a different Nuget file with the ones that should fix the issue until the new format is fully supported. 


