### PR TITLE
[wasm] Use TrimMode=partial for microbenchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.props
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <WasmMainJSPath>$(WasmDataDir)\test-main.js</WasmMainJSPath>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix `dotnet-runtime-perf` microbenchmarks failing with:

```
 System.NullReferenceException: Object reference not set to an instance of an object.
    at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] )
```

This was triggered by https://github.com/dotnet/runtime/pull/80940 .