### PR TITLE
Create the file system test directory if it does not exist.

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
@@ -93,7 +93,7 @@ namespace System.IO.Tests
         public void SetupReadAllBytes()
         {
             // use non-temp file path to ensure that we don't test some unusal File System on Unix
-            string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, SpecialFolderOption.Create);
             File.WriteAllBytes(_testFilePath = Path.Combine(baseDir, Path.GetRandomFileName()), Array.Empty<byte>());
             _filesToRead = new Dictionary<int, string>()
             {


### PR DESCRIPTION
When dotnet/runtime@62db361 changed the `SpecialFolder.MyDocuments` value from HOME to the documents folder, a performance regression in the file benchmarks was introduced, as the folder did not exist which lead to the benchmarks testing wherever the working directory was.

By creating the folder before we test, we should go back to the previous behaviour.

Fixes https://github.com/dotnet/perf-autofiling-issues/issues/8832
Fixes https://github.com/dotnet/runtime/issues/76390

---
Some notes:
An alternative solution would be to change the testing folder back to the home folder. However, some systems have Home as read only, in order to stop programs from "polluting" it, which would cause the benchmarks to not run. I've thus opted for this approach instead.

Additionally, it's currently possible that the cleanup function potentially doesn't cleanup properly: in the scenario where the documents folder did not exist beforehand, the documents folder will not be deleted to put the system back to the state as it was before. I am currently under the assumption that the documents folder is essential enough that it doesn't need to be cleaned, if the opposite is preferred however, I can change the PR accordingly.


