### PR TITLE
Update AffinityParam Assignment based on feedback

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -23,11 +23,10 @@ jobs:
         displayName: '${{ parameters.osName }} ${{ parameters.osVersion }} ${{ parameters.architecture }} ${{ parameters.kind }} ${{ parameters.machinePool }}'
         timeoutInMinutes: 320
         variables:
-        - ${{ if ne(parameters.affinity, '0')}}:
-          - name: AffinityParam
+        - name: AffinityParam
+          ${{ if ne(parameters.affinity, '0')}}:
             value: '--affinity ${{ parameters.affinity }}'
-        - ${{ if eq(parameters.affinity, '0')}}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
-          - name: AffinityParam
+          ${{ else }}: # Affinity of 0 seems to cause problems with BDN, so don't set it if we don't need to
             value: ''
         - ${{ if eq(parameters.osName, 'windows') }}:
           - name: CliArguments


### PR DESCRIPTION
Switch from assigning AffinityParam in two different if statements to only assigning the value based on an if else. This was done to match the format for envvars from https://github.com/dotnet/performance/pull/3025.