### PR TITLE
Remove optimizeForReading parameter to compensate for dotnet/runtime#87988

### DIFF
--- a/src/benchmarks/micro/libraries/System.Collections/Create/CtorFromCollection.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Create/CtorFromCollection.cs
@@ -104,6 +104,6 @@ namespace System.Collections
         public FrozenDictionary<T, T> FrozenDictionary() => _dictionary.ToFrozenDictionary();
 
         [Benchmark]
-        public FrozenDictionary<T, T> FrozenDictionaryOptimized() => _dictionary.ToFrozenDictionary(optimizeForReading: true);
+        public FrozenDictionary<T, T> FrozenDictionaryOptimized() => _dictionary.ToFrozenDictionary();
     }
 }

--- a/src/benchmarks/micro/libraries/System.Collections/TryGetValue/TryGetValueFalse.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/TryGetValue/TryGetValueFalse.cs
@@ -48,7 +48,7 @@ namespace System.Collections
             _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
             _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
             _frozenDictionary = _source.ToFrozenDictionary();
-            _frozenDictionaryOptimized = _source.ToFrozenDictionary(optimizeForReading: true);
+            _frozenDictionaryOptimized = _source.ToFrozenDictionary();
         }
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Collections/TryGetValue/TryGetValueTrue.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/TryGetValue/TryGetValueTrue.cs
@@ -46,7 +46,7 @@ namespace System.Collections
             _immutableDictionary = Immutable.ImmutableDictionary.CreateRange<TKey, TValue>(_source);
             _immutableSortedDictionary = Immutable.ImmutableSortedDictionary.CreateRange<TKey, TValue>(_source);
             _frozenDictionary = _source.ToFrozenDictionary();
-            _frozenDictionaryOptimized = _source.ToFrozenDictionary(optimizeForReading: true);
+            _frozenDictionaryOptimized = _source.ToFrozenDictionary();
         }
 
         [Benchmark]


### PR DESCRIPTION
With dotnet/runtime#87988, we removed the `optimizeForReading` overloads from FrozenDictionary/Set. We need to remove our references to that parameter to fix the build.