### PR TITLE
Mitigate Maui android publish failing due to NETSDK1191

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,41 +270,41 @@ jobs:
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
-  # # Scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios.proj
-  #       channels:
-  #         - main
+  # Scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios.proj
+        channels:
+          - main
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -312,7 +312,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        # - win-x64-android-arm64-galaxy
+        - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
@@ -320,49 +320,49 @@ jobs:
         dotnetVersionsLinks:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # # Maui iOS scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_ios
-  #       projectFile: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # Maui iOS scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # ## Maui scenario benchmarks
-  # #- template: /eng/performance/build_machine_matrix.yml
-  # #  parameters:
-  # #    jobTemplate: /eng/performance/scenarios.yml
-  # #    buildMachines:
-  # #      - win-x64
-  # #      - ubuntu-x64
-  # #      - win-arm64
-  # #      - ubuntu-arm64
-  # #    isPublic: false
-  # #    jobParameters:
-  # #      kind: maui_scenarios
-  # #      projectFile: maui_scenarios.proj
-  # #      channels:
-  # #        - main
+  ## Maui scenario benchmarks
+  #- template: /eng/performance/build_machine_matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/performance/scenarios.yml
+  #    buildMachines:
+  #      - win-x64
+  #      - ubuntu-x64
+  #      - win-arm64
+  #      - ubuntu-arm64
+  #    isPublic: false
+  #    jobParameters:
+  #      kind: maui_scenarios
+  #      projectFile: maui_scenarios.proj
+  #      channels:
+  #        - main
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: nativeaot_scenarios
-  #       projectFile: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
 
 ################################################
 # Scheduled Private jobs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,41 +270,41 @@ jobs:
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
-  # Scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios.proj
-        channels:
-          - main
+  # # Scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios.proj
+  #       channels:
+  #         - main
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -312,7 +312,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
+        # - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
@@ -320,49 +320,49 @@ jobs:
         dotnetVersionsLinks:
           main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # Maui iOS scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # # Maui iOS scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_ios
+  #       projectFile: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  ## Maui scenario benchmarks
-  #- template: /eng/performance/build_machine_matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/performance/scenarios.yml
-  #    buildMachines:
-  #      - win-x64
-  #      - ubuntu-x64
-  #      - win-arm64
-  #      - ubuntu-arm64
-  #    isPublic: false
-  #    jobParameters:
-  #      kind: maui_scenarios
-  #      projectFile: maui_scenarios.proj
-  #      channels:
-  #        - main
+  # ## Maui scenario benchmarks
+  # #- template: /eng/performance/build_machine_matrix.yml
+  # #  parameters:
+  # #    jobTemplate: /eng/performance/scenarios.yml
+  # #    buildMachines:
+  # #      - win-x64
+  # #      - ubuntu-x64
+  # #      - win-arm64
+  # #      - ubuntu-arm64
+  # #    isPublic: false
+  # #    jobParameters:
+  # #      kind: maui_scenarios
+  # #      projectFile: maui_scenarios.proj
+  # #      channels:
+  # #        - main
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: nativeaot_scenarios
+  #       projectFile: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
 
 ################################################
 # Scheduled Private jobs

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py build -f $(PERFLAB_Framework)-android -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py build -f $(PERFLAB_Framework)-android -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>


### PR DESCRIPTION
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2196823&view=logs&j=d610060c-e82a-5178-ebd9-7afbbedc05c2

Fixes: https://github.com/dotnet/performance/issues/3045

May impact the SOD tests with only android-arm64 being built for sure now.