### PR TITLE
Update channel map to have net6.0 tfm match 6.0 branch before master channel + update 6.0 branch

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,10 +7,6 @@ class ChannelMap():
             'branch': '8.0',
             'quality': 'daily'
         },
-        'master': {
-            'tfm': 'net6.0',
-            'branch': 'master'
-        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',
@@ -53,17 +49,17 @@ class ChannelMap():
         },
         '6.0': {
             'tfm': 'net6.0',
-            'branch': '6.0.1xx',
+            'branch': '6.0',
             'quality': 'daily'
         },
         'release/6.0': {
             'tfm': 'net6.0',
-            'branch': '6.0.1xx',
+            'branch': '6.0',
             'quality': 'daily'
         },
         'nativeaot6.0': {
             'tfm': 'nativeaot6.0',
-            'branch': '6.0.1xx',
+            'branch': '6.0',
             'quality': 'daily'
         },
         'release/3.1.3xx':{
@@ -90,6 +86,10 @@ class ChannelMap():
         'net48': {
             'tfm': 'net48', # For Full Framework download the LTS for dotnet cli.
             'branch': 'LTS'
+        },
+        'master': {
+            'tfm': 'net6.0',
+            'branch': 'master'
         }
     }
     @staticmethod


### PR DESCRIPTION
Update channel map to have net6.0 tfm match 6.0 branch before master branch, fixes #2701. Also updated net6.0 branches to point to 6.0 instead of 6.0.1xx to get the latest 6.0 version.



