### PR TITLE
don't build Vector128 benchmarks for older runtimes

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -191,6 +191,7 @@
     <Compile Remove="runtime\Math\Functions\Single\SinCosPi.cs" />
     <Compile Remove="runtime\Math\Functions\Single\TanPi.cs" />
     <Compile Remove="libraries\System.Formats.Tar\*.cs" />
+    <Compile Remove="libraries\System.Runtime.Intrinsics\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Extensions;
 using MicroBenchmarks;
 
 namespace System.Runtime.Intrinsics.Tests
@@ -12,7 +10,6 @@ namespace System.Runtime.Intrinsics.Tests
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128
     {
-#if !NETFRAMEWORK
         private static readonly Vector128<double> _vectorDouble = Vector128.Create(1.0, 2.0);
         private static readonly Vector128<float> _vectorFloat = Vector128.Create(1.0F, 2.0F, 3.0F, 4.0F);
         private static readonly Vector128<long> _vectorLong = Vector128.Create(1, 2);
@@ -55,13 +52,11 @@ namespace System.Runtime.Intrinsics.Tests
         
         [Benchmark]
         public Vector128<ulong> ConvertDoubleToULongBenchmark() => Vector128.ConvertToUInt64(_vectorDouble);
-#endif
     }
 
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128Float
     {
-#if !NETFRAMEWORK
         private static readonly Vector128<float> Value1 = Vector128<float>.AllBitsSet;
         private static readonly Vector128<float> Value2 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
         private static readonly Vector128<float> Value3 = Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet + Vector128<float>.AllBitsSet;
@@ -209,17 +204,14 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<float> XorBenchmark() => Vector128.Xor(Value1, Value2);
-#endif
     }
 
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
     public class Perf_Vector128Int
     {
-#if !NETFRAMEWORK
         private static readonly Vector128<int> Value1 = Vector128<int>.AllBitsSet;
         private static readonly Vector128<int> Value2 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
         private static readonly Vector128<int> Value3 = Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet + Vector128<int>.AllBitsSet;
-
 
         [Benchmark]
         public int CountBenchmark() => Vector128<int>.Count;
@@ -364,6 +356,5 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<int> XorBenchmark() => Vector128.Xor(Value1, Value2);
-#endif
     }
 }

--- a/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Intrinsics/Perf_Vector128OfT.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Extensions;
 using MicroBenchmarks;
 
 namespace System.Runtime.Intrinsics.Tests
@@ -23,11 +21,9 @@ namespace System.Runtime.Intrinsics.Tests
     public class Perf_Vector128Of<T>
         where T : struct
     {
-#if !NETFRAMEWORK
         private static readonly Vector128<T> Value1 = Vector128<T>.AllBitsSet;
         private static readonly Vector128<T> Value2 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
         private static readonly Vector128<T> Value3 = Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet + Vector128<T>.AllBitsSet;
-
 
         [Benchmark]
         public int CountBenchmark() => Vector128<T>.Count;
@@ -172,6 +168,5 @@ namespace System.Runtime.Intrinsics.Tests
 
         [Benchmark]
         public Vector128<T> XorBenchmark() => Vector128.Xor(Value1, Value2);
-#endif
     }
 }


### PR DESCRIPTION
I am trying to run the benchmarks for .NET 6 vs 7 comparison and I am getting a lot of compiler errors.