### PR TITLE
Add ability to fetch an internal RC2 build using a secret "--internal-build-key" argument fetched from a keyvault

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -41,7 +41,8 @@ def init_tools(
         dotnet_versions: str,
         target_framework_monikers: list,
         verbose: bool,
-        key: str = None) -> None:
+        azure_feed_url: str = None,
+        internal_build_key: str = None) -> None:
     '''
     Install tools used by this repository into the tools folder.
     This function writes a semaphore file when tools have been successfully
@@ -58,7 +59,8 @@ def init_tools(
         channels=channels,
         versions=dotnet_versions,
         verbose=verbose,
-        key=key
+        azure_feed_url=azure_feed_url,
+        internal_build_key=internal_build_key
     )
 
 
@@ -192,11 +194,19 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     )
 
     parser.add_argument(
+        '--azure-feed-url',
+        dest='azure_feed_url',
+        required=False,
+        default=None,
+        help='Internal azure feed to fetch the build from',
+    )
+
+    parser.add_argument(
         '--internal-build-key',
         dest='internal_build_key',
         required=False,
         default=None,
-        help='Key used to fetch the build from an internal source',
+        help='Key used to fetch the build from an internal azure feed',
     )
 
     return parser
@@ -233,7 +243,8 @@ def __main(args: list) -> int:
             dotnet_versions=args.dotnet_versions,
             target_framework_monikers=target_framework_monikers,
             verbose=verbose,
-            key=args.internal_build_key
+            azure_feed_url=args.azure_feed_url,
+            internal_build_key=args.internal_build_key
         )
     else:
         dotnet.setup_dotnet(args.dotnet_path)

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -40,7 +40,8 @@ def init_tools(
         architecture: str,
         dotnet_versions: str,
         target_framework_monikers: list,
-        verbose: bool) -> None:
+        verbose: bool,
+        key: str = None) -> None:
     '''
     Install tools used by this repository into the tools folder.
     This function writes a semaphore file when tools have been successfully
@@ -57,6 +58,7 @@ def init_tools(
         channels=channels,
         versions=dotnet_versions,
         verbose=verbose,
+        key=key
     )
 
 
@@ -189,6 +191,14 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Skips the logger setup, for cases when invoked by another script that already sets logging up',
     )
 
+    parser.add_argument(
+        '--internal-build-key',
+        dest='internal_build_key',
+        required=False,
+        default=None,
+        help='Key used to fetch the build from an internal source',
+    )
+
     return parser
 
 
@@ -222,7 +232,8 @@ def __main(args: list) -> int:
             architecture=args.architecture,
             dotnet_versions=args.dotnet_versions,
             target_framework_monikers=target_framework_monikers,
-            verbose=verbose
+            verbose=verbose,
+            key=args.internal_build_key
         )
     else:
         dotnet.setup_dotnet(args.dotnet_path)

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -20,6 +20,7 @@ import sys
 import os
 
 VERSIONS = {
+    'net7.0-rc2': { 'tfm': 'net7.0', 'build': '7.0.100-rc.2.22477.23' },
     'net7.0-rc1': { 'tfm': 'net7.0', 'build': '7.0.100-rc.1.22425.9' },
     'net7.0-preview7': { 'tfm': 'net7.0', 'build': '7.0.100-preview.7.22370.3' },
     'net7.0-preview5': { 'tfm': 'net7.0', 'build': '7.0.100-preview.5.22276.3' },
@@ -100,6 +101,11 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         action='store_true',
         help='Runs each benchmark only once, useful for testing')
 
+    parser.add_argument(
+        '--internal-build-key',
+        dest='internal_build_key',
+        help='Key used to fetch the build from an internal source')
+
     return parser
 
 def __process_arguments(args: list):
@@ -171,6 +177,9 @@ def __main(args: list) -> int:
                 benchmarkArgs += ['--bdn-arguments', args.bdn_arguments]
         elif version['tfm'].startswith('nativeaot'):
             benchmarkArgs += ['--bdn-arguments', '--ilCompilerVersion ' + version['ilc']]
