### PR TITLE
[Microbenchmarks] TFMs cleanup + Microsoft.Extensions* update

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,12 +195,12 @@ jobs:
       channels:
         - main
 
-  # Windows x64 net461 micro benchmarks
+  # Windows x64 net462 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml
     parameters:
       osName: windows
       osVersion: RS5
-      kind: micro_net461
+      kind: micro_net462
       architecture: x64
       pool:
         vmImage: windows-2019
@@ -209,7 +209,7 @@ jobs:
       csproj: src\benchmarks\micro\MicroBenchmarks.csproj
       runCategories: 'runtime libraries'
       channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-        - LTS # use LTS channel for net461 framework
+        - LTS # use LTS channel for net462 framework
 
   # Windows x86 micro benchmarks
   - template: /eng/performance/benchmark_jobs.yml

--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -285,7 +285,7 @@ M00_L00:
 
 The `--runtimes` or just `-r` allows you to run the benchmarks for **multiple Runtimes**.
 
-Available options are: Mono, wasmnet70, CoreRT, net461, net462, net47, net471, net472, netcoreapp3.1, net6.0 and net7.0.
+Available options are: Mono, wasmnet70, CoreRT, net462, net47, net471, net472, netcoreapp3.1, net6.0 and net7.0.
 
 Example: run the benchmarks for .NET 6.0 and 7.0:
 

--- a/eng/performance/helix.proj
+++ b/eng/performance/helix.proj
@@ -12,7 +12,7 @@
     <WorkItemCommand>$(Python) $(WorkItemCommand) --incremental no --architecture $(Architecture) -f $(PERFLAB_Framework) $(_PerfLabArguments)</WorkItemCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(PERFLAB_Framework)' != 'net461'">
+  <PropertyGroup Condition="'$(PERFLAB_Framework)' != 'net462'">
     <WorkItemCommand>$(WorkItemCommand) $(CliArguments)</WorkItemCommand>
   </PropertyGroup>
 

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -84,7 +84,7 @@ class ChannelMap():
             'quality': 'daily'
         },
         'LTS': {
-            'tfm': 'net461', # For Full Framework download the LTS for dotnet cli.
+            'tfm': 'net462', # For Full Framework download the LTS for dotnet cli.
             'branch': 'LTS'
         },
         'net48': {

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -262,7 +262,7 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
     if framework.startswith("nativeaot"):
         run_args += ['--runtimes', framework]
     if args.wasm:
-        if framework == "net5.0" or framework == "net6.0":
+        if framework == "net6.0":
             run_args += ['--runtimes', 'wasm']
         else:
             run_args += ['--runtimes', 'wasmnet70']

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -27,12 +27,6 @@
         <PropertyGroup>
             <ExtensionsVersion>3.1.22</ExtensionsVersion>
             <SystemVersion>4.7.1</SystemVersion>
-        </PropertyGroup>
-    </When>
-    <When Condition="'$(TargetFramework)' == 'net5.0'">
-        <PropertyGroup>
-            <ExtensionsVersion>5.0.0</ExtensionsVersion>
-            <SystemVersion>5.0.0</SystemVersion>
         </PropertyGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,7 +4,7 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
@@ -42,7 +42,7 @@
         </PropertyGroup>
     </When>
     <Otherwise>
-        <!-- when comparing against Full .NET Framework we are usually interested in CLR differences, so net461 belongs to this block -->
+        <!-- when comparing against Full .NET Framework we are usually interested in CLR differences, so net462 belongs to this block -->
         <PropertyGroup>
             <ExtensionsVersion>7.0.0</ExtensionsVersion>
             <SystemVersion>7.0.0</SystemVersion>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -35,11 +35,17 @@
             <SystemVersion>5.0.0</SystemVersion>
         </PropertyGroup>
     </When>
-    <Otherwise>
-        <!-- when comparing against Full .NET Framework we are usually interested in CLR differences, so net461 belongs to this block -->
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
         <PropertyGroup>
             <ExtensionsVersion>6.0.0</ExtensionsVersion>
             <SystemVersion>6.0.0</SystemVersion>
+        </PropertyGroup>
+    </When>
+    <Otherwise>
+        <!-- when comparing against Full .NET Framework we are usually interested in CLR differences, so net461 belongs to this block -->
+        <PropertyGroup>
+            <ExtensionsVersion>7.0.0</ExtensionsVersion>
+            <SystemVersion>7.0.0</SystemVersion>
         </PropertyGroup>
     </Otherwise>
   </Choose>
@@ -62,7 +68,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" />
     <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '5.0'" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,7 +12,7 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net461`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net7.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net462`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net7.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -4,8 +4,7 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I've investigated https://github.com/dotnet/runtime/issues/77900#issuecomment-1303834563 and the reason behind the "regression" was not using the appropriate version of `Microsoft.Extensions*`.  These particular libraries and not shipped as part of .NET SDK (they are often called OOB:  "out-of-band") and they require manual version update in the `.csproj`. Since 7.0 versions of all `Microsoft.Extensions*` packages were shipped to nuget.org yesterday, it was a perfect moment to update them and the `System*` libraries.

But the `System*` libraries don't support `net461` anymore:

```log
System.Security.Cryptography.Pkcs 7.0.0 doesn't support net461 and has not been
tested with it. Consider upgrading your TargetFramework to net462 or later. 
```

So I've upgraded `net461` to `net462`.

Then the other warning I was getting was:

```log
The target framework 'net5.0' is out of support and will not receive security updates in the future.
```

So I've removed the `net5.0` tfm. And last but not least, I've limited the test projects to target single tfm (net7.0)


fixes https://github.com/dotnet/runtime/issues/77900
fixes #2079