### PR TITLE
Fixes for GC infrastructure

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/ASPNetBenchmarks.CommandBuilder.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/ASPNetBenchmarks.CommandBuilder.cs
@@ -75,7 +75,8 @@ namespace GC.Infrastructure.Core.CommandBuilders
             commandStringBuilder.Append($" --application.framework net8.0 ");
 
             string corerunToSend = run.Value.corerun.EndsWith("\\") ? run.Value.corerun.Remove(run.Value.corerun.Length - 1) : run.Value.corerun;
-            commandStringBuilder.Append($" --application.options.outputFiles {Path.Combine(Path.GetDirectoryName(corerunToSend), "*.*" )}");
+            commandStringBuilder.Append($" --application.options.outputFiles {Path.Combine(Path.GetDirectoryName(corerunToSend), "coreclr.dll" )}");
+            commandStringBuilder.Append($" --application.options.outputFiles {Path.Combine(Path.GetDirectoryName(corerunToSend), "clrgc.dll" )}");
 
             // Get the log.
             commandStringBuilder.Append(" --application.options.downloadOutput true ");

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/InputConfiguration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/InputConfiguration.cs
@@ -27,7 +27,14 @@
             // Preconditions.
             if (configuration.coreruns == null)
             {
-                throw new ArgumentException($"{nameof(InputConfigurationParser)}: Provide a set of coreruns use for the analysis.");
+                throw new ArgumentException($"{nameof(InputConfigurationParser)}: Provide a set of coreruns use for the analysis.");                
+            }
+            foreach (CoreRunInfo corerun in configuration.coreruns.Values)
+            {
+                if (string.IsNullOrEmpty(corerun.Path) || !File.Exists(corerun.Path))
+                {
+                    throw new ArgumentException($"{nameof(InputConfigurationParser)}: CoreRun.exe must be provided or exist.");                
+                }
             }
 
             if (string.IsNullOrEmpty(configuration.output_path))
@@ -40,7 +47,9 @@
                 throw new ArgumentException($"{nameof(InputConfigurationParser)}: A path to the gcperfsim dll must be provided or exist.");
             }
 
-            if (string.IsNullOrEmpty(configuration.microbenchmark_path) || !Directory.Exists(configuration.microbenchmark_path))
+            string microbenchmarkExecutablePath = Path.Combine(configuration.microbenchmark_path, "../../../artifacts/bin/MicroBenchmarks/Release/net7.0/MicroBenchmarks.exe");
+
+            if (string.IsNullOrEmpty(configuration.microbenchmark_path) || !Directory.Exists(configuration.microbenchmark_path) || !File.Exists(microbenchmarkExecutablePath))
             {
                 throw new ArgumentException($"{nameof(InputConfigurationParser)}: A path to the microbenchmarks must be provided or exist.");
             }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/ASPNetBenchmarks/AspNetBenchmarksAnalyzeCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/ASPNetBenchmarks/AspNetBenchmarksAnalyzeCommand.cs
@@ -183,6 +183,11 @@ namespace GC.Infrastructure.Commands.ASPNetBenchmarks
             List<MetricResult> results = new();
             string[] firstLineSplit = resultsLineSplit[0].Split("|", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
+            if (firstLineSplit.Length < 3)
+            {
+                return results;
+            }
+
             string baseline  = firstLineSplit[1];
             string comparand = firstLineSplit[2];
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/RunCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/RunCommand.cs
@@ -153,8 +153,11 @@ namespace GC.Infrastructure.Commands.RunCommand
                         uniqueMicrobenchmarks.Add(r);
                     }
 
-                    MicrobenchmarkComparisonResults comparisonResults = microbenchmarkResults.AnalysisResults.First();
-                    allMicrobenchmarkResults[config.Name] = comparisonResults;
+                    if (microbenchmarkResults.AnalysisResults.Count > 0)
+                    {
+                        MicrobenchmarkComparisonResults comparisonResults = microbenchmarkResults.AnalysisResults.First();
+                        allMicrobenchmarkResults[config.Name] = comparisonResults;
+                    }
                 }
 
                 catch (Exception e)

--- a/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
+++ b/src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.cs
@@ -1808,7 +1808,9 @@ class ArgsParser
         {
             SizeSlot.BuildSOHBucketSpecsFromSizeDistribution(bucketList, sohSurvInterval, reqSohSurvInterval, sohPinInterval, sohFinalizableInterval);
             SizeSlot.BuildLOHBucketSpecsFromSizeDistribution(bucketList, lohSurvInterval, reqLohSurvInterval, lohPinInterval, lohFinalizableInterval);
+#if NET5_0_OR_GREATER
             SizeSlot.BuildPOHBucketSpecsFromSizeDistribution(bucketList, pohSurvInterval, reqPohSurvInterval, 0,              pohFinalizableInterval);
+#endif
         }
         else
         {


### PR DESCRIPTION
This fixes a few things:

- GCPerfSim to build on netcore3.1 and netcore2.2 (not sure why we still build for them, but better keep the build working)

- Add some more checks to fail faster in case of human errors (e.g. microbenchmark not built, core_root has no corerun.exe). These are huge time sinks, wasting time running and debugging just to realize forgot to build.

- Avoid crashing when a baseline is not provided (e.g. I already had the baseline run/I am not interested in comparing) 

