### PR TITLE
Add performance test for XmlSerializationWriter.WriteTypedPrimitive

### DIFF
--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -16,6 +16,15 @@ namespace MicroBenchmarks
     {
         static int Main(string[] args)
         {
+            //var bb = new System.Xml.Tests.Perf_XmlSerializationWriter();
+            //var xml = bb.AddPrimitives();
+            //bb.CleanWriter();
+            //var xml2 = bb.AddPrimitives();
+            //if (xml != xml2)
+            //{
+            //    Console.WriteLine("diff");
+            //}
+
             var argsList = new List<string>(args);
             int? partitionCount;
             int? partitionIndex;

--- a/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlSerializationWriter.cs
+++ b/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlSerializationWriter.cs
@@ -26,7 +26,7 @@ namespace System.Xml.Tests
 		public void CleanWriter() => _writer.Clean();
 
 		[Benchmark(OperationsPerInvoke = Iterations)]
-		public string AddPrimitives()
+		public int AddPrimitives()
 		{
 			for (int i = 0; i < Iterations; i++)
 			{
@@ -47,7 +47,7 @@ namespace System.Xml.Tests
 				_writer.Write(Guid.NewGuid());
 			}
 
-			return _writer.GetXml();
+			return _writer.GetXmlLength();
 		}
 	}
 
@@ -67,6 +67,6 @@ namespace System.Xml.Tests
 		public void Write<T>(T value) => WriteTypedPrimitive(null, null, value, false);
 
 		public void Clean() => _builder.Clear();
-		public string GetXml() => _builder.ToString();
+		public int GetXmlLength() => _builder.Length;
 	}
 }

--- a/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlSerializationWriter.cs
+++ b/src/benchmarks/micro/libraries/System.Private.Xml/Perf.XmlSerializationWriter.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text;
+using System.Xml.Serialization;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Xml.Tests
+{
+	[BenchmarkCategory(Categories.Libraries)]
+	public class Perf_XmlSerializationWriter
+	{
+		private const int Iterations = 1000;
+
+		private readonly MyXmlSerializationWriter _writer = new MyXmlSerializationWriter();
+
+		private static readonly DateTime Now = new DateTime(2022, 9, 30, 9, 4, 15, DateTimeKind.Utc);
+		private static readonly DateTimeOffset DtoNow = Now.AddDays(1);
+		private static readonly TimeSpan Ts = new TimeSpan(1, 2, 3, 4, 5);
+		private static readonly byte[] BArray = new byte[] { 33, 44, 55 };
+
+		[IterationSetup]
+		public void CleanWriter() => _writer.Clean();
+
+		[Benchmark(OperationsPerInvoke = Iterations)]
+		public string AddPrimitives()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				_writer.Write('a');
+				_writer.Write(123);
+				_writer.Write(123.45m);
+				_writer.Write(Now);
+				_writer.Write(Ts);
+				_writer.Write(DtoNow);
+				_writer.Write((short)55);
+				_writer.Write(2345324L);
+				_writer.Write((sbyte)11);
+				_writer.Write((ushort)34);
+				_writer.Write((uint)4564);
+				_writer.Write((ulong)456734767);
+				_writer.Write((byte) 67);
+				_writer.Write(BArray);
+				_writer.Write(Guid.NewGuid());
+			}
+
+			return _writer.GetXml();
+		}
+	}
+
+	internal class MyXmlSerializationWriter : XmlSerializationWriter
+	{
+		private readonly StringBuilder _builder = new StringBuilder();
+
+		public MyXmlSerializationWriter()
+		{
+			Writer = new XmlTextWriter(new StringWriter(_builder));
+		}
+
+		protected override void InitCallbacks()
+		{
+		}
+
+		public void Write<T>(T value) => WriteTypedPrimitive(null, null, value, false);
+
+		public void Clean() => _builder.Clear();
+		public string GetXml() => _builder.ToString();
+	}
+}


### PR DESCRIPTION
Benchmark used in https://github.com/dotnet/runtime/pull/76436
Maybe merge can wait until owners agree that it is good optimization and deserves benchmark.

