### PR TITLE
Add iOS Maui Mobile tests to release/6.0, backport of #2942

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -574,63 +574,48 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual')) }}:
 
-  # # Windows x64 SDK scenario benchmarks
-  # - template: /eng/performance/scenarios.yml
-  #   parameters:
-  #     osName: windows
-  #     osVersion: RS5
-  #     architecture: x64
-  #     pool:
-  #       vmImage: windows-2019
-  #     kind: sdk_scenarios
-  #     machinePool: Tiger
-  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
-  #     projectFile: sdk_scenarios.proj
-  #     channels:
-  #       - $(channel) # for manual runs we can specify channel variable 
-
-  # # Windows x86 SDK scenario benchmarks
-  # - template: /eng/performance/scenarios.yml
-  #   parameters:
-  #     osName: windows
-  #     osVersion: RS5
-  #     architecture: x86
-  #     pool:
-  #       vmImage: windows-2019
-  #     kind: sdk_scenarios
-  #     machinePool: Tiger
-  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
-  #     projectFile: sdk_scenarios.proj
-  #     channels:
-  #       - $(channel) # for manual runs we can specify channel variable 
-
-  # # Ubuntu 1804 x64 SDK scenario benchmarks
-  # - template: /eng/performance/scenarios.yml
-  #   parameters:
-  #     osName: ubuntu
-  #     osVersion: 1804
-  #     architecture: x64
-  #     pool:
-  #       vmImage: ubuntu-latest
-  #     kind: sdk_scenarios
-  #     machinePool: Tiger
-  #     queue: Ubuntu.1804.Amd64.Tiger.Perf
-  #     container: ubuntu_x64_build_container
-  #     projectFile: sdk_scenarios.proj
-  #     channels:
-  #       - $(channel)
-
-  # Maui iOS scenario benchmarks
+  # Windows x64 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
-      osName: osx
+      osName: windows
+      osVersion: RS5
       architecture: x64
-      osVersion: 12
       pool:
-        vmImage: 'macos-12'
-      queue: OSX.1015.Amd64.Iphone.Perf
-      machinePool: iPhoneMini12
-      kind: maui_scenarios_ios
-      projectFile: maui_scenarios_ios.proj
+        vmImage: windows-2019
+      kind: sdk_scenarios
+      machinePool: Tiger
+      queue: Windows.10.Amd64.19H1.Tiger.Perf
+      projectFile: sdk_scenarios.proj
       channels:
-        - release/6.0
+        - $(channel) # for manual runs we can specify channel variable 
+
+  # Windows x86 SDK scenario benchmarks
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: windows
+      osVersion: RS5
+      architecture: x86
+      pool:
+        vmImage: windows-2019
+      kind: sdk_scenarios
+      machinePool: Tiger
+      queue: Windows.10.Amd64.19H1.Tiger.Perf
+      projectFile: sdk_scenarios.proj
+      channels:
+        - $(channel) # for manual runs we can specify channel variable 
+
+  # Ubuntu 1804 x64 SDK scenario benchmarks
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: ubuntu
+      osVersion: 1804
+      architecture: x64
+      pool:
+        vmImage: ubuntu-latest
+      kind: sdk_scenarios
+      machinePool: Tiger
+      queue: Ubuntu.1804.Amd64.Tiger.Perf
+      container: ubuntu_x64_build_container
+      projectFile: sdk_scenarios.proj
+      channels:
+        - $(channel)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,7 +303,7 @@ jobs:
       channels:
         - release/6.0
       
-    # Maui Android scenario benchmarks
+  # Maui Android scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
       osName: windows
@@ -315,6 +315,21 @@ jobs:
       machinePool: Pixel
       kind: maui_scenarios_android
       projectFile: maui_scenarios_android.proj
+      channels:
+        - release/6.0
+
+  # Maui Android scenario benchmarks
+  - template: /eng/performance/scenarios.yml
+    parameters:
+      osName: osx
+      architecture: x64
+      osVersion: 12
+      pool:
+        vmImage: 'macos-12'
+      queue: OSX.1015.Amd64.Iphone.Perf
+      machinePool: iPhoneMini12
+      kind: maui_scenarios_ios
+      projectFile: maui_scenarios_ios.proj
       channels:
         - release/6.0
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -318,7 +318,7 @@ jobs:
       channels:
         - release/6.0
 
