### PR TITLE
Use no-self-contained for Maui Android Publish to keep SOD consistent

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android --no-self-contained -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>


### PR DESCRIPTION
Publishing no-self-contained appears to result in the expected APK file, but allows for the building of all of the RIDs at once. This should keep the SOD results consistent pre and post break. This is a direct follow up to #3076 which used self-contained, meaning only one of the 4 RIDs would be built.

Test Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2197034&view=results

SOD for Maui Android Default APK for validation:
Pre-break run: 33039638.000 bytes
Test run: 33142038.000 bytes 