### PR TITLE
Make it so that setup_loggers will only setup 1 logger globally

### DIFF
--- a/scripts/performance/logger.py
+++ b/scripts/performance/logger.py
@@ -14,6 +14,7 @@ import __main__
 
 from .common import get_repo_root_path
 
+__initialized = False
 
 def setup_loggers(verbose: bool):
     '''Setup the root logger for the performance scripts.'''
@@ -72,4 +73,7 @@ def setup_loggers(verbose: bool):
         file_handler.setFormatter(__formatter())
         return file_handler
 
-    __initialize(verbose)
+    global __initialized
+    if not __initialized:
+        __initialize(verbose)
+        __initialized = True


### PR DESCRIPTION
Make it so that setup_loggers will only setup 1 logger in a at most once fashion. This will keep child calls to setup_loggers from creating duplicate loggers and duplicate output lines.

One side effect of this is that multiple setup_loggers calls will only have the first verbosity value set.

Open to feedback on whether we think this is how the functionality should work.