+        
+        if args.internal_build_key:
+            benchmarkArgs += ['--internal-build-key', args.internal_build_key]
 
         log('Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
 

--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -102,9 +102,14 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         help='Runs each benchmark only once, useful for testing')
 
     parser.add_argument(
+        '--azure-feed-url',
+        dest='azure_feed_url',
+        help='Internal azure feed to fetch the build from')
+
+    parser.add_argument(
         '--internal-build-key',
         dest='internal_build_key',
-        help='Key used to fetch the build from an internal source')
+        help='Key used to fetch the build from an internal azure feed')
 
     return parser
 
@@ -178,10 +183,15 @@ def __main(args: list) -> int:
         elif version['tfm'].startswith('nativeaot'):
             benchmarkArgs += ['--bdn-arguments', '--ilCompilerVersion ' + version['ilc']]
         
-        if args.internal_build_key:
-            benchmarkArgs += ['--internal-build-key', args.internal_build_key]
-
-        log('Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
+        if args.azure_feed_url or args.internal_build_key:
+            if args.azure_feed_url and args.internal_build_key:
+                benchmarkArgs += ['--azure-feed-url', args.azure_feed_url]
+                benchmarkArgs += ['--internal-build-key', args.internal_build_key]
+                log('Executing: benchmarks_ci.py ')
+            else:
+                raise("Must include both a --azure-feed-url and a --internal-build-key")
+        else:
+            log('Executing: benchmarks_ci.py ' + str.join(' ', benchmarkArgs))
 
         if not args.dry_run:
             try:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -744,7 +744,8 @@ def install(
         channels: list,
         versions: str,
         verbose: bool,
-        install_dir: str = None) -> None:
+        install_dir: str = None,
+        key: str = None) -> None:
     '''
     Downloads dotnet cli into the tools folder.
     '''
@@ -802,6 +803,10 @@ def install(
         '-InstallDir', install_dir,
         '-Architecture', architecture
     ]
+
+    if key is not None:
+        common_cmdline_args += ['-AzureFeed', 'https://dotnetbuilds.blob.core.windows.net/internal']
+        common_cmdline_args += ['-FeedCredential', key]
 
     # Install Runtime/SDKs
     if versions:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -745,7 +745,8 @@ def install(
         versions: str,
         verbose: bool,
         install_dir: str = None,
-        key: str = None) -> None:
+        azure_feed_url: str = None,
+        internal_build_key: str = None) -> None:
     '''
     Downloads dotnet cli into the tools folder.
     '''
@@ -804,9 +805,9 @@ def install(
         '-Architecture', architecture
     ]
 
-    if key is not None:
-        common_cmdline_args += ['-AzureFeed', 'https://dotnetbuilds.blob.core.windows.net/internal']
-        common_cmdline_args += ['-FeedCredential', key]
+    if azure_feed_url and internal_build_key:
+        common_cmdline_args += ['-AzureFeed', azure_feed_url]
+        common_cmdline_args += ['-FeedCredential', internal_build_key]
 
     # Install Runtime/SDKs
     if versions:

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -212,6 +212,9 @@ class RunCommand:
             quoted_cmdline = '$ '
             quoted_cmdline += list2cmdline(self.cmdline)
 
+            if '-AzureFeed' in self.cmdline or '-FeedCredential' in self.cmdline:
+                quoted_cmdline = "<dotnet-install command contains secrets, skipping log>"
+            
             getLogger().info(quoted_cmdline)
 
             with Popen(


### PR DESCRIPTION
This solution is a bit hacky, but users in the correct security group should be able to run the perf report with an internal build using the following workflow:

1. `$value = az keyvault secret show --vault-name dnceng-partners-kv --name dotnetbuilds-internal-container-read-token --query "value"`
2. `$value = $value.replace('"', "'")`
3. `py .\scripts\benchmarks_monthly.py net7.0-rc2 --architecture x64 --device-name drew-x64 --azure-feed-url https://dotnetbuilds.blob.core.windows.net/internal --internal-build-key $value`
> 

I haven't tested this on Linux or Mac, might need to adjust it as needed.
