### PR TITLE
Add windows ampere queue to build machines and use them were desired

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,7 +278,7 @@ jobs:
         - win-x64
         - ubuntu-x64
         - win-arm64
-        - ubuntu-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -292,7 +292,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        - win-arm64
+        - win-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -341,7 +341,7 @@ jobs:
   #      - win-x64
   #      - ubuntu-x64
   #      - win-arm64
-  #      - ubuntu-arm64
+  #      - ubuntu-arm64-ampere
   #    isPublic: false
   #    jobParameters:
   #      kind: maui_scenarios
@@ -407,7 +407,7 @@ jobs:
         - win-x64
         - ubuntu-x64
         - win-arm64
-        - ubuntu-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: fsharp
@@ -424,7 +424,7 @@ jobs:
         - win-x64
         - ubuntu-x64
         - win-arm64
-        - ubuntu-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: bepuphysics
@@ -441,7 +441,7 @@ jobs:
         - win-x64
         - ubuntu-x64
         - win-arm64
-        - ubuntu-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: imagesharp
@@ -457,8 +457,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: mlnet
@@ -479,8 +479,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: roslyn

--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -80,7 +80,19 @@ jobs:
       queue: Windows.10.Arm64.Perf.Surf
       ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if and(containsValue(parameters.buildMachines, 'ubuntu-arm64'), not(eq(parameters.isPublic, true))) }}: # Ubuntu ARM64 only used in private builds currently
+- ${{ if and(containsValue(parameters.buildMachines, 'win-arm64-ampere'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 only used in private builds currently
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osName: windows
+      osVersion: 20H1
+      architecture: arm64
+      pool:
+        vmImage: windows-2019
+      machinePool: Ampere
+      queue: Windows.Server.Arm64.Perf
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if and(containsValue(parameters.buildMachines, 'ubuntu-arm64-ampere'), not(eq(parameters.isPublic, true))) }}: # Ubuntu ARM64 only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osName: ubuntu


### PR DESCRIPTION
Add windows ampere queue to build machines, add the ampere specifier to the ubuntu ampere, and switch to using them for the real world runs.
