### PR TITLE
Try forcing wasm to use 7.0 channel.

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -28,7 +28,7 @@ class ChannelMap():
         },
         '7.0': {
             'tfm': 'net7.0',
-            'branch': '7.0.1xx',
+            'branch': '7.0',
             'quality': 'daily'
         },
         'release/7.0-rc2': {

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -242,6 +242,9 @@ def __main(args: list) -> int:
     verbose = not args.quiet
     setup_loggers(verbose=verbose)
 
+    if("main" in args.channel and "CompilationMode=wasm" in args.build_configs):
+        args.channel = "7.0"
+
     # if repository is not set, then we are doing a core-sdk in performance repo run
     # if repository is set, user needs to supply the commit_sha
     if not ((args.commit_sha is None) == (args.repository is None)):


### PR DESCRIPTION
A less impactful replacement for https://github.com/dotnet/performance/pull/2695. Fixes a wasm build issue by forcing wasm to target net7.0 instead of net8.0, while leaving the rest of the runs to use net8.0.