### PR TITLE
Micro benchmarks for System.Formats.Tar.TarWriter.WriteEntry

### DIFF
--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Formats.Tar.Tests
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
+    public class Perf_TarWriter
+    {
+        private static readonly string _fileName = "file.txt";
+        private static Dictionary<string, string> _ea;
+        private static MemoryStream _memoryStream;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _memoryStream = new MemoryStream();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup() => _memoryStream.Dispose();
+
+        [GlobalSetup(Targets = new[] { nameof(PaxTarEntry_WriteEntry), nameof(PaxTarEntry_WriteEntry_Async) })]
+        public void SetupPax()
+        {
+            _ea = new Dictionary<string, string>
+            {
+                { "uname", "username" },
+                { "gname", "groupname" },
+                { "uid", "483745" },
+                { "gid", "193783" },
+                { "mtime", "1409547224" },
+                { "ctime", "1409547225" },
+                { "atime", "1409547226" },
+                // real world scenario:
+                { "MSWINDOWS.rawsd", "AQAAgBQAAAAkAAAAAAAAAAAAAAABAgAAAAAABSAAAAAhAgAAAQIAAAAAAAUgAAAAIQIAAA==" }
+            };
+        }
+
+        [Benchmark]
+        public void V7TarEntry_WriteEntry()
+        {
+            V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
+            using TarWriter writer = new TarWriter(_memoryStream);
+            writer.WriteEntry(entry);
+        }
+
+        [Benchmark]
+        public async Task V7TarEntry_WriteEntry_Async()
+        {
+            V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
+            await using TarWriter writer = new TarWriter(_memoryStream);
+            await writer.WriteEntryAsync(entry);
+        }
+
+        [Benchmark]
+        public void UstarTarEntry_WriteEntry()
+        {
+            UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, _fileName);
+            using TarWriter writer = new TarWriter(_memoryStream);
+            writer.WriteEntry(entry);
+        }
+
+        [Benchmark]
+        public async Task UstarTarEntry_WriteEntry_Async()
+        {
+            UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, _fileName);
+            await using TarWriter writer = new TarWriter(_memoryStream);
+            await writer.WriteEntryAsync(entry);
+        }
+
+        [Benchmark]
+        public void PaxTarEntry_WriteEntry()
+        {
+            PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, _fileName, _ea);
+            using TarWriter writer = new TarWriter(_memoryStream);
+            writer.WriteEntry(entry);
+        }
+
+        [Benchmark]
+        public async Task PaxTarEntry_WriteEntry_Async()
+        {
+            PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, _fileName, _ea);
+            await using TarWriter writer = new TarWriter(_memoryStream);
+            await writer.WriteEntryAsync(entry);
+        }
+
+        [Benchmark]
+        public void GnuTarEntry_WriteEntry()
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, _fileName);
+            using TarWriter writer = new TarWriter(_memoryStream);
+            writer.WriteEntry(entry);
+        }
+
+        [Benchmark]
+        public async Task GnuTarEntry_WriteEntry_Async()
+        {
+            GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, _fileName);
+            await using TarWriter writer = new TarWriter(_memoryStream);
+            await writer.WriteEntryAsync(entry);
+        }
+
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -47,7 +47,7 @@ namespace System.Formats.Tar.Tests
         public void V7TarEntry_WriteEntry()
         {
             V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
-            using TarWriter writer = new TarWriter(_memoryStream);
+            using TarWriter writer = CreateWriter();
             writer.WriteEntry(entry);
         }
 
@@ -55,7 +55,7 @@ namespace System.Formats.Tar.Tests
         public async Task V7TarEntry_WriteEntry_Async()
         {
             V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
-            await using TarWriter writer = new TarWriter(_memoryStream);
+            await using TarWriter writer = CreateWriter();
             await writer.WriteEntryAsync(entry);
         }
 
@@ -63,7 +63,7 @@ namespace System.Formats.Tar.Tests
         public void UstarTarEntry_WriteEntry()
         {
             UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, _fileName);
-            using TarWriter writer = new TarWriter(_memoryStream);
+            using TarWriter writer = CreateWriter();
             writer.WriteEntry(entry);
         }
 
@@ -71,7 +71,7 @@ namespace System.Formats.Tar.Tests
         public async Task UstarTarEntry_WriteEntry_Async()
         {
             UstarTarEntry entry = new UstarTarEntry(TarEntryType.RegularFile, _fileName);
-            await using TarWriter writer = new TarWriter(_memoryStream);
+            await using TarWriter writer = CreateWriter();
             await writer.WriteEntryAsync(entry);
         }
 
@@ -79,7 +79,7 @@ namespace System.Formats.Tar.Tests
         public void PaxTarEntry_WriteEntry()
         {
             PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, _fileName, _ea);
-            using TarWriter writer = new TarWriter(_memoryStream);
+            using TarWriter writer = CreateWriter();
             writer.WriteEntry(entry);
         }
 
