### PR TITLE
Issue #75070 (Dotnet Runtime) - Add a performance microbenchmark for …

### DIFF
--- a/src/benchmarks/micro/libraries/System.Collections/PriorityQueue/Perf_PriorityQueue.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/PriorityQueue/Perf_PriorityQueue.cs
@@ -106,5 +106,30 @@ namespace System.Collections.Tests
                 queue.Dequeue();
             }
         }
+
+        [Benchmark]
+        public void KMaxElements_DequeueEnqueue_PerformanceRegressionBenchmark()
+        {
+            const int k = 5;
+            var queue = _priorityQueue;
+            var items = _items;
+
+            for (int i = 0; i < k; i++)
+            {
+                (TElement element, TPriority priority) = items[i];
+                queue.Enqueue(element, priority);
+            }
+
+            for (int i = k; i < Size; i++)
+            {
+                (TElement element, TPriority priority) = items[i];
+                queue.DequeueEnqueue(element, priority);
+            }
+
+            for (int i = 0; i < k; i++)
+            {
+                queue.Dequeue();
+            }
+        }
     }
 }


### PR DESCRIPTION
…the new PriorityQueue DequeueEnqueue method to help monitor for performance regressions

Serves as a performance regression check benchmark for the new `PriorityQueue` `DequeueEnqueue` public api method added as part of this dotnet runtime issue https://github.com/dotnet/runtime/issues/75070


