### PR TITLE
[release/6.0] New version of Microsoft.Diagnostics.Tracing.TraceEvent (and using wildcard for future)

### DIFF
--- a/src/tools/ScenarioMeasurement/Startup/Startup.csproj
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.54" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.*" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20158.1" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Backport of #2844.