### PR TITLE
Update benchmarks_monthly.py for net7.0 GA

### DIFF
--- a/scripts/benchmarks_monthly.py
+++ b/scripts/benchmarks_monthly.py
@@ -20,6 +20,7 @@ import sys
 import os
 
 VERSIONS = {
+    'net7.0': { 'tfm': 'net7.0' }
     'net7.0-rc2': { 'tfm': 'net7.0', 'build': '7.0.100-rc.2.22477.23' },
     'net7.0-rc1': { 'tfm': 'net7.0', 'build': '7.0.100-rc.1.22425.9' },
     'net7.0-preview7': { 'tfm': 'net7.0', 'build': '7.0.100-preview.7.22370.3' },


### PR DESCRIPTION
@adamsitnik I'm mirroring how 6.0 was set up in this file. Should this work for 7.0 GA, or do I still need to find a specific build number like we did for the previews?

