### PR TITLE
Add Maui Mobile Testing to the perf repo (port from release/7.0 Test)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,6 +273,19 @@ jobs:
         channels:
           - main
 
+  # Maui Android scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64-android-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_android
+        projectFile: maui_scenarios_android.proj
+        dotnetVersionsLinks:
+          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
   #  parameters:

--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -92,3 +92,15 @@ jobs:
       machinePool: Tiger
       queue: Windows.10.Arm64.Perf.Surf
       ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if and(containsValue(parameters.buildMachines, 'win-x64-android-arm64'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 Pixel only used in private builds currently
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osName: windows
+      architecture: x64
+      osVersion: 19H1
+      pool:
+        vmImage: 'windows-2022'
+      queue: Windows.10.Amd64.Pixel.Perf
+      machinePool: Pixel
+      ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -1,0 +1,82 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+
+  <Import Project="Scenarios.Common.props" />
+
+  <PropertyGroup>
+    <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21566.2</MicrosoftDotNetXHarnessCLIVersion>
+    <XharnessPath>%HELIX_CORRELATION_PAYLOAD%\microsoft.dotnet.xharness.cli\$(MicrosoftDotNetXHarnessCLIVersion)\tools\net6.0\any\Microsoft.DotNet.XHarness.CLI.dll</XharnessPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AfterPreparePayloadWorkItemCommand>$(Python) post.py</AfterPreparePayloadWorkItemCommand>
+    <PreparePayloadOutDirectoryName>scenarios_out</PreparePayloadOutDirectoryName>
+    <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' == 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)\</PreparePayloadWorkItemBaseDirectory>
+    <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
+  </PropertyGroup>
+
+  <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
+    <Message Text="Removing Dotnet Packs from Correlation Staging" Importance="high" />
+    <RemoveDir Directories="$(CorrelationPayloadDirectory)dotnet\packs" />
+  </Target>
+
+  <ItemDefinitionGroup>
+    <HelixWorkItem>
+      <Timeout>00:30</Timeout>
+    </HelixWorkItem>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <MAUIAndroidScenario Include="Maui Android Default">
+      <ScenarioDirectoryName>mauiandroid</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <ApkName>com.companyname.mauiandroiddefault-Signed</ApkName>
+      <PackageName>com.companyname.mauiandroiddefault</PackageName>
+    </MAUIAndroidScenario>
+    <MAUIAndroidScenario Include="Maui Android Podcast">
+      <ScenarioDirectoryName>mauiandroidpodcast</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <ApkName>com.Microsoft.NetConf2021.Maui-Signed</ApkName>
+      <PackageName>com.Microsoft.NetConf2021.Maui</PackageName>
+    </MAUIAndroidScenario>
+    <MAUIAndroidScenario Include="Maui Blazor Android Default">
+      <ScenarioDirectoryName>mauiblazorandroid</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <ApkName>com.companyname.mauiblazorandroiddefault-Signed</ApkName>
+      <PackageName>com.companyname.mauiblazorandroiddefault</PackageName>
+    </MAUIAndroidScenario>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName) -r android-arm64 --self-contained</Command>
+      <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
+    </PreparePayloadWorkItem>
+  </ItemGroup>
+
+
+<!-- We only run the android tests from Windows machines (at least for now) -->
+  <ItemGroup>
+    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'SOD - %(Identity) APK Size')">
+      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'SOD - %(Identity) Extracted Size')">
+      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y; ren %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).apk %(HelixWorkItem.ApkName).zip; powershell.exe -nologo -noprofile -command "&amp; {Expand-Archive %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip -DestinationPath %HELIX_WORKITEM_ROOT%\pub\}"; del %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity)')">
+      <PreCommands>echo on; set XHARNESSPATH=$(XharnessPath); xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity) NoAnimation')">
+      <PreCommands>echo on; set XHARNESSPATH=$(XharnessPath); xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot; --disable-animations</Command>
+    </HelixWorkItem>
+  </ItemGroup>
+
+
+  <Import Project="PreparePayloadWorkItems.targets" />
+
+</Project>

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -6,7 +6,8 @@ parameters:
   pool: ''              # required -- name of the Helix pool
   queue: ''             # required -- name of the Helix queue
   container: ''         # optional -- id of the container
-  channels: []          # required -- list of channels to download .NET from
+  channels: []          # optional (must have dotnetVersionsLinks if not used) -- list of channels to download .NET from
+  dotnetVersionsLinks: [] # optional alternative to channels that uses 'channel: link' values to scrape the link's json for dotnet_version or version
   projectFile: ''       # required -- project file to build (current choices: scenarios.proj/sdk_scenarios.proj )
   machinePool: ''       # required -- Name of perf machine pool (Tiger, Owl, etc)
 
