### PR TITLE
Fix the file name

### DIFF
--- a/src/benchmarks/real-world/ImageSharp/TestUtilities/TestImages.cs
+++ b/src/benchmarks/real-world/ImageSharp/TestUtilities/TestImages.cs
@@ -36,7 +36,7 @@ namespace SixLabors.ImageSharp.Tests
                 public const string Winter444_Interleaved = "Jpg/baseline/winter444_interleaved.jpg";
                 public const string Hiyamugi = "Jpg/baseline/Hiyamugi.jpg";
                 public const string Jpeg400 = "Jpg/baseline/jpeg400jfif.jpg";
-                public const string Snake = "Jpg/baseline/snake.jpg";
+                public const string Snake = "Jpg/baseline/Snake.jpg";
             }
 
             public static class Issues


### PR DESCRIPTION
Fix the file name of image file used by ImageSharp since it is case sensitive on linux.