### PR TITLE
Backport of #2685 to release/7.0, fixes nativeAot run and changes centos queue.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -261,7 +261,7 @@ jobs:
       pool: 
         vmImage: ubuntu-latest
       machinePool: Open
-      queue: centos.7.amd64.open.rt
+      queue: centos.7.amd64.open
       container: centos_x64_build_container
       csproj: src/benchmarks/micro/MicroBenchmarks.csproj
       runCategories: 'runtime libraries'

--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.Configuration/ConfigurationBinderBenchmarks.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.Configuration/ConfigurationBinderBenchmarks.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Filters;
 using MicroBenchmarks;
 using System;
 using System.Collections.Generic;
@@ -41,6 +42,7 @@ namespace Microsoft.Extensions.Configuration
         }
 
         [Benchmark]
+        [AotFilter("Not supported.")]  // System.NotSupportedException: This object cannot be invoked because no code was generated for it: 'System.Collections.Generic.IDictionary`2[System.String, System.String].Item'.
         public MySettings Get() => _configuration.Get<MySettings>();
 
         public class MySettings


### PR DESCRIPTION
Backport of #2685 to release/7.0.
Removed .rt from the CentOS.
Add AOTFilter to the failing nativeAOT test.
