### PR TITLE
Use latest docker containers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,9 @@
 resources:
   containers:
     - container: ubuntu_x64_build_container
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20210311173856-047508b
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04
     - container: centos_x64_build_container
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20220107135107-9b5bbc2
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
 
 # CI Trigger on main branch
 trigger:


### PR DESCRIPTION
This change moves all of the docker images to the latest tag as part of https://github.com/dotnet/arcade/issues/10377.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


