### PR TITLE
Add Environment namespace to fix specialfolderoptions not found.

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
+++ b/src/benchmarks/micro/libraries/System.IO.FileSystem/Perf.File.cs
@@ -93,7 +93,7 @@ namespace System.IO.Tests
         public void SetupReadAllBytes()
         {
             // use non-temp file path to ensure that we don't test some unusal File System on Unix
-            string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, SpecialFolderOption.Create);
+            string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments, Environment.SpecialFolderOption.Create);
             File.WriteAllBytes(_testFilePath = Path.Combine(baseDir, Path.GetRandomFileName()), Array.Empty<byte>());
             _filesToRead = new Dictionary<int, string>()
             {


### PR DESCRIPTION
Microbenchmarks are hitting specialfolderoptions not found errors from merging in: https://github.com/dotnet/performance/pull/2654. This adds the beginning namespace and should fix the issue.