### PR TITLE
Run ILLink only on x64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -452,7 +452,6 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        - win-arm64
       isPublic: false
       jobParameters:
         kind: illink


### PR DESCRIPTION
Fixes failure after #2864. [Here](https://github.com/dotnet/performance/blob/main/src/benchmarks/real-world/ILLink/Utilities.cs#L27) is the check.