### PR TITLE
Update markdownlint.yml versions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,11 +13,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: '16'
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"


### PR DESCRIPTION
Update markdownlint.yml actions/checkout@v2->v3 and setup-node@v1->v3 with node version 16. Per: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/


