### PR TITLE
Upload perf-lab-reports to helix if uploading to our storage

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -311,7 +311,7 @@ def __main(args: list) -> int:
                 '*perf-lab-report.json')
 
             for file in glob(globpath, recursive=True):
-                copy(file, os.path.join(helixuploadroot(), 'report-jsons', file.split(os.sep)[-1]))
+                copy(file, os.path.join(helixuploadroot(), file.split(os.sep)[-1]))
         except CalledProcessError:
             getLogger().info("Run failure registered")
             # rethrow the caught CalledProcessError exception so that the exception being bubbled up correctly.

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -309,6 +309,9 @@ def __main(args: list) -> int:
                 get_artifacts_directory() if not args.bdn_artifacts else args.bdn_artifacts,
                 '**',
                 '*perf-lab-report.json')
+
+            for file in glob.glob(globpath, recursive=True):
+                copy(file, os.path.join(helixuploadroot(), file))
         except CalledProcessError:
             getLogger().info("Run failure registered")
             # rethrow the caught CalledProcessError exception so that the exception being bubbled up correctly.
@@ -318,8 +321,6 @@ def __main(args: list) -> int:
 
         if args.upload_to_perflab_container:
             import upload
-            for file in glob.glob(globpath, recursive=True):
-                copy(file, os.path.join(helixuploadroot(), file))
             upload_code = upload.upload(globpath, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
             getLogger().info("Benchmarks Upload Code: " + str(upload_code))
             if upload_code != 0:

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -310,7 +310,7 @@ def __main(args: list) -> int:
                 '**',
                 '*perf-lab-report.json')
 
-            for file in glob.glob(globpath, recursive=True):
+            for file in glob(globpath, recursive=True):
                 copy(file, os.path.join(helixuploadroot(), file))
         except CalledProcessError:
             getLogger().info("Run failure registered")

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -27,11 +27,13 @@ from logging import getLogger
 import os
 import sys
 
-from performance.common import extension, helixpayload, runninginlab, validate_supported_runtime, get_artifacts_directory, RunCommand
+from performance.common import extension, helixpayload, runninginlab, validate_supported_runtime, get_artifacts_directory, helixuploadroot, RunCommand
 from performance.logger import setup_loggers
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from channel_map import ChannelMap
 from subprocess import Popen, CalledProcessError
+from shutil import copy
+from glob import glob
 
 import dotnet
 import micro_benchmarks
@@ -316,6 +318,8 @@ def __main(args: list) -> int:
 
         if args.upload_to_perflab_container:
             import upload
+            for file in glob.glob(globpath, recursive=True):
+                copy(file, os.path.join(helixuploadroot(), file))
             upload_code = upload.upload(globpath, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
             getLogger().info("Benchmarks Upload Code: " + str(upload_code))
             if upload_code != 0:

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -311,7 +311,7 @@ def __main(args: list) -> int:
                 '*perf-lab-report.json')
 
             for file in glob(globpath, recursive=True):
-                copy(file, os.path.join(helixuploadroot(), file))
+                copy(file, os.path.join(helixuploadroot(), 'report-jsons', file.split(os.sep)[-1]))
         except CalledProcessError:
             getLogger().info("Run failure registered")
             # rethrow the caught CalledProcessError exception so that the exception being bubbled up correctly.


### PR DESCRIPTION
Upload perf-lab-reports to helix if uploading to our storage. This is so we have some way to get the report data if uploading to our storage fails for some reason.