### PR TITLE
Bump BDN version to include recent bug fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.4</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNetILLinkTasksVersion>7.0.100-1.22057.1</MicrosoftNetILLinkTasksVersion>
     <MicrosoftNetILLinkPackageVersion>7.0.100-1.22057.1</MicrosoftNetILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.2.1950</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.2.2007</BenchmarkDotNetVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -22,7 +22,6 @@ namespace MicroBenchmarks
             List<string> exclusionFilterValue;
             List<string> categoryExclusionFilterValue;
             bool getDiffableDisasm;
-            bool resumeRun;
 
             // Parse and remove any additional parameters that we need that aren't part of BDN
             try
@@ -32,7 +31,6 @@ namespace MicroBenchmarks
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out exclusionFilterValue);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--category-exclusion-filter", out categoryExclusionFilterValue);
                 CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--disasm-diff", out getDiffableDisasm);
-                CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--resume", out resumeRun);
 
                 CommandLineOptions.ValidatePartitionParameters(partitionCount, partitionIndex);
             }
@@ -52,8 +50,7 @@ namespace MicroBenchmarks
                         partitionIndex: partitionIndex,
                         exclusionFilterValue: exclusionFilterValue,
                         categoryExclusionFilterValue: categoryExclusionFilterValue,
-                        getDiffableDisasm: getDiffableDisasm,
-                        resumeRun: resumeRun)
+                        getDiffableDisasm: getDiffableDisasm)
                     .AddValidator(new NoWasmValidator(Categories.NoWASM)))
                 .ToExitCode();
         }

--- a/src/benchmarks/real-world/ILLink/BasicBenchmark.cs
+++ b/src/benchmarks/real-world/ILLink/BasicBenchmark.cs
@@ -8,7 +8,6 @@ using BenchmarkDotNet.Engines;
 namespace ILLinkBenchmarks;
 
 [BenchmarkCategory("ILLink")]
-[SimpleJob(RunStrategy.Monitoring, launchCount: 5, warmupCount: 3, targetCount: 20)]
 public partial class BasicBenchmark
 {
     MethodInfo _linkerMain;

--- a/src/benchmarks/real-world/ILLink/MSBuildBenchmark.cs
+++ b/src/benchmarks/real-world/ILLink/MSBuildBenchmark.cs
@@ -6,7 +6,6 @@ using BenchmarkDotNet.Engines;
 namespace ILLinkBenchmarks;
 
 [BenchmarkCategory("ILLink")]
-[SimpleJob(RunStrategy.Monitoring, launchCount: 5, warmupCount: 3, targetCount: 20)]
 public class RunMSBuildPublish
 {
     string _projectFilePath;

--- a/src/benchmarks/real-world/ILLink/Program.cs
+++ b/src/benchmarks/real-world/ILLink/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
+using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
@@ -21,13 +22,20 @@ public class ILLinkBench
         // to communicate information is pass by environment variable
         Environment.SetEnvironmentVariable("ILLINK_SAMPLE_PROJECT", sampleProjectFile);
 
+        Job job = Job.Default
+            .WithLaunchCount(5)
+            .WithWarmupCount(3)
+            .WithIterationCount(20)
+            .WithStrategy(RunStrategy.Monitoring)
+            .WithMaxRelativeError(0.01);
+
         return BenchmarkSwitcher
             .FromAssembly(typeof(BasicBenchmark).Assembly)
             .Run(args, RecommendedConfig.Create(
                            artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(BasicBenchmark).Assembly.Location),
                                                                          "BenchmarkDotNet.Artifacts")),
                            mandatoryCategories: ImmutableHashSet.Create("ILLink"),
-                           job: Job.Default.WithMaxRelativeError(0.01)))
+                           job: job))
             .ToExitCode();
     }
 }


### PR DESCRIPTION
This version update contains fix for resource leak that was preventing me from running all benchmarks on my Ubuntu machine (https://github.com/dotnet/performance/issues/2738) and full .NET 8 support (https://github.com/dotnet/BenchmarkDotNet/pull/2192).

Since `--resume` support has been now officialy added to BDN itself (https://github.com/dotnet/BenchmarkDotNet/pull/2164), I've removed the previous implementation that was added only to this repo.

@LoopedBard3 In an hour from now [this](https://ci.appveyor.com/project/dotnetfoundation/benchmarkdotnet/builds/45417285) build should get green and publish `0.13.2.2007` to BDN feed. Could you please upload it to our mirror feed?