### PR TITLE
Add retries to result uploading

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -17,6 +17,7 @@ from platform import machine
 
 import os
 import sys
+import time
 
 
 def get_machine_architecture():
@@ -156,6 +157,37 @@ def push_dir(path: str = None) -> None:
             os.chdir(prev)
     else:
         yield
+
+def retry_on_exception(function, retry_count=3, retry_delay=5, retry_delay_multiplier=1, retry_on_exception=None):
+    '''
+    Retries the specified function if it throws an exception.
+
+    :param function: The function to execute.
+    :param retry_count: The number of times to retry the function.
+    :param retry_delay: The delay between retries (seconds).
+    :param retry_delay_multiplier: The multiplier to apply to the retry delay after failure.
+    :param retry_on_exception: The exception to retry on (Defaults to Exception).
+    '''
+    if retry_count < 0:
+        raise ValueError('retry_count must be >= 0')
+    if retry_delay < 0:
+        raise ValueError('retry_delay must be >= 0')
+    if retry_delay_multiplier < 1:
+        raise ValueError('retry_delay_multiplier must be >= 1')
+
+    if retry_on_exception is None:
+        retry_on_exception = Exception
+
+    for i in range(retry_count):
+        try:
+            return function()
+        except retry_on_exception as e:
+            if i == retry_count - 1:
+                raise
+            getLogger().info('Exception caught: %s', e)
+            getLogger().info('Retrying in %d seconds...', retry_delay)
+            time.sleep(retry_delay)
+            retry_delay *= retry_delay_multiplier
 
 
 class RunCommand:

--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -158,7 +158,7 @@ def push_dir(path: str = None) -> None:
     else:
         yield
 
-def retry_on_exception(function, retry_count=3, retry_delay=5, retry_delay_multiplier=1, retry_on_exception=None):
+def retry_on_exception(function, retry_count=3, retry_delay=5, retry_delay_multiplier=1, retry_on_exception=Exception):
     '''
     Retries the specified function if it throws an exception.
 
@@ -175,9 +175,6 @@ def retry_on_exception(function, retry_count=3, retry_delay=5, retry_delay_multi
     if retry_delay_multiplier < 1:
         raise ValueError('retry_delay_multiplier must be >= 1')
 
-    if retry_on_exception is None:
-        retry_on_exception = Exception
-
     for i in range(retry_count):
         try:
             return function()
@@ -188,7 +185,6 @@ def retry_on_exception(function, retry_count=3, retry_delay=5, retry_delay_multi
             getLogger().info('Retrying in %d seconds...', retry_delay)
             time.sleep(retry_delay)
             retry_delay *= retry_delay_multiplier
-
 
 class RunCommand:
     '''

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -2,6 +2,7 @@ from azure.storage.blob import BlobClient, ContentSettings
 from azure.storage.queue import QueueClient, TextBase64EncodePolicy
 from traceback import format_exc
 from glob import glob
+from performance.common import retry_on_exception
 import os
 import time
 
@@ -23,7 +24,7 @@ def upload(globpath, container, queue, sas_token_env, storage_account_uri):
             return 1
 
         files = glob(globpath, recursive=True)
-
+        any_upload_or_queue_failed = False
         for infile in files:
             blob_name = get_unique_name(infile, os.getenv('HELIX_WORKITEM_ID'))
 
@@ -31,34 +32,30 @@ def upload(globpath, container, queue, sas_token_env, storage_account_uri):
 
             blob_client = BlobClient(account_url=storage_account_uri.format('blob'), container_name=container, blob_name=blob_name, credential=sas_token)
             
-            uploadedSuccessfully = False
-            for i in range(3):
+            upload_succeded = False
+            with open(infile, "rb") as data:
                 try:
-                    with open(infile, "rb") as data:
-                        blob_client.upload_blob(data, blob_type="BlockBlob", content_settings=ContentSettings(content_type="application/json"))
-                    uploadedSuccessfully = True
-                    break
+                    retry_on_exception(lambda: blob_client.upload_blob(data, blob_type="BlockBlob", content_settings=ContentSettings(content_type="application/json")))
+                    upload_succeded = True
                 except Exception as ex:
+                    any_upload_or_queue_failed = True
+                    getLogger().error("upload failed")
                     getLogger().error('{0}: {1}'.format(type(ex), str(ex)))
-                    time.sleep(5)
-                    continue
-                
-            if uploadedSuccessfully:
-                for i in range(3):
+
+            if upload_succeded:
+                if queue is not None:
                     try:
-                        if queue is not None:
-                            queue_client = QueueClient(account_url=storage_account_uri.format('queue'), queue_name=queue, credential=sas_token, message_encode_policy=TextBase64EncodePolicy())
-                            queue_client.send_message(blob_client.url)
-                        break
+                        queue_client = QueueClient(account_url=storage_account_uri.format('queue'), queue_name=queue, credential=sas_token, message_encode_policy=TextBase64EncodePolicy())
+                        retry_on_exception(lambda: queue_client.send_message(blob_client.url))
+                        getLogger().info("upload and queue complete")
                     except Exception as ex:
+                        any_upload_or_queue_failed = True
+                        getLogger().error("queue failed")
                         getLogger().error('{0}: {1}'.format(type(ex), str(ex)))
-                        time.sleep(5)
-                        continue
-                getLogger().info("upload complete")
-            else:
-                getLogger().error("upload failed")
-                return 1
-        return 0
+                else:
+                    getLogger().info("upload complete")
+
+        return any_upload_or_queue_failed # 0 (False) if all uploads and queues succeeded, 1 (True) otherwise
 
     except Exception as ex:
         getLogger().error('{0}: {1}'.format(type(ex), str(ex)))


### PR DESCRIPTION
Put the upload blob and queue send message into a looping try catch that tries to do the action 3 times with 5 seconds between attempts. This is to hopefully help with individual jobs from the pipeline failing due to Server Busy errors (API limit reached). This was a quick change so am open to other suggestions.