### PR TITLE
Fix build for `runtime/7.0-rc2` branch by adding the

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -12,6 +12,11 @@ class ChannelMap():
             'branch': '7.0-rc1',
             'quality': 'daily'
         },
+        'release/7.0-rc2': {
+            'tfm': 'net7.0',
+            'branch': '7.0-rc2',
+            'quality': 'daily'
+        },
         'release/7.0': {
             'tfm': 'net7.0',
             'branch': '7.0',


### PR DESCRIPTION
.. missing 7.0-rc2 channel.

Fails with:

```
ci_setup.py: error: argument --channel: invalid choice: 'release/7.0-rc2' (choose from 'main', 'release/7.0-rc1', 'release/7.0', 'release/6.0', '6.0', 'nativeaot7.0', 'master', 'nativeaot6.0', '5.0', 'release/5.0.1xx-rc2', 'release/5.0.1xx', 'release/3.1.3xx', 'release/3.1.2xx', 'release/3.1.1xx', '3.1', '3.0', 'release/2.1.6xx', '2.1', 'LTS', 'net48')
```