### PR TITLE
Allow for the passing of the runtime commit time to use in ci_setup.

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -5,9 +5,8 @@ from logging import getLogger
 
 import os
 import sys
+import datetime
 
-
-from dateutil import parser as date_parser
 from subprocess import check_output
 
 from performance.common import get_repo_root_path
@@ -318,8 +317,11 @@ def __main(args: list) -> int:
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
         dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
-        timestamp_value = dotnet.get_commit_date(target_framework_moniker, commit_sha, repo_url) if args.commit_time is None else args.commit_time
-        source_timestamp = date_parser.parse(timestamp_value).strftime('%Y-%m-%dT%H:%M:%SZ')
+        if(args.commit_time is not None):
+            parsed_timestamp = datetime.datetime.strptime(timestamp_value, '%Y-%m-%d %H:%M:%S %z').astimezone(datetime.timezone.utc)
+            source_timestamp = parsed_timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
+        else:
+            source_timestamp = dotnet.get_commit_date(target_framework_moniker, commit_sha, repo_url)
 
         branch = ChannelMap.get_branch(args.channel) if not args.branch else args.branch
 

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -100,7 +100,7 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         dest='commit_time',
         required=False,
         type=str,
-        help='Product commit time.'
+        help='Product commit time. Format: %Y-%m-%d %H:%M:%S %z'
     )
     parser.add_argument(
         '--repository',

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -6,6 +6,8 @@ from logging import getLogger
 import os
 import sys
 
+
+from dateutil import parser as date_parser
 from subprocess import check_output
 
 from performance.common import get_repo_root_path
@@ -93,6 +95,13 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         required=False,
         type=str,
         help='Product commit sha.'
+    )
+    parser.add_argument(
+        '--commit-time',
+        dest='commit_time',
+        required=False,
+        type=str,
+        help='Product commit time.'
     )
     parser.add_argument(
         '--repository',
@@ -309,7 +318,8 @@ def __main(args: list) -> int:
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
         dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
-        source_timestamp = dotnet.get_commit_date(target_framework_moniker, commit_sha, repo_url)
+        timestamp_value = dotnet.get_commit_date(target_framework_moniker, commit_sha, repo_url) if args.commit_time is None else args.commit_time
+        source_timestamp = date_parser.parse(timestamp_value).strftime('%Y-%m-%dT%H:%M:%SZ')
 
         branch = ChannelMap.get_branch(args.channel) if not args.branch else args.branch
 

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -318,7 +318,7 @@ def __main(args: list) -> int:
         dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
         if(args.commit_time is not None):
-            parsed_timestamp = datetime.datetime.strptime(timestamp_value, '%Y-%m-%d %H:%M:%S %z').astimezone(datetime.timezone.utc)
+            parsed_timestamp = datetime.datetime.strptime(args.commit_time, '%Y-%m-%d %H:%M:%S %z').astimezone(datetime.timezone.utc)
             source_timestamp = parsed_timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
         else:
             source_timestamp = dotnet.get_commit_date(target_framework_moniker, commit_sha, repo_url)


### PR DESCRIPTION
Allow for the passing of the runtime commit time to use in ci_setup. This is to allow for bypassing of calling to github for the commit timestamp.