### PR TITLE
[wasm] Update to build for tfm=net8.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
+        - ubuntu-x64
       isPublic: true
       jobParameters:
         kind: blazor_scenarios

--- a/eng/performance/blazor_scenarios.proj
+++ b/eng/performance/blazor_scenarios.proj
@@ -1,11 +1,18 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
 
-  <ItemGroup>
-    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
-      <PayloadDirectory>%(Identity)</PayloadDirectory>
-    </HelixCorrelationPayload>
-  </ItemGroup>
-  
+  <PropertyGroup>
+    <LogDirectory Condition="'$(TargetsWindows)' == 'true'">%HELIX_WORKITEM_UPLOAD_ROOT%\</LogDirectory>
+    <LogDirectory Condition="'$(TargetsWindows)' != 'true'">%24{HELIX_WORKITEM_UPLOAD_ROOT}/</LogDirectory>
+
+    <PerfLabTargetFrameworksEnvVar Condition="'$(TargetsWindows)' == 'true'">%PERFLAB_TARGET_FRAMEWORKS%</PerfLabTargetFrameworksEnvVar>
+    <PerfLabTargetFrameworksEnvVar Condition="'$(TargetsWindows)' != 'true'">%24{PERFLAB_TARGET_FRAMEWORKS}</PerfLabTargetFrameworksEnvVar>
+    <PublishArgs>--msbuild "/p:_TrimmerDumpDependencies=true" --msbuild /warnaserror:NU1602,NU1604 --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
+    <PublishCommand>$(Python) pre.py publish $(PublishArgs)</PublishCommand>
+
+    <PizzaAppPubLocation Condition="'$(TargetsWindows)' == 'true'">pub\wwwroot</PizzaAppPubLocation>
+    <PizzaAppPubLocation Condition="'$(TargetsWindows)' != 'true'">pub/wwwroot</PizzaAppPubLocation>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
     <ScenariosDir>$(WorkItemDirectory)\src\scenarios\</ScenariosDir>
     <HelixPreCommands>$(HelixPreCommands);set PYTHONPATH=%HELIX_CORRELATION_PAYLOAD%\scripts%3B%HELIX_CORRELATION_PAYLOAD%</HelixPreCommands>
@@ -17,6 +24,13 @@
     <HelixPreCommands>$(HelixPreCommands);export PYTHONPATH=$HELIX_CORRELATION_PAYLOAD/scripts:$HELIX_CORRELATION_PAYLOAD</HelixPreCommands>
     <RID>linux-$(Architecture)</RID>
   </PropertyGroup>
+
+  <ItemGroup>
+    <HelixCorrelationPayload Include="$(CorrelationPayloadDirectory)">
+      <PayloadDirectory>%(Identity)</PayloadDirectory>
+    </HelixCorrelationPayload>
+    <HelixCorrelationPayload Include="$(ScenariosDir)build-common" Destination="build-common" />
+  </ItemGroup>
 
   <ItemDefinitionGroup>
       <HelixWorkItem>
@@ -30,49 +44,38 @@
     <HelixWorkItem Include="SOD - Minimum Blazor Template - Publish">
       <PayloadDirectory>$(ScenariosDir)blazorminapp</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
 
     <HelixWorkItem Include="SOD - Minimum Blazor Template - Publish - AOT">
       <PayloadDirectory>$(ScenariosDir)blazorminappaot</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
 
     <HelixWorkItem Include="SOD - New Blazor Template - Publish">
       <PayloadDirectory>$(ScenariosDir)blazor</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
 
     <HelixWorkItem Include="SOD - New Blazor Template - Publish - AOT">
       <PayloadDirectory>$(ScenariosDir)blazoraot</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>$(PublishCommand) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
     </HelixWorkItem>
     
     <HelixWorkItem Include="SOD - Pizza App - Publish">
       <PayloadDirectory>$(ScenariosDir)blazorpizza</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish -f %PERFLAB_TARGET_FRAMEWORKS% --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs pub\wwwroot</Command>
+      <Command>$(PublishCommand) -f $(PerfLabTargetFrameworksEnvVar) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation)</Command>
     </HelixWorkItem>
-
 
     <HelixWorkItem Include="SOD - Pizza App - Publish - AOT"> 
       <PayloadDirectory>$(ScenariosDir)blazorpizzaaot</PayloadDirectory>
       <!-- Specifying both linker dump msbuild properties in case linker version is not updated -->
-      <PreCommands>$(Python) pre.py publish -f %PERFLAB_TARGET_FRAMEWORKS% --msbuild "/p:_TrimmerDumpDependencies=true" --msbuild-static AdditionalMonoLinkerOptions=&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;</PreCommands>
-      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs pub\wwwroot</Command>
+      <Command>$(PublishCommand) -f $(PerfLabTargetFrameworksEnvVar) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation)</Command>
     </HelixWorkItem>
   </ItemGroup>
-
-
   <Import Project="PreparePayloadWorkItems.targets" />
-
-
 </Project>

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -242,9 +242,6 @@ def __main(args: list) -> int:
     verbose = not args.quiet
     setup_loggers(verbose=verbose)
 
-    if("main" in args.channel and "CompilationMode=wasm" in args.build_configs):
-        args.channel = "7.0"
-
     # if repository is not set, then we are doing a core-sdk in performance repo run
     # if repository is set, user needs to supply the commit_sha
     if not ((args.commit_sha is None) == (args.repository is None)):

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -264,8 +264,10 @@ def __get_benchmarkdotnet_arguments(framework: str, args: tuple) -> list:
     if args.wasm:
         if framework == "net6.0":
             run_args += ['--runtimes', 'wasm']
-        else:
+        elif framework == "net7.0":
             run_args += ['--runtimes', 'wasmnet70']
+        elif framework == "net8.0":
+            run_args += ['--runtimes', 'wasmnet80']
 
     # Increase default 2 min build timeout to accommodate slow (or even very slow) hardware
     if not args.bdn_arguments or '--buildTimeout' not in args.bdn_arguments:

--- a/src/scenarios/blazorpizza/Directory.Build.props
+++ b/src/scenarios/blazorpizza/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <BuildCommonPath>$(MSBuildProjectDirectory)\..\..\..\build-common\</BuildCommonPath>
+    <BuildCommonPath Condition="!Exists($(BuildCommonPath)) and '$(HELIX_CORRELATION_PAYLOAD)' != ''">$(HELIX_CORRELATION_PAYLOAD)\build-common\</BuildCommonPath>
+  </PropertyGroup>
+</Project>

--- a/src/scenarios/blazorpizza/Directory.Build.targets
+++ b/src/scenarios/blazorpizza/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+ <Import Project="$(BuildCommonPath)\Blazor.Directory.Build.targets" />
+
  <Target Name="UpdateTargetingAndRuntimePack"
          AfterTargets="ResolveFrameworkReferences"
          Condition="Exists('$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.ref')">

--- a/src/scenarios/blazorpizza/src/BlazingComponents/BlazingComponents.csproj
+++ b/src/scenarios/blazorpizza/src/BlazingComponents/BlazingComponents.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />

--- a/src/scenarios/blazorpizza/src/BlazingPizza.Client/BlazingPizza.Client.csproj
+++ b/src/scenarios/blazorpizza/src/BlazingPizza.Client/BlazingPizza.Client.csproj
@@ -4,8 +4,9 @@
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
-    <BlazorVersion Condition="$(TargetFrameworks.Contains('net5.0'))">5.0.0</BlazorVersion>
   </PropertyGroup>
+
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(BlazorVersion)" />

--- a/src/scenarios/blazorpizza/src/BlazingPizza.ComponentsLibrary/BlazingPizza.ComponentsLibrary.csproj
+++ b/src/scenarios/blazorpizza/src/BlazingPizza.ComponentsLibrary/BlazingPizza.ComponentsLibrary.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />

--- a/src/scenarios/blazorpizza/src/BlazingPizza.Shared/BlazingPizza.Shared.csproj
+++ b/src/scenarios/blazorpizza/src/BlazingPizza.Shared/BlazingPizza.Shared.csproj
@@ -7,6 +7,8 @@
     <RootNamespace>BlazingPizza</RootNamespace>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\BlazingPizza.ComponentsLibrary\BlazingPizza.ComponentsLibrary.csproj" />
   </ItemGroup>

--- a/src/scenarios/blazorpizza/src/Directory.Build.props
+++ b/src/scenarios/blazorpizza/src/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-        <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
-        <BlazorVersion>6.0.0-preview*</BlazorVersion>
-        <EntityFrameworkVersion>5.0.0</EntityFrameworkVersion>
-        <SystemNetHttpJsonVersion>6.0.0-preview*</SystemNetHttpJsonVersion>
-    </PropertyGroup>
-</Project>

