### PR TITLE
Fix windows forms large test by enabling the binary formatter

### DIFF
--- a/src/scenarios/windowsformslarge/pre.py
+++ b/src/scenarios/windowsformslarge/pre.py
@@ -10,4 +10,4 @@ from shared import const
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing(os.path.join(sys.path[0], const.SRCDIR), 'WinformsNetCorePerfApp1.csproj')
-precommands.execute()
+precommands.execute(["/p:EnableUnsafeBinaryFormatterSerialization=true"]) # Enable Binary Formatter until https://github.com/dotnet/winforms/issues/9110 is fixed


### PR DESCRIPTION
Fix windows forms large test by enabling the binary formatter until a proper fix is in place in the winforms repo. The change includes a comment explaining what we are waiting on a fix for.
This fixes https://github.com/dotnet/performance/issues/3037. 
Reverting this temporary fix is tracked by: https://github.com/dotnet/performance/issues/3041