### PR TITLE
[release/6.0] Use net6.0 NuGet config.

### DIFF
--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -14,7 +14,7 @@ import requests
 import winreg
 
 setup_loggers(True)
-NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
+NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/net6.0/NuGet.config'
 WebViewURL = 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' # Obtained from https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section
 WebViewInstalled = False
 NugetFile = requests.get(NugetURL)

--- a/src/scenarios/mauidesktop/pre.py
+++ b/src/scenarios/mauidesktop/pre.py
@@ -12,7 +12,7 @@ from test import EXENAME
 import requests
 
 setup_loggers(True)
-NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config'
+NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/net6.0/NuGet.config'
 NugetFile = requests.get(NugetURL)
 open('./Nuget.config', 'wb').write(NugetFile.content)
 


### PR DESCRIPTION
Fixes restore part of net6.0 builds when restoring _maui_ workload.

Fixes #2797.