### PR TITLE
Reduce randomness of invoke benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
@@ -78,13 +78,16 @@ namespace System.Reflection
             s_dummy++;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Method0_NoParms()
         {
-            s_method.Invoke(s_MyClass, null);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_method.Invoke(s_MyClass, null);
+            }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         // Include the array allocation and population for a typical scenario.
         public void StaticMethod4_arrayNotCached_int_string_struct_class()
         {
@@ -95,7 +98,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void StaticMethod4_int_string_struct_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -104,7 +107,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void StaticMethod4_ByRefParams_int_string_struct_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -113,7 +116,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Ctor0_NoParams()
         {
             for (int i = 0; i < Iterations; i++)
@@ -122,7 +125,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Ctor0_ActivatorCreateInstance_NoParams()
         {
             for (int i = 0; i < Iterations; i++)
@@ -131,7 +134,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Ctor4_int_string_struct_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -140,7 +143,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Ctor4_ActivatorCreateInstance()
         {
             for (int i = 0; i < Iterations; i++)
@@ -149,7 +152,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Property_Get_int()
         {
             for (int i = 0; i < Iterations; i++)
@@ -158,7 +161,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Property_Get_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -167,7 +170,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Property_Set_int()
         {
             for (int i = 0; i < 1000; i++)
@@ -176,7 +179,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Property_Set_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -185,7 +188,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Field_Get_int()
         {
             for (int i = 0; i < Iterations; i++)
@@ -194,7 +197,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Field_Get_class()
         {
             for (int i = 0; i < Iterations; i++)
@@ -203,7 +206,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Field_Set_int()
         {
             for (int i = 0; i < Iterations; i++)
@@ -212,7 +215,7 @@ namespace System.Reflection
             }
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = Iterations)]
         public void Field_Set_class()
         {
             for (int i = 0; i < Iterations; i++)

--- a/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/Invoke.cs
@@ -10,6 +10,8 @@ namespace System.Reflection
     [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
     public class Invoke
     {
+        private const int Iterations = 1_000; // Reduce the randomness of these short-lived calls.
+
         private static MyClass s_MyClass = new MyClass();
         private static object[] s_args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
         private static int s_dummy;
@@ -23,6 +25,9 @@ namespace System.Reflection
         private static PropertyInfo s_property_class;
         private static FieldInfo s_field_int;
         private static FieldInfo s_field_class;
+
+        public static int s_int;
+        public static object s_class;
 
         [GlobalSetup]
         public void Setup()
@@ -83,80 +88,137 @@ namespace System.Reflection
         // Include the array allocation and population for a typical scenario.
         public void StaticMethod4_arrayNotCached_int_string_struct_class()
         {
-            object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
-            s_method_int_string_struct_class.Invoke(null, args);
+            for (int i = 0; i < Iterations; i++)
+            {
+                object[] args = new object[] { 42, "Hello", default(MyBlittableStruct), s_MyClass };
+                s_method_int_string_struct_class.Invoke(null, args);
+            }
         }
 
         [Benchmark]
         public void StaticMethod4_int_string_struct_class()
         {
-            s_method_int_string_struct_class.Invoke(null, s_args);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_method_int_string_struct_class.Invoke(null, s_args);
+            }
         }
 
         [Benchmark]
         public void StaticMethod4_ByRefParams_int_string_struct_class()
         {
-            s_method_byref_int_string_struct_class.Invoke(null, s_args);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_method_byref_int_string_struct_class.Invoke(null, s_args);
+            }
         }
 
         [Benchmark]
         public void Ctor0_NoParams()
         {
-            s_ctor_NoParams.Invoke(null);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_ctor_NoParams.Invoke(null);
+            }
         }
 
         [Benchmark]
         public void Ctor0_ActivatorCreateInstance_NoParams()
         {
-            Activator.CreateInstance(typeof(MyClass));
+            for (int i = 0; i < Iterations; i++)
+            {
+                Activator.CreateInstance(typeof(MyClass));
+            }
         }
 
         [Benchmark]
         public void Ctor4_int_string_struct_class()
         {
-            s_ctor_int_string_struct_class.Invoke(s_args);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_ctor_int_string_struct_class.Invoke(s_args);
+            }
         }
 
         [Benchmark]
         public void Ctor4_ActivatorCreateInstance()
         {
-            Activator.CreateInstance(typeof(MyClass), s_args);
+            for (int i = 0; i < Iterations; i++)
+            {
+                Activator.CreateInstance(typeof(MyClass), s_args);
+            }
         }
 
         [Benchmark]
         public void Property_Get_int()
         {
-            s_property_int.GetValue(s_MyClass);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_int = (int)s_property_int.GetValue(s_MyClass);
+            }
         }
 
         [Benchmark]
         public void Property_Get_class()
         {
-            s_property_class.GetValue(s_MyClass);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_class = s_property_class.GetValue(s_MyClass);
+            }
         }
 
         [Benchmark]
         public void Property_Set_int()
         {
-            s_property_int.SetValue(s_MyClass, 42);
+            for (int i = 0; i < 1000; i++)
+            {
+                s_property_int.SetValue(s_MyClass, 42);
+            }
         }
 
         [Benchmark]
         public void Property_Set_class()
         {
-            s_property_class.SetValue(s_MyClass, null);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_property_class.SetValue(s_MyClass, null);
+            }
         }
 
         [Benchmark]
         public void Field_Get_int()
         {
-            s_field_int.GetValue(s_MyClass);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_int = (int)s_field_int.GetValue(s_MyClass);
+            }
+        }
+
+        [Benchmark]
+        public void Field_Get_class()
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_class = s_field_class.GetValue(s_MyClass);
+            }
         }
 
         [Benchmark]
         public void Field_Set_int()
         {
-            s_field_int.SetValue(s_MyClass, 42);
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_field_int.SetValue(s_MyClass, 42);
+            }
+        }
+
+        [Benchmark]
+        public void Field_Set_class()
+        {
+            for (int i = 0; i < Iterations; i++)
+            {
+                s_field_class.SetValue(s_MyClass, 42);
+            }
         }
 
         public struct MyBlittableStruct


