### PR TITLE
Update BDN to 0.13.2.1950.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,7 @@
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.4</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNetILLinkTasksVersion>7.0.100-1.22057.1</MicrosoftNetILLinkTasksVersion>
     <MicrosoftNetILLinkPackageVersion>7.0.100-1.22057.1</MicrosoftNetILLinkPackageVersion>
+    <BenchmarkDotNetVersion>0.13.2.1950</BenchmarkDotNetVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/benchmarks/real-world/FSharp/FSharp.fsproj
+++ b/src/benchmarks/real-world/FSharp/FSharp.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="FSharp.Compiler.Service" Version="41.0.5" />
     <PackageReference Update="FSharp.Core" Version="6.0.5" />
   </ItemGroup>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -7,8 +7,8 @@
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' == ''">
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2.1940" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2.1940" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2.1950" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2.1950" />
   </ItemGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet\BenchmarkDotNet.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -7,8 +7,8 @@
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>
   </PropertyGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' == ''">
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2.1950" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2.1950" />
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <ProjectReference Include="$(_BenchmarkDotNetSourcesN)src\BenchmarkDotNet\BenchmarkDotNet.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />


### PR DESCRIPTION
Update BDN to 0.13.2.1950. Updates to this fix: https://github.com/dotnet/BenchmarkDotNet/pull/2154 and should fix mono runs.