-  # Maui Android scenario benchmarks
+  # Maui iOS scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
       osName: osx
@@ -574,48 +574,63 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual')) }}:
 
-  # Windows x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x64
-      pool:
-        vmImage: windows-2019
-      kind: sdk_scenarios
-      machinePool: Tiger
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: sdk_scenarios.proj
-      channels:
-        - $(channel) # for manual runs we can specify channel variable 
+  # # Windows x64 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS5
+  #     architecture: x64
+  #     pool:
+  #       vmImage: windows-2019
+  #     kind: sdk_scenarios
+  #     machinePool: Tiger
+  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - $(channel) # for manual runs we can specify channel variable 
 
-  # Windows x86 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      osVersion: RS5
-      architecture: x86
-      pool:
-        vmImage: windows-2019
-      kind: sdk_scenarios
-      machinePool: Tiger
-      queue: Windows.10.Amd64.19H1.Tiger.Perf
-      projectFile: sdk_scenarios.proj
-      channels:
-        - $(channel) # for manual runs we can specify channel variable 
+  # # Windows x86 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     osVersion: RS5
+  #     architecture: x86
+  #     pool:
+  #       vmImage: windows-2019
+  #     kind: sdk_scenarios
+  #     machinePool: Tiger
+  #     queue: Windows.10.Amd64.19H1.Tiger.Perf
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - $(channel) # for manual runs we can specify channel variable 
 
-  # Ubuntu 1804 x64 SDK scenario benchmarks
+  # # Ubuntu 1804 x64 SDK scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: ubuntu
+  #     osVersion: 1804
+  #     architecture: x64
+  #     pool:
+  #       vmImage: ubuntu-latest
+  #     kind: sdk_scenarios
+  #     machinePool: Tiger
+  #     queue: Ubuntu.1804.Amd64.Tiger.Perf
+  #     container: ubuntu_x64_build_container
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - $(channel)
+
+  # Maui iOS scenario benchmarks
   - template: /eng/performance/scenarios.yml
     parameters:
-      osName: ubuntu
-      osVersion: 1804
+      osName: osx
       architecture: x64
+      osVersion: 12
       pool:
-        vmImage: ubuntu-latest
-      kind: sdk_scenarios
-      machinePool: Tiger
-      queue: Ubuntu.1804.Amd64.Tiger.Perf
-      container: ubuntu_x64_build_container
-      projectFile: sdk_scenarios.proj
+        vmImage: 'macos-12'
+      queue: OSX.1015.Amd64.Iphone.Perf
+      machinePool: iPhoneMini12
+      kind: maui_scenarios_ios
+      projectFile: maui_scenarios_ios.proj
       channels:
-        - $(channel)
+        - release/6.0

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,6 +8,7 @@
   <!--Package versions-->
   <PropertyGroup>
     <MicrosoftDotnetSdkInternalPackageVersion>5.0.104-servicing.21213.7</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.23157.1</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.4</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETSdkInternalPackageVersion>
     </MicrosoftNETSdkInternalPackageVersion>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -1,0 +1,161 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <Import Project="Scenarios.Common.props" />
