### PR TITLE
Add release/7.0-staging to the channel map

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,6 +7,11 @@ class ChannelMap():
             'branch': '7.0.1xx',
             'quality': 'daily'
         },
+        'release/7.0-staging': {
+            'tfm': 'net7.0',
+            'branch': '7.0',
+            'quality': 'daily'
+        },
         'release/7.0-rc2': {
             'tfm': 'net7.0',
             'branch': '7.0-rc2',


### PR DESCRIPTION
Add release/7.0-staging to the channel map since the release/7.0 runtime now has a staging branch.

