### PR TITLE
More precise SOD measurement for NativeAOT.

### DIFF
--- a/src/scenarios/emptyconsolenativeaot/pre.py
+++ b/src/scenarios/emptyconsolenativeaot/pre.py
@@ -14,7 +14,9 @@ precommands.new(template='console',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-args = ['/p:PublishAot=true', '/p:StripSymbols=true', '/p:IlcGenerateMstatFile=true'] if iswin() else ['/p:PublishAot=true', '/p:StripSymbols=true', '/p:IlcGenerateMstatFile=true', '/p:ObjCopyName=objcopy']
+args = ['/p:PublishAot=true', '/p:StripSymbols=true', '/p:IlcGenerateMstatFile=true', '/p:DebugType=None']
+if not iswin():
+    args.extend(['/p:ObjCopyName=objcopy'])
 precommands.execute(args)
 
 src = os.path.join(const.APPDIR, 'obj', precommands.configuration, precommands.framework, precommands.runtime_identifier, 'native', f'{EXENAME}.mstat')

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -56,7 +56,8 @@ namespace ScenarioMeasurement
                 {
                     var fileName = RemoveVersions(file.Key);
                     var fileExtension = GetExtension(fileName);
-                    counters.Add(new Counter { MetricName = "bytes", Name = $"{Path.Join(name, fileName)}", Results = new[] { (double)file.Value } });
+                    var counterName = Path.Join(name, fileName);
+                    counters.Add(new Counter { MetricName = "bytes", Name = $"{counterName}", Results = new[] { (double)file.Value } });
 
                     AddToBucket(buckets, $"Aggregate - {fileExtension}", file.Value);
                     if (fileName.Contains(Path.Join("wwwroot", "_framework")))
@@ -66,15 +67,18 @@ namespace ScenarioMeasurement
                     if (fileExtension.Equals(".mstat", StringComparison.OrdinalIgnoreCase))
                     {
                         var processor = new MStatProcessor();
-                        processor.Process(Path.Join(directory.Key, file.Key));
+                        var fullName = Path.Join(directory.Key, file.Key);
+                        processor.Process(fullName);
                         foreach (var item in processor.AssemblyStats)
                         {
-                            counters.Add(new Counter { MetricName = "bytes", Name = $"{Path.Join(name, fileName)} - Assembly - {item.Name}", Results = new[] { (double)item.Size } });
+                            counters.Add(new Counter { MetricName = "bytes", Name = $"{counterName} - Assembly - {item.Name}", Results = new[] { (double)item.Size } });
                         }
                         foreach (var item in processor.BlobStats)
                         {
-                            counters.Add(new Counter { MetricName = "bytes", Name = $"{Path.Join(name, fileName)} - Blob - {item.Name}", Results = new[] { (double)item.Size } });
+                            counters.Add(new Counter { MetricName = "bytes", Name = $"{counterName} - Blob - {item.Name}", Results = new[] { (double)item.Size } });
                         }
+                        totalSize -= new FileInfo(fullName).Length;
+                        totalCount -= 1;
                     }
                 }
             }


### PR DESCRIPTION
* Ignore MSTAT file(s) in global measurements.
* Do not generated debug/pdb files.

Fixes #2958.