### PR TITLE
[Net8.0] Update channel_map with net8 and organized 6v7v8 groupings.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -307,7 +307,7 @@ jobs:
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels:
-        - nativeaot7.0
+        - nativeaot8.0
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -307,7 +307,7 @@ jobs:
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels:
-        - nativeaot8.0
+        - nativeaot7.0
 
   # Ubuntu 1804 x64 ML.NET benchmarks
   - template: /eng/performance/benchmark_jobs.yml

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -61,6 +61,9 @@ jobs:
           - ${{ if eq(parameters.osName, 'ubuntu')}}:
             - name: InstallPrerequisites
               value: 'sudo apt-get -y install python3-venv'
+          - ${{ if ne(parameters.osName, 'ubuntu')}}:
+            - name: InstallPrerequisites
+              value: ''
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
           # for public runs, we do not want to upload perflab data
           - name: PerfLabArguments

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -105,7 +105,7 @@ jobs:
           - powershell: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
-              .\src\scenarios\init.ps1
+              .\src\scenarios\init.ps1 -DotnetDirectory $(CorrelationStaging)dotnet
               .\eng\common\msbuild.ps1 .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
@@ -141,7 +141,7 @@ jobs:
           - script: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
-              . ./src/scenarios/init.sh
+              . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
               ./eng/common/msbuild.sh ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -106,7 +106,7 @@ jobs:
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
               .\src\scenarios\init.ps1 -DotnetDirectory $(CorrelationStaging)dotnet
-              .\eng\common\msbuild.ps1 .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
+              dotnet msbuild .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
               CorrelationPayloadDirectory: $(CorrelationStaging)
@@ -142,7 +142,7 @@ jobs:
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
               . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
-              ./eng/common/msbuild.sh ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
+              dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
               CorrelationPayloadDirectory: $(CorrelationStaging)

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -51,11 +51,6 @@ class ChannelMap():
             'branch': '7.0',
             'quality': 'daily'
         },
-        'release/6.0': {
-            'tfm': 'net6.0',
-            'branch': '6.0.1xx',
-            'quality': 'daily'
-        },
         '6.0': {
             'tfm': 'net6.0',
             'branch': '6.0.1xx',

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -3,6 +3,30 @@ from argparse import ArgumentParser
 class ChannelMap():
     channel_map = {
         'main': {
+            'tfm': 'net8.0',
+            'branch': '8.0',
+            'quality': 'daily'
+        },
+        'master': {
+            'tfm': 'net6.0',
+            'branch': 'master'
+        },
+        '8.0': {
+            'tfm': 'net8.0',
+            'branch': '8.0',
+            'quality': 'daily'
+        },
+        'release/8.0': {
+            'tfm': 'net8.0',
+            'branch': '8.0',
+            'quality': 'daily'
+        },
+        'nativeaot8.0': {
+            'tfm': 'nativeaot8.0',
+            'branch': '8.0',
+            'quality': 'daily'
+        },
+        '7.0': {
             'tfm': 'net7.0',
             'branch': '7.0.1xx',
             'quality': 'daily'
@@ -17,19 +41,20 @@ class ChannelMap():
             'branch': '7.0-rc1',
             'quality': 'daily'
         },
-        'release/7.0': {
-            'tfm': 'net7.0',
-            'branch': '7.0',
-            'quality': 'daily'
-        },
         'nativeaot7.0': {
             'tfm': 'nativeaot7.0',
             'branch': '7.0.1xx',
             'quality': 'daily'
         },
-        'master': {
+        'release/7.0': {
+            'tfm': 'net7.0',
+            'branch': '7.0',
+            'quality': 'daily'
+        },
+        'release/6.0': {
             'tfm': 'net6.0',
-            'branch': 'master'
+            'branch': '6.0.1xx',
+            'quality': 'daily'
         },
         '6.0': {
             'tfm': 'net6.0',

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -60,7 +60,7 @@
     <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" />
-    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'" />
+    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '5.0'" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />


### PR DESCRIPTION
Updated the channel_map with net8 channels and cleaned up the groups between net6, net7, and net8. Updating to net8 included setting main channel to point to net8. This is part of work to bring up net8.0 testing.

