### PR TITLE
Fix wasm builds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,7 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -254,6 +254,7 @@ def __main(args: list) -> int:
             target_framework_monikers,
             args.incremental,
             args.run_isolated,
+            args.wasm,
             verbose
         )
 

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -325,7 +325,7 @@ class CSharpProject:
               target_framework_monikers: list = None,
               output_to_bindir: bool = False,
               runtime_identifier: str = None,
-              *args) -> None:
+              args: list = None) -> None:
         '''Calls dotnet to build the specified project.'''
         if not target_framework_monikers:  # Build all supported frameworks.
             cmdline = [
@@ -344,7 +344,7 @@ class CSharpProject:
                 cmdline = cmdline + ['--runtime', runtime_identifier]
             
             if args:
-                cmdline = cmdline + list(args)
+                cmdline = cmdline + args
             
             RunCommand(cmdline, verbose=verbose).run(
                 self.working_directory)
@@ -368,7 +368,7 @@ class CSharpProject:
                     cmdline = cmdline + ['--runtime', runtime_identifier]
 
                 if args:
-                    cmdline = cmdline + list(args)
+                    cmdline = cmdline + args
                 
                 RunCommand(cmdline, verbose=verbose).run(
                     self.working_directory)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -288,6 +288,7 @@ def build(
         target_framework_monikers: list,
         incremental: str,
         run_isolated: bool,
+        for_wasm: bool,
         verbose: bool) -> None:
     '''Restores and builds the benchmarks'''
 
@@ -306,6 +307,10 @@ def build(
     __log_script_header("Restoring .NET micro benchmarks")
     BENCHMARKS_CSPROJ.restore(packages_path=packages, verbose=verbose)
 
+    build_args = []
+    if for_wasm:
+        build_args += ['/p:BuildingForWasm=true']
+
     # dotnet build
     build_title = "Building .NET micro benchmarks for '{}'".format(
         ' '.join(target_framework_monikers))
@@ -315,7 +320,8 @@ def build(
         target_framework_monikers=target_framework_monikers,
         output_to_bindir=run_isolated,
         verbose=verbose,
-        packages_path=packages)
+        packages_path=packages,
+        args=build_args)
 
     # When running isolated, artifacts/obj/{project_name} will still be
     # there, and would interfere with any subsequent builds. So, remove
@@ -398,7 +404,8 @@ def __main(args: list) -> int:
             target_framework_monikers,
             incremental,
             args.run_isolated,
-            verbose
+            for_wasm=args.wasm,
+            verbose=verbose
         )
 
         for framework in frameworks:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -17,6 +17,8 @@
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
     <LangVersion>8.0</LangVersion>
+    <!-- Allow building with one major version, and running using a sdk with a higher major version -->
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
   <!-- out-of-band packages that are not included in NetCoreApp have TFM-specific versions -->
   <Choose>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -17,8 +17,9 @@
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
     <LangVersion>8.0</LangVersion>
+
     <!-- Allow building with one major version, and running using a sdk with a higher major version -->
-    <RollForward>LatestMajor</RollForward>
+    <RollForward Condition="'$(BuildingForWasm)' == 'true'">LatestMajor</RollForward>
   </PropertyGroup>
   <!-- out-of-band packages that are not included in NetCoreApp have TFM-specific versions -->
   <Choose>


### PR DESCRIPTION
## NuGet.config: add dotnet8 feed

Building blazor scenarios with 8.0 sdk (used by `dotnet/runtime` `main`)
fails:

```
blazorminappaot/app/emptyblazorwasmtemplate.csproj:
error nu1102: Unable to find package Microsoft.AspNetCore.Components.WebAssembly with version (>= 8.0.0-alpha.1.22479.18)
error nu1102:   - Found 2091 version(s) in dotnet6 [ Nearest version: 6.0.0-rtm.21520.4 ]
error nu1102:   - Found 1610 version(s) in dotnet7 [ Nearest version: 7.0.0-rtm.22503.15 ]
error nu1102:   - Found 579 version(s) in dotnet5 [ Nearest version: 5.0.0-rtm.20512.8 ]
error nu1102:   - Found 58 version(s) in dotnet-public [ Nearest version: 7.0.0-rc.1.22427.2 ]
error nu1102:   - Found 1 version(s) in dotnet-tools [ Nearest version: 5.0.0-rc.2.20513.11 ]
error nu1102:   - Found 0 version(s) in benchmark-dotnet-prerelease
error nu1102:   - Found 0 version(s) in dotnet-eng
error nu1102:   - Found 0 version(s) in dotnet3.1-transport
error nu1102:   - Found 0 version(s) in dotnet3.1
error nu1102:   - Found 0 version(s) in dotnet5-transport
```

Add the new dotnet8 feed.

## Use RollForward=LatestMajor for MicroBenchmarks project

The project is built for `net7.0`, but run with `8.0` sdk, which fails
with:

```
App: /home/helixbot/work/ADE4096E/w/B4B209A5/e/performance/artifacts/bin/for-running/MicroBenchmarks/MicroBenchmarks.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '7.0.0-rc.1.22426.10' (x64)
.NET location: /home/helixbot/work/ADE4096E/p/dotnet/

The following frameworks were found:
  8.0.0-alpha.1.22478.11 at [/home/helixbot/work/ADE4096E/p/dotnet/shared/Microsoft.NETCore.App]
  8.0.0-alpha.1.22502.5 at [/home/helixbot/work/ADE4096E/p/dotnet/shared/Microsoft.NETCore.App]

Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0-rc.1.22426.10&arch=x64&rid=ubuntu.18.04-x64
```

Add `RollForward=LatestMajor`.

cc @lewing