### PR TITLE
Add System.Text.Json to JSON serializer benchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -14,9 +14,8 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-    <!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
-    <LangVersion>8.0</LangVersion>
+    <EnableXlfLocalization>false</EnableXlfLocalization>    
+    <LangVersion>9.0</LangVersion>
 
     <!-- Allow building with one major version, and running using a sdk with a higher major version -->
     <RollForward Condition="'$(BuildingForWasm)' == 'true'">LatestMajor</RollForward>
@@ -27,6 +26,8 @@
         <PropertyGroup>
             <ExtensionsVersion>3.1.22</ExtensionsVersion>
             <SystemVersion>4.7.1</SystemVersion>
+			<!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
+			<LangVersion>8.0</LangVersion>
         </PropertyGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -26,8 +26,8 @@
         <PropertyGroup>
             <ExtensionsVersion>3.1.22</ExtensionsVersion>
             <SystemVersion>4.7.1</SystemVersion>
-			<!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
-			<LangVersion>8.0</LangVersion>
+            <!-- this repo needs to build with netcoreapp3.1, so we can't use latest C# syntax -->
+            <LangVersion>8.0</LangVersion>
         </PropertyGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/benchmarks/micro/Serializers/DataGenerator.cs
+++ b/src/benchmarks/micro/Serializers/DataGenerator.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text.Json;
 #if NET6_0_OR_GREATER
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -19,7 +20,7 @@ using ProtoBuf;
 
 namespace MicroBenchmarks.Serializers
 {
-    internal static partial class DataGenerator
+    internal static class DataGenerator
     {
         internal static T Generate<T>()
         {
@@ -220,32 +221,19 @@ namespace MicroBenchmarks.Serializers
             return xmlElement;
         }
 
+        internal static JsonSerializerOptions GetJsonSerializerOptions(SystemTextJsonSerializationMode mode)
+            => mode switch
+            {
+                SystemTextJsonSerializationMode.Reflection => new JsonSerializerOptions(),
+#if NET6_0_OR_GREATER
+                SystemTextJsonSerializationMode.SourceGen => SystemTextJsonSourceGeneratedContext.Default.Options,
+#endif
+                _ => throw new NotSupportedException(mode.ToString())
+            };
+
 #if NET6_0_OR_GREATER
         internal static JsonTypeInfo<T> GetSystemTextJsonSourceGenMetadata<T>()
             => (JsonTypeInfo<T>)SystemTextJsonSourceGeneratedContext.Default.GetTypeInfo(typeof(T));
-
-        [JsonSerializable(typeof(LoginViewModel))]
-        [JsonSerializable(typeof(Location))]
-        [JsonSerializable(typeof(IndexViewModel))]
-        [JsonSerializable(typeof(MyEventsListerViewModel))]
-        [JsonSerializable(typeof(BinaryData))]
-        [JsonSerializable(typeof(CollectionsOfPrimitives))]
-        [JsonSerializable(typeof(XmlElement))]
-        [JsonSerializable(typeof(SimpleStructWithProperties))]
-        [JsonSerializable(typeof(SimpleListOfInt))]
-        [JsonSerializable(typeof(ClassImplementingIXmlSerialiable))]
-        [JsonSerializable(typeof(Dictionary<string, string>))]
-        [JsonSerializable(typeof(ImmutableDictionary<string, string>))]
-        [JsonSerializable(typeof(ImmutableSortedDictionary<string, string>))]
-        [JsonSerializable(typeof(HashSet<string>))]
-        [JsonSerializable(typeof(ArrayList))]
-        [JsonSerializable(typeof(Hashtable))]
-        [JsonSerializable(typeof(LargeStructWithProperties))]
-        [JsonSerializable(typeof(DateTimeOffset?))]
-        [JsonSerializable(typeof(int))]
-        private partial class SystemTextJsonSourceGeneratedContext : JsonSerializerContext
-        {
-        }
 #endif
     }
 
@@ -453,4 +441,42 @@ namespace MicroBenchmarks.Serializers
             writer.WriteAttributeString("BoolValue", BoolValue.ToString());
         }
     }
+
+    public class ClassWithObjectProperty
+    {
+        public object Prop { get; set; }
+    }
+
+    public enum SystemTextJsonSerializationMode
+    {
+        Reflection = 0,
+        SourceGen = 1
+    }
+
+#if NET6_0_OR_GREATER
+    [JsonSerializable(typeof(ClassWithObjectProperty))]
+    [JsonSerializable(typeof(LoginViewModel))]
+    [JsonSerializable(typeof(Location))]
+    [JsonSerializable(typeof(IndexViewModel))]
+    [JsonSerializable(typeof(MyEventsListerViewModel))]
+    [JsonSerializable(typeof(BinaryData))]
+    [JsonSerializable(typeof(CollectionsOfPrimitives))]
+    [JsonSerializable(typeof(XmlElement))]
+    [JsonSerializable(typeof(SimpleStructWithProperties))]
+    [JsonSerializable(typeof(SimpleListOfInt))]
+    [JsonSerializable(typeof(ClassImplementingIXmlSerialiable))]
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    [JsonSerializable(typeof(ImmutableDictionary<string, string>))]
+    [JsonSerializable(typeof(ImmutableSortedDictionary<string, string>))]
+    [JsonSerializable(typeof(HashSet<string>))]
+    [JsonSerializable(typeof(ArrayList))]
+    [JsonSerializable(typeof(Hashtable))]
+    [JsonSerializable(typeof(LargeStructWithProperties))]
+    [JsonSerializable(typeof(DateTimeOffset?))]
+    [JsonSerializable(typeof(int))]
+    [JsonSerializable(typeof(object))]
+    internal partial class SystemTextJsonSourceGeneratedContext : JsonSerializerContext
+    {
+    }
+#endif
 }

--- a/src/benchmarks/micro/Serializers/DataGenerator.cs
+++ b/src/benchmarks/micro/Serializers/DataGenerator.cs
@@ -7,6 +7,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+#endif
 using System.Xml;
 using System.Xml.Serialization;
 using BenchmarkDotNet.Extensions;
@@ -15,7 +19,7 @@ using ProtoBuf;
 
 namespace MicroBenchmarks.Serializers
 {
-    internal static class DataGenerator
+    internal static partial class DataGenerator
     {
         internal static T Generate<T>()
         {
@@ -215,6 +219,34 @@ namespace MicroBenchmarks.Serializers
             xmlElement.InnerText = "Element innertext";
             return xmlElement;
         }
+
+#if NET6_0_OR_GREATER
+        internal static JsonTypeInfo<T> GetSystemTextJsonSourceGenMetadata<T>()
+            => (JsonTypeInfo<T>)SystemTextJsonSourceGeneratedContext.Default.GetTypeInfo(typeof(T));
+
+        [JsonSerializable(typeof(LoginViewModel))]
+        [JsonSerializable(typeof(Location))]
+        [JsonSerializable(typeof(IndexViewModel))]
+        [JsonSerializable(typeof(MyEventsListerViewModel))]
+        [JsonSerializable(typeof(BinaryData))]
+        [JsonSerializable(typeof(CollectionsOfPrimitives))]
+        [JsonSerializable(typeof(XmlElement))]
+        [JsonSerializable(typeof(SimpleStructWithProperties))]
+        [JsonSerializable(typeof(SimpleListOfInt))]
+        [JsonSerializable(typeof(ClassImplementingIXmlSerialiable))]
+        [JsonSerializable(typeof(Dictionary<string, string>))]
+        [JsonSerializable(typeof(ImmutableDictionary<string, string>))]
+        [JsonSerializable(typeof(ImmutableSortedDictionary<string, string>))]
+        [JsonSerializable(typeof(HashSet<string>))]
+        [JsonSerializable(typeof(ArrayList))]
+        [JsonSerializable(typeof(Hashtable))]
+        [JsonSerializable(typeof(LargeStructWithProperties))]
+        [JsonSerializable(typeof(DateTimeOffset?))]
+        [JsonSerializable(typeof(int))]
+        private partial class SystemTextJsonSourceGeneratedContext : JsonSerializerContext
+        {
+        }
+#endif
     }
 
     // the view models come from a real world app called "AllReady"

--- a/src/benchmarks/micro/Serializers/Json_FromString.cs
+++ b/src/benchmarks/micro/Serializers/Json_FromString.cs
@@ -41,5 +41,27 @@ namespace MicroBenchmarks.Serializers
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Utf8Json")]
         public T Utf8Json_() => Utf8Json.JsonSerializer.Deserialize<T>(serialized);
+
+        [GlobalSetup(Target = nameof(SystemTextJson_Reflection_))]
+        public void SetupSystemTextJson_Reflection_() => serialized = System.Text.Json.JsonSerializer.Serialize(DataGenerator.Generate<T>());
+
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_Reflection")]
+        public T SystemTextJson_Reflection_() => System.Text.Json.JsonSerializer.Deserialize<T>(serialized);
+
+#if NET6_0_OR_GREATER
+        private System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> sourceGenMetadata;
+
+        [GlobalSetup(Target = nameof(SystemTextJson_SourceGen_))]
+        public void SetupSystemTextJson_SourceGen_()
+        {
+            sourceGenMetadata = DataGenerator.GetSystemTextJsonSourceGenMetadata<T>();
+            serialized = System.Text.Json.JsonSerializer.Serialize(DataGenerator.Generate<T>(), sourceGenMetadata);
+        }
+
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_SourceGen")]
+        public T SystemTextJson_SourceGen_() => System.Text.Json.JsonSerializer.Deserialize(serialized, sourceGenMetadata);
+#endif
     }
 }

--- a/src/benchmarks/micro/Serializers/Json_ToStream.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToStream.cs
@@ -72,10 +72,49 @@ namespace MicroBenchmarks.Serializers
             dataContractJsonSerializer.WriteObject(memoryStream, value);
         }
 
+#if NET6_0_OR_GREATER
+        [GlobalSetup(Target = nameof(SystemTextJson_Reflection_))]
+        public void SetupSystemTextJson_Reflection_()
+        {
+            value = DataGenerator.Generate<T>();
+
+            // the stream is pre-allocated, we don't want the benchmarks to include stream allocaton cost
+            memoryStream = new MemoryStream(capacity: short.MaxValue);
+        }
+
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_Reflection")]
+        public void SystemTextJson_Reflection_()
+        {
+            memoryStream.Position = 0;
+            System.Text.Json.JsonSerializer.Serialize(memoryStream, value);
+        }
+
+        private System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> sourceGenMetadata;
+
+        [GlobalSetup(Target = nameof(SystemTextJson_SourceGen_))]
+        public void SetupSystemTextJson_SourceGen_()
+        {
+            value = DataGenerator.Generate<T>();
+            sourceGenMetadata = DataGenerator.GetSystemTextJsonSourceGenMetadata<T>();
+
+            // the stream is pre-allocated, we don't want the benchmarks to include stream allocaton cost
+            memoryStream = new MemoryStream(capacity: short.MaxValue);
+        }
+
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_SourceGen")]
+        public void SystemTextJson_SourceGen_()
+        {
+            memoryStream.Position = 0;
+            System.Text.Json.JsonSerializer.Serialize(memoryStream, value, sourceGenMetadata);
+        }
+#endif
+
         [GlobalCleanup]
         public void Cleanup()
         {
-            streamWriter.Dispose();
+            streamWriter?.Dispose();
             memoryStream.Dispose();
         }
     }

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -17,9 +17,18 @@ namespace MicroBenchmarks.Serializers
     public class Json_ToString<T>
     {
         private T value;
+#if NET6_0_OR_GREATER
+        private System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> sourceGenMetadata;
+#endif
 
         [GlobalSetup]
-        public void Setup() => value = DataGenerator.Generate<T>();
+        public void Setup()
+        {
+            value = DataGenerator.Generate<T>();
+#if NET6_0_OR_GREATER
+            sourceGenMetadata = DataGenerator.GetSystemTextJsonSourceGenMetadata<T>();
+#endif
+        }
 
         [BenchmarkCategory(Categories.ThirdParty)]
         [Benchmark(Description = "Jil")]
@@ -35,5 +44,15 @@ namespace MicroBenchmarks.Serializers
 
         // DataContractJsonSerializer does not provide an API to serialize to string
         // so it's not included here (apples vs apples thing)
+
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_Reflection")]
+        public string SystemTextJson_Reflection_() => System.Text.Json.JsonSerializer.Serialize(value);
+
+#if NET6_0_OR_GREATER
+        [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
+        [Benchmark(Description = "SystemTextJson_SourceGen")]
+        public void SystemTextJson_SourceGen_() => System.Text.Json.JsonSerializer.Serialize(value, sourceGenMetadata);
+#endif
     }
 }

--- a/src/benchmarks/micro/Serializers/Json_ToString.cs
+++ b/src/benchmarks/micro/Serializers/Json_ToString.cs
@@ -52,7 +52,7 @@ namespace MicroBenchmarks.Serializers
 #if NET6_0_OR_GREATER
         [BenchmarkCategory(Categories.Runtime, Categories.Libraries)]
         [Benchmark(Description = "SystemTextJson_SourceGen")]
-        public void SystemTextJson_SourceGen_() => System.Text.Json.JsonSerializer.Serialize(value, sourceGenMetadata);
+        public string SystemTextJson_SourceGen_() => System.Text.Json.JsonSerializer.Serialize(value, sourceGenMetadata);
 #endif
     }
 }

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
@@ -40,6 +40,20 @@ namespace System.Text.Json.Serialization.Tests
         [Benchmark]
         public T NewDefaultOptions() => RoundtripSerialization(new JsonSerializerOptions());
 
+#if NET6_0_OR_GREATER
+        [Benchmark]
+        public T CachedJsonSerializerContext() 
+            => RoundtripSerialization(SystemTextJsonSourceGeneratedContext.Default.Options);
+
+        [Benchmark]
+        public T NewJsonSerializerContext()
+        {
+            var options = new JsonSerializerOptions();
+            options.AddContext<SystemTextJsonSourceGeneratedContext>();
+            return RoundtripSerialization(options);
+        }
+#endif
+
         [Benchmark]
         public T NewCustomizedOptions() => 
             RoundtripSerialization(
@@ -61,11 +75,11 @@ namespace System.Text.Json.Serialization.Tests
 
         [Benchmark]
         public T NewCachedCustomConverter() =>
-            RoundtripSerialization(
-                new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    Converters = { _converter }
-                });
+    RoundtripSerialization(
+        new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { _converter }
+        });
     }
 }


### PR DESCRIPTION
Adds System.Text.Json (reflection & source gen) to the benchmark suite comparing .NET JSON serializers. Here's a few representative results using `IndexViewModel` values:

## String Serialization

|                    Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |   Gen0 |   Gen1 | Allocated |
|-------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|-------:|----------:|
| SystemTextJson_Reflection | 15.04 μs | 0.832 μs | 0.924 μs | 14.82 μs | 13.79 μs | 16.71 μs | 2.4789 | 0.1771 |  24.85 KB |
|  SystemTextJson_SourceGen | 10.51 μs | 0.114 μs | 0.096 μs | 10.49 μs | 10.35 μs | 10.65 μs | 2.4715 |      - |  24.55 KB |
|                  JSON.NET | 33.38 μs | 1.074 μs | 1.149 μs | 33.09 μs | 31.62 μs | 36.20 μs | 5.9487 | 1.1154 |  59.33 KB |
|                       Jil | 39.15 μs | 1.095 μs | 1.172 μs | 38.73 μs | 37.49 μs | 42.10 μs | 5.7115 | 0.9791 |   56.7 KB |
|                  Utf8Json | 26.08 μs | 1.140 μs | 1.313 μs | 25.71 μs | 24.51 μs | 28.99 μs | 2.4222 | 0.1938 |  24.55 KB |

## String Deserialization

|                    Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |   Gen0 |   Gen1 | Allocated |
|-------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|-------:|----------:|
| SystemTextJson_Reflection | 24.53 μs | 0.437 μs | 0.388 μs | 24.65 μs | 23.93 μs | 25.31 μs | 2.1980 | 0.2867 |  22.01 KB |
|  SystemTextJson_SourceGen | 24.23 μs | 0.464 μs | 0.388 μs | 24.10 μs | 23.82 μs | 25.00 μs | 2.1654 | 0.2953 |  22.01 KB |
|                  JSON.NET | 53.29 μs | 2.270 μs | 2.614 μs | 53.07 μs | 50.14 μs | 58.43 μs | 3.0352 | 0.4047 |  31.31 KB |
|                       Jil | 41.49 μs | 0.542 μs | 0.453 μs | 41.63 μs | 40.56 μs | 42.18 μs | 2.3217 | 0.1658 |  23.49 KB |
|                  Utf8Json | 39.39 μs | 2.146 μs | 2.471 μs | 39.98 μs | 36.40 μs | 42.61 μs | 3.3665 | 0.2927 |  33.87 KB |

## Stream Serialization

|                     Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |   Gen0 | Allocated |
|--------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DataContractJsonSerializer | 81.58 μs | 4.635 μs | 5.337 μs | 81.90 μs | 75.71 μs | 93.49 μs |      - |    2416 B |
|  SystemTextJson_Reflection | 14.04 μs | 0.648 μs | 0.746 μs | 13.93 μs | 12.99 μs | 15.38 μs |      - |     464 B |
|   SystemTextJson_SourceGen | 14.05 μs | 0.858 μs | 0.989 μs | 13.69 μs | 13.06 μs | 16.27 μs |      - |     464 B |
|                   JSON.NET | 33.31 μs | 1.696 μs | 1.953 μs | 32.63 μs | 30.73 μs | 37.13 μs | 0.1249 |    2448 B |
|                        Jil | 40.21 μs | 2.319 μs | 2.670 μs | 40.84 μs | 36.95 μs | 47.08 μs |      - |      96 B |
|                   Utf8Json | 24.51 μs | 1.040 μs | 1.156 μs | 24.01 μs | 23.42 μs | 26.92 μs |      - |         - |

## Stream Deserialization

|                     Method |      Mean |    Error |   StdDev |    Median |       Min |       Max |   Gen0 |   Gen1 | Allocated |
|--------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|-------:|----------:|
| DataContractJsonSerializer | 223.90 μs | 2.331 μs | 1.820 μs | 223.84 μs | 221.09 μs | 226.39 μs | 9.0726 | 1.0081 |  94.25 KB |
|  SystemTextJson_Reflection |  25.92 μs | 1.005 μs | 1.158 μs |  25.56 μs |  24.81 μs |  28.44 μs | 2.1930 | 0.2990 |  22.01 KB |
|   SystemTextJson_SourceGen |  25.27 μs | 0.583 μs | 0.599 μs |  25.22 μs |  24.32 μs |  26.64 μs | 2.1619 | 0.2948 |  22.01 KB |
|                   JSON.NET |  56.12 μs | 2.302 μs | 2.651 μs |  55.36 μs |  53.00 μs |  60.91 μs | 3.4079 | 0.4260 |  34.27 KB |
|                        Jil |  61.04 μs | 1.036 μs | 0.919 μs |  60.84 μs |  60.07 μs |  62.32 μs | 2.6918 | 0.2692 |   26.7 KB |
|                   Utf8Json |  35.55 μs | 0.341 μs | 0.267 μs |  35.55 μs |  35.14 μs |  35.98 μs | 2.1067 | 0.2809 |  21.58 KB |

Fix https://github.com/dotnet/runtime/issues/78451.