@@ -81,16 +82,37 @@ jobs:
         container: ${{ parameters.container }}
         strategy:
           matrix:
-            ${{ each channel in parameters.channels }}:
-              ${{ channel }}:
-                _Channel: ${{ channel }}
-                _Configs: CompilationMode=Tiered RunKind="${{ parameters.kind }}"
-                _BuildConfig: ${{ parameters.architecture }}_$(_Channel)_${{ parameters.kind }} # needs to be unique to avoid logs overwriting in mc.dot.net
+            ${{ if ne(length(parameters.channels), 0) }}:
+              ${{ each channel in parameters.channels }}:
+                ${{ channel }}:
+                  _Channel: ${{ channel }}
+                  _Configs: CompilationMode=Tiered RunKind="${{ parameters.kind }}"
+                  _BuildConfig: ${{ parameters.architecture }}_$(_Channel)_${{ parameters.kind }} # needs to be unique to avoid logs overwriting in mc.dot.net
+            ${{ if ne(length(parameters.dotnetVersionsLinks), 0) }}:
+              ${{ each versionPair in parameters.dotnetVersionsLinks }}:
+                ${{ versionPair.key }}_Link:
+                  _Channel: ${{ versionPair.key }}
+                  _DotnetVersionLink: ${{ versionPair.value }}
+                  _Configs: CompilationMode=Tiered RunKind="${{ parameters.kind }}"
+                  _BuildConfig: ${{ parameters.architecture }}_$(_Channel)_Linked_${{ parameters.kind }} # needs to be unique to avoid logs overwriting in mc.dot.net
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
-          displayName: Run ci_setup.py
+        - ${{ if ne(length(parameters.channels), 0) }}:
+          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
+            displayName: Run ci_setup.py
+        - ${{ elseif ne(length(parameters.dotnetVersionsLinks), 0) }}:
+          - powershell: |
+              $data = Invoke-WebRequest -Uri "$(_DotnetVersionLink)"
+              $values = ConvertFrom-Json $data.content
+              $dotnet_version_check = $values.dotnet_version
+              $version_check = $values.version
+              $dotnet_version = if ($dotnet_version_check) {$dotnet_version_check} Else {$version_check}
+              Write-Host "##vso[task.setvariable variable=DotnetVersion;]$dotnet_version"
+              Write-Host "Found dotnet version $dotnet_version"
+            displayName: Get dotnetVersion to use
+          - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet
+            displayName: Run ci_setup.py with dotnetVersionsLinks
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -5,13 +5,14 @@ Contains the functionality around DotNet Cli.
 """
 
 import ssl
+import datetime
 from argparse import Action, ArgumentParser, ArgumentTypeError, ArgumentError
 from collections import namedtuple
 from glob import iglob
 from json import loads
 from logging import getLogger
 from os import chmod, environ, listdir, makedirs, path, pathsep, system
-from re import search
+from re import search, match, MULTILINE
 from shutil import rmtree
 from stat import S_IRWXU
 from subprocess import CalledProcessError, check_output
@@ -619,27 +620,30 @@ def get_commit_date(
     if not commit_sha:
         raise ValueError('.NET Commit sha was not defined.')
 
+    # Example URL: https://github.com/dotnet/runtime/commit/2d76178d5faa97be86fc8d049c7dbcbdf66dc497.patch
     url = None
-    urlformat = 'https://api.github.com/repos/%s/%s/commits/%s'
     if repository is None:
         # The origin of the repo where the commit belongs to has changed
         # between release. Here we attempt to naively guess the repo.
         core_sdk_frameworks = ChannelMap.get_supported_frameworks()
         repo = 'core-sdk' if framework  in core_sdk_frameworks else 'cli'
-        url = urlformat % ('dotnet', repo, commit_sha)
+        url = f'https://github.com/dotnet/{repo}/commit/{commit_sha}.patch'
     else:
         owner, repo = get_repository(repository)
-        url = urlformat % (owner, repo, commit_sha)
+        url = f'https://github.com/{owner}/{repo}/commit/{commit_sha}.patch'
 
     build_timestamp = None
-    sleep_time = 10 # Start with 10 second sleep timer
+    sleep_time = 10 # Start with 10 second sleep timer        
     for retrycount in range(5):
         try:
             with urlopen(url) as response:
                 getLogger().info("Commit: %s", url)
-                item = loads(response.read().decode('utf-8'))
-                build_timestamp = item['commit']['committer']['date']
-                break
+                patch = response.read().decode('utf-8')
+                dateMatch = search(r'^Date: (.+)$', patch, MULTILINE)
+                if dateMatch:
+                    build_timestamp = datetime.datetime.strptime(dateMatch.group(1), '%a, %d %b %Y %H:%M:%S %z').astimezone(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+                    getLogger().info(f"Got UTC timestamp {build_timestamp} from {dateMatch.group(1)}")
+                    break
         except URLError as error:
             getLogger().warning(f"URL Error trying to get commit date from {url}; Reason: {error.reason}; Attempt {retrycount}")
             sleep(sleep_time)

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -3,27 +3,17 @@ pre-command
 '''
 import sys
 import requests
-from mauishared.mauisharedpython import RemoveAABFiles
 from performance.logger import setup_loggers, getLogger
 from shared import const
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
 from shared.precommands import PreCommands
-from shared.versionmanager import versionswritejson, GetVersionFromDllPowershell
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell
 from test import EXENAME
 
 setup_loggers(True)
 
 precommands = PreCommands()
-target_framework_wo_platform = precommands.framework.split('-')[0]
-
-# Download what we need
-with open ("MauiNuGet.config", "wb") as f:
-    f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
-
-workload_install_args = ['--configfile', 'MauiNuGet.config']
-if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
-    workload_install_args += ['--from-rollback-file', f'https://aka.ms/dotnet/maui/{target_framework_wo_platform}.json']
-
-precommands.install_workload('maui', workload_install_args) 
+install_versioned_maui(precommands)
 
 # Setup the Maui folder
 precommands.new(template='maui',
@@ -40,10 +30,10 @@ precommands.execute(['--no-restore', '--source', 'MauiNuGet.config'])
 output_dir = const.PUBDIR
 if precommands.output:
     output_dir = precommands.output
-RemoveAABFiles(output_dir)
+remove_aab_files(output_dir)
 
 # Copy the MauiVersion to a file so we have it on the machine
-maui_version = GetVersionFromDllPowershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
+maui_version = get_version_from_dll_powershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
 version_dict = { "mauiVersion": maui_version }
-versionswritejson(version_dict, rf"{output_dir}\versions.json")
+versions_write_json(version_dict, rf"{output_dir}\versions.json")
 print(f"Versions: {version_dict}")

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -2,7 +2,6 @@
 pre-command
 '''
 import sys
-import requests
 from performance.logger import setup_loggers, getLogger
 from shared import const
 from shared.mauisharedpython import remove_aab_files, install_versioned_maui

--- a/src/scenarios/mauiandroid/test.py
+++ b/src/scenarios/mauiandroid/test.py
@@ -3,12 +3,12 @@ Mobile Maui App
 '''
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
-from shared.versionmanager import versionsreadjsonfilesaveenv
+from shared.versionmanager import versions_read_json_file_save_env
 
 EXENAME = 'MauiAndroidDefault'
 
 if __name__ == "__main__":    
-    versionsreadjsonfilesaveenv(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauiandroidpodcast/post.py
+++ b/src/scenarios/mauiandroidpodcast/post.py
@@ -1,0 +1,9 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+from performance.common import remove_directory
+
+remove_directory("dotnet-podcasts")
+clean_directories()

--- a/src/scenarios/mauiandroidpodcast/pre.py
+++ b/src/scenarios/mauiandroidpodcast/pre.py
@@ -3,30 +3,21 @@ pre-command
 '''
 import requests
 import subprocess
-from mauishared.mauisharedpython import RemoveAABFiles
 from performance.logger import setup_loggers, getLogger
 from shared.precommands import PreCommands
-from shared.versionmanager import versionswritejson, GetVersionFromDllPowershell
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell
 from shared import const
 
 setup_loggers(True)
 precommands = PreCommands()
-target_framework_wo_platform = precommands.framework.split('-')[0]
-
-# Download what we need
-with open ("MauiNuGet.config", "wb") as f:
-    f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
+install_versioned_maui(precommands)
 
 branch = f'{precommands.framework[:6]}'
 subprocess.run(['git', 'clone', 'https://github.com/microsoft/dotnet-podcasts.git', '-b', branch, '--single-branch', '--depth', '1'])
 subprocess.run(['powershell', '-Command', r'Remove-Item -Path .\\dotnet-podcasts\\.git -Recurse -Force']) # Git files have permission issues, do their deletion separately
 
-workload_install_args = ['--configfile', 'MauiNuGet.config']
-if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
-    workload_install_args += ['--from-rollback-file', f'https://aka.ms/dotnet/maui/{target_framework_wo_platform}.json']
-
-precommands.install_workload('maui', workload_install_args) 
-precommands.existing(projectdir='./dotnet-podcasts',projectfile='./src/Mobile/Microsoft.NetConf2021.Maui.csproj')
+precommands.existing(projectdir='./dotnet-podcasts', projectfile='./src/Mobile/Microsoft.NetConf2021.Maui.csproj')
 
 # Build the APK
 precommands._restore()
@@ -36,10 +27,10 @@ precommands.execute(['--no-restore'])
 output_dir = const.PUBDIR
 if precommands.output:
     output_dir = precommands.output
-RemoveAABFiles(output_dir)
+remove_aab_files(output_dir)
 
 # Copy the MauiVersion to a file so we have it on the machine
-maui_version = GetVersionFromDllPowershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
+maui_version = get_version_from_dll_powershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
 version_dict = { "mauiVersion": maui_version }
-versionswritejson(version_dict, rf"{output_dir}\versions.json")
+versions_write_json(version_dict, rf"{output_dir}\versions.json")
 print(f"Versions: {version_dict}")

--- a/src/scenarios/mauiandroidpodcast/pre.py
+++ b/src/scenarios/mauiandroidpodcast/pre.py
@@ -1,7 +1,6 @@
 '''
 pre-command
 '''
-import requests
 import subprocess
 from performance.logger import setup_loggers, getLogger
 from shared.precommands import PreCommands

--- a/src/scenarios/mauiandroidpodcast/test.py
+++ b/src/scenarios/mauiandroidpodcast/test.py
@@ -3,12 +3,12 @@ Mobile Maui App
 '''
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
-from shared.versionmanager import versionsreadjsonfilesaveenv
+from shared.versionmanager import versions_read_json_file_save_env
 
 EXENAME = 'MauiAndroidPodcast'
 
 if __name__ == "__main__":
-    versionsreadjsonfilesaveenv(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauiandroidpodcast/test.py
+++ b/src/scenarios/mauiandroidpodcast/test.py
@@ -5,9 +5,9 @@ from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versionsreadjsonfilesaveenv
 
-EXENAME = 'MauiAndroidDefault'
+EXENAME = 'MauiAndroidPodcast'
 
-if __name__ == "__main__":    
+if __name__ == "__main__":
     versionsreadjsonfilesaveenv(rf".\{PUBDIR}\versions.json")
 
     traits = TestTraits(exename=EXENAME, 

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -3,26 +3,16 @@ pre-command
 '''
 import sys
 import requests
-from mauishared.mauisharedpython import RemoveAABFiles
 from performance.logger import setup_loggers, getLogger
 from shared import const
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
 from shared.precommands import PreCommands
-from shared.versionmanager import versionswritejson, GetVersionFromDllPowershell
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell
 from test import EXENAME
 
 setup_loggers(True)
 precommands = PreCommands()
-target_framework_wo_platform = precommands.framework.split('-')[0]
-
-# Download what we need
-with open ("MauiNuGet.config", "wb") as f:
-    f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
-
-workload_install_args = ['--configfile', 'MauiNuGet.config']
-if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
-    workload_install_args += ['--from-rollback-file', f'https://aka.ms/dotnet/maui/{target_framework_wo_platform}.json']
-
-precommands.install_workload('maui', workload_install_args) 
+install_versioned_maui(precommands)
 
 # Setup the Maui folder
 precommands.new(template='maui-blazor',
@@ -77,11 +67,11 @@ precommands.execute(['--no-restore', '--source', 'MauiNuGet.config'])
 output_dir = const.PUBDIR
 if precommands.output:
     output_dir = precommands.output
-RemoveAABFiles(output_dir)
+remove_aab_files(output_dir)
 
 # Copy the MauiVersion to a file so we have it on the machine
-maui_version = GetVersionFromDllPowershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
+maui_version = get_version_from_dll_powershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
 version_dict = { "mauiVersion": maui_version }
-versionswritejson(version_dict, rf"{output_dir}\versions.json")
+versions_write_json(version_dict, rf"{output_dir}\versions.json")
 print(f"Versions: {version_dict}")
 

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -2,48 +2,86 @@
 pre-command
 '''
 import sys
-import os
-from zipfile import ZipFile
+import requests
+from mauishared.mauisharedpython import RemoveAABFiles
 from performance.logger import setup_loggers, getLogger
-from shutil import copyfile
+from shared import const
 from shared.precommands import PreCommands
-from shared.const import PUBDIR
-from argparse import ArgumentParser
+from shared.versionmanager import versionswritejson, GetVersionFromDllPowershell
+from test import EXENAME
 
 setup_loggers(True)
+precommands = PreCommands()
+target_framework_wo_platform = precommands.framework.split('-')[0]
 
-parser = ArgumentParser()
-parser.add_argument('--unzip', help='Unzip APK and report extracted tree', action='store_true', default=False)
-parser.add_argument(
-        '--apk-name',
-        dest='apk',
-        required=True,
-        type=str,
-        help='Name of the APK to setup')
-args = parser.parse_args()
+# Download what we need
+with open ("MauiNuGet.config", "wb") as f:
+    f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
 
-if not os.path.exists(PUBDIR):
-    os.mkdir(PUBDIR)
-apkname = args.apk
-apknamezip = '%s.zip' % (apkname)
-if not os.path.exists(apkname):
-    getLogger().error('Cannot find %s' % (apkname))
-    exit(-1)
-if args.unzip:
-    if not os.path.exists(apknamezip):
-        copyfile(apkname, apknamezip)
+workload_install_args = ['--configfile', 'MauiNuGet.config']
+if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
+    workload_install_args += ['--from-rollback-file', f'https://aka.ms/dotnet/maui/{target_framework_wo_platform}.json']
 
-    with ZipFile(apknamezip) as zip:
-        zip.extractall(os.path.join('.', PUBDIR))
+precommands.install_workload('maui', workload_install_args) 
 
-    assets_dir = os.path.join(PUBDIR, 'assets')
-    assets_zip = os.path.join(assets_dir, 'assets.zip')
-    with ZipFile(assets_zip) as zip:
-        zip.extractall(assets_dir)
+# Setup the Maui folder
+precommands.new(template='maui-blazor',
+                output_dir=const.APPDIR,
+                bin_dir=const.BINDIR,
+                exename=EXENAME,
+                working_directory=sys.path[0],
+                no_restore=False)
 
-    os.remove(assets_zip)
-else:
-    copyfile(apkname, os.path.join(PUBDIR, apkname))
+# Add the index.razor.cs file
+with open(f"{const.APPDIR}/Pages/Index.razor.cs", "w") as indexCSFile:
+    indexCSFile.write('''
+    using Microsoft.AspNetCore.Components;
+    #if ANDROID
+        using Android.App;
+    #endif\n\n''' 
+    + f"    namespace {EXENAME}.Pages" + 
+'''
+    {
+        public partial class Index
+        {
+            protected override void OnAfterRender(bool firstRender)
+            {
+                if (firstRender)
+                {
+                    #if ANDROID
+                        var activity = MainActivity.Context as Activity;
+                        activity.ReportFullyDrawn();
+                    #else
+                        System.Console.WriteLine(\"__MAUI_Blazor_WebView_OnAfterRender__\");
+                    #endif
+                }
+            }
+        }
+    }
+''')
 
+# Replace line in the Android MainActivity.cs file
+with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "r") as mainActivityFile:
+    mainActivityFileLines = mainActivityFile.readlines()
 
+with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "w") as mainActivityFile:
+    for line in mainActivityFileLines:
+        if line.startswith("{"):
+            mainActivityFile.write("{\npublic static Android.Content.Context Context { get; private set; }\npublic MainActivity() { Context = this; }")
+        else:
+            mainActivityFile.write(line)
+
+# Build the APK
+precommands.execute(['--no-restore', '--source', 'MauiNuGet.config'])
+
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+RemoveAABFiles(output_dir)
+
+# Copy the MauiVersion to a file so we have it on the machine
+maui_version = GetVersionFromDllPowershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\{precommands.runtime_identifier}\linked\Microsoft.Maui.dll")
+version_dict = { "mauiVersion": maui_version }
+versionswritejson(version_dict, rf"{output_dir}\versions.json")
+print(f"Versions: {version_dict}")
 

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -2,7 +2,6 @@
 pre-command
 '''
 import sys
-import requests
 from performance.logger import setup_loggers, getLogger
 from shared import const
 from shared.mauisharedpython import remove_aab_files, install_versioned_maui

--- a/src/scenarios/mauiblazorandroid/test.py
+++ b/src/scenarios/mauiblazorandroid/test.py
@@ -1,11 +1,15 @@
 '''
-C# Console app
+Mobile Maui App
 '''
+from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
+from shared.versionmanager import versionsreadjsonfilesaveenv
 
 EXENAME = 'MauiBlazorAndroidDefault'
 
 if __name__ == "__main__":
+    versionsreadjsonfilesaveenv(rf".\{PUBDIR}\versions.json")
+
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',
                         )

--- a/src/scenarios/mauiblazorandroid/test.py
+++ b/src/scenarios/mauiblazorandroid/test.py
@@ -3,12 +3,12 @@ Mobile Maui App
 '''
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
-from shared.versionmanager import versionsreadjsonfilesaveenv
+from shared.versionmanager import versions_read_json_file_save_env
 
 EXENAME = 'MauiBlazorAndroidDefault'
 
 if __name__ == "__main__":
-    versionsreadjsonfilesaveenv(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauishared/mauisharedpython.py
+++ b/src/scenarios/mauishared/mauisharedpython.py
@@ -1,0 +1,9 @@
+import subprocess
+import os
+
+# Remove the aab files as we don't need them, this saves space in the correlation payload
+def RemoveAABFiles(output_dir="."):
+    file_list = os.listdir(output_dir)
+    for file in file_list:
+        if file.endswith(".aab"):
+            os.remove(os.path.join(output_dir, file))

--- a/src/scenarios/mauishared/mauisharedpython.py
+++ b/src/scenarios/mauishared/mauisharedpython.py
@@ -1,9 +1,0 @@
-import subprocess
-import os
-
-# Remove the aab files as we don't need them, this saves space in the correlation payload
-def RemoveAABFiles(output_dir="."):
-    file_list = os.listdir(output_dir)
-    for file in file_list:
-        if file.endswith(".aab"):
-            os.remove(os.path.join(output_dir, file))

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -1,5 +1,7 @@
 import subprocess
 import os
+import requests
+from shared.precommands import PreCommands
 
 # Remove the aab files as we don't need them, this saves space in the correlation payload
 def remove_aab_files(output_dir="."):

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -1,0 +1,22 @@
+import subprocess
+import os
+
+# Remove the aab files as we don't need them, this saves space in the correlation payload
+def remove_aab_files(output_dir="."):
+    file_list = os.listdir(output_dir)
+    for file in file_list:
+        if file.endswith(".aab"):
+            os.remove(os.path.join(output_dir, file))
+
+def install_versioned_maui(precommands):
+    target_framework_wo_platform = precommands.framework.split('-')[0]
+
+    # Download what we need
+    with open ("MauiNuGet.config", "wb") as f:
+        f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
+
+    workload_install_args = ['--configfile', 'MauiNuGet.config']
+    if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
+        workload_install_args += ['--from-rollback-file', f'https://aka.ms/dotnet/maui/{target_framework_wo_platform}.json']
+
+    precommands.install_workload('maui', workload_install_args) 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -440,6 +440,14 @@ ex: C:\repos\performance;C:\repos\runtime
                 getLogger().info(f"Animation values successfully set to {animationValue}.")
 
             try:
+                stopAppCmd = [ 
+                    adb.stdout.strip(),
+                    'shell',
+                    'am',
+                    'force-stop',
+                    self.packagename
+                ]
+
                 installCmd = xharnesscommand() + [
                     'android',
                     'install',
@@ -493,7 +501,7 @@ ex: C:\repos\performance;C:\repos\runtime
 
                 # Actual testing some run stuff
                 getLogger().info("Test run to check if permissions are needed")
-                activityname = getActivity.stdout
+                activityname = getActivity.stdout.strip()
 
                 # -W in the start command waits for the app to finish initial draw.
                 startAppCmd = [ 
@@ -509,18 +517,9 @@ ex: C:\repos\performance;C:\repos\runtime
                 testRun.run()
                 testRunStats = re.findall(runSplitRegex, testRun.stdout) # Split results saving value (List: Starting, Status, LaunchState, Activity, TotalTime, WaitTime) 
                 getLogger().info(f"Test run activity: {testRunStats[3]}")
-
                 time.sleep(10) # Add delay to ensure app is fully installed and give it some time to settle
-
-                stopAppCmd = [ 
-                    adb.stdout.strip(),
-                    'shell',
-                    'am',
-                    'force-stop',
-                    self.packagename
-                ]
+                
                 RunCommand(stopAppCmd, verbose=True).run()
-
                 if "com.google.android.permissioncontroller" in testRunStats[3]:
                     # On perm screen, use the buttons to close it. it will stay away until the app is reinstalled
                     RunCommand(keyInputCmd + ['22'], verbose=True).run() # Select next button

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -1,0 +1,31 @@
+'''
+Version File Manager
+'''
+import json
+import os
+import subprocess
+
+def versionswritejson(versiondict: dict, outputfile = 'versions.json'):
+    with open(outputfile, 'w') as file:
+        json.dump(versiondict, file)
+
+def versionsreadjson(inputfile = 'versions.json'):
+    with open(inputfile, 'r') as file:
+        return json.load(file)
+
+def versionswriteenv(versiondict: dict):
+    for key, value in versiondict.items():
+        os.environ[key] = value
+
+def versionsreadjsonfilesaveenv(inputfile = 'versions.json'):
+    versions = versionsreadjson(inputfile)
+    print(f"Versions: {versions}")
+    versionswriteenv(versions)
+
+    # Remove the versions.json file if we are in the lab to ensure SOD doesn't pick it up
+    if "PERFLAB_INLAB" in os.environ and os.environ["PERFLAB_INLAB"] == "1":
+        os.remove(inputfile)
+
+def GetVersionFromDllPowershell(dll_path: str):
+    result = subprocess.run(['powershell', '-Command', rf'Get-ChildItem {dll_path} | Select-Object -ExpandProperty VersionInfo | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    return result.stdout.decode('utf-8').strip()

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -5,27 +5,27 @@ import json
 import os
 import subprocess
 
-def versionswritejson(versiondict: dict, outputfile = 'versions.json'):
+def versions_write_json(versiondict: dict, outputfile = 'versions.json'):
     with open(outputfile, 'w') as file:
         json.dump(versiondict, file)
 
-def versionsreadjson(inputfile = 'versions.json'):
+def versions_read_json(inputfile = 'versions.json'):
     with open(inputfile, 'r') as file:
         return json.load(file)
 
-def versionswriteenv(versiondict: dict):
+def versions_write_env(versiondict: dict):
     for key, value in versiondict.items():
         os.environ[key] = value
 
-def versionsreadjsonfilesaveenv(inputfile = 'versions.json'):
-    versions = versionsreadjson(inputfile)
+def versions_read_json_file_save_env(inputfile = 'versions.json'):
+    versions = versions_read_json(inputfile)
     print(f"Versions: {versions}")
-    versionswriteenv(versions)
+    versions_write_env(versions)
 
     # Remove the versions.json file if we are in the lab to ensure SOD doesn't pick it up
     if "PERFLAB_INLAB" in os.environ and os.environ["PERFLAB_INLAB"] == "1":
         os.remove(inputfile)
 
-def GetVersionFromDllPowershell(dll_path: str):
+def get_version_from_dll_powershell(dll_path: str):
     result = subprocess.run(['powershell', '-Command', rf'Get-ChildItem {dll_path} | Select-Object -ExpandProperty VersionInfo | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     return result.stdout.decode('utf-8').strip()

--- a/src/tools/Reporting/Reporting.Tests/EnvironmentProviderMock.cs
+++ b/src/tools/Reporting/Reporting.Tests/EnvironmentProviderMock.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Reporting.Tests
@@ -14,6 +15,10 @@ namespace Reporting.Tests
         {
             return Vars?[variable];
         }
+        public IDictionary GetEnvironmentVariables()
+        {
+            return Vars;
+        }
     }
     internal class PerfLabEnvironmentProviderMock : EnvironmentProviderMockBase
     {
@@ -23,6 +28,7 @@ namespace Reporting.Tests
             {
                 {"PERFLAB_INLAB", "1" },
                 {"HELIX_CORRELATION_ID","testCorrelationId" },
+                {"HELIX_WORKITEM_FRIENDLYNAME","Test Friendly Name" },
                 {"PERFLAB_PERFHASH","testPerfHash" },
                 {"PERFLAB_QUEUE","testQueue" },
                 {"PERFLAB_REPO","testRepo" },
@@ -34,7 +40,7 @@ namespace Reporting.Tests
                 {"PERFLAB_HIDDEN", "false" },
                 {"PERFLAB_RUNNAME", "testRunName" },
                 {"PERFLAB_CONFIGS", "KEY1=VALUE1;KEY2=VALUE2" },
-                {"PERFLAB_BUILDTIMESTAMP", new DateTime(1970,1,1).ToString("o") },
+                {"PERFLAB_BUILDTIMESTAMP", new DateTime(1970,1,1).ToString("o") }
             };
         }
 

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -106,6 +106,7 @@ CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |100000000000
             var jsonObj = JsonConvert.DeserializeAnonymousType(jsonString, jsonType);
 
             Assert.Equal(environment.GetEnvironmentVariable("HELIX_CORRELATION_ID"), jsonObj.Run.CorrelationId);
+            Assert.Equal(environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME"), jsonObj.Run.WorkItemName);
             Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_PERFHASH"), jsonObj.Run.PerfRepoHash);
             Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_QUEUE"), jsonObj.Run.Queue);
             Assert.Equal(environment.GetEnvironmentVariable("PERFLAB_REPO"), jsonObj.Build.Repo);

--- a/src/tools/Reporting/Reporting/EnvironmentProvider.cs
+++ b/src/tools/Reporting/Reporting/EnvironmentProvider.cs
@@ -11,5 +11,6 @@ namespace Reporting
     public class EnvironmentProvider : IEnvironment
     {
         public string GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
+        public System.Collections.IDictionary GetEnvironmentVariables() => Environment.GetEnvironmentVariables();
     }
 }

--- a/src/tools/Reporting/Reporting/IEnvironment.cs
+++ b/src/tools/Reporting/Reporting/IEnvironment.cs
@@ -2,14 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Reporting
 {
     public interface IEnvironment
     {
         string GetEnvironmentVariable(string variable);
+        System.Collections.IDictionary GetEnvironmentVariables(); 
     }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -90,7 +90,8 @@ namespace Reporting
                 TimeStamp = DateTime.Parse(environment.GetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP")),
             };
 
-            foreach (DictionaryEntry entry in environment.GetEnvironmentVariables()){
+            foreach (DictionaryEntry entry in environment.GetEnvironmentVariables())
+            {
                 if (entry.Key.ToString().Equals("PERFLAB_TARGET_FRAMEWORKS", StringComparison.InvariantCultureIgnoreCase)) 
                 {
                     build.AdditionalData["targetFrameworks"] = entry.Value.ToString();

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -95,7 +95,7 @@ namespace Reporting
                 {
                     build.AdditionalData["targetFrameworks"] = entry.Value.ToString();
                 }
-                if (entry.Key.ToString().EndsWith("version", ignoreCase: true, culture: CultureInfo.InvariantCulture))
+                else if(entry.Key.ToString().EndsWith("version", true, CultureInfo.InvariantCulture))
                 {
                     // Special case the original two special cases, MAUI_VERSION is only needed because runtime based runs use MAUI_VERSION
                     if(entry.Key.ToString().Equals("DOTNET_VERSION", StringComparison.InvariantCultureIgnoreCase)){

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -5,6 +5,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -88,14 +89,24 @@ namespace Reporting
                 BuildName = environment.GetEnvironmentVariable("PERFLAB_BUILDNUM"),
                 TimeStamp = DateTime.Parse(environment.GetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP")),
             };
-            build.AdditionalData["productVersion"] = environment.GetEnvironmentVariable("DOTNET_VERSION");
-            build.AdditionalData["targetFrameworks"] = environment.GetEnvironmentVariable("PERFLAB_TARGET_FRAMEWORKS");
 
-            // Additional Data we only want populated if it is available
-            if (!String.IsNullOrEmpty(environment.GetEnvironmentVariable("MAUI_VERSION")))
-            {
-                build.AdditionalData["mauiVersion"] = environment.GetEnvironmentVariable("MAUI_VERSION");
-            }
+            foreach (DictionaryEntry entry in environment.GetEnvironmentVariables()){
+                if (entry.Key.ToString().Equals("PERFLAB_TARGET_FRAMEWORKS", StringComparison.InvariantCultureIgnoreCase)) 
+                {
+                    build.AdditionalData["targetFrameworks"] = entry.Value.ToString();
+                }
+                if (entry.Key.ToString().EndsWith("version", ignoreCase: true, culture: CultureInfo.InvariantCulture))
+                {
+                    // Special case the original two special cases, MAUI_VERSION is only needed because runtime based runs use MAUI_VERSION
+                    if(entry.Key.ToString().Equals("DOTNET_VERSION", StringComparison.InvariantCultureIgnoreCase)){
+                        build.AdditionalData["productVersion"] = entry.Value.ToString();
+                    } else if(entry.Key.ToString().Equals("MAUI_VERSION", StringComparison.InvariantCultureIgnoreCase)){
+                        build.AdditionalData["mauiVersion"] = entry.Value.ToString();
+                    } else { 
+                        build.AdditionalData[entry.Key.ToString()] = entry.Value.ToString();
+                    }
+                }
+            }            
         }
         public string GetJson()
         {


### PR DESCRIPTION
This enables android mobile testing for Maui in the performance pipeline. This includes adding the scenarios for the Maui runs, adding some version passing capabilities, and a working queue for the runs. The first version of this is https://github.com/dotnet/performance/pull/2789, with some main branch specific changes made.

This also includes the updates made to dotnet.py to make getting the commit datetime more resilient, and changes to how _Version environment variables are saved such that they are added dynamically.