+
+  <PropertyGroup>
+    <IncludeXHarnessCli>true</IncludeXHarnessCli>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AfterPreparePayloadWorkItemCommand>$(Python) post.py</AfterPreparePayloadWorkItemCommand>
+    <PreparePayloadOutDirectoryName>scenarios_out</PreparePayloadOutDirectoryName>
+    <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' == 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)\</PreparePayloadWorkItemBaseDirectory>
+    <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
+  </PropertyGroup>
+
+  <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
+    <Message Text="Removing Dotnet Packs from Correlation Staging" Importance="high" />
+    <RemoveDir Directories="$(CorrelationPayloadDirectory)dotnet\packs" />
+  </Target>
+
+  <ItemDefinitionGroup>
+    <HelixWorkItem>
+      <Timeout>00:30</Timeout>
+    </HelixWorkItem>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <MAUIiOSScenario Include="Maui iOS Default">
+      <ScenarioDirectoryName>mauiios</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <IPAName>MauiiOSDefault</IPAName>
+      <PackageName>net.dot.mauitesting</PackageName>
+    </MAUIiOSScenario>
+    <!-- MessagingCenter was removed: https://github.com/dotnet/maui/pull/12582, needs to be replaced likely with something like: https://github.com/dotnet/maui/commit/762e07e04d1fdf8fca3edd948bab294c8762cd2c -->
+    <!-- <MAUIiOSScenario Include="Maui iOS Podcast">
+      <ScenarioDirectoryName>mauiiospodcast</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <IPAName>MauiiOSPodcast</IPAName>
+      <PackageName>net.dot.net.dot.netconf2021.maui</PackageName>
+    </MAUIiOSScenario> -->
+    <MAUIiOSScenario Include="Maui Blazor iOS Default">
+      <ScenarioDirectoryName>mauiblazorios</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <IPAName>MauiBlazoriOSDefault</IPAName>
+      <PackageName>net.dot.mauiblazortesting</PackageName>
+    </MAUIiOSScenario>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command> 
+      <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
+    </PreparePayloadWorkItem>
+  </ItemGroup>
+
+  <ItemGroup>
+    <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) IPA Size')">
+      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) Unzipped')">
+      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; mv $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; unzip -d $HELIX_WORKITEM_ROOT/pub $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; rm $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+    </HelixWorkItem>
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default">
+      <AppBundlePath>$(ScenariosDir)mauiios.zip</AppBundlePath>
+      <WorkItemTimeout>00:15:00</WorkItemTimeout>
+      <TestTarget>ios-device</TestTarget>
+      <CustomCommands>
+        <![CDATA[
+            # PreCommands
+            export XHARNESSPATH=$XHARNESS_CLI_PATH
+            
+            cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauiios/MauiiOSDefault.ipa $HELIX_WORKITEM_ROOT/mauiios/MauiiOSDefault.zip
+            mkdir $HELIX_WORKITEM_ROOT/mauiios/pub
+            cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauiios/versions.json $HELIX_WORKITEM_ROOT/mauiios/pub/versions.json
+            unzip -d $HELIX_WORKITEM_ROOT/mauiios $HELIX_WORKITEM_ROOT/mauiios/MauiiOSDefault.zip
+            mv $HELIX_WORKITEM_ROOT/mauiios/Payload/MauiiOSDefault.app $HELIX_WORKITEM_ROOT/mauiios/MauiiOSDefault.app
+            cp -f embedded.mobileprovision $HELIX_WORKITEM_ROOT/mauiios/MauiiOSDefault.app
+            cd $HELIX_WORKITEM_ROOT/mauiios
+            sign MauiiOSDefault.app
+
+            # Testing commands
+            $(Python) test.py devicestartup --device-type ios --package-path MauiiOSDefault.app --package-name net.dot.mauitesting --scenario-name "%(Identity)"
+            ((result=$?))
+
+            # Post commands
+            $(Python) post.py
+            exit $result
+          ]]>
+        </CustomCommands>
+    </XHarnessAppBundleToTest>
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Blazor Default">
+      <AppBundlePath>$(ScenariosDir)mauiblazorios.zip</AppBundlePath>
+      <WorkItemTimeout>00:15:00</WorkItemTimeout>
+      <TestTarget>ios-device</TestTarget>
+      <CustomCommands>
+        <![CDATA[
+          # PreCommands
+          export XHARNESSPATH=$XHARNESS_CLI_PATH
+
+          cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauiblazorios/MauiBlazoriOSDefault.ipa $HELIX_WORKITEM_ROOT/mauiblazorios/MauiBlazoriOSDefault.zip
+          mkdir $HELIX_WORKITEM_ROOT/mauiblazorios/pub
+          cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauiblazorios/versions.json $HELIX_WORKITEM_ROOT/mauiblazorios/pub/versions.json
+          unzip -d $HELIX_WORKITEM_ROOT/mauiblazorios $HELIX_WORKITEM_ROOT/mauiblazorios/MauiBlazoriOSDefault.zip
+          mv $HELIX_WORKITEM_ROOT/mauiblazorios/Payload/MauiBlazoriOSDefault.app $HELIX_WORKITEM_ROOT/mauiblazorios/MauiBlazoriOSDefault.app
+          cp -f embedded.mobileprovision $HELIX_WORKITEM_ROOT/mauiblazorios/MauiBlazoriOSDefault.app
+          cd $HELIX_WORKITEM_ROOT/mauiblazorios
+          sign MauiBlazoriOSDefault.app
+
+          # Testing commands
+          $(Python) test.py devicestartup --device-type ios --package-path MauiBlazoriOSDefault.app --package-name net.dot.mauiblazortesting --scenario-name "%(Identity)" --use-fully-drawn-time --fully-drawn-magic-string __MAUI_Blazor_WebView_OnAfterRender__ --startup-iterations 5
+          ((result=$?))
+
+          # Post commands
+          $(Python) post.py
+          exit $result
+        ]]>
+      </CustomCommands>
+    </XHarnessAppBundleToTest>
+    <!-- <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Podcast" Condition="'$(iOSLlvmBuild)' == 'False'">
+      <AppBundlePath>$(WorkItemDirectory).zip</AppBundlePath>
+      <WorkItemTimeout>00:15:00</WorkItemTimeout>
+      <TestTarget>ios-device</TestTarget>
+      <CustomCommands>
+        <![CDATA[
+          # PreCommands
+          export XHARNESSPATH=$XHARNESS_CLI_PATH
+
+          cp -r $HELIX_CORRELATION_PAYLOAD/Microsoft.NetConf2021.Maui.app $(ScenarioDirectory)mauiios/Microsoft.NetConf2021.Maui.app
+          cp -f embedded.mobileprovision $(ScenarioDirectory)mauiios/Microsoft.NetConf2021.Maui.app
+          cd $(ScenarioDirectory)mauiios
+          sign Microsoft.NetConf2021.Maui.app
+
+          $(Python) pre.py -1-name Microsoft.NetConf2021.Maui.app
+
+          # Testing commands
+          $(Python) test.py devicestartup -1-device-type ios -1-package-path Microsoft.NetConf2021.Maui.app -1-package-name net.dot.netconf2021.maui -1-scenario-name "%(Identity)"
+          ((result=$?))
+          
+          # Post commands
+          $(Python) post.py
+          exit $result
+        ]]>
+      </CustomCommands>
+    </XHarnessAppBundleToTest> -->
+  </ItemGroup>
+
+
+  <!--
+    This target is to work around the XHarness command that depend on scripts in ORIGPYPATH
+    being run before we get to run our normal Post commands. AddXHarnessCLI is the XHarness
+    Target so we just make sure we add this after that.
+  -->
+  <Target Name="ResetPYTHONPATHBeforeXHarnessCommand" AfterTargets="AddXHarnessCLI">
+    <PropertyGroup>
+      <HelixPostCommands>export PYTHONPATH=$ORIGPYPATH;$(HelixPostCommands)</HelixPostCommands>
+    </PropertyGroup>
+  </Target>
+
+  <Import Project="PreparePayloadWorkItems.targets" />
+</Project>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command> 
+      <Command>$(Python) pre.py publish -f $(_Framework)-ios --self-contained -c Release -r ios-arm64 -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command> 
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -117,7 +117,34 @@ jobs:
               TargetsWindows: 'true'
               WorkItemDirectory: $(Build.SourcesDirectory)
               HelixTargetQueues: ${{ parameters.queue }}
