### PR TITLE
[Release7.0] Update Scenario prepare dotnet version used

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -106,6 +106,7 @@ jobs:
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
               .\src\scenarios\init.ps1 -DotnetDirectory $(CorrelationStaging)dotnet
+              dotnet --info
               dotnet msbuild .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
@@ -142,6 +143,7 @@ jobs:
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
               . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
+              dotnet --info
               dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -105,8 +105,8 @@ jobs:
           - powershell: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
-              .\src\scenarios\init.ps1
-              .\eng\common\msbuild.ps1 .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
+              .\src\scenarios\init.ps1 -DotnetDirectory $(CorrelationStaging)dotnet
+              dotnet msbuild .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
               CorrelationPayloadDirectory: $(CorrelationStaging)
@@ -141,8 +141,8 @@ jobs:
           - script: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install requests
-              . ./src/scenarios/init.sh
-              ./eng/common/msbuild.sh ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
+              . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
+              dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
             displayName: Prepare scenarios
             env:
               CorrelationPayloadDirectory: $(CorrelationStaging)


### PR DESCRIPTION
Make scenarios.yml use the ci_setup dotnet version instead of downloading the global.json version.