### PR DESCRIPTION
Helps reduce randomness\error of the invoke benchmarks by changing the iteration from 1 to 1,000 for each benchmark by adding a simple `for` loop. Once these changes are in, we will document and ignore newly generated perf regressions issues.

Also added was a benchmark for getting\setting a field that contains a reference type.

These were noted in https://github.com/dotnet/runtime/issues/74938. The benchmarks details below were before and after the change to https://github.com/dotnet/runtime/pull/74614 which now show:
- ~0-1% faster for Field_Get_int 
- ~2-5% faster for Field_Get_class
- ~4-5% faster for Field_Set_int 
- ~6-10% faster for Field_Set_class 

Basically, those changes avoid two method calls (caller to invoker, and from the invoker back to the callee). These actual perf results are heavily dependent on the JIT as to whether these calls add overhead or not...

Note that only these 4 field get\set benchmarks are affected by the before\after results below, so these are also useful to compare randomness\error:

<details closed>
<summary>Benchmarks with 1 iteration of each test (two full runs) (+- ~6% accuracy)</summary>

```
|                                               Method |        Job |                      Toolchain |          Mean |       Error |      StdDev |        Median |           Min |           Max | Ratio | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|----------------------------------------------------- |----------- |------------------------------- |--------------:|------------:|------------:|--------------:|--------------:|--------------:|------:|--------:|-------:|----------:|------------:|
|                                      Method0_NoParms | Job-UJFMHH |  \AfterFieldChange\corerun.exe |      8.164 ns |   0.1265 ns |   0.1183 ns |      8.127 ns |      8.021 ns |      8.368 ns |  1.01 |    0.02 |      - |         - |          NA |
|                                      Method0_NoParms | Job-WIALXA | \BeforeFieldChange\corerun.exe |      8.058 ns |   0.0511 ns |   0.0427 ns |      8.040 ns |      8.007 ns |      8.147 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     50.507 ns |   0.4005 ns |   0.3127 ns |     50.545 ns |     49.987 ns |     50.950 ns |  1.05 |    0.02 | 0.0099 |     104 B |        1.00 |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     48.192 ns |   0.9532 ns |   0.8449 ns |     48.021 ns |     47.202 ns |     50.083 ns |  1.00 |    0.00 | 0.0098 |     104 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                StaticMethod4_int_string_struct_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     37.045 ns |   0.2648 ns |   0.2477 ns |     36.924 ns |     36.781 ns |     37.499 ns |  0.98 |    0.01 |      - |         - |          NA |
|                StaticMethod4_int_string_struct_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     37.915 ns |   0.5314 ns |   0.4970 ns |     37.735 ns |     37.231 ns |     38.807 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |    160.014 ns |   1.6414 ns |   1.5353 ns |    159.981 ns |    156.865 ns |    162.313 ns |  0.99 |    0.01 | 0.0045 |      48 B |        1.00 |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |    161.971 ns |   1.0118 ns |   0.8969 ns |    161.877 ns |    160.442 ns |    163.443 ns |  1.00 |    0.00 | 0.0045 |      48 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                       Ctor0_NoParams | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     10.732 ns |   0.2373 ns |   0.2219 ns |     10.641 ns |     10.357 ns |     11.137 ns |  0.98 |    0.02 | 0.0054 |      56 B |        1.00 |
|                                       Ctor0_NoParams | Job-WIALXA | \BeforeFieldChange\corerun.exe |     10.905 ns |   0.1242 ns |   0.1101 ns |     10.882 ns |     10.756 ns |     11.128 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-UJFMHH |  \AfterFieldChange\corerun.exe |      7.796 ns |   0.0890 ns |   0.0789 ns |      7.790 ns |      7.684 ns |      7.955 ns |  1.00 |    0.01 | 0.0054 |      56 B |        1.00 |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-WIALXA | \BeforeFieldChange\corerun.exe |      7.828 ns |   0.0809 ns |   0.0717 ns |      7.809 ns |      7.709 ns |      7.958 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                        Ctor4_int_string_struct_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     38.424 ns |   0.3334 ns |   0.3119 ns |     38.352 ns |     38.053 ns |     38.971 ns |  1.02 |    0.01 | 0.0053 |      56 B |        1.00 |
|                        Ctor4_int_string_struct_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     37.645 ns |   0.4050 ns |   0.3590 ns |     37.584 ns |     37.238 ns |     38.496 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                        Ctor4_ActivatorCreateInstance | Job-UJFMHH |  \AfterFieldChange\corerun.exe |    240.899 ns |   1.3404 ns |   1.1193 ns |    240.782 ns |    239.173 ns |    243.032 ns |  1.01 |    0.01 | 0.0398 |     416 B |        1.00 |
|                        Ctor4_ActivatorCreateInstance | Job-WIALXA | \BeforeFieldChange\corerun.exe |    237.683 ns |   1.8027 ns |   1.5981 ns |    237.509 ns |    235.274 ns |    240.851 ns |  1.00 |    0.00 | 0.0389 |     416 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                     Property_Get_int | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     11.215 ns |   0.0833 ns |   0.0650 ns |     11.206 ns |     11.110 ns |     11.360 ns |  0.98 |    0.01 | 0.0023 |      24 B |        1.00 |
|                                     Property_Get_int | Job-WIALXA | \BeforeFieldChange\corerun.exe |     11.408 ns |   0.0847 ns |   0.0707 ns |     11.395 ns |     11.323 ns |     11.579 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                   Property_Get_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |      9.106 ns |   0.0082 ns |   0.0064 ns |      9.105 ns |      9.097 ns |      9.116 ns |  0.93 |    0.03 |      - |         - |          NA |
|                                   Property_Get_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |      9.755 ns |   0.2719 ns |   0.3131 ns |      9.861 ns |      9.140 ns |     10.133 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                     Property_Set_int | Job-UJFMHH |  \AfterFieldChange\corerun.exe | 26,168.695 ns | 162.9306 ns | 144.4337 ns | 26,115.487 ns | 25,883.193 ns | 26,479.748 ns |  1.00 |    0.01 | 2.2085 |   24000 B |        1.00 |
|                                     Property_Set_int | Job-WIALXA | \BeforeFieldChange\corerun.exe | 26,162.160 ns | 195.3377 ns | 163.1159 ns | 26,123.424 ns | 25,905.186 ns | 26,506.240 ns |  1.00 |    0.00 | 2.2955 |   24000 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                   Property_Set_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     21.083 ns |   0.1462 ns |   0.1296 ns |     21.050 ns |     20.948 ns |     21.336 ns |  1.01 |    0.01 |      - |         - |          NA |
|                                   Property_Set_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     20.807 ns |   0.0905 ns |   0.0802 ns |     20.792 ns |     20.699 ns |     20.993 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                        Field_Get_int | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     34.923 ns |   0.3109 ns |   0.2756 ns |     34.864 ns |     34.476 ns |     35.536 ns |  1.00 |    0.01 | 0.0022 |      24 B |        1.00 |
|                                        Field_Get_int | Job-WIALXA | \BeforeFieldChange\corerun.exe |     34.819 ns |   0.2373 ns |   0.1981 ns |     34.883 ns |     34.356 ns |     35.192 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                      Field_Get_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     24.233 ns |   0.3052 ns |   0.2855 ns |     24.112 ns |     23.933 ns |     24.825 ns |  0.97 |    0.02 |      - |         - |          NA |
|                                      Field_Get_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     24.858 ns |   0.5088 ns |   0.4997 ns |     24.756 ns |     23.964 ns |     25.774 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                        Field_Set_int | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     33.617 ns |   0.2436 ns |   0.2159 ns |     33.568 ns |     33.203 ns |     34.013 ns |  0.86 |    0.01 | 0.0022 |      24 B |        1.00 |
|                                        Field_Set_int | Job-WIALXA | \BeforeFieldChange\corerun.exe |     39.129 ns |   0.4167 ns |   0.3898 ns |     39.102 ns |     38.598 ns |     39.820 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                      Field_Set_class | Job-UJFMHH |  \AfterFieldChange\corerun.exe |     34.026 ns |   0.1344 ns |   0.1122 ns |     33.995 ns |     33.915 ns |     34.318 ns |  0.76 |    0.01 | 0.0023 |      24 B |        1.00 |
|                                      Field_Set_class | Job-WIALXA | \BeforeFieldChange\corerun.exe |     44.712 ns |   0.3254 ns |   0.3044 ns |     44.659 ns |     44.233 ns |     45.152 ns |  1.00 |    0.00 | 0.0023 |      24 B |        1.00 |

|                                               Method |        Job |                      Toolchain |          Mean |       Error |      StdDev |        Median |           Min |           Max | Ratio | RatioSD |  Gen 0 | Allocated | Alloc Ratio |
|----------------------------------------------------- |----------- |------------------------------- |--------------:|------------:|------------:|--------------:|--------------:|--------------:|------:|--------:|-------:|----------:|------------:|
|                                      Method0_NoParms | Job-UFKFIS |  \AfterFieldChange\corerun.exe |      8.192 ns |   0.0756 ns |   0.0670 ns |      8.179 ns |      8.089 ns |      8.329 ns |  0.99 |    0.01 |      - |         - |          NA |
|                                      Method0_NoParms | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |      8.270 ns |   0.0446 ns |   0.0395 ns |      8.250 ns |      8.225 ns |      8.339 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     47.852 ns |   0.5929 ns |   0.4951 ns |     47.722 ns |     47.045 ns |     48.730 ns |  0.98 |    0.01 | 0.0098 |     104 B |        1.00 |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     48.781 ns |   0.3802 ns |   0.3370 ns |     48.654 ns |     48.446 ns |     49.473 ns |  1.00 |    0.00 | 0.0098 |     104 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                StaticMethod4_int_string_struct_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     36.718 ns |   0.5395 ns |   0.5046 ns |     36.846 ns |     35.524 ns |     37.338 ns |  0.99 |    0.01 |      - |         - |          NA |
|                StaticMethod4_int_string_struct_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     37.057 ns |   0.2445 ns |   0.2287 ns |     36.911 ns |     36.863 ns |     37.514 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |    193.574 ns |   2.0315 ns |   1.6964 ns |    194.232 ns |    189.209 ns |    194.893 ns |  1.17 |    0.02 | 0.0045 |      48 B |        1.00 |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |    165.028 ns |   2.9144 ns |   2.7261 ns |    165.073 ns |    160.688 ns |    169.415 ns |  1.00 |    0.00 | 0.0045 |      48 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                       Ctor0_NoParams | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     10.539 ns |   0.0695 ns |   0.0616 ns |     10.523 ns |     10.437 ns |     10.649 ns |  0.98 |    0.01 | 0.0053 |      56 B |        1.00 |
|                                       Ctor0_NoParams | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     10.733 ns |   0.1613 ns |   0.1429 ns |     10.707 ns |     10.521 ns |     11.025 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-UFKFIS |  \AfterFieldChange\corerun.exe |      8.010 ns |   0.1827 ns |   0.1709 ns |      7.923 ns |      7.789 ns |      8.337 ns |  0.99 |    0.03 | 0.0053 |      56 B |        1.00 |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |      8.060 ns |   0.1683 ns |   0.1492 ns |      7.990 ns |      7.866 ns |      8.397 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                        Ctor4_int_string_struct_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     37.883 ns |   0.4457 ns |   0.3951 ns |     37.817 ns |     37.303 ns |     38.489 ns |  0.99 |    0.01 | 0.0053 |      56 B |        1.00 |
|                        Ctor4_int_string_struct_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     38.311 ns |   0.2865 ns |   0.2392 ns |     38.224 ns |     38.019 ns |     38.765 ns |  1.00 |    0.00 | 0.0053 |      56 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                        Ctor4_ActivatorCreateInstance | Job-UFKFIS |  \AfterFieldChange\corerun.exe |    248.490 ns |   3.4582 ns |   3.0656 ns |    247.764 ns |    244.531 ns |    254.633 ns |  1.03 |    0.01 | 0.0392 |     416 B |        1.00 |
|                        Ctor4_ActivatorCreateInstance | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |    240.830 ns |   1.2925 ns |   1.1458 ns |    240.450 ns |    239.662 ns |    243.192 ns |  1.00 |    0.00 | 0.0396 |     416 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                     Property_Get_int | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     11.566 ns |   0.0714 ns |   0.0633 ns |     11.557 ns |     11.469 ns |     11.672 ns |  0.98 |    0.01 | 0.0023 |      24 B |        1.00 |
|                                     Property_Get_int | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     11.798 ns |   0.1007 ns |   0.0786 ns |     11.774 ns |     11.659 ns |     11.904 ns |  1.00 |    0.00 | 0.0023 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                   Property_Get_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |      9.084 ns |   0.0134 ns |   0.0112 ns |      9.087 ns |      9.065 ns |      9.104 ns |  0.97 |    0.03 |      - |         - |          NA |
|                                   Property_Get_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |      9.441 ns |   0.2172 ns |   0.2501 ns |      9.417 ns |      9.052 ns |      9.857 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                     Property_Set_int | Job-UFKFIS |  \AfterFieldChange\corerun.exe | 26,162.313 ns | 157.3953 ns | 139.5268 ns | 26,153.192 ns | 25,968.646 ns | 26,473.528 ns |  0.94 |    0.02 | 2.2803 |   24000 B |        1.00 |
|                                     Property_Set_int | Job-SSEEBQ | \BeforeFieldChange\corerun.exe | 27,742.611 ns | 642.3901 ns | 714.0149 ns | 27,624.702 ns | 26,819.940 ns | 29,213.637 ns |  1.00 |    0.00 | 2.2321 |   24000 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                   Property_Set_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     20.854 ns |   0.1056 ns |   0.0937 ns |     20.863 ns |     20.666 ns |     21.001 ns |  0.97 |    0.01 |      - |         - |          NA |
|                                   Property_Set_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     21.391 ns |   0.3344 ns |   0.3128 ns |     21.355 ns |     20.924 ns |     21.959 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                        Field_Get_int | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     35.037 ns |   0.3683 ns |   0.3445 ns |     34.991 ns |     34.539 ns |     35.745 ns |  0.94 |    0.04 | 0.0023 |      24 B |        1.00 |
|                                        Field_Get_int | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     36.782 ns |   1.1839 ns |   1.3634 ns |     36.240 ns |     35.071 ns |     39.481 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                      Field_Get_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     24.352 ns |   0.0640 ns |   0.0567 ns |     24.350 ns |     24.266 ns |     24.477 ns |  0.95 |    0.01 |      - |         - |          NA |
|                                      Field_Get_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     25.641 ns |   0.2234 ns |   0.2090 ns |     25.640 ns |     25.396 ns |     26.020 ns |  1.00 |    0.00 |      - |         - |          NA |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                        Field_Set_int | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     37.149 ns |   0.2932 ns |   0.2599 ns |     37.083 ns |     36.832 ns |     37.820 ns |  0.98 |    0.02 | 0.0022 |      24 B |        1.00 |
|                                        Field_Set_int | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     37.885 ns |   0.6118 ns |   0.5723 ns |     37.686 ns |     37.147 ns |     39.161 ns |  1.00 |    0.00 | 0.0022 |      24 B |        1.00 |
|                                                      |            |                                |               |             |             |               |               |               |       |         |        |           |             |
|                                      Field_Set_class | Job-UFKFIS |  \AfterFieldChange\corerun.exe |     33.841 ns |   0.1182 ns |   0.0987 ns |     33.859 ns |     33.671 ns |     34.056 ns |  0.86 |    0.00 | 0.0023 |      24 B |        1.00 |
|                                      Field_Set_class | Job-SSEEBQ | \BeforeFieldChange\corerun.exe |     39.316 ns |   0.2262 ns |   0.2005 ns |     39.327 ns |     38.924 ns |     39.603 ns |  1.00 |    0.00 | 0.0023 |      24 B |        1.00 |
```

</details>


<details closed>
<summary>Benchmarks with 1,000 iterations of each test (two full runs) (+- ~2% accuracy)</summary>

```
|                                               Method |        Job |                      Toolchain |           Mean |         Error |        StdDev |         Median |            Min |            Max | Ratio | RatioSD |   Gen 0 | Allocated | Alloc Ratio |
|----------------------------------------------------- |----------- |------------------------------- |---------------:|--------------:|--------------:|---------------:|---------------:|---------------:|------:|--------:|--------:|----------:|------------:|
|                                      Method0_NoParms | Job-ASIHDH |  \AfterFieldChange\corerun.exe |       8.197 ns |     0.0800 ns |     0.0748 ns |       8.199 ns |       8.072 ns |       8.330 ns |  1.02 |    0.01 |       - |         - |          NA |
|                                      Method0_NoParms | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |       8.042 ns |     0.0556 ns |     0.0520 ns |       8.034 ns |       7.971 ns |       8.139 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  47,752.218 ns |   452.6277 ns |   401.2427 ns |  47,845.389 ns |  47,117.025 ns |  48,329.122 ns |  0.99 |    0.01 |  9.7776 |  104000 B |        1.00 |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  48,041.562 ns |   595.6233 ns |   528.0045 ns |  47,912.451 ns |  47,274.941 ns |  49,005.815 ns |  1.00 |    0.00 |  9.8892 |  104000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                StaticMethod4_int_string_struct_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  37,516.172 ns |   161.6656 ns |   143.3123 ns |  37,481.981 ns |  37,294.748 ns |  37,809.505 ns |  0.98 |    0.01 |       - |         - |          NA |
|                StaticMethod4_int_string_struct_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  38,269.265 ns |   224.3016 ns |   187.3020 ns |  38,190.972 ns |  38,036.867 ns |  38,663.719 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe | 154,049.636 ns | 1,627.1055 ns | 1,521.9955 ns | 154,078.095 ns | 150,765.655 ns | 156,191.383 ns |  1.00 |    0.01 |  4.2476 |   48000 B |        1.00 |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe | 153,891.328 ns | 1,740.0493 ns | 1,627.6432 ns | 153,630.821 ns | 152,092.770 ns | 157,213.480 ns |  1.00 |    0.00 |  4.2892 |   48000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                       Ctor0_NoParams | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  10,562.154 ns |   112.3843 ns |    93.8460 ns |  10,536.995 ns |  10,450.884 ns |  10,762.740 ns |  1.01 |    0.01 |  5.3487 |   56000 B |        1.00 |
|                                       Ctor0_NoParams | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  10,471.974 ns |    54.9419 ns |    48.7045 ns |  10,476.152 ns |  10,348.416 ns |  10,544.423 ns |  1.00 |    0.00 |  5.3512 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-ASIHDH |  \AfterFieldChange\corerun.exe |   6,616.502 ns |    69.6458 ns |    61.7392 ns |   6,615.655 ns |   6,523.419 ns |   6,747.648 ns |  1.01 |    0.01 |  5.3385 |   56000 B |        1.00 |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |   6,547.104 ns |    83.6375 ns |    69.8411 ns |   6,542.832 ns |   6,408.606 ns |   6,680.078 ns |  1.00 |    0.00 |  5.3347 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                        Ctor4_int_string_struct_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  42,367.337 ns |   424.2981 ns |   396.8887 ns |  42,429.655 ns |  41,402.474 ns |  42,858.643 ns |  1.05 |    0.02 |  5.2083 |   56000 B |        1.00 |
|                        Ctor4_int_string_struct_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  40,513.925 ns |   777.6876 ns |   689.3998 ns |  40,283.849 ns |  39,744.990 ns |  42,469.599 ns |  1.00 |    0.00 |  5.2649 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                        Ctor4_ActivatorCreateInstance | Job-ASIHDH |  \AfterFieldChange\corerun.exe | 243,237.402 ns | 1,114.2792 ns |   869.9559 ns | 243,151.172 ns | 241,268.262 ns | 244,578.711 ns |  1.00 |    0.01 | 39.0625 |  416000 B |        1.00 |
|                        Ctor4_ActivatorCreateInstance | Job-JFFKJJ | \BeforeFieldChange\corerun.exe | 243,897.922 ns | 1,999.4937 ns | 1,669.6678 ns | 244,577.596 ns | 241,097.308 ns | 245,870.385 ns |  1.00 |    0.00 | 39.4231 |  416000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                     Property_Get_int | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  11,692.331 ns |    39.3744 ns |    32.8794 ns |  11,689.891 ns |  11,649.791 ns |  11,758.716 ns |  1.00 |    0.01 |  2.2753 |   24000 B |        1.00 |
|                                     Property_Get_int | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  11,720.011 ns |    81.1029 ns |    71.8956 ns |  11,718.604 ns |  11,627.035 ns |  11,849.275 ns |  1.00 |    0.00 |  2.2770 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                   Property_Get_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |   9,842.803 ns |    75.8716 ns |    70.9703 ns |   9,826.342 ns |   9,718.131 ns |   9,975.091 ns |  1.00 |    0.01 |       - |         - |          NA |
|                                   Property_Get_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |   9,794.414 ns |    57.6734 ns |    53.9478 ns |   9,778.720 ns |   9,732.264 ns |   9,890.929 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                     Property_Set_int | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  26,377.886 ns |   208.1774 ns |   184.5438 ns |  26,390.209 ns |  26,123.043 ns |  26,813.473 ns |  1.00 |    0.02 |  2.2708 |   24000 B |        1.00 |
|                                     Property_Set_int | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  26,387.849 ns |   489.2494 ns |   523.4914 ns |  26,204.299 ns |  25,835.432 ns |  27,560.610 ns |  1.00 |    0.00 |  2.2361 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                   Property_Set_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  22,165.582 ns |   105.8851 ns |    88.4188 ns |  22,138.697 ns |  22,051.998 ns |  22,317.931 ns |  1.00 |    0.01 |       - |         - |          NA |
|                                   Property_Set_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  22,163.834 ns |   160.1992 ns |   149.8505 ns |  22,124.213 ns |  22,005.384 ns |  22,488.357 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                        Field_Get_int | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  36,563.409 ns |   647.8607 ns |   540.9930 ns |  36,428.963 ns |  36,130.507 ns |  38,035.140 ns |  0.99 |    0.02 |  2.1853 |   24000 B |        1.00 |
|                                        Field_Get_int | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  36,885.470 ns |   255.8090 ns |   226.7680 ns |  36,799.663 ns |  36,669.219 ns |  37,403.433 ns |  1.00 |    0.00 |  2.2007 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                      Field_Get_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  25,187.835 ns |   183.9906 ns |   172.1049 ns |  25,182.635 ns |  24,886.946 ns |  25,473.656 ns |  0.98 |    0.01 |       - |         - |          NA |
|                                      Field_Get_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  25,638.716 ns |    95.2595 ns |    79.5460 ns |  25,638.006 ns |  25,532.399 ns |  25,839.366 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                        Field_Set_int | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  35,031.621 ns |   461.5875 ns |   409.1853 ns |  34,892.757 ns |  34,391.749 ns |  35,910.361 ns |  0.95 |    0.01 |  2.2075 |   24000 B |        1.00 |
|                                        Field_Set_int | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  36,727.634 ns |   283.9319 ns |   251.6982 ns |  36,729.552 ns |  36,197.102 ns |  37,042.623 ns |  1.00 |    0.00 |  2.1956 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                      Field_Set_class | Job-ASIHDH |  \AfterFieldChange\corerun.exe |  37,250.522 ns |   728.5179 ns |   715.5020 ns |  36,955.533 ns |  36,428.813 ns |  38,663.847 ns |  0.94 |    0.02 |  2.2936 |   24000 B |        1.00 |
|                                      Field_Set_class | Job-JFFKJJ | \BeforeFieldChange\corerun.exe |  39,656.660 ns |   574.4379 ns |   537.3295 ns |  39,455.098 ns |  39,125.884 ns |  40,758.065 ns |  1.00 |    0.00 |  2.2096 |   24000 B |        1.00 |

|                                               Method |        Job |                      Toolchain |           Mean |         Error |        StdDev |         Median |            Min |            Max | Ratio | RatioSD |   Gen 0 | Allocated | Alloc Ratio |
|----------------------------------------------------- |----------- |------------------------------- |---------------:|--------------:|--------------:|---------------:|---------------:|---------------:|------:|--------:|--------:|----------:|------------:|
|                                      Method0_NoParms | Job-RGDKOI |  \AfterFieldChange\corerun.exe |       8.242 ns |     0.1074 ns |     0.0952 ns |       8.212 ns |       8.120 ns |       8.429 ns |  1.02 |    0.02 |       - |         - |          NA |
|                                      Method0_NoParms | Job-VRSRPD | \BeforeFieldChange\corerun.exe |       8.119 ns |     0.0953 ns |     0.0892 ns |       8.085 ns |       8.031 ns |       8.289 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  48,983.859 ns |   551.1205 ns |   430.2786 ns |  49,039.284 ns |  48,320.771 ns |  49,719.988 ns |  1.01 |    0.01 |  9.9010 |  104000 B |        1.00 |
| StaticMethod4_arrayNotCached_int_string_struct_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  48,574.059 ns |   476.7120 ns |   398.0761 ns |  48,580.850 ns |  47,740.835 ns |  49,168.369 ns |  1.00 |    0.00 |  9.9085 |  104000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                StaticMethod4_int_string_struct_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  36,860.506 ns |   329.9147 ns |   308.6024 ns |  36,727.444 ns |  36,508.607 ns |  37,403.001 ns |  1.01 |    0.01 |       - |         - |          NA |
|                StaticMethod4_int_string_struct_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  36,527.602 ns |   473.7275 ns |   443.1250 ns |  36,343.087 ns |  36,092.202 ns |  37,366.863 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe | 154,021.294 ns | 2,600.6110 ns | 2,432.6132 ns | 153,117.840 ns | 151,665.595 ns | 159,284.102 ns |  1.01 |    0.03 |  4.2476 |   48000 B |        1.00 |
|    StaticMethod4_ByRefParams_int_string_struct_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe | 152,955.974 ns | 3,015.1980 ns | 3,226.2281 ns | 152,001.838 ns | 149,701.471 ns | 160,252.328 ns |  1.00 |    0.00 |  4.2892 |   48000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                       Ctor0_NoParams | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  11,035.535 ns |   142.0932 ns |   118.6543 ns |  11,003.567 ns |  10,906.493 ns |  11,304.005 ns |  1.03 |    0.01 |  5.3311 |   56000 B |        1.00 |
|                                       Ctor0_NoParams | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  10,711.945 ns |   124.4714 ns |    97.1791 ns |  10,711.026 ns |  10,601.227 ns |  10,846.485 ns |  1.00 |    0.00 |  5.3255 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-RGDKOI |  \AfterFieldChange\corerun.exe |   6,776.170 ns |    42.8534 ns |    35.7845 ns |   6,770.059 ns |   6,723.918 ns |   6,839.288 ns |  1.01 |    0.03 |  5.3442 |   56000 B |        1.00 |
|               Ctor0_ActivatorCreateInstance_NoParams | Job-VRSRPD | \BeforeFieldChange\corerun.exe |   6,714.712 ns |   163.5822 ns |   188.3815 ns |   6,627.721 ns |   6,539.994 ns |   7,044.837 ns |  1.00 |    0.00 |  5.3325 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                        Ctor4_int_string_struct_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  40,305.202 ns |   219.9395 ns |   171.7143 ns |  40,347.935 ns |  39,997.624 ns |  40,604.369 ns |  0.99 |    0.01 |  5.2615 |   56000 B |        1.00 |
|                        Ctor4_int_string_struct_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  40,616.185 ns |   600.3698 ns |   532.2122 ns |  40,523.685 ns |  39,825.698 ns |  41,775.568 ns |  1.00 |    0.00 |  5.1948 |   56000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                        Ctor4_ActivatorCreateInstance | Job-RGDKOI |  \AfterFieldChange\corerun.exe | 251,341.199 ns | 1,758.7288 ns | 1,468.6182 ns | 251,093.246 ns | 249,441.532 ns | 254,222.581 ns |  1.03 |    0.01 | 39.3145 |  416000 B |        1.00 |
|                        Ctor4_ActivatorCreateInstance | Job-VRSRPD | \BeforeFieldChange\corerun.exe | 243,355.488 ns | 2,431.0853 ns | 2,030.0663 ns | 242,456.442 ns | 241,220.000 ns | 247,890.192 ns |  1.00 |    0.00 | 39.4231 |  416000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                     Property_Get_int | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  12,174.834 ns |    95.0264 ns |    84.2384 ns |  12,170.775 ns |  12,075.212 ns |  12,379.735 ns |  1.04 |    0.01 |  2.2683 |   24000 B |        1.00 |
|                                     Property_Get_int | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  11,688.879 ns |    75.5925 ns |    67.0108 ns |  11,680.087 ns |  11,599.461 ns |  11,819.660 ns |  1.00 |    0.00 |  2.2753 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                   Property_Get_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |   9,746.444 ns |    40.2489 ns |    35.6796 ns |   9,739.051 ns |   9,703.403 ns |   9,829.443 ns |  1.00 |    0.01 |       - |         - |          NA |
|                                   Property_Get_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |   9,793.841 ns |    95.5501 ns |    84.7026 ns |   9,749.613 ns |   9,720.829 ns |  10,003.727 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                     Property_Set_int | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  26,774.507 ns |   203.0195 ns |   179.9715 ns |  26,733.403 ns |  26,563.242 ns |  27,079.578 ns |  1.01 |    0.01 |  2.1948 |   24000 B |        1.00 |
|                                     Property_Set_int | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  26,421.713 ns |   335.9407 ns |   297.8027 ns |  26,313.030 ns |  26,105.466 ns |  27,118.994 ns |  1.00 |    0.00 |  2.2246 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                   Property_Set_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  22,119.948 ns |   178.5899 ns |   158.3153 ns |  22,042.619 ns |  21,999.217 ns |  22,515.246 ns |  0.93 |    0.02 |       - |         - |          NA |
|                                   Property_Set_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  23,817.883 ns |   461.3729 ns |   473.7960 ns |  23,935.194 ns |  22,292.277 ns |  24,276.337 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                        Field_Get_int | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  35,489.141 ns |   684.9368 ns |   672.6995 ns |  35,171.549 ns |  34,822.339 ns |  37,145.053 ns |  1.00 |    0.02 |  2.2173 |   24000 B |        1.00 |
|                                        Field_Get_int | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  35,510.203 ns |   384.9457 ns |   321.4471 ns |  35,395.682 ns |  35,145.270 ns |  36,323.551 ns |  1.00 |    0.00 |  2.2727 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                      Field_Get_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  24,850.854 ns |   295.9978 ns |   247.1716 ns |  24,706.148 ns |  24,620.630 ns |  25,465.229 ns |  0.95 |    0.02 |       - |         - |          NA |
|                                      Field_Get_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  26,291.235 ns |   292.8133 ns |   259.5713 ns |  26,325.696 ns |  25,724.000 ns |  26,580.105 ns |  1.00 |    0.00 |       - |         - |          NA |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                        Field_Set_int | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  35,765.515 ns |   709.2836 ns |   728.3820 ns |  35,475.930 ns |  34,975.588 ns |  37,345.514 ns |  0.96 |    0.02 |  2.1882 |   24000 B |        1.00 |
|                                        Field_Set_int | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  37,109.912 ns |   596.8235 ns |   529.0685 ns |  37,179.706 ns |  36,280.989 ns |  38,120.302 ns |  1.00 |    0.00 |  2.1752 |   24000 B |        1.00 |
|                                                      |            |                                |                |               |               |                |                |                |       |         |         |           |             |
|                                      Field_Set_class | Job-RGDKOI |  \AfterFieldChange\corerun.exe |  35,542.118 ns |   438.1358 ns |   388.3959 ns |  35,524.614 ns |  34,979.805 ns |  36,285.240 ns |  0.90 |    0.01 |  2.2883 |   24000 B |        1.00 |
|                                      Field_Set_class | Job-VRSRPD | \BeforeFieldChange\corerun.exe |  39,328.132 ns |   458.2774 ns |   382.6824 ns |  39,254.527 ns |  38,814.818 ns |  40,063.769 ns |  1.00 |    0.00 |  2.1930 |   24000 B |        1.00 |
```
</details>
