### PR TITLE
Augment System.Uri tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
@@ -4,16 +4,64 @@
 
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace System.Tests
 {
     [BenchmarkCategory(Categories.Libraries)]
     public class Perf_Uri
     {
-        private Uri _uri = new Uri("http://dot.net");
+        public static IEnumerable<object[]> Ctor_MemberData()
+        {
+            yield return new object[] { "http://dot.net" };
+            yield return new object[] { "https://contoso.com" };
+            yield return new object[] { "https://CONTOSO.com" };
+            yield return new object[] { "https://a.much.longer.domain.name" };
+            yield return new object[] { "http://h\u00F6st.with.\u00FCnicode" };
+            yield return new object[] { "http://xn--hst-sna.with.xn--nicode-2ya" };
+        }
+
+        public static IEnumerable<object[]> CtorIdnHostPathAndQuery_MemberData()
+        {
+            foreach (object[] schemeAndAuthority in Ctor_MemberData())
+            {
+                yield return new object[] { $"{schemeAndAuthority[0]}/path/with?key=value#fragment" };
+            }
+
+            string[] paths = new[]
+            {
+                "/",
+                "/path?key1=value1&key2=value2&key3=value3&key4=value4",
+                "/path with escapable values?key=va lue",
+                "/path%20with%20escapable%20values?key=va%20lue",
+                "/path with escapable values?key=\u00FCnicode",
+                "/path%20with%20escapable%20values?key=%C3%BCnicode",
+            };
+
+            foreach (string path in paths)
+            {
+                yield return new object[] { $"http://host{path}" };
+            }
+        }
+
+        public static IEnumerable<object[]> EscapeDataString_MemberData()
+        {
+            yield return new object[] { new string('a', 1000) }; // Nothing to escape
+            yield return new object[] { new string('{', 1000) }; // ASCII that needs escaping
+            yield return new object[] { new string('\u00FC', 1000) }; // Unicode
+            yield return new object[] { string.Concat(Enumerable.Repeat("a{\u00FC", 333)) };
+        }
+
+        private static readonly Uri _uri = new Uri("http://contoso.com/path/with?key=value#fragment");
 
         [Benchmark]
-        public Uri Ctor() => new Uri("http://dot.net");
+        [ArgumentsSource(nameof(Ctor_MemberData))]
+        public Uri Ctor(string input) => new Uri(input);
+
+        [Benchmark]
+        [Arguments("/new/path")]
+        public Uri CombineAbsoluteRelative(string input) => new Uri(_uri, input);
 
         [Benchmark]
         public string ParseAbsoluteUri() => new Uri("http://127.0.0.1:80").AbsoluteUri;
@@ -28,7 +76,22 @@ namespace System.Tests
         public string PathAndQuery() => _uri.PathAndQuery;
 
         [Benchmark]
-        public string Unescape() => Uri.UnescapeDataString("%E4%BD%A0%E5%A5%BD");
+        [ArgumentsSource(nameof(CtorIdnHostPathAndQuery_MemberData))]
+        public (string, string) CtorIdnHostPathAndQuery(string input)
+        {
+            // Representative of the most common usage with HttpClient
+            var uri = new Uri(input, UriKind.Absolute);
+            return (uri.IdnHost, uri.PathAndQuery);
+        }
+
+        [Benchmark]
+        [Arguments("abc%20def%20ghi%20")]
+        [Arguments("%E4%BD%A0%E5%A5%BD")]
+        public string UnescapeDataString(string input) => Uri.UnescapeDataString(input);
+
+        [Benchmark]
+        [ArgumentsSource(nameof(EscapeDataString_MemberData))]
+        public string EscapeDataString(string input) => Uri.EscapeDataString(input);
 
         [Benchmark]
         public string BuilderToString()
@@ -40,5 +103,8 @@ namespace System.Tests
             builder.Path = "/platform/try-dotnet";
             return builder.ToString();
         }
+
+        [Benchmark]
+        public string UriBuilderReplacePort() => new UriBuilder(_uri) { Port = 8080 }.ToString();
     }
 }


### PR DESCRIPTION
This change also modifies the existing benchmarks (not sure how much we care in this case):
- `Ctor` now takes arguments
- `Unescape` now takes arguments, so I took the opportunity to rename it if we're already breaking history
- The Uri used by `GetComponents` is longer, which will show up as a regression (it wasn't really doing much before)