--- a/src/scenarios/blazorpizzaaot/Directory.Build.props
+++ b/src/scenarios/blazorpizzaaot/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <BuildCommonPath>$(MSBuildProjectDirectory)\..\..\..\build-common\</BuildCommonPath>
+    <BuildCommonPath Condition="!Exists($(BuildCommonPath)) and '$(HELIX_CORRELATION_PAYLOAD)' != ''">$(HELIX_CORRELATION_PAYLOAD)\build-common\</BuildCommonPath>
+  </PropertyGroup>
+</Project>

--- a/src/scenarios/blazorpizzaaot/Directory.Build.targets
+++ b/src/scenarios/blazorpizzaaot/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project>
+ <Import Project="$(BuildCommonPath)\Blazor.Directory.Build.targets" />
+
  <Target Name="UpdateTargetingAndRuntimePack"
          AfterTargets="ResolveFrameworkReferences"
          Condition="Exists('$(HELIX_CORRELATION_PAYLOAD)/microsoft.netcore.app.ref')">

--- a/src/scenarios/blazorpizzaaot/src/BlazingComponents/BlazingComponents.csproj
+++ b/src/scenarios/blazorpizzaaot/src/BlazingComponents/BlazingComponents.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />

--- a/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/BlazingPizza.Client.csproj
+++ b/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/BlazingPizza.Client.csproj
@@ -4,8 +4,9 @@
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
-    <BlazorVersion Condition="$(TargetFrameworks.Contains('net5.0'))">5.0.0</BlazorVersion>
   </PropertyGroup>
+
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(BlazorVersion)" />

--- a/src/scenarios/blazorpizzaaot/src/BlazingPizza.ComponentsLibrary/BlazingPizza.ComponentsLibrary.csproj
+++ b/src/scenarios/blazorpizzaaot/src/BlazingPizza.ComponentsLibrary/BlazingPizza.ComponentsLibrary.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(AspNetCoreVersion)" />

--- a/src/scenarios/blazorpizzaaot/src/BlazingPizza.Shared/BlazingPizza.Shared.csproj
+++ b/src/scenarios/blazorpizzaaot/src/BlazingPizza.Shared/BlazingPizza.Shared.csproj
@@ -7,6 +7,8 @@
     <RootNamespace>BlazingPizza</RootNamespace>
   </PropertyGroup>
 
+  <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\BlazingPizza.ComponentsLibrary\BlazingPizza.ComponentsLibrary.csproj" />
   </ItemGroup>

--- a/src/scenarios/blazorpizzaaot/src/Directory.Build.props
+++ b/src/scenarios/blazorpizzaaot/src/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-        <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
-        <BlazorVersion>6.0.0-preview*</BlazorVersion>
-        <EntityFrameworkVersion>5.0.0</EntityFrameworkVersion>
-        <SystemNetHttpJsonVersion>5.0.0</SystemNetHttpJsonVersion>
-    </PropertyGroup>
-</Project>

--- a/src/scenarios/build-common/Blazor.Directory.Build.targets
+++ b/src/scenarios/build-common/Blazor.Directory.Build.targets
@@ -1,0 +1,11 @@
+<Project>
+  <Target Name="ValidateBlazorVersions" BeforeTargets="ResolvePackageAssets">
+    <Error
+      Condition="'$(AspNetCoreVersion)' == '' or '$(BlazorVersion)' == '' or '$(SystemNetHttpJsonVersion)' == ''"
+      Text="Package versions for blazor/aspnetcore not set. %24(AspNetCoreVersion)=$(AspNetCoreVersion), %24(BlazorVersion)==$(BlazorVersion), and %24(SystemNetHttpJsonVersion)=$(SystemNetHttpJsonVersion). TFM: $(TargetFramework)" />
+
+    <Warning
+      Condition="$(TargetFrameworks.Contains('net9.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '9.0')))"
+      Text="Package versions being used for blazor project might need to be updated for a new tfm. Current values: %24(AspNetCoreVersion)=$(AspNetCoreVersion), %24(BlazorVersion)==$(BlazorVersion), and %24(SystemNetHttpJsonVersion)=$(SystemNetHttpJsonVersion). TFM: $(TargetFramework)" />
+  </Target>
+</Project>

--- a/src/scenarios/build-common/Blazor.Directory.Build.targets
+++ b/src/scenarios/build-common/Blazor.Directory.Build.targets
@@ -8,4 +8,24 @@
       Condition="$(TargetFrameworks.Contains('net9.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '9.0')))"
       Text="Package versions being used for blazor project might need to be updated for a new tfm. Current values: %24(AspNetCoreVersion)=$(AspNetCoreVersion), %24(BlazorVersion)==$(BlazorVersion), and %24(SystemNetHttpJsonVersion)=$(SystemNetHttpJsonVersion). TFM: $(TargetFramework)" />
   </Target>
