### PR TITLE
Span benchmarks should cover both vectorized and non-vectorized code paths

### DIFF
--- a/src/benchmarks/micro/libraries/System.Memory/Span.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/Span.cs
@@ -18,7 +18,10 @@ namespace System.Memory
     public class Span<T> 
         where T : struct, IComparable<T>, IEquatable<T>
     {
-        [Params(Utils.DefaultCollectionSize)]
+        [Params(
+            4, // non-vectorized code path
+            33, // both vectorized and non-vectorized code path
+            512)] // vectorized code path
         public int Size;
 
         private T[] _array, _same, _different, _emptyWithSingleValue;


### PR DESCRIPTION
context: https://github.com/dotnet/runtime/issues/78604