### PR TITLE
Vector128 microbenchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
@@ -1,0 +1,364 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Runtime.Intrinsics.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Vector128
+    {
+        private static readonly Vector128<double> _vectorDouble = Vector128.Create(1.0, 2.0);
+        private static readonly Vector128<float> _vectorFloat = Vector128.Create(1.0F, 2.0F, 3.0F, 4.0F);
+        private static readonly Vector128<long> _vectorLong = Vector128.Create(1, 2);
+        private static readonly Vector128<ulong> _vectorULong = Vector128.Create((ulong)1, 2);
+        private static readonly Vector128<int> _vectorInt = Vector128.Create(1, 2, 3, 4);
+        private static readonly Vector128<uint> _vectorUInt = Vector128.Create((uint)1, 2, 3, 4);
+        
+        [Benchmark]
+        public Vector128<double> FloorDoubleBenchmark() => Vector128.Floor(_vectorDouble);
+
+        [Benchmark]
+        public Vector128<float> FloorFloatBenchmark() => Vector128.Floor(_vectorFloat);
+
+        [Benchmark]
+        public Vector128<double> CeilingDoubleBenchmark() => Vector128.Ceiling(_vectorDouble);
+
+        [Benchmark]
+        public Vector128<float> CeilingFloatBenchmark() => Vector128.Ceiling(_vectorFloat);
+
+        [Benchmark]
+        public Vector128<double> ConvertLongToDoubleBenchmark() => Vector128.ConvertToDouble(_vectorLong);
+
+        [Benchmark]
+        public Vector128<double> ConvertULongToDoubleBenchmark() => Vector128.ConvertToDouble(_vectorULong);
+
+        [Benchmark]
+        public Vector128<int> ConvertFloatToIntBenchmark() => Vector128.ConvertToInt32(_vectorFloat);
+
+        [Benchmark]
+        public Vector128<long> ConvertDoubleToLongBenchmark() => Vector128.ConvertToInt64(_vectorDouble);
+
+        [Benchmark]
+        public Vector128<float> ConvertIntToFloatBenchmark() => Vector128.ConvertToSingle(_vectorInt);
+
+        [Benchmark]
+        public Vector128<float> ConvertUIntToFloatBenchmark() => Vector128.ConvertToSingle(_vectorUInt);
+
+        [Benchmark]
+        public Vector128<uint> ConvertFloatToUIntBenchmark() => Vector128.ConvertToUInt32(_vectorFloat);
+        
+        [Benchmark]
+        public Vector128<ulong> ConvertDoubleToULongBenchmark() => Vector128.ConvertToUInt64(_vectorDouble);
+    }
+
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Vector128Float
+    {
+        private static readonly Vector128<float> Value1 = Vector128<float>.AllBitsSet;
+        private static readonly Vector128<float> Value2 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
+        private static readonly Vector128<float> Value3 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
+
+
+        [Benchmark]
+        public int CountBenchmark() => Vector128<float>.Count;
+
+        [Benchmark]
+        public Vector128<float> AllBitsSetBenchmark() => Vector128<float>.AllBitsSet;
+
+        [Benchmark]
+        public Vector128<float> ZeroBenchmark() => Vector128<float>.Zero;
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Value1.Equals(Value2);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => Value1.GetHashCode();
+
+        [Benchmark]
+        public Vector128<float> AddOperatorBenchmark() => Value1 + Value2;
+
+        [Benchmark]
+        public Vector128<float> BitwiseAndOperatorBenchmark() => Value1 & Value2;
+
+        [Benchmark]
+        public Vector128<float> BitwiseOrOperatorBenchmark() => Value1 | Value2;
+
+        [Benchmark]
+        public Vector128<float> DivisionOperatorBenchmark() => Value1 / Value2;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Value1 == Value2;
+
+        [Benchmark]
+        public Vector128<float> ExclusiveOrOperatorBenchmark() => Value1 ^ Value2;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Value1 != Value2;
+
+        [Benchmark]
+        public Vector128<float> MultiplyOperatorBenchmark() => Value1 * Value2;
+
+        [Benchmark]
+        public Vector128<float> OnesComplementOperatorBenchmark() => ~Value1;
+
+        [Benchmark]
+        public Vector128<float> SubtractionOperatorBenchmark() => Value1 - Value2;
+
+        [Benchmark]
+        public Vector128<float> UnaryNegateOperatorBenchmark() => -Value1;
+
+        [Benchmark]
+        public Vector128<float> AbsBenchmark() => Vector128.Abs(Value1);
+
+        [Benchmark]
+        public Vector128<float> AddBenchmark() => Vector128.Add(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> AndNotBenchmark() => Vector128.AndNot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> BitwiseAndBenchmark() => Vector128.BitwiseAnd(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> BitwiseOrBenchmark() => Vector128.BitwiseOr(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> ConditionalSelectBenchmark() => Vector128.ConditionalSelect(Value1, Value2, Value3);
+
+        [Benchmark]
+        public Vector128<float> DivideBenchmark() => Vector128.Divide(Value1, Value2);
+
+        [Benchmark]
+        public float DotBenchmark() => Vector128.Dot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> EqualsStaticBenchmark() => Vector128.Equals(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAllBenchmark() => Vector128.EqualsAll(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAnyBenchmark() => Vector128.EqualsAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> GreaterThanBenchmark() => Vector128.GreaterThan(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAllBenchmark() => Vector128.GreaterThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAnyBenchmark() => Vector128.GreaterThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> GreaterThanOrEqualBenchmark() => Vector128.GreaterThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAllBenchmark() => Vector128.GreaterThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAnyBenchmark() => Vector128.GreaterThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> LessThanBenchmark() => Vector128.LessThan(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAllBenchmark() => Vector128.LessThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAnyBenchmark() => Vector128.LessThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> LessThanOrEqualBenchmark() => Vector128.LessThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAllBenchmark() => Vector128.LessThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAnyBenchmark() => Vector128.LessThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> MaxBenchmark() => Vector128.Max(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> MinBenchmark() => Vector128.Min(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> MultiplyBenchmark() => Vector128.Multiply(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<float> NegateBenchmark() => Vector128.Negate(Value1);
+
+        [Benchmark]
+        public Vector128<float> OnesComplementBenchmark() => Vector128.OnesComplement(Value1);
+
+        [Benchmark]
+        public Vector128<float> SquareRootBenchmark() => Vector128.Sqrt(Value1);
+
+        [Benchmark]
+        public Vector128<float> SubtractBenchmark() => Vector128.Subtract(Value1, Value2);
+
+        [Benchmark]
+        public float SumBenchmark() =>  Vector128.Sum(Value1);
+
+        [Benchmark]
+        public Vector128<float> XorBenchmark() => Vector128.Xor(Value1, Value2);
+    }
+
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Vector128Int
+    {
+        private static readonly Vector128<int> Value1 = Vector128<int>.AllBitsSet;
+        private static readonly Vector128<int> Value2 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
+        private static readonly Vector128<int> Value3 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
+
+
+        [Benchmark]
+        public int CountBenchmark() => Vector128<int>.Count;
+
+        [Benchmark]
+        public Vector128<int> AllBitsSetBenchmark() => Vector128<int>.AllBitsSet;
+
+        [Benchmark]
+        public Vector128<int> ZeroBenchmark() => Vector128<int>.Zero;
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Value1.Equals(Value2);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => Value1.GetHashCode();
+
+        [Benchmark]
+        public Vector128<int> AddOperatorBenchmark() => Value1 + Value2;
+
+        [Benchmark]
+        public Vector128<int> BitwiseAndOperatorBenchmark() => Value1 & Value2;
+
+        [Benchmark]
+        public Vector128<int> BitwiseOrOperatorBenchmark() => Value1 | Value2;
+
+        [Benchmark]
+        public Vector128<int> DivisionOperatorBenchmark() => Value1 / Value2;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Value1 == Value2;
+
+        [Benchmark]
+        public Vector128<int> ExclusiveOrOperatorBenchmark() => Value1 ^ Value2;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Value1 != Value2;
+
+        [Benchmark]
+        public Vector128<int> MultiplyOperatorBenchmark() => Value1 * Value2;
+
+        [Benchmark]
+        public Vector128<int> OnesComplementOperatorBenchmark() => ~Value1;
+
+        [Benchmark]
+        public Vector128<int> SubtractionOperatorBenchmark() => Value1 - Value2;
+
+        [Benchmark]
+        public Vector128<int> UnaryNegateOperatorBenchmark() => -Value1;
+
+        [Benchmark]
+        public Vector128<int> AbsBenchmark() => Vector128.Abs(Value1);
+
+        [Benchmark]
+        public Vector128<int> AddBenchmark() => Vector128.Add(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> AndNotBenchmark() => Vector128.AndNot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> BitwiseAndBenchmark() => Vector128.BitwiseAnd(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> BitwiseOrBenchmark() => Vector128.BitwiseOr(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> ConditionalSelectBenchmark() => Vector128.ConditionalSelect(Value1, Value2, Value3);
+
+        [Benchmark]
+        public Vector128<int> DivideBenchmark() => Vector128.Divide(Value1, Value2);
+
+        [Benchmark]
+        public int DotBenchmark() => Vector128.Dot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> EqualsStaticBenchmark() => Vector128.Equals(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAllBenchmark() => Vector128.EqualsAll(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAnyBenchmark() => Vector128.EqualsAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> GreaterThanBenchmark() => Vector128.GreaterThan(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAllBenchmark() => Vector128.GreaterThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAnyBenchmark() => Vector128.GreaterThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> GreaterThanOrEqualBenchmark() => Vector128.GreaterThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAllBenchmark() => Vector128.GreaterThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAnyBenchmark() => Vector128.GreaterThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> LessThanBenchmark() => Vector128.LessThan(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAllBenchmark() => Vector128.LessThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAnyBenchmark() => Vector128.LessThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> LessThanOrEqualBenchmark() => Vector128.LessThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAllBenchmark() => Vector128.LessThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAnyBenchmark() => Vector128.LessThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> MaxBenchmark() => Vector128.Max(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> MinBenchmark() => Vector128.Min(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> MultiplyBenchmark() => Vector128.Multiply(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<int> NegateBenchmark() => Vector128.Negate(Value1);
+
+        [Benchmark]
+        public Vector128<int> OnesComplementBenchmark() => Vector128.OnesComplement(Value1);
+
+        [Benchmark]
+        public Vector128<int> SquareRootBenchmark() => Vector128.Sqrt(Value1);
+
+        [Benchmark]
+        public Vector128<int> SubtractBenchmark() => Vector128.Subtract(Value1, Value2);
+
+        [Benchmark]
+        public int SumBenchmark() =>  Vector128.Sum(Value1);
+
+        [Benchmark]
+        public Vector128<int> XorBenchmark() => Vector128.Xor(Value1, Value2);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.Intrinsics.Tests
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128
     {
+#if !NETFRAMEWORK
         private static readonly Vector128<double> _vectorDouble = Vector128.Create(1.0, 2.0);
         private static readonly Vector128<float> _vectorFloat = Vector128.Create(1.0F, 2.0F, 3.0F, 4.0F);
         private static readonly Vector128<long> _vectorLong = Vector128.Create(1, 2);
@@ -54,11 +55,13 @@ namespace System.Runtime.Intrinsics.Tests
         
         [Benchmark]
         public Vector128<ulong> ConvertDoubleToULongBenchmark() => Vector128.ConvertToUInt64(_vectorDouble);
+#endif
     }
 
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128Float
     {
+#if !NETFRAMEWORK
         private static readonly Vector128<float> Value1 = Vector128<float>.AllBitsSet;
         private static readonly Vector128<float> Value2 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
         private static readonly Vector128<float> Value3 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
@@ -206,11 +209,13 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<float> XorBenchmark() => Vector128.Xor(Value1, Value2);
+#endif
     }
 
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128Int
     {
+#if !NETFRAMEWORK
         private static readonly Vector128<int> Value1 = Vector128<int>.AllBitsSet;
         private static readonly Vector128<int> Value2 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
         private static readonly Vector128<int> Value3 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
@@ -359,5 +364,6 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<int> XorBenchmark() => Vector128.Xor(Value1, Value2);
+#endif
     }
 }

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
@@ -63,7 +63,6 @@ namespace System.Runtime.Intrinsics.Tests
         private static readonly Vector128<float> Value2 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
         private static readonly Vector128<float> Value3 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
 
-
         [Benchmark]
         public int CountBenchmark() => Vector128<float>.Count;
 

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
@@ -23,6 +23,7 @@ namespace System.Runtime.Intrinsics.Tests
     public class Perf_Vector128Of<T>
         where T : struct
     {
+#if !NETFRAMEWORK
         private static readonly Vector128<T> Value1 = Vector128<T>.AllBitsSet;
         private static readonly Vector128<T> Value2 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
         private static readonly Vector128<T> Value3 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
@@ -171,5 +172,6 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<T> XorBenchmark() => Vector128.Xor(Value1, Value2);
+#endif
     }
 }

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.Intrinsics.Tests
     [GenericTypeArguments(typeof(uint))]
     [GenericTypeArguments(typeof(ulong))]
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
-    public class Perf_Vector128T<T>
+    public class Perf_Vector128Of<T>
         where T : struct
     {
         private static readonly Vector128<T> Value1 = Vector128<T>.AllBitsSet;

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128T.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128T.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using MicroBenchmarks;
+
+namespace System.Runtime.Intrinsics.Tests
+{
+    [GenericTypeArguments(typeof(byte))]
+    [GenericTypeArguments(typeof(double))]
+    [GenericTypeArguments(typeof(short))]
+    [GenericTypeArguments(typeof(int))]
+    [GenericTypeArguments(typeof(long))]
+    [GenericTypeArguments(typeof(sbyte))]
+    [GenericTypeArguments(typeof(float))]
+    [GenericTypeArguments(typeof(ushort))]
+    [GenericTypeArguments(typeof(uint))]
+    [GenericTypeArguments(typeof(ulong))]
+    [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    public class Perf_Vector128T<T>
+        where T : struct
+    {
+        private static readonly Vector128<T> Value1 = Vector128<T>.AllBitsSet;
+
+        private static readonly Vector128<T> Value2 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
+
+        private static readonly Vector128<T> Value3 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
+
+
+        [Benchmark]
+        public int CountBenchmark() => Vector128<T>.Count;
+
+        [Benchmark]
+        public Vector128<T> AllBitsSetBenchmark() => Vector128<T>.AllBitsSet;
+
+        [Benchmark]
+        public Vector128<T> ZeroBenchmark() => Vector128<T>.Zero;
+
+        [Benchmark]
+        public bool EqualsBenchmark() => Value1.Equals(Value2);
+
+        [Benchmark]
+        public int GetHashCodeBenchmark() => Value1.GetHashCode();
+
+        [Benchmark]
+        public Vector128<T> AddOperatorBenchmark() => Value1 + Value2;
+
+        [Benchmark]
+        public Vector128<T> BitwiseAndOperatorBenchmark() => Value1 & Value2;
+
+        [Benchmark]
+        public Vector128<T> BitwiseOrOperatorBenchmark() => Value1 | Value2;
+
+        [Benchmark]
+        public Vector128<T> DivisionOperatorBenchmark() => Value1 / Value2;
+
+        [Benchmark]
+        public bool EqualityOperatorBenchmark() => Value1 == Value2;
+
+        [Benchmark]
+        public Vector128<T> ExclusiveOrOperatorBenchmark() => Value1 ^ Value2;
+
+        [Benchmark]
+        public bool InequalityOperatorBenchmark() => Value1 != Value2;
+
+        [Benchmark]
+        public Vector128<T> MultiplyOperatorBenchmark() => Value1 * Value2;
+
+        [Benchmark]
+        public Vector128<T> OnesComplementOperatorBenchmark() => ~Value1;
+
+        [Benchmark]
+        public Vector128<T> SubtractionOperatorBenchmark() => Value1 - Value2;
+
+        [Benchmark]
+        public Vector128<T> UnaryNegateOperatorBenchmark() => -Value1;
+
+        [Benchmark]
+        public Vector128<T> AbsBenchmark() => Vector128.Abs(Value1);
+
+        [Benchmark]
+        public Vector128<T> AddBenchmark() => Vector128.Add(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> AndNotBenchmark() => Vector128.AndNot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> BitwiseAndBenchmark() => Vector128.BitwiseAnd(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> BitwiseOrBenchmark() => Vector128.BitwiseOr(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> ConditionalSelectBenchmark() => Vector128.ConditionalSelect(Value1, Value2, Value3);
+
+        [Benchmark]
+        public Vector128<T> DivideBenchmark() => Vector128.Divide(Value1, Value2);
+
+        [Benchmark]
+        public T DotBenchmark() => Vector128.Dot(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> EqualsStaticBenchmark() => Vector128.Equals(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAllBenchmark() => Vector128.EqualsAll(Value1, Value2);
+
+        [Benchmark]
+        public bool EqualsAnyBenchmark() => Vector128.EqualsAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> GreaterThanBenchmark() => Vector128.GreaterThan(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAllBenchmark() => Vector128.GreaterThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanAnyBenchmark() => Vector128.GreaterThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> GreaterThanOrEqualBenchmark() => Vector128.GreaterThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAllBenchmark() => Vector128.GreaterThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool GreaterThanOrEqualAnyBenchmark() => Vector128.GreaterThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> LessThanBenchmark() => Vector128.LessThan(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAllBenchmark() => Vector128.LessThanAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanAnyBenchmark() => Vector128.LessThanAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> LessThanOrEqualBenchmark() => Vector128.LessThanOrEqual(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAllBenchmark() => Vector128.LessThanOrEqualAll(Value1, Value2);
+
+        [Benchmark]
+        public bool LessThanOrEqualAnyBenchmark() => Vector128.LessThanOrEqualAny(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> MaxBenchmark() => Vector128.Max(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> MinBenchmark() => Vector128.Min(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> MultiplyBenchmark() => Vector128.Multiply(Value1, Value2);
+
+        [Benchmark]
+        public Vector128<T> NegateBenchmark() => Vector128.Negate(Value1);
+
+        [Benchmark]
+        public Vector128<T> OnesComplementBenchmark() => Vector128.OnesComplement(Value1);
+
+        [Benchmark]
+        public Vector128<T> SquareRootBenchmark() => Vector128.Sqrt(Value1);
+
+        [Benchmark]
+        public Vector128<T> SubtractBenchmark() => Vector128.Subtract(Value1, Value2);
+
+        [Benchmark]
+        public T SumBenchmark() =>  Vector128.Sum(Value1);
+
+        [Benchmark]
+        public Vector128<T> XorBenchmark() => Vector128.Xor(Value1, Value2);
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128T.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128T.cs
@@ -24,9 +24,7 @@ namespace System.Runtime.Intrinsics.Tests
         where T : struct
     {
         private static readonly Vector128<T> Value1 = Vector128<T>.AllBitsSet;
-
         private static readonly Vector128<T> Value2 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
-
         private static readonly Vector128<T> Value3 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
 
 


### PR DESCRIPTION
Vector128 microbenchmarks. Both non-generics and generics versions. 

  
Local testing setup:
```
BenchmarkDotNet=v0.13.2.1940-nightly, OS=ubuntu 20.04
Intel Core i7-8665U CPU 1.90GHz (Coffee Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100-rc.1.22431.12
  [Host]     : .NET 7.0.0 (7.0.22.42610), X64 RyuJIT AVX2
  Job-ZRCHKB : .NET 8.0.0 (42.42.42.42424), X64 RyuJIT SSE4.2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Runtime=MonoAOTLLVM  Toolchain=MonoAOTLLVM
IterationTime=250.0000 ms  MaxIterationCount=20  MinIterationCount=15
WarmupCount=1
```

Time needed to run new microbenchmarks locally using Mono AOT compilation with MiniJIT fallback:

| Microbenchmark         | Num benchmarks | Run time (hh:mm:ss) | Global time (hh:mm:ss) |
| ------------------------ | -------------------: |  ----------------------:| -------------------------:|   
| `Perf_Vector128`          |                          12 |                    00:01:33 |                        00:09:55 |
| `Perf_Vector128Float`  |                          48 |                    00:06:44 |                        00:15:07 |
| `Perf_Vector128Int`      |                          48 |                     00:06:47|                        00:15:23 |
| `Perf_Vector128Of<T>` |                        480 |                              XX |                         01:05:18 |

|  X X `<T>`  |  Run time (hh:mm:ss) |
|------------ | -----------------------:|
|`Byte`          |                     00:05:44|
|`Double`     |                     00:05:29|
|`Int16`        |                      00:05:29|
|`Int32`        |                      00:05:37|
|`Int64`        |                      00:05:33|
|`SByte`       |                      00:05:21|
|`Single`      |                      00:05:25|
|`UInt16`     |                      00:05:29|
|`UInt32`     |                      00:05:34|
|`UInt64`     |                      00:05:42|