### PR TITLE
Use a different build container for Ubuntu runs (CentOS testing needed)

### DIFF
--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -78,7 +78,7 @@ jobs:
         vmImage: ubuntu-latest
       machinePool: Open
       queue: centos.7.amd64.open
-      container: ubuntu_x64_build_container
+      container: centos_x64_build_container
       ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if and(containsValue(parameters.buildMachines, 'win-arm64'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 only used in private builds currently

--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -59,7 +59,7 @@ jobs:
       architecture: x64
       pool: 
         vmImage: ubuntu-latest
-      container: centos_x64_build_container
+      container: ubuntu_x64_build_container
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
         machinePool: Open
@@ -78,7 +78,7 @@ jobs:
         vmImage: ubuntu-latest
       machinePool: Open
       queue: centos.7.amd64.open
-      container: centos_x64_build_container
+      container: ubuntu_x64_build_container
       ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if and(containsValue(parameters.buildMachines, 'win-arm64'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 only used in private builds currently


### PR DESCRIPTION
Run demonstrating that this allows for dotnet to be installed and what not: https://dev.azure.com/dnceng/internal/_build/results?buildId=2163615&view=results

Related to https://github.com/dotnet/sdk/issues/31893. CentOS container may need extra stuff to work properly.