### PR TITLE
Set main to run net7.0 until sdk+runtime are supported 

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -3,8 +3,8 @@ from argparse import ArgumentParser
 class ChannelMap():
     channel_map = {
         'main': {
-            'tfm': 'net8.0',
-            'branch': '8.0',
+            'tfm': 'net7.0',
+            'branch': '7.0',
             'quality': 'daily'
         },
         'master': {


### PR DESCRIPTION
Set main to run net7.0 until sdk+runtime are supported per: https://github.com/dotnet/runtime/pull/77913#issuecomment-1304220925.

@radical is this the fix you had in mind from the above comment?



