### PR TITLE
Fix some randomly failing Perf.File tests on wasm/aot

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
@@ -94,7 +94,7 @@ namespace System.IO.Tests
         {
             // use non-temp file path to ensure that we don't test some unusal File System on Unix
             string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            File.WriteAllBytes(_testFilePath = Path.Combine(baseDir, Path.GetTempFileName()), Array.Empty<byte>());
+            File.WriteAllBytes(_testFilePath = Path.Combine(baseDir, Path.GetRandomFileName()), Array.Empty<byte>());
             _filesToRead = new Dictionary<int, string>()
             {
                 { HalfKibibyte, WriteBytes(HalfKibibyte) },
@@ -106,7 +106,7 @@ namespace System.IO.Tests
 
             string WriteBytes(int fileSize)
             {
-                string filePath = Path.Combine(baseDir, Path.GetTempFileName());
+                string filePath = Path.Combine(baseDir, Path.GetRandomFileName());
                 File.WriteAllBytes(filePath, ValuesGenerator.Array<byte>(fileSize));
                 return filePath;
             }


### PR DESCRIPTION
On wasm/aot, `System.IO.FileSystem/Perf.File`'s `CopyTo`, `CopyToOverride`, and `ReadAllBytes` benchmarks fail randomly with:
```
---> System.IO.IOException: The file '/tmp/' already exists.
  at BenchmarkDotNet.Autogenerated.Runnable_48.Run(IHost host, String benchmarkName)
  at System.Reflection.MethodInvoker.InterpretedInvoke(Object , Span`1 , BindingFlags )
  --- End of inner exception stack trace ---
  at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args)
```

.. due to `Path.GetTempFileName()` being buggy - https://github.com/dotnet/runtime/issues/73721.

In `SetupReadAllBytes`, we are building the test file path as:
```csharp
_testFilePath = Path.Combine(baseDir, Path.GetTempFileName())
```

.. but the `Path.GetTempFileName()` is not appropriate here, as it will return a full path, and it will create the file. Instead we can use `Path.GetRandomFileName()` which should avoid the underlying issue completely.

Fixes https://github.com/dotnet/runtime/issues/74104 .