### PR TITLE
Block AddContext to net6.0 and net7.0 microbenchmarks, and use TypeInfoResolver

### DIFF
--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ColdStartSerialization.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json.Serialization.Tests
         [Benchmark]
         public T NewDefaultOptions() => RoundtripSerialization(new JsonSerializerOptions());
 
-#if NET6_0_OR_GREATER
+#if NET6_0 || NET7_0
         [Benchmark]
         public T CachedJsonSerializerContext() 
             => RoundtripSerialization(SystemTextJsonSourceGeneratedContext.Default.Options);
@@ -50,6 +50,21 @@ namespace System.Text.Json.Serialization.Tests
         {
             var options = new JsonSerializerOptions();
             options.AddContext<SystemTextJsonSourceGeneratedContext>();
+            return RoundtripSerialization(options);
+        }
+#endif
+
+#if NET8_0_OR_GREATER
+        [Benchmark]
+        public T CachedJsonSerializerContext() 
+            => RoundtripSerialization(SystemTextJsonSourceGeneratedContext.Default.Options);
+
+        [Benchmark]
+        public T NewJsonSerializerContext()
+        {
+            var options = new JsonSerializerOptions(){
+                TypeInfoResolver = SystemTextJsonSourceGeneratedContext.Default
+            };
             return RoundtripSerialization(options);
         }
 #endif


### PR DESCRIPTION
Block AddContext to net6.0 and net7.0 microbenchmarks, and use TypeInfoResolver for Net8.0+.

Fixes https://github.com/dotnet/performance/issues/2953