+
+  <Target Name="PrintBlazorPackageVersions" AfterTargets="ResolvePackageAssets" Condition="$(MSBuildProjectName) == 'BlazingPizza.Client'">
+    <PropertyGroup>
+      <_MicrosoftAspNetCoreComponents Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Microsoft.AspNetCore.Components'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</_MicrosoftAspNetCoreComponents>
+      <_MicrosoftAspNetCoreComponentsWebAssembly Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Microsoft.AspNetCore.Components.WebAssembly'">%(RuntimeCopyLocalItems.NuGetPackageVersion)</_MicrosoftAspNetCoreComponentsWebAssembly>
+    </PropertyGroup>
+
+    <Message Text="
+  *** Microsoft.AspNetCore.Components package version: $(_MicrosoftAspNetCoreComponents) ***
+  *** Microsoft.AspNetCore.Components.WebAssembly package version: $(_MicrosoftAspNetCoreComponentsWebAssembly) ***
+  "
+             Importance="High" />
+  </Target>
+
+  <Target Name="PrintPackageReferences" AfterTargets="CollectPackageReferences">
+    <Message
+      Text="** PackageReference: %(PackageReference.Identity) - %(PackageReference.Version)"
+      Condition="%(PackageReference.Identity) != ''"
+      Importance="High" />
+  </Target>
 </Project>

--- a/src/scenarios/build-common/Blazor.PackageVersions.props
+++ b/src/scenarios/build-common/Blazor.PackageVersions.props
@@ -1,0 +1,19 @@
+<Project>
+    <PropertyGroup Condition="$(TargetFrameworks.Contains('net8.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '8.0')))">
+        <AspNetCoreVersion>8.0.0-*</AspNetCoreVersion>
+        <BlazorVersion>8.0.0-*</BlazorVersion>
+        <SystemNetHttpJsonVersion>8.0.0-*</SystemNetHttpJsonVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFrameworks.Contains('net7.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '7.0')))">
+        <AspNetCoreVersion>7.0.0</AspNetCoreVersion>
+        <BlazorVersion>7.0.0</BlazorVersion>
+        <SystemNetHttpJsonVersion>7.0.0</SystemNetHttpJsonVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFrameworks.Contains('net5.0')) or $(TargetFrameworks.Contains('net6.0')) or
+                              ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '6.0'))) or
+                              ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '7.0')))">
+        <AspNetCoreVersion Condition="'$(AspNetCoreVersion)' == ''">5.0.0</AspNetCoreVersion>
+        <BlazorVersion Condition="'$(BlazorVersion)' == ''">6.0.0-preview*</BlazorVersion>
+        <SystemNetHttpJsonVersion Condition="'$(SystemNetHttpJsonVersion)' == ''">6.0.0-preview*</SystemNetHttpJsonVersion>
+    </PropertyGroup>
+</Project>

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -89,13 +89,13 @@ namespace Reporting
                 TimeStamp = DateTime.Parse(environment.GetEnvironmentVariable("PERFLAB_BUILDTIMESTAMP")),
             };
             build.AdditionalData["productVersion"] = environment.GetEnvironmentVariable("DOTNET_VERSION");
+            build.AdditionalData["targetFrameworks"] = environment.GetEnvironmentVariable("PERFLAB_TARGET_FRAMEWORKS");
 
             // Additional Data we only want populated if it is available
-            if (environment.GetEnvironmentVariable("MAUI_VERSION") != null)
+            if (!String.IsNullOrEmpty(environment.GetEnvironmentVariable("MAUI_VERSION")))
             {
                 build.AdditionalData["mauiVersion"] = environment.GetEnvironmentVariable("MAUI_VERSION");
             }
-            
         }
         public string GetJson()
         {


### PR DESCRIPTION
- Blazor scenarios: Use 8.0.0-* nugets when building for net8.0 .
  - Without this change, when building for net7/net8, the aspnetcore assemblies were used from 6.0.0 packages.
- Also, remove workarounds added earlier when we were targeting net7.0 but with the 8.0 sdk. This allows building for net8.0 with the 8.0 sdk.
- Add a `blazor_scenarios` job for `ubuntu`
- Add binlogs for blazor scenarios