### PR TITLE
Remove .NET 5 links, because it's no longer officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 | Build Source Version                        | Public Build Status                                                         | Internal Build Status                                                           |
 | :------------------------------------------ | :-------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
 | main                                        | [![public_build_icon_main]][public_build_status_main]                       | [![internal_build_icon_main]][internal_build_status_main]                       |
-| release/5.0.1xx                             | [![public_build_icon_release_5.0.1xx]][public_build_status_release_5.0.1xx] | [![internal_build_icon_release_5.0.1xx]][internal_build_status_release_5.0.1xx] |
 | release/3.1.4xx                             | [![public_build_icon_release_3.1.4xx]][public_build_status_release_3.1.4xx] | [![internal_build_icon_release_3.1.4xx]][internal_build_status_release_3.1.4xx] |
 
 This repo contains benchmarks used for testing the performance of all .NET Runtimes: .NET Core, Full .NET Framework, Mono and CoreRT.
@@ -25,11 +24,6 @@ This project has adopted the code of conduct defined by the Contributor Covenant
 [public_build_status_main]:                      https://dev.azure.com/dnceng-public/public/_build/latest?definitionId=271&branchName=main
 [internal_build_icon_main]:                      https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=main
 [internal_build_status_main]:                    https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=main
-
-[public_build_icon_release_5.0.1xx]:             https://dev.azure.com/dnceng-public/public/_apis/build/status/dotnet/performance/performance-ci?branchName=release%2F5.0.1xx
-[public_build_status_release_5.0.1xx]:           https://dev.azure.com/dnceng-public/public/_build/latest?definitionId=271&branchName=release%2F5.0.1xx
-[internal_build_icon_release_5.0.1xx]:           https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/performance/dotnet-performance?branchName=release%2F5.0.1xx
-[internal_build_status_release_5.0.1xx]:         https://dev.azure.com/dnceng/internal/_build/latest?definitionId=306&branchName=release%2F5.0.1xx
 
 [public_build_icon_release_3.1.4xx]:             https://dev.azure.com/dnceng-public/public/_apis/build/status/dotnet/performance/performance-ci?branchName=release%2F3.1.4xx
 [public_build_status_release_3.1.4xx]:           https://dev.azure.com/dnceng-public/public/_build/latest?definitionId=271&branchName=release%2F3.1.4xx


### PR DESCRIPTION
Based on a suggestion from #2632.