### PR TITLE
Workaround the weird Linux musl failure by explicitily deleting the directory before really installing again.

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -56,6 +56,9 @@ def init_tools(
         for target_framework_moniker in target_framework_monikers
     ]
 
+    dotnet.remove_dotnet(
+        architecture=architecture
+    )
     dotnet.install(
         architecture=architecture,
         channels=channels,

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -734,7 +734,9 @@ def remove_dotnet(architecture: str) -> str:
     Removes the dotnet installed in the tools directory associated with the
     specified architecture.
     '''
-    rmtree(__get_directory(architecture))
+    dotnet_path = __get_directory(architecture)
+    if path.isdir(dotnet_path):
+        rmtree(dotnet_path)
 
 def shutdown_server(verbose:bool) -> None:
     '''


### PR DESCRIPTION
Fixes #3052.