-        - ${{ if ne(parameters.osName, 'windows') }}:
+        - ${{ if eq(parameters.osName, 'osx') }}:
+          - script: cp ./NuGet.config $(CorrelationStaging);cp -r ./scripts $(CorrelationStaging)scripts;cp -r ./src/scenarios/shared $(CorrelationStaging)shared;cp -r ./src/scenarios/staticdeps $(CorrelationStaging)staticdeps
+            displayName: Copy python libraries and NuGet.config
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+            displayName: Build startup tool
+            env:
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+            displayName: Build SOD tool
+            env:
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)MemoryConsumption -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/MemoryConsumption/MemoryConsumption.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+            displayName: Build MemoryConsumption tool
+            env:
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+          - script: |
+              $(Python) -m pip install --user --upgrade pip
+              $(Python) -m pip install --user requests
+              . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
+              dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
+            displayName: Prepare scenarios
+            env:
+              CorrelationPayloadDirectory: $(CorrelationStaging)
+              Architecture: ${{ parameters.architecture }}
+              TargetsWindows: 'false'
+              WorkItemDirectory: $(Build.SourcesDirectory)
+              HelixTargetQueues: ${{ parameters.queue }}
+        - ${{ if and(ne(parameters.osName, 'windows'), ne(parameters.osName, 'osx')) }}:
           - script: cp ./NuGet.config $(CorrelationStaging);cp -r ./scripts $(CorrelationStaging)scripts;cp -r ./src/scenarios/shared $(CorrelationStaging)shared;cp -r ./src/scenarios/staticdeps $(CorrelationStaging)staticdeps
             displayName: Copy python libraries and NuGet.config
           - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r linux-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -120,18 +120,18 @@ jobs:
         - ${{ if eq(parameters.osName, 'osx') }}:
           - script: cp ./NuGet.config $(CorrelationStaging);cp -r ./scripts $(CorrelationStaging)scripts;cp -r ./src/scenarios/shared $(CorrelationStaging)shared;cp -r ./src/scenarios/staticdeps $(CorrelationStaging)staticdeps
             displayName: Copy python libraries and NuGet.config