@@ -87,7 +87,7 @@ namespace System.Formats.Tar.Tests
         public async Task PaxTarEntry_WriteEntry_Async()
         {
             PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, _fileName, _ea);
-            await using TarWriter writer = new TarWriter(_memoryStream);
+            await using TarWriter writer = CreateWriter();
             await writer.WriteEntryAsync(entry);
         }
 
@@ -95,7 +95,7 @@ namespace System.Formats.Tar.Tests
         public void GnuTarEntry_WriteEntry()
         {
             GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, _fileName);
-            using TarWriter writer = new TarWriter(_memoryStream);
+            using TarWriter writer = CreateWriter();
             writer.WriteEntry(entry);
         }
 
@@ -103,8 +103,16 @@ namespace System.Formats.Tar.Tests
         public async Task GnuTarEntry_WriteEntry_Async()
         {
             GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, _fileName);
-            await using TarWriter writer = new TarWriter(_memoryStream);
+            await using TarWriter writer = CreateWriter();
             await writer.WriteEntryAsync(entry);
+        }
+
+        private TarWriter CreateWriter()
+        {
+            // BDN runs every benchmark more than once, so we want to reuse the memory stream instance
+            // and have it always perform the same amount of work.
+            _memoryStream.Position = 0;
+            return new TarWriter(_memoryStream, leaveOpen: true);
         }
 
     }

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -23,9 +23,6 @@ namespace System.Formats.Tar.Tests
             _memoryStream = new MemoryStream();
         }
 
-        [GlobalCleanup]
-        public void Cleanup() => _memoryStream.Dispose();
-
         [GlobalSetup(Targets = new[] { nameof(PaxTarEntry_WriteEntry), nameof(PaxTarEntry_WriteEntry_Async) })]
         public void SetupPax()
         {

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -114,6 +114,5 @@ namespace System.Formats.Tar.Tests
             _memoryStream.Position = 0;
             return new TarWriter(_memoryStream, leaveOpen: true);
         }
-
     }
 }

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -43,7 +43,7 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public void V7TarEntry_WriteEntry()
         {
-            V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
+            V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, _fileName);
             using TarWriter writer = CreateWriter();
             writer.WriteEntry(entry);
         }
@@ -51,7 +51,7 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public async Task V7TarEntry_WriteEntry_Async()
         {
-            V7TarEntry entry = new V7TarEntry(TarEntryType.RegularFile, _fileName);
+            V7TarEntry entry = new V7TarEntry(TarEntryType.V7RegularFile, _fileName);
             await using TarWriter writer = CreateWriter();
             await writer.WriteEntryAsync(entry);
         }

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.Tar.cs
@@ -14,18 +14,20 @@ namespace System.Formats.Tar.Tests
     public class Perf_TarWriter
     {
         private static readonly string _fileName = "file.txt";
-        private static Dictionary<string, string> _ea;
-        private static MemoryStream _memoryStream;
+        private Dictionary<string, string> _ea;
+        private MemoryStream _memoryStream;
 
         [GlobalSetup]
-        public void Setup()
-        {
-            _memoryStream = new MemoryStream();
-        }
+        public void Setup() => _memoryStream = new MemoryStream();
+        
+        [GlobalCleanup]
+        public void Cleanup() => _memoryStream.Dispose();
 
         [GlobalSetup(Targets = new[] { nameof(PaxTarEntry_WriteEntry), nameof(PaxTarEntry_WriteEntry_Async) })]
         public void SetupPax()
         {
+            Setup();
+
             _ea = new Dictionary<string, string>
             {
                 { "uname", "username" },

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -67,15 +67,15 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public void CreateFromDirectory_Stream()
         {
-            MemoryStream ms = new MemoryStream();
+            using MemoryStream ms = new MemoryStream();
             TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]
-        public Task CreateFromDirectory_Stream_Async()
+        public async Task CreateFromDirectory_Stream_Async()
         {
-            MemoryStream ms = new MemoryStream();
-            return TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
+            await using MemoryStream ms = new MemoryStream();
+            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
+++ b/src/benchmarks/micro/libraries/System.Formats.Tar/Perf.TarFile.cs
@@ -67,15 +67,15 @@ namespace System.Formats.Tar.Tests
         [Benchmark]
         public void CreateFromDirectory_Stream()
         {
-            using MemoryStream ms = new MemoryStream();
+            MemoryStream ms = new MemoryStream();
             TarFile.CreateFromDirectory(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]
-        public async Task CreateFromDirectory_Stream_Async()
+        public Task CreateFromDirectory_Stream_Async()
         {
-            await using MemoryStream ms = new MemoryStream();
-            await TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
+            MemoryStream ms = new MemoryStream();
+            return TarFile.CreateFromDirectoryAsync(sourceDirectoryName: _inputDirPath, destination: ms, includeBaseDirectory: false);
         }
 
         [Benchmark]


### PR DESCRIPTION
Making sure we have coverage for the scenario of manually creating an TarEntry then writing it to a tar archive using a TarWriter.