### PR TITLE
Set value into registry to prevent PDN checking for updates

### DIFF
--- a/src/scenarios/paintdotnet/test.py
+++ b/src/scenarios/paintdotnet/test.py
@@ -1,12 +1,15 @@
 import os
+import winreg
+from datetime import datetime, timezone
 from shared.runner import TestTraits, Runner
 from shared import const
+from logging import getLogger
 
 EXENAME = 'paintdotnet'
 
 def main():
-    os.environ['DOTNET_ROLL_FORWARD'] = 'LatestMajor'
-    os.environ['DOTNET_ROLL_FORWARD_TO_PRERELEASE'] = '1'
+    set_environment()
+    set_registry()
     traits = TestTraits(exename=EXENAME,
                         guiapp='true',
                         startupmetric='PDN', 
@@ -18,6 +21,17 @@ def main():
                         )
     runner = Runner(traits)
     runner.run()
+
+def set_environment():
+    os.environ['DOTNET_ROLL_FORWARD'] = 'LatestMajor'
+    os.environ['DOTNET_ROLL_FORWARD_TO_PRERELEASE'] = '1'
+    getLogger().info("Environment variables set.")
+
+def set_registry():
+    value = (datetime.now(timezone.utc) - datetime(1, 1, 1, tzinfo=timezone.utc)).total_seconds() * 10000000
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, r'Software\paint.net') as key:
+        winreg.SetValueEx(key, 'Updates/LastCheckTimeUtc', None, winreg.REG_SZ, str(int(value)))
+    getLogger().info("Fixed up Updates/LastCheckTimeUtc.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Workaround by setting `Updates/LastCheckTimeUtc` to "recent" value.

Successful run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2089541&view=results.

Fixes #2841.