-          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)startup -f $(_Framework) -r osx-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/Startup/Startup.csproj
             displayName: Build startup tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
-          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(_Framework) -r osx-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.csproj
             displayName: Build SOD tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
-          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)MemoryConsumption -f $(PERFLAB_Framework) -r osx-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)/src/tools/ScenarioMeasurement/MemoryConsumption/MemoryConsumption.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
-            displayName: Build MemoryConsumption tool
+              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
+          - script: $(CorrelationStaging)dotnet/dotnet publish -c Release -o $(CorrelationStaging)FailureReporter -f $(_Framework) -r osx-${{parameters.architecture}} $(Build.SourcesDirectory)/src/tools/Reporting/FailureReporting/FailureReporting.csproj
+            displayName: Build FailureReporter tool
             env:
-              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
+              PERFLAB_TARGET_FRAMEWORKS: $(_Framework)
           - script: |
               $(Python) -m pip install --user --upgrade pip
               $(Python) -m pip install --user requests

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -87,6 +87,12 @@ def helixuploadroot():
     '''
     return environ.get('HELIX_WORKITEM_UPLOAD_ROOT')
 
+def helixworkitemroot():
+    '''
+    Returns the helix workitem root. Will be None outside of helix.
+    '''
+    return environ.get('HELIX_WORKITEM_ROOT')
+
 def runninginlab():
     return environ.get('PERFLAB_INLAB') is not None
 

--- a/src/scenarios/mauiblazorios/post.py
+++ b/src/scenarios/mauiblazorios/post.py
@@ -1,0 +1,7 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+
+clean_directories()

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -1,0 +1,78 @@
+'''
+pre-command
+'''
+import shutil
+import sys
+from performance.logger import setup_loggers, getLogger
+from shared import const
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.precommands import PreCommands
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell_ios
+from test import EXENAME
+
+setup_loggers(True)
+precommands = PreCommands()
+install_versioned_maui(precommands)
+
+# Setup the Maui folder
+precommands.new(template='maui-blazor',
+                output_dir=const.APPDIR,
+                bin_dir=const.BINDIR,
+                exename=EXENAME,
+                working_directory=sys.path[0],
+                no_restore=False)
+
+# Add the index.razor.cs file
+with open(f"{const.APPDIR}/Pages/Index.razor.cs", "w") as indexCSFile:
+    indexCSFile.write('''
+    using Microsoft.AspNetCore.Components;
+    #if ANDROID
+        using Android.App;
+    #endif\n\n''' 
+    + f"    namespace {EXENAME}.Pages" + 
+'''
+    {
+        public partial class Index
+        {
+            protected override void OnAfterRender(bool firstRender)
+            {
+                if (firstRender)
+                {
+                    #if ANDROID
+                        var activity = MainActivity.Context as Activity;
+                        activity.ReportFullyDrawn();
+                    #else
+                        System.Console.WriteLine(\"__MAUI_Blazor_WebView_OnAfterRender__\");
+                    #endif
+                }
+            }
+        }
+    }
+''')
+
+# Replace line in the Android MainActivity.cs file
+with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "r") as mainActivityFile:
+    mainActivityFileLines = mainActivityFile.readlines()
+
+with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "w") as mainActivityFile:
+    for line in mainActivityFileLines:
+        if line.startswith("{"):
+            mainActivityFile.write("{\npublic static Android.Content.Context Context { get; private set; }\npublic MainActivity() { Context = this; }")
+        else:
+            mainActivityFile.write(line)
+
+# Build the APK
+# NuGet.config file cannot be in the build directory currently due to https://github.com/dotnet/aspnetcore/issues/41397
+# shutil.copy('./MauiNuGet.config', './app/Nuget.config')
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
+
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+remove_aab_files(output_dir)
+
+# Copy the MauiVersion to a file so we have it on the machine
+maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/ipa/Payload/{EXENAME}.app/Microsoft.Maui.dll")
+version_dict = { "mauiVersion": maui_version }
+versions_write_json(version_dict, rf"{output_dir}/versions.json")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/ipa/Payload/{EXENAME}.app/Microsoft.Maui.dll")

