### PR TITLE
Add processor affinity option for BDN runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -351,101 +351,101 @@ jobs:
 # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
 - ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
 
-  # # SDK scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-x86
-  #       - ubuntu-x64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: sdk_scenarios
-  #       projectFile: sdk_scenarios.proj
-  #       channels:
-  #         - main
+  # SDK scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-x86
+        - ubuntu-x64
+      isPublic: false
+      jobParameters:
+        kind: sdk_scenarios
+        projectFile: sdk_scenarios.proj
+        channels:
+          - main
 
-  # # Blazor 3.2 scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: blazor_scenarios
-  #       projectFile: blazor_scenarios.proj
-  #       channels:
-  #         - main
+  # Blazor 3.2 scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+      isPublic: false
+      jobParameters:
+        kind: blazor_scenarios
+        projectFile: blazor_scenarios.proj
+        channels:
+          - main
   
-  # # ML.NET benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: mlnet
-  #       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-  #       runCategories: 'mldotnet'
-  #       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
-  #         - main
+  # ML.NET benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: mlnet
+        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet'
+        channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
 
-  # # F# benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: fsharp
-  #       csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-  #       runCategories: 'fsharp'
-  #       channels:
-  #         - main
+  # F# benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: fsharp
+        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+        runCategories: 'fsharp'
+        channels:
+          - main
 
-  # # bepuphysics benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: bepuphysics
-  #       csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-  #       runCategories: 'BepuPhysics'
-  #       channels:
-  #         - main
+  # bepuphysics benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: bepuphysics
+        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+        runCategories: 'BepuPhysics'
+        channels:
+          - main
 
-  # # ImageSharp benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: imagesharp
-  #       csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-  #       runCategories: 'ImageSharp'
-  #       channels:
-  #         - main
+  # ImageSharp benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: imagesharp
+        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+        runCategories: 'ImageSharp'
+        channels:
+          - main
 
   # Roslyn benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -479,41 +479,41 @@ jobs:
           - main
         affinity: '15'
 
-  # # ILLink benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: illink
-  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-  #       runCategories: 'illink'
-  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-  #         - main
+  # ILLink benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: false
+      jobParameters:
+        kind: illink
+        csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+        runCategories: 'illink'
+        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
 
-  # # Secret Sync
-  # - job: Synchronize
-  #   pool:
-  #     name: NetCore1ESPool-Internal-NoMSI
-  #     demands: ImageOverride -equals 1es-windows-2019
-  #   steps:
-  #   - task: UseDotNet@2
-  #     displayName: Install .NET 6.0 runtime
-  #     inputs:
-  #       version: 6.x
+  # Secret Sync
+  - job: Synchronize
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    - task: UseDotNet@2
+      displayName: Install .NET 6.0 runtime
+      inputs:
+        version: 6.x
 
-  #   - script: dotnet tool restore
+    - script: dotnet tool restore
 
-  #   - task: AzureCLI@2
-  #     inputs:
-  #       azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-  #       scriptType: ps
-  #       scriptLocation: inlineScript
-  #       inlineScript: |
-  #         Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
 ################################################
 # Manually Triggered Job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -351,101 +351,101 @@ jobs:
 # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
 - ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
 
-  # SDK scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-x86
-        - ubuntu-x64
-      isPublic: false
-      jobParameters:
-        kind: sdk_scenarios
-        projectFile: sdk_scenarios.proj
-        channels:
-          - main
+  # # SDK scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-x86
+  #       - ubuntu-x64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: sdk_scenarios
+  #       projectFile: sdk_scenarios.proj
+  #       channels:
+  #         - main
 
-  # Blazor 3.2 scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-      isPublic: false
-      jobParameters:
-        kind: blazor_scenarios
-        projectFile: blazor_scenarios.proj
-        channels:
-          - main
+  # # Blazor 3.2 scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: blazor_scenarios
+  #       projectFile: blazor_scenarios.proj
+  #       channels:
+  #         - main
   
-  # ML.NET benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: mlnet
-        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-        runCategories: 'mldotnet'
-        channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
+  # # ML.NET benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: mlnet
+  #       csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+  #       runCategories: 'mldotnet'
+  #       channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
+  #         - main
 
-  # F# benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: fsharp
-        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-        runCategories: 'fsharp'
-        channels:
-          - main
+  # # F# benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: fsharp
+  #       csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+  #       runCategories: 'fsharp'
+  #       channels:
+  #         - main
 
-  # bepuphysics benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: bepuphysics
-        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-        runCategories: 'BepuPhysics'
-        channels:
-          - main
+  # # bepuphysics benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: bepuphysics
+  #       csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+  #       runCategories: 'BepuPhysics'
+  #       channels:
+  #         - main
 
-  # ImageSharp benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: imagesharp
-        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-        runCategories: 'ImageSharp'
-        channels:
-          - main
+  # # ImageSharp benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: imagesharp
+  #       csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+  #       runCategories: 'ImageSharp'
+  #       channels:
+  #         - main
 
   # Roslyn benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -479,41 +479,41 @@ jobs:
           - main
         affinity: '15'
 
-  # ILLink benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: false
-      jobParameters:
-        kind: illink
-        csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-        runCategories: 'illink'
-        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
+  # # ILLink benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: illink
+  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+  #       runCategories: 'illink'
+  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+  #         - main
 
-  # Secret Sync
-  - job: Synchronize
-    pool:
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
-    steps:
-    - task: UseDotNet@2
-      displayName: Install .NET 6.0 runtime
-      inputs:
-        version: 6.x
+  # # Secret Sync
+  # - job: Synchronize
+  #   pool:
+  #     name: NetCore1ESPool-Internal-NoMSI
+  #     demands: ImageOverride -equals 1es-windows-2019
+  #   steps:
+  #   - task: UseDotNet@2
+  #     displayName: Install .NET 6.0 runtime
+  #     inputs:
+  #       version: 6.x
 
-    - script: dotnet tool restore
+  #   - script: dotnet tool restore
 
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+  #   - task: AzureCLI@2
+  #     inputs:
+  #       azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+  #       scriptType: ps
+  #       scriptLocation: inlineScript
+  #       inlineScript: |
+  #         Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
 ################################################
 # Manually Triggered Job

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -454,6 +454,20 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+      isPublic: false
+      jobParameters:
+        kind: roslyn
+        csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+        runCategories: 'roslyn'
+        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
+        affinity: '85'
+
+        # Roslyn benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
         - win-arm64
         - ubuntu-arm64
       isPublic: false
@@ -463,6 +477,7 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
+        affinity: '15'
 
   # ILLink benchmarks
   - template: /eng/performance/build_machine_matrix.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -378,23 +378,6 @@ jobs:
         projectFile: blazor_scenarios.proj
         channels:
           - main
-  
-  # ML.NET benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: mlnet
-        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-        runCategories: 'mldotnet'
-        channels: # for ML.NET jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
 
   # F# benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -447,6 +430,38 @@ jobs:
         channels:
           - main
 
+  # ML.NET benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: false
+      jobParameters:
+        kind: mlnet
+        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet'
+        channels:
+          - main
+        affinity: '85'
+
+  # ML.NET benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: mlnet
+        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet'
+        channels:
+          - main
+        affinity: '15'
+
   # Roslyn benchmarks
   - template: /eng/performance/build_machine_matrix.yml
     parameters:
@@ -463,7 +478,7 @@ jobs:
           - main
         affinity: '85'
 
-        # Roslyn benchmarks
+  # Roslyn benchmarks
   - template: /eng/performance/build_machine_matrix.yml
     parameters:
       jobTemplate: /eng/performance/benchmark_jobs.yml

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -10,6 +10,7 @@ parameters:
   channels: []          # required -- list of channels to download .NET from
   runCategories: ''     # required -- string of space separated categories supplied to benchmark dotnet
   machinePool: ''       # required -- Name of perf machine pool (Tiger, Owl, etc)
+  affinity: '0'         # optional -- Affinity bitmask to a specific machine in the pool (e.g. 1, 2, etc)
 
 jobs:
 - template: ../common/templates/jobs/jobs.yml
@@ -22,6 +23,16 @@ jobs:
         displayName: '${{ parameters.osName }} ${{ parameters.osVersion }} ${{ parameters.architecture }} ${{ parameters.kind }} ${{ parameters.machinePool }}'
         timeoutInMinutes: 320
         variables:
+        - ${{ if ne(parameters.affinity, '0')}}:
+          - name: AffinityBDN
+            value: '--affinity ${{ parameters.affinity }}'
+          - name: AffinityEnvVar
+            value: 'PERFLAB_DATA_AFFINITY_${{ parameters.affinity }}'
+        - ${{ if eq(parameters.affinity, '0')}}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
+          - name: AffinityBDN
+            value: ''
+          - name: AffinityEnvVar
+            value: ''
         - ${{ if eq(parameters.osName, 'windows') }}:
           - name: CliArguments
             value: '--dotnet-versions %DOTNET_VERSION% --cli-source-info args --cli-branch %PERFLAB_BRANCH% --cli-commit-sha %PERFLAB_HASH% --cli-repository https://github.com/%PERFLAB_REPO% --cli-source-timestamp %PERFLAB_BUILDTIMESTAMP%'
@@ -74,7 +85,7 @@ jobs:
             value: dotnet-performance
           # for public runs we want to run the benchmarks exactly once, no warmup, no pilot, no overhead
           - name: BenchmarkDotNetArguments
-            value: '--anyCategories ${{ parameters.runCategories }} --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true'
+            value: '--anyCategories ${{ parameters.runCategories }} --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true $(AffinityBDN)'
           - name: HelixApiAccessToken
             value: ''
           - name: HelixPreCommand
@@ -87,7 +98,7 @@ jobs:
             value: '--upload-to-perflab-container'
           # for private runs we don't provide any custom BDN arguments (the ones from Program.Main are used)
           - name: BenchmarkDotNetArguments
-            value: '--anyCategories ${{ parameters.runCategories }}'
+            value: '--anyCategories ${{ parameters.runCategories }} $(AffinityBDN)'
           - name: Creator
             value: ''
           - name: HelixSourcePrefix
@@ -116,7 +127,7 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs)
+        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --additional-environment-variables $(AffinityEnvVar)
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -24,14 +24,10 @@ jobs:
         timeoutInMinutes: 320
         variables:
         - ${{ if ne(parameters.affinity, '0')}}:
-          - name: AffinityBDN
+          - name: AffinityParam
             value: '--affinity ${{ parameters.affinity }}'
-          - name: AffinityEnvVar
-            value: 'PERFLAB_DATA_AFFINITY=${{ parameters.affinity }}'
         - ${{ if eq(parameters.affinity, '0')}}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
-          - name: AffinityBDN
-            value: ''
-          - name: AffinityEnvVar
+          - name: AffinityParam
             value: ''
         - ${{ if eq(parameters.osName, 'windows') }}:
           - name: CliArguments
@@ -85,7 +81,7 @@ jobs:
             value: dotnet-performance
           # for public runs we want to run the benchmarks exactly once, no warmup, no pilot, no overhead
           - name: BenchmarkDotNetArguments
-            value: '--anyCategories ${{ parameters.runCategories }} --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true $(AffinityBDN)'
+            value: '--anyCategories ${{ parameters.runCategories }} --iterationCount 1 --warmupCount 0 --invocationCount 1 --unrollFactor 1 --strategy ColdStart --stopOnFirstError true $(AffinityParam)'
           - name: HelixApiAccessToken
             value: ''
           - name: HelixPreCommand
@@ -98,7 +94,7 @@ jobs:
             value: '--upload-to-perflab-container'
           # for private runs we don't provide any custom BDN arguments (the ones from Program.Main are used)
           - name: BenchmarkDotNetArguments
-            value: '--anyCategories ${{ parameters.runCategories }} $(AffinityBDN)'
+            value: '--anyCategories ${{ parameters.runCategories }} $(AffinityParam)'
           - name: Creator
             value: ''
           - name: HelixSourcePrefix
@@ -127,7 +123,7 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --additional-environment-variables $(AffinityEnvVar)
+        - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) $(AffinityParam)
           displayName: Run ci_setup.py
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: (robocopy $(Build.SourcesDirectory) $(Build.SourcesDirectory)\notLocked /E /XD $(Build.SourcesDirectory)\notLocked $(Build.SourcesDirectory)\artifacts $(Build.SourcesDirectory)\.git) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -27,7 +27,7 @@ jobs:
           - name: AffinityBDN
             value: '--affinity ${{ parameters.affinity }}'
           - name: AffinityEnvVar
-            value: 'PERFLAB_DATA_AFFINITY_${{ parameters.affinity }}'
+            value: 'PERFLAB_DATA_AFFINITY=${{ parameters.affinity }}'
         - ${{ if eq(parameters.affinity, '0')}}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
           - name: AffinityBDN
             value: ''

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -219,6 +219,12 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
         type=str,
         help='Version of Maui used to build app packages'
     )
+
+    parser.add_argument(
+        '--additional-environment-variables',
+        nargs='*',
+        help='Additional environment variables to set in the setup script'
+    )
     return parser
 
 def __process_arguments(args: list):
@@ -355,6 +361,8 @@ def __main(args: list) -> int:
             out_file.write(variable_format % ('UseSharedCompilation', 'false'))
             out_file.write(variable_format % ('DOTNET_ROOT', dotnet_path))
             out_file.write(variable_format % ('MAUI_VERSION', args.maui_version))
+            for env_var in args.additional_environment_variables:
+                out_file.write(variable_format % (env_var.split('=')[0], env_var.split('=')[1]))
             out_file.write(path_variable % dotnet_path)
             out_file.write(showenv)
     else:

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -221,9 +221,9 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     )
 
     parser.add_argument(
-        '--additional-environment-variables',
-        nargs='*',
-        help='Additional environment variables to set in the setup script'
+        '--affinity',
+        required=False,
+        help='Affinity value set for BenchmarkDotNet to set as PERFLAB_DATA_AFFINITY'
     )
     return parser
 
@@ -361,8 +361,8 @@ def __main(args: list) -> int:
             out_file.write(variable_format % ('UseSharedCompilation', 'false'))
             out_file.write(variable_format % ('DOTNET_ROOT', dotnet_path))
             out_file.write(variable_format % ('MAUI_VERSION', args.maui_version))
-            for env_var in args.additional_environment_variables:
-                out_file.write(variable_format % (env_var.split('=')[0], env_var.split('=')[1]))
+            if args.affinity:
+                out_file.write(variable_format % ('PERFLAB_DATA_AFFINITY', args.affinity))
             out_file.write(path_variable % dotnet_path)
             out_file.write(showenv)
     else:


### PR DESCRIPTION
This adds processor affinity passthrough option for BDN runs that is defined in the yml files. This also sets up Roslyn and Ml.NET to us this affinity parameter. This will likely be quickly iterated on once a path forward for passing environment variables through is figured out.