### PR TITLE
Bump BDN to 0.13.2.2009 to pick up a wasm fix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>5.0.4</MicrosoftAspNetCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNetILLinkTasksVersion>7.0.100-1.22057.1</MicrosoftNetILLinkTasksVersion>
     <MicrosoftNetILLinkPackageVersion>7.0.100-1.22057.1</MicrosoftNetILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.2.2007</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.2.2009</BenchmarkDotNetVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>


### PR DESCRIPTION
BDN fix being picked up - https://github.com/dotnet/BenchmarkDotNet/pull/2201
This is to fix a regression for wasm benchmarks seen in `dotnet/runtime`: https://github.com/dotnet/runtime/issues/78575 .

Thanks to @adamsitnik for the quick turnaround on this!