--- a/src/scenarios/mauiblazorios/test.py
+++ b/src/scenarios/mauiblazorios/test.py
@@ -5,9 +5,9 @@ from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
 
-EXENAME = 'MauiiOSDefault'
+EXENAME = 'MauiBlazoriOSDefault'
 
-if __name__ == "__main__":    
+if __name__ == "__main__":
     versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
 
     traits = TestTraits(exename=EXENAME, 

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -1,10 +1,41 @@
 '''
 pre-command
 '''
-from performance.logger import setup_loggers
-from shutil import copytree
-from shared.const import PUBDIR
+import shutil
+import sys
+import subprocess
+from performance.logger import setup_loggers, getLogger
+from shared import const
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.precommands import PreCommands
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell_ios
+from test import EXENAME
 
 setup_loggers(True)
 
-copytree('app', PUBDIR)
+precommands = PreCommands()
+install_versioned_maui(precommands)
+
+# Setup the Maui folder
+precommands.new(template='maui',
+                output_dir=const.APPDIR,
+                bin_dir=const.BINDIR,
+                exename=EXENAME,
+                working_directory=sys.path[0],
+                no_restore=False)
+
+# Build the APK
+shutil.copy('./MauiNuGet.config', './app/Nuget.config')
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
+
+# Remove the aab files as we don't need them, this saves space
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+remove_aab_files(output_dir)
+
+# Copy the MauiVersion to a file so we have it on the machine
+maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/ipa/Payload/{EXENAME}.app/Microsoft.Maui.dll")
+version_dict = { "mauiVersion": maui_version }
+versions_write_json(version_dict, rf"{output_dir}/versions.json")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/ipa/Payload/{EXENAME}.app/Microsoft.Maui.dll")

--- a/src/scenarios/mauiiospodcast/post.py
+++ b/src/scenarios/mauiiospodcast/post.py
@@ -1,0 +1,9 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+from performance.common import remove_directory
+
+remove_directory("dotnet-podcasts")
+clean_directories()

--- a/src/scenarios/mauiiospodcast/pre.py
+++ b/src/scenarios/mauiiospodcast/pre.py
@@ -1,0 +1,34 @@
+'''
+pre-command
+'''
+import subprocess
+from performance.logger import setup_loggers, getLogger
+from shared.precommands import PreCommands
+from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.versionmanager import versions_write_json, get_version_from_dll_powershell
+from shared import const
+
+setup_loggers(True)
+precommands = PreCommands()
+install_versioned_maui(precommands)
+
+branch = f'{precommands.framework[:6]}'
+subprocess.run(['git', 'clone', 'https://github.com/microsoft/dotnet-podcasts.git', '-b', branch, '--single-branch', '--depth', '1'])
+subprocess.run(['powershell', '-Command', r'Remove-Item -Path .\\dotnet-podcasts\\.git -Recurse -Force']) # Git files have permission issues, do their deletion separately
+
+precommands.existing(projectdir='./dotnet-podcasts', projectfile='./src/Mobile/Microsoft.NetConf2021.Maui.csproj')
+
+# Build the APK
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.netconf2021.maui'])
+
+# Remove the aab files as we don't need them, this saves space
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+remove_aab_files(output_dir)
+
+# Copy the MauiVersion to a file so we have it on the machine
+# maui_version = get_version_from_dll_powershell(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked\Microsoft.Maui.dll")
+# version_dict = { "mauiVersion": maui_version }
+# versions_write_json(version_dict, rf"{output_dir}\versions.json")
+# print(f"Versions: {version_dict}")

--- a/src/scenarios/mauiiospodcast/test.py
+++ b/src/scenarios/mauiiospodcast/test.py
@@ -5,10 +5,10 @@ from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
 
-EXENAME = 'MauiiOSDefault'
+EXENAME = 'MauiiOSPodcast'
 
-if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
+if __name__ == "__main__":
+    #versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -20,7 +20,7 @@ from shared.startup import StartupWrapper
 from shared.util import publishedexe, pythoncommand, appfolder, xharnesscommand
 from shared.sod import SODWrapper
 from shared import const
-from performance.common import RunCommand, iswin, extension
+from performance.common import RunCommand, iswin, extension, helixworkitemroot
 from performance.logger import setup_loggers
 from shared.testtraits import TestTraits, testtypes
 from subprocess import CalledProcessError

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -7,15 +7,14 @@ import sys
 import os
 import glob
 import re
-from datetime import datetime
 import time
+from datetime import datetime
+import json
 
 from logging import getLogger
-from collections import namedtuple
 from argparse import ArgumentParser
 from argparse import RawTextHelpFormatter
-from io import StringIO
-from shutil import move
+from shutil import rmtree
 from shared.crossgen import CrossgenArguments
 from shared.startup import StartupWrapper
 from shared.util import publishedexe, pythoncommand, appfolder, xharnesscommand
@@ -24,6 +23,7 @@ from shared import const
 from performance.common import RunCommand, iswin, extension
 from performance.logger import setup_loggers
 from shared.testtraits import TestTraits, testtypes
+from subprocess import CalledProcessError
 
 
 class Runner:

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -7,6 +7,7 @@ import sys
 import os
 import glob
 import re
+from datetime import datetime
 import time
 
 from logging import getLogger

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -29,3 +29,7 @@ def versions_read_json_file_save_env(inputfile = 'versions.json'):
 def get_version_from_dll_powershell(dll_path: str):
     result = subprocess.run(['powershell', '-Command', rf'Get-ChildItem {dll_path} | Select-Object -ExpandProperty VersionInfo | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     return result.stdout.decode('utf-8').strip()
+
+def get_version_from_dll_powershell_ios(dll_path: str):
+    result = subprocess.run(['pwsh', '-Command', rf'Get-ChildItem {dll_path} | Select-Object -ExpandProperty VersionInfo | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
+    return result.stdout.decode('utf-8').strip()


### PR DESCRIPTION
Essentially a backport of https://github.com/dotnet/performance/pull/2942 with minor additions to fix missing includes, such as importing json and adding helixworkitemroot in common.py. maui_ios_scenario Test run here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2155672&view=results. Only failure appears to be Blazor, which we have seen before as the issue is not being able to collect all the startups successfully. Flow improvement issue to fix this here: https://github.com/dotnet/performance/issues/2965