### PR TITLE
Setup android power consumption test capability

### DIFF
--- a/src/scenarios/shared/androidhelper.py
+++ b/src/scenarios/shared/androidhelper.py
@@ -18,7 +18,7 @@ class AndroidHelper:
         self.startanimatordurationscale = None
         self.startscreenofftimeout = None
 
-    def setup_device(self, packagename, packagepath, animationsdisabled):
+    def setup_device(self, packagename: str, packagepath: str, animationsdisabled: bool, forcewaitstart: bool = True):
         runSplitRegex = ":\s(.+)" 
         self.screenwasoff = False
         self.packagename = packagename
@@ -199,6 +199,7 @@ class AndroidHelper:
             '-n',
             self.activityname
         ]
+
         testRun = RunCommand(self.startappcommand, verbose=True)
         testRun.run()
         testRunStats = re.findall(runSplitRegex, testRun.stdout) # Split results saving value (List: Starting, Status, LaunchState, Activity, TotalTime, WaitTime) 
@@ -229,6 +230,20 @@ class AndroidHelper:
             if "com.google.android.permissioncontroller" in testRunStats[3]:
                 getLogger().exception("Failed to get past permission screen, run locally to see if enough next button presses were used.")
                 raise Exception("Failed to get past permission screen, run locally to see if enough next button presses were used.")
+            
+        self.startappcommand = [ 
+            self.adbpath,
+            'shell',
+            'am',
+            'start-activity'
+        ]
+        if forcewaitstart:
+            self.startappcommand += '-W'
+
+        self.startappcommand += [
+            '-n',
+            self.activityname
+        ]
 
     def close_device(self):
         keyInputCmd = [

--- a/src/scenarios/shared/const.py
+++ b/src/scenarios/shared/const.py
@@ -17,6 +17,7 @@ DOTNETWATCH = "dotnetwatch"
 DEVICESTARTUP = "devicestartup"
 DEVICEMEMORYCONSUMPTION = "devicememoryconsumption"
 ANDROIDINSTRUMENTATION = "androidinstrumentation"
+DEVICEPOWERCONSUMPTION = "devicepowerconsumption"
 
 SCENARIO_NAMES = {STARTUP: 'Startup',
                   SDK: 'SDK',
@@ -52,5 +53,7 @@ STARTUP_CROSSGEN2 = "Crossgen2"
 STARTUP_DEVICETIMETOMAIN = "DeviceTimeToMain"
 
 MEMORYCONSUMPTION_ANDROID = "AndroidMemoryConsumption"
+
+POWERCONSUMPTION_ANDROID = "AndroidPowerConsumption"
 
 MINUTE = 60

--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -186,8 +186,8 @@ class DevicePowerConsumptionHelper(object):
 
                 # Get the Uid from the captureUid output
                 # The output format and target are as follows:
-                # package:com.companyname.mauiandroiddefault uid:1<capture start>1453<end capture>
-                uidSearchString = r"package:" + packagename + r" uid:([0-9]*)"
+                # package:com.companyname.mauiandroiddefault uid:<capture start>11453<end capture>
+                uidSearchString = r"package:" + packagename + r" uid:([0-9]+)"
                 uidCapture = re.search(uidSearchString, captureUid.stdout)
                 if not uidCapture:
                     raise Exception("Failed to capture the uid!")
@@ -215,7 +215,7 @@ class DevicePowerConsumptionHelper(object):
                 # Explanation of the 4 groups: https://stackoverflow.com/questions/75390939/android-how-to-interpret-pwi-power-use-item-from-battery-stats-dumpsys
                 # Example output section and target:
                 # 9,11458,l,pwi,uid,0.0820,0,0.134,0.0342 captures total usage, is battery consumer (consult link below), screen usage, and proportional usage
-                totalPowerSearchString = r"[\d]*," + uid + r",l,pwi,uid,([\d]*.?[\d]*),([\d]*.?[\d]*),([\d]*.?[\d]*),([\d]*.?[\d]*)"
+                totalPowerSearchString = r"\d+," + uid + r",l,pwi,uid,(\d+.?\d*),(\d+.?\d*),(\d+.?\d*),(\d+.?\d*)"
                 totalPowerCapture = re.search(totalPowerSearchString, captureProcStats.stdout)
                 if not totalPowerCapture:
                     raise Exception("Failed to capture the total power!")
@@ -227,16 +227,16 @@ class DevicePowerConsumptionHelper(object):
                 # Get timing information
                 # 9,11458,l,fg,10294,0 # Foreground Time (ms, count)
                 # Total cpu time: u=567ms s=167ms               #(user and system/kernel?)
-                foregroundTimeSearchString = r"[\d]*," + uid + r",l,fg,([\d]*),([\d]*)"
+                foregroundTimeSearchString = r"\d+," + uid + r",l,fg,(\d+),(\d+)"
                 foregroundTimeCapture = re.search(foregroundTimeSearchString, captureProcStats.stdout)
                 if not foregroundTimeCapture:
                     raise Exception("Failed to capture the foreground running time!")
                 capturedValues["foregroundTimeMs"] = foregroundTimeCapture.group(1)
                 capturedValues["foregroundTimeCount"] = foregroundTimeCapture.group(2)
 
-                # Get timing information https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/BatteryStats.java;l=4894
+                # Get more timing information https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/BatteryStats.java;l=4894
                 # 9,11458,l,cpu,668,155,0 # cpu time (user, system, 0)
-                cpuTimeSearchString = r"[\d]*," + uid + r",l,cpu,([\d]*),([\d]*),[\d]*"
+                cpuTimeSearchString = r"\d+," + uid + r",l,cpu,(\d+),(\d+),\d+"
                 cpuTimeCapture = re.search(cpuTimeSearchString, captureProcStats.stdout)
                 if not cpuTimeCapture:
                     raise Exception("Failed to capture the cpu running time!")
@@ -247,7 +247,7 @@ class DevicePowerConsumptionHelper(object):
                 #  level: 93
                 #  scale: 100 # ignore
                 #  voltage: 4237
-                levelAndVoltageSearchString = r"level: ([\d]*)[\s\S]*voltage: ([\d]*)"
+                levelAndVoltageSearchString = r"level: (\d+)[\s\S]*voltage: (\d+)"
                 preExecutionCapture = re.search(levelAndVoltageSearchString, preExecutionBatteryInfo.stdout)
                 postExecutionCapture = re.search(levelAndVoltageSearchString, postExecutionBatteryInfo.stdout)
                 if not preExecutionCapture or not postExecutionCapture:

--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -1,0 +1,218 @@
+'''
+Helper/Runner for Android Instrumentation Scenarios tool.
+'''
+import glob
+import re
+import sys
+import os
+from logging import getLogger
+from shutil import copytree
+import time
+from performance.common import extension, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from dotnet import CSharpProject, CSharpProjFile
+from shared import const
+from shared.androidhelper import AndroidHelper
+from shared.util import helixworkitempayload, helixuploaddir, uploadtokenpresent, getruntimeidentifier, xharnesscommand
+from shared.const import *
+from shared.testtraits import TestTraits
+from subprocess import CalledProcessError
+
+class DevicePowerConsumptionHelper(object):
+    '''
+    Wraps powerconsumption.exe, building it if necessary.
+    '''
+    #def __init__(self):
+        # powerconsumptiondir = 'powerconsumption'
+        # self.reportjson = os.path.join(TRACEDIR, 'perf-lab-report.json')
+        # if helixpayload() and os.path.exists(os.path.join(helixpayload(), powerconsumptiondir)):
+        #     self._setpowerconsumptionpath(os.path.join(helixpayload(), powerconsumptiondir))
+        # elif helixworkitempayload() and os.path.exists(os.path.join(helixworkitempayload(), powerconsumptiondir)):
+        #     self._setpowerconsumptionpath(os.path.join(helixworkitempayload(), powerconsumptiondir))
+        # else:
+        #     relpath = os.path.join(get_artifacts_directory(), powerconsumptiondir)
+        #     powerconsumptionproj = os.path.join('..',
+        #                                '..',
+        #                                'tools',
+        #                                'ScenarioMeasurement',
+        #                                'PowerConsumption',
+        #                                'PowerConsumption.csproj')
+        #     powerconsumption = CSharpProject(CSharpProjFile(powerconsumptionproj,
+        #                                            sys.path[0]),
+        #                                            os.path.join(os.path.dirname(powerconsumptionproj),
+        #                                            os.path.join(get_artifacts_directory(), powerconsumptiondir)))
+        #     if not os.path.exists(relpath):
+        #         powerconsumption.restore(get_packages_directory(),
+        #                         True,
+        #                         getruntimeidentifier())
+        #         powerconsumption.publish('Release',
+        #                         relpath,
+        #                         True,
+        #                         get_packages_directory(),
+        #                         None,
+        #                         getruntimeidentifier(),
+        #                         None,
+        #                         '--no-restore'
+        #                         )
+        #     self._setpowerconsumptionpath(powerconsumption.bin_path)
+  
+    def _setpowerconsumptionpath(self, path: str):
+        self.powerconsumptionpath = os.path.join(path, "powerconsumption%s" % extension()) 
+
+    def parsetraces(self, traits: TestTraits):
+        directory = TRACEDIR
+        if traits.tracefolder:
+            directory = TRACEDIR + '/' + traits.tracefolder
+            getLogger().info("Parse Directory: " + directory)
+
+        powerconsumption_args = [
+            self.powerconsumptionpath,
+            '--app-exe', traits.apptorun,
+            '--parse-only',
+            '--power-metric-type', traits.powerconsumptionmetric, 
+            '--trace-name', traits.tracename,
+            '--report-json-path', self.reportjson,
+            '--trace-directory', directory
+        ]
+        if traits.scenarioname:
+            powerconsumption_args.extend(['--scenario-name', traits.scenarioname])
+
+        upload_container = UPLOAD_CONTAINER
+
+        try:
+            RunCommand(powerconsumption_args, verbose=True).run()
+        except CalledProcessError:
+            getLogger().info("Run failure registered")
+            # rethrow the original exception 
+            raise
+
+        if runninginlab():
+            copytree(TRACEDIR, os.path.join(helixuploaddir(), 'traces'))
+            if uploadtokenpresent():
+                import upload
+                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+
+    def runtestsandroid(self, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
+        getLogger().info("Clearing potential previous run nettraces")
+        for file in glob.glob(os.path.join(const.TRACEDIR, 'PerfTest', 'runoutput.trace')):
+            if os.path.exists(file):   
+                getLogger().info("Removed: " + os.path.join(const.TRACEDIR, file))
+                os.remove(file)
+
+        androidHelper = AndroidHelper()
+        try:
+            androidHelper.setup_device(packagename, packagepath, False, False)
+
+            listYepkitBoardsCmd = [
+                'ykushcmd',
+                'ykushxs',
+                '-l'
+            ]
+
+            # Create the fullydrawn command
+            clearBatteryStatsCmd = [ 
+                androidHelper.adbpath,
+                'shell',
+                'dumpsys',
+                'batterystats',
+                '--reset'
+            ]
+
+            disconnectYepKitPowerCmd = [
+                'ykushcmd',
+                'ykushxs',
+                '-d'
+            ]
+
+            reconnectYepKitPowerCmd = [
+                'ykushcmd',
+                'ykushxs',
+                '-u'
+            ]
+
+            captureBatteryStatsCmd = [ 
+                androidHelper.adbpath,
+                'shell',
+                'dumpsys',
+                'batterystats',
+                '--charged',
+                packagename,
+            ]
+
+            clearLogsCmd = [
+                androidHelper.adbpath,
+                'logcat',
+                '-c'
+            ]
+
+            allResults = []
+            # Verify that a yepkit board is found
+            yepkitCheck = RunCommand(listYepkitBoardsCmd, verbose=True)
+            yepkitCheck.run()
+            if "Board found with serial number" not in yepkitCheck.stdout:
+                raise EnvironmentError("Yepkit board not connected.")
+            RunCommand(reconnectYepKitPowerCmd, verbose=True).run() # Make sure the board is connected
+            
+            for i in range(testiterations):
+                # Clear logs
+                RunCommand(clearLogsCmd, verbose=True).run()
+                RunCommand(clearBatteryStatsCmd, verbose=True).run()
+                startStats = RunCommand(androidHelper.startappcommand, verbose=True)
+                startStats.run()
+                RunCommand(disconnectYepKitPowerCmd, verbose=True).run()
+                time.sleep(runtimeseconds)
+                RunCommand(reconnectYepKitPowerCmd, verbose=True).run()
+                time.sleep(5) # Wait for the phone to reconnect to the commputer
+                captureProcStats = RunCommand(captureBatteryStatsCmd, verbose=True)
+                captureProcStats.run()
+
+                # Save the results and get them from the log
+                RunCommand(androidHelper.stopappcommand, verbose=True).run()
+                
+                # # Part of the output we are regexing:
+                # # Process summary:
+                # # * net.dot.HelloAndroid / u0a1219 / v1:
+                # #        TOTAL: ###% (<Part we want>52MB-52MB-52MB/44MB-44MB-44MB/135MB-135MB-135MB over 1</Part we want>)
+                # #        Top: 100% (52MB-52MB-52MB/44MB-44MB-44MB/135MB-135MB-135MB over 1)
+                # regexSearchString = r"TOTAL: [0-9]{2,3}% \((\d+MB-\d+MB-\d+MB\/\d+MB-\d+MB-\d+MB\/\d+MB-\d+MB-\d+MB over \d+)\)"
+                # dirtyCapture = re.search(regexSearchString, captureProcStats.stdout)
+                # if not dirtyCapture:
+                #     raise Exception("Failed to capture the reported start time!")
+                # splitNumber = dirtyCapture.group(1).replace("MB", "").strip().split(" over ")
+                # splitMemory = splitNumber[0].split("/")
+                # pss = splitMemory[0].split("-")
+                # uss = splitMemory[1].split("-")
+                # rss = splitMemory[2].split("-")
+                # memoryCapture = f"PSS: min {pss[0]}, avg {pss[1]}, max {pss[2]}; USS: min {uss[0]}, avg {uss[1]}, max {uss[2]}; RSS: min {rss[0]}, avg {rss[1]}, max {rss[2]}; Number: {splitNumber[1]}\n"
+                # print(f"Memory Capture: {memoryCapture}")
+                # allResults.append(memoryCapture)
+                time.sleep(closeToStartDelay) # Delay in seconds for ensuring a cold start
+                
+        finally:
+            androidHelper.close_device()
+
+        # Create traces to store the data so we can keep the current general parse trace flow
+        getLogger().info(f"Logs: \n{allResults}")
+        outputdir = os.path.join(const.TRACEDIR,"PerfTest")
+        os.makedirs(outputdir, exist_ok=True)
+        outputtracefile = os.path.join(outputdir, "runoutput.trace")
+        tracefile = open(outputtracefile, "w")
+        for result in allResults:
+            tracefile.write(result)
+        tracefile.close()
+
+        # self.traits.add_traits(overwrite=True, apptorun="app", powerconsumptionmetric=const.POWERCONSUMPTION_ANDROID, tracefolder='PerfTest/', tracename='runoutput.trace', scenarioname=self.scenarioname)
+        # self.parsetraces(self.traits)
+
+    def runtests(self, devicetype: str, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
+        '''
+        Runs Device Power Consumption tests.
+        '''
+        try:
+            if devicetype == 'android':
+                self.runtestsandroid(packagepath, packagename, testiterations, runtimeseconds, closeToStartDelay, traits)
+
+        except CalledProcessError:
+            getLogger().info("Run failure registered")
+            # rethrow the original exception 
+            raise

--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -246,8 +246,7 @@ class DevicePowerConsumptionHelper(object):
             tracefile.write(result)
         tracefile.close()
 
-        # self.traits.add_traits(overwrite=True, apptorun="app", powerconsumptionmetric=const.POWERCONSUMPTION_ANDROID, tracefolder='PerfTest/', tracename='runoutput.trace', scenarioname=self.scenarioname)
-        # self.parsetraces(self.traits)
+        #self.parsetraces(traits)
 
     def runtests(self, devicetype: str, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
         '''

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -46,7 +46,8 @@ class MemoryConsumptionWrapper(object):
                                 None,
                                 getruntimeidentifier(),
                                 None,
-                                '--no-restore'
+                                '--no-restore',
+                                '--self-contained'
                                 )
             self._setmemoryconsumptionpath(memoryconsumption.bin_path)
 

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -3,14 +3,12 @@ Wrapper around memoryconsumption tool.
 '''
 import sys
 import os
-import platform
 from logging import getLogger
 from shutil import copytree
-from performance.logger import setup_loggers
-from performance.common import extension, iswin, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
+from performance.common import extension, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
 from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
-from shared.util import helixworkitempayload, helixuploaddir, builtexe, publishedexe, uploadtokenpresent, getruntimeidentifier, iswin
+from shared.util import helixworkitempayload, helixuploaddir, uploadtokenpresent, getruntimeidentifier
 from shared.const import *
 from shared.testtraits import TestTraits
 from subprocess import CalledProcessError

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -46,8 +46,7 @@ class MemoryConsumptionWrapper(object):
                                 None,
                                 getruntimeidentifier(),
                                 None,
-                                '--no-restore',
-                                '--self-contained'
+                                '--no-restore'
                                 )
             self._setmemoryconsumptionpath(memoryconsumption.bin_path)
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -102,8 +102,8 @@ class Runner:
         devicepowerconsumptionparser.add_argument('--device-type', choices=['android'],type=str.lower,help='Device type for testing', dest='devicetype') # choices=['android','ios'] Only android is supported for now
         devicepowerconsumptionparser.add_argument('--package-path', help='Location of test application', dest='packagepath')
         devicepowerconsumptionparser.add_argument('--package-name', help='Classname (Android)', dest='packagename')
-        devicepowerconsumptionparser.add_argument('--iterations', help='Iterations to run (1+)', type=int, default=6, dest='iterations')
-        devicepowerconsumptionparser.add_argument('--runtime', help='Amount of time to run the app between clearing procstats and dumping them', type=int, default=30, dest='runtimeseconds')
+        devicepowerconsumptionparser.add_argument('--test-iterations', help='Iterations to run (1+)', type=int, default=4, dest='testiterations')
+        devicepowerconsumptionparser.add_argument('--runtime', help='Amount of time to run the app between clearing procstats and dumping them', type=int, default=60, dest='runtimeseconds')
         devicepowerconsumptionparser.add_argument('--time-from-kill-to-start', help='Set an additional delay time for ensuring an app is cleared after closing the app on Android, not on iOS. This should be greater than the greatest amount of expected time needed between closing an app and starting it again for a cold start. Default = 3 seconds', type=int, default=3, dest='closeToStartDelay')
         self.add_common_arguments(devicepowerconsumptionparser)
 
@@ -217,7 +217,7 @@ ex: C:\repos\performance;C:\repos\runtime
             self.devicetype = args.devicetype
             self.packagepath = args.packagepath
             self.packagename = args.packagename
-            self.testiterations = args.iterations
+            self.testiterations = args.testiterations
             self.runtimeseconds = args.runtimeseconds
             self.closeToStartDelay = args.closeToStartDelay
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -402,12 +402,12 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.ANDROIDINSTRUMENTATION:
             androidInstrumentation = AndroidInstrumentationHelper()
-            androidInstrumentation.runtests(self.packagepath, self.packagename, self.instrumentationname) # TODO Do we want to make these part of traits? or keep them separate?
+            androidInstrumentation.runtests(self.packagepath, self.packagename, self.instrumentationname)
 
         elif self.testtype == const.DEVICEPOWERCONSUMPTION:
             devicePowerConsumption = DevicePowerConsumptionHelper()
-            self.traits.add_traits(overwrite=True, apptorun="app", powerconsumptionmetric=const.POWERCONSUMPTION_ANDROID, scenarioname=self.scenarioname)
-            devicePowerConsumption.runtests(self.devicetype, self.packagepath, self.packagename, self.testiterations, self.runtimeseconds, self.closeToStartDelay, self.traits) # TODO Do we want to make these part of traits? or keep them separate?
+            self.traits.add_traits(overwrite=True, apptorun="app", powerconsumptionmetric=const.POWERCONSUMPTION_ANDROID, tracefolder='PerfTest/', tracename='runoutput.trace', scenarioname=self.scenarioname)
+            devicePowerConsumption.runtests(self.devicetype, self.packagepath, self.packagename, self.testiterations, self.runtimeseconds, self.closeToStartDelay, self.traits)
   
         elif self.testtype == const.DEVICEMEMORYCONSUMPTION and self.devicetype == 'android':
             getLogger().info("Clearing potential previous run nettraces")

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -402,12 +402,12 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.ANDROIDINSTRUMENTATION:
             androidInstrumentation = AndroidInstrumentationHelper()
-            androidInstrumentation.runtests(self.packagepath, self.packagename, self.instrumentationname) # Do we want to make these part of traits? or keep them separate?
+            androidInstrumentation.runtests(self.packagepath, self.packagename, self.instrumentationname) # TODO Do we want to make these part of traits? or keep them separate?
 
         elif self.testtype == const.DEVICEPOWERCONSUMPTION:
             devicePowerConsumption = DevicePowerConsumptionHelper()
             self.traits.add_traits(overwrite=True, apptorun="app", powerconsumptionmetric=const.POWERCONSUMPTION_ANDROID, scenarioname=self.scenarioname)
-            devicePowerConsumption.runtests(self.devicetype, self.packagepath, self.packagename, self.testiterations, self.runtimeseconds, self.closeToStartDelay, self.traits) # Do we want to make these part of traits? or keep them separate?
+            devicePowerConsumption.runtests(self.devicetype, self.packagepath, self.packagename, self.testiterations, self.runtimeseconds, self.closeToStartDelay, self.traits) # TODO Do we want to make these part of traits? or keep them separate?
   
         elif self.testtype == const.DEVICEMEMORYCONSUMPTION and self.devicetype == 'android':
             getLogger().info("Clearing potential previous run nettraces")

--- a/src/scenarios/shared/testtraits.py
+++ b/src/scenarios/shared/testtraits.py
@@ -21,6 +21,7 @@ class TestTraits:
         self.guiapp = ''
         self.startupmetric = ''
         self.memoryconsumptionmetric = ''
+        self.powerconsumptionmetric = ''
         self.appargs = ''
         self.iterations = ''
         self.timeout = ''

--- a/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
@@ -1,0 +1,73 @@
+using Microsoft.Diagnostics.Tracing;
+using Reporting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace ScenarioMeasurement
+{
+    /// <summary>
+    /// This is a custom parser that does not enable any profiling. Instead, it relies on being passed files collected
+    /// off the test machine (usually on a device.)
+    /// </summary>
+    class AndroidPowerParser : IParser
+    {
+        public void EnableKernelProvider(ITraceSession kernel)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void EnableUserProviders(ITraceSession user)
+        {
+            throw new NotSupportedException();
+        }
+
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        {
+            // Single data line: "totalPowermAh": "0.0886", "isSystemBatteryConsumer": "0", "screenPowermAh": "0.133", "proportionalPowermAh": "0.0250", "foregroundTimeMs": "10311", "foregroundTimeCount": "0", "cpuTimeUserMs": "668", "cpuTimeSystemMs": "147"
+            var totalPowermAh = new List<double>();
+            var isSystemBatteryConsumer = new List<double>();
+            var screenPowermAh = new List<double>();
+            var proportionalPowermAh = new List<double>();
+            var foregroundTimeMs = new List<double>();
+            var foregroundTimeCount = new List<double>();
+            var cpuTimeUserMs = new List<double>();
+            var cpuTimeSystemMs = new List<double>();
+            var counters = new List<Counter>();
+
+            if (File.Exists(mergeTraceFile))
+            {
+                var jsonText = File.ReadAllText(mergeTraceFile);
+                using (JsonDocument document = JsonDocument.Parse(jsonText)){
+                    var root = document.RootElement;
+                    foreach (var test in root.EnumerateArray())
+                    {
+                        totalPowermAh.Add(Double.Parse(test.GetProperty("totalPowermAh").GetString()));
+                        isSystemBatteryConsumer.Add(Double.Parse(test.GetProperty("isSystemBatteryConsumer").GetString()));
+                        screenPowermAh.Add(Double.Parse(test.GetProperty("screenPowermAh").GetString()));
+                        proportionalPowermAh.Add(Double.Parse(test.GetProperty("proportionalPowermAh").GetString()));
+                        foregroundTimeMs.Add(Double.Parse(test.GetProperty("foregroundTimeMs").GetString()));
+                        foregroundTimeCount.Add(Double.Parse(test.GetProperty("foregroundTimeCount").GetString()));
+                        cpuTimeUserMs.Add(Double.Parse(test.GetProperty("cpuTimeUserMs").GetString()));
+                        cpuTimeSystemMs.Add(Double.Parse(test.GetProperty("cpuTimeSystemMs").GetString()));
+                    }
+                }
+
+            }
+
+            counters.Add(new Counter() { Name = "Total Power Usage", MetricName = "mAh", DefaultCounter = true, TopCounter = true, Results = totalPowermAh.ToArray() });
+            counters.Add(new Counter() { Name = "Is System Battery Consumer", MetricName = "Bool", DefaultCounter = false, TopCounter = false, Results = isSystemBatteryConsumer.ToArray() });
+            counters.Add(new Counter() { Name = "Screen Power Usage", MetricName = "mAh", DefaultCounter = false, TopCounter = true, Results = screenPowermAh.ToArray() });
+            counters.Add(new Counter() { Name = "Proportional Power Usage", MetricName = "mAh", DefaultCounter = false, TopCounter = true, Results = proportionalPowermAh.ToArray() });
+            counters.Add(new Counter() { Name = "Foreground Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = foregroundTimeMs.ToArray() });
+            counters.Add(new Counter() { Name = "Foreground Time Count", MetricName = "Count", DefaultCounter = false, TopCounter = false, Results = foregroundTimeCount.ToArray() });
+            counters.Add(new Counter() { Name = "CPU User Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = cpuTimeUserMs.ToArray() });
+            counters.Add(new Counter() { Name = "CPU System Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = cpuTimeSystemMs.ToArray() });
+            return counters;
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
@@ -37,6 +37,17 @@ namespace ScenarioMeasurement
             var foregroundTimeCount = new List<double>();
             var cpuTimeUserMs = new List<double>();
             var cpuTimeSystemMs = new List<double>();
+            var cpuTimeTotalMs = new List<double>();
+            var preExecutionBatteryLevel = new List<double>();
+            var preExecutionBatteryVoltage = new List<double>();
+            var postExecutionBatteryLevel = new List<double>();
+            var postExecutionBatteryVoltage = new List<double>();
+            var executionBatteryLevelChange = new List<double>();
+            var executionBatteryVoltageChange = new List<double>();
+            var totalJouleUsageEstimate = new List<double>();
+            var screenJouleUsageEstimate = new List<double>();
+            var proportionalJouleUsageEstimate = new List<double>();
+            var allJouleUsageEstimate = new List<double>();
             var counters = new List<Counter>();
 
             if (File.Exists(mergeTraceFile))
@@ -47,14 +58,44 @@ namespace ScenarioMeasurement
                     var root = document.RootElement;
                     foreach (var test in root.EnumerateArray())
                     {
-                        totalPowermAh.Add(Double.Parse(test.GetProperty("totalPowermAh").GetString()));
+                        var cpuTimeUserMsValue = Double.Parse(test.GetProperty("cpuTimeUserMs").GetString());
+                        var cpuTimeSystemMsValue = Double.Parse(test.GetProperty("cpuTimeSystemMs").GetString());
+                        var totalCpuTimeMsValue = cpuTimeUserMsValue + cpuTimeSystemMsValue;
+                        var totalPowermAhValue = Double.Parse(test.GetProperty("totalPowermAh").GetString());
+                        var screenPowermAhValue = Double.Parse(test.GetProperty("screenPowermAh").GetString());
+                        var proportionalPowermAhValue = Double.Parse(test.GetProperty("proportionalPowermAh").GetString());
+                        var preExecutionBatteryLevelValue = Double.Parse(test.GetProperty("preExecutionBatteryLevel").GetString());
+                        var preExecutionBatteryVoltageValue = Double.Parse(test.GetProperty("preExecutionBatteryVoltage").GetString());
+                        var postExecutionBatteryLevelValue = Double.Parse(test.GetProperty("postExecutionBatteryLevel").GetString());
+                        var postExecutionBatteryVoltageValue = Double.Parse(test.GetProperty("postExecutionBatteryVoltage").GetString());
+                        var executionBatteryLevelChangeValue = preExecutionBatteryLevelValue - postExecutionBatteryLevelValue;
+                        var executionBatteryVoltageChangeValue = preExecutionBatteryVoltageValue - postExecutionBatteryVoltageValue;
+                        // Joule calculation: mAh X voltage x 3.6 = Joules (https://www.axconnectorlubricant.com/rce/battery-electronics-101.html#:~:text=Choosing%201%20Volts%20for%20the%20voltage%2C%20we%20can,X%20voltage%20x%203.6%20%3D%20Joules%20of%20energy.)
+                        var estimatedBatteryVoltageValueForJouleCalculation = (preExecutionBatteryVoltageValue + postExecutionBatteryVoltageValue) / (2 * 1000); // change from mV to V and get the average (we assume a small change in voltage during the test)
+                        var totalJouleUsageEstimateValue = totalPowermAhValue * 3.6 * estimatedBatteryVoltageValueForJouleCalculation;
+                        var screenJouleUsageEstimateValue = screenPowermAhValue * 3.6 * estimatedBatteryVoltageValueForJouleCalculation;
+                        var proportionalJouleUsageEstimateValue = proportionalPowermAhValue * 3.6 * estimatedBatteryVoltageValueForJouleCalculation;
+                        var allJouleUsageEstimateValue = totalJouleUsageEstimateValue + screenJouleUsageEstimateValue + proportionalJouleUsageEstimateValue;
+
+                        totalPowermAh.Add(totalPowermAhValue);
                         isSystemBatteryConsumer.Add(Double.Parse(test.GetProperty("isSystemBatteryConsumer").GetString()));
-                        screenPowermAh.Add(Double.Parse(test.GetProperty("screenPowermAh").GetString()));
-                        proportionalPowermAh.Add(Double.Parse(test.GetProperty("proportionalPowermAh").GetString()));
+                        screenPowermAh.Add(screenPowermAhValue);
+                        proportionalPowermAh.Add(proportionalPowermAhValue);
                         foregroundTimeMs.Add(Double.Parse(test.GetProperty("foregroundTimeMs").GetString()));
                         foregroundTimeCount.Add(Double.Parse(test.GetProperty("foregroundTimeCount").GetString()));
-                        cpuTimeUserMs.Add(Double.Parse(test.GetProperty("cpuTimeUserMs").GetString()));
-                        cpuTimeSystemMs.Add(Double.Parse(test.GetProperty("cpuTimeSystemMs").GetString()));
+                        cpuTimeUserMs.Add(cpuTimeUserMsValue);
+                        cpuTimeSystemMs.Add(cpuTimeSystemMsValue);
+                        cpuTimeTotalMs.Add(totalCpuTimeMsValue);
+                        preExecutionBatteryLevel.Add(preExecutionBatteryLevelValue);
+                        preExecutionBatteryVoltage.Add(preExecutionBatteryVoltageValue);
+                        postExecutionBatteryLevel.Add(postExecutionBatteryLevelValue);
+                        postExecutionBatteryVoltage.Add(postExecutionBatteryVoltageValue);
+                        executionBatteryLevelChange.Add(executionBatteryLevelChangeValue);
+                        executionBatteryVoltageChange.Add(executionBatteryVoltageChangeValue);
+                        totalJouleUsageEstimate.Add(totalJouleUsageEstimateValue);
+                        screenJouleUsageEstimate.Add(screenJouleUsageEstimateValue);
+                        proportionalJouleUsageEstimate.Add(proportionalJouleUsageEstimateValue);
+                        allJouleUsageEstimate.Add(allJouleUsageEstimateValue);
                     }
                 }
 
@@ -68,6 +109,16 @@ namespace ScenarioMeasurement
             counters.Add(new Counter() { Name = "Foreground Time Count", MetricName = "Count", DefaultCounter = false, TopCounter = false, Results = foregroundTimeCount.ToArray() });
             counters.Add(new Counter() { Name = "CPU User Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = cpuTimeUserMs.ToArray() });
             counters.Add(new Counter() { Name = "CPU System Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = cpuTimeSystemMs.ToArray() });
+            counters.Add(new Counter() { Name = "Pre Execution Battery Level", MetricName = "Percent", DefaultCounter = false, TopCounter = false, Results = preExecutionBatteryLevel.ToArray() });
+            counters.Add(new Counter() { Name = "Pre Execution Battery Voltage", MetricName = "MilliVolt", DefaultCounter = false, TopCounter = false, Results = preExecutionBatteryVoltage.ToArray() });
+            counters.Add(new Counter() { Name = "Post Execution Battery Level", MetricName = "Percent", DefaultCounter = false, TopCounter = false, Results = postExecutionBatteryLevel.ToArray() });
+            counters.Add(new Counter() { Name = "Post Execution Battery Voltage", MetricName = "MilliVolt", DefaultCounter = false, TopCounter = false, Results = postExecutionBatteryVoltage.ToArray() });
+            counters.Add(new Counter() { Name = "Execution Battery Level Change", MetricName = "Percent", DefaultCounter = false, TopCounter = false, Results = executionBatteryLevelChange.ToArray() });
+            counters.Add(new Counter() { Name = "Execution Battery Voltage Change", MetricName = "MilliVolt", DefaultCounter = false, TopCounter = false, Results = executionBatteryVoltageChange.ToArray() });
+            counters.Add(new Counter() { Name = "Total Joule Usage Estimate", MetricName = "Joule", DefaultCounter = false, TopCounter = true, Results = totalJouleUsageEstimate.ToArray() });
+            counters.Add(new Counter() { Name = "Screen Joule Usage Estimate", MetricName = "Joule", DefaultCounter = false, TopCounter = true, Results = screenJouleUsageEstimate.ToArray() });
+            counters.Add(new Counter() { Name = "Proportional Joule Usage Estimate", MetricName = "Joule", DefaultCounter = false, TopCounter = true, Results = proportionalJouleUsageEstimate.ToArray() });
+            counters.Add(new Counter() { Name = "All Joule Usage Estimate", MetricName = "Joule", DefaultCounter = false, TopCounter = true, Results = allJouleUsageEstimate.ToArray() });
             return counters;
         }
     }

--- a/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/AndroidPowerParser.cs
@@ -42,7 +42,8 @@ namespace ScenarioMeasurement
             if (File.Exists(mergeTraceFile))
             {
                 var jsonText = File.ReadAllText(mergeTraceFile);
-                using (JsonDocument document = JsonDocument.Parse(jsonText)){
+                using (JsonDocument document = JsonDocument.Parse(jsonText))
+                {
                     var root = document.RootElement;
                     foreach (var test in root.EnumerateArray())
                     {

--- a/src/tools/ScenarioMeasurement/PowerConsumption/IParser.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/IParser.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Reporting;
+using System;
+
+namespace ScenarioMeasurement
+{
+    public interface IParser
+    {
+        void EnableUserProviders(ITraceSession user);
+        void EnableKernelProvider(ITraceSession kernel);
+        IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine);
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/LinuxTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/LinuxTraceSession.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using System.Collections.Generic;
+
+namespace ScenarioMeasurement
+{
+    public class LinuxTraceSession : ITraceSession
+    {
+        public string TraceFilePath
+        {
+            get { return perfCollect?.TraceFilePath; }
+        }
+        private PerfCollect perfCollect;
+        private Dictionary<TraceSessionManager.KernelKeyword, PerfCollect.KernelKeyword> kernelKeywords;
+        private Dictionary<TraceSessionManager.ClrKeyword, PerfCollect.ClrKeyword> clrKeywords;
+
+        public LinuxTraceSession(string sessionName, string traceName, string traceDirectory, Logger logger)
+        {
+            perfCollect = new PerfCollect(traceName, traceDirectory, logger);
+            InitLinuxKeywordMaps();
+        }
+
+        public void EnableProviders(IParser parser)
+        {
+            // Enable both providers and start the session
+            parser.EnableKernelProvider(this);
+            parser.EnableUserProviders(this);
+            perfCollect.Start();
+        }
+
+        public void Dispose()
+        {
+            perfCollect.Stop();
+        }
+
+        public void EnableKernelProvider(params TraceSessionManager.KernelKeyword[] keywords)
+        {
+            foreach (var keyword in keywords)
+            {
+                perfCollect.AddKernelKeyword(kernelKeywords[keyword]);
+            }
+        }
+
+        public void EnableUserProvider(params TraceSessionManager.ClrKeyword[] keywords)
+        {
+            foreach (var keyword in keywords)
+            {
+                perfCollect.AddClrKeyword(clrKeywords[keyword]);
+            }
+        }
+
+        private void InitLinuxKeywordMaps()
+        {
+            // initialize linux kernel keyword map
+            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, PerfCollect.KernelKeyword>();
+            kernelKeywords[TraceSessionManager.KernelKeyword.Process] = PerfCollect.KernelKeyword.LTTng_Kernel_ProcessLifetimeKeyword;
+            kernelKeywords[TraceSessionManager.KernelKeyword.Thread] = PerfCollect.KernelKeyword.LTTng_Kernel_ThreadKeyword;
+            kernelKeywords[TraceSessionManager.KernelKeyword.ContextSwitch] = PerfCollect.KernelKeyword.LTTng_Kernel_ContextSwitchKeyword;
+
+            // initialize linux clr keyword map
+            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, PerfCollect.ClrKeyword>();
+            clrKeywords[TraceSessionManager.ClrKeyword.Startup] = PerfCollect.ClrKeyword.DotNETRuntimePrivate_StartupKeyword;
+        }
+
+        public void EnableUserProvider(string provider, TraceEventLevel verboseLevel = TraceEventLevel.Verbose)
+        {
+            // Enable all EventSource events on Linux
+            perfCollect.AddClrKeyword(PerfCollect.ClrKeyword.EventSource);
+            // Filter events from the provider
+            PowerConsumption.AddTestProcessEnvironmentVariable("COMPlus_EventSourceFilter", provider);
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/ParserUtility.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/ParserUtility.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.IO;
+
+
+namespace ScenarioMeasurement
+{
+    class ParserUtility
+    {
+        public static bool MatchProcessStart(TraceEvent evt, TraceSourceManager source, string processName, IList<int> pids, string commandLine)
+        {
+            return MatchCommandLine(evt, source, commandLine) &&
+                   MatchProcessName(evt, source, processName) &&
+                   MatchProcessID(evt, source, pids);
+        }
+
+        public static bool MatchCommandLine(TraceEvent evt, TraceSourceManager source, string commandLine)
+        {
+            if (source.IsWindows)
+            {
+                int bufferMax = 512;
+                string payloadCommandLine = (string)GetPayloadValue(evt, "CommandLine");
+                if (payloadCommandLine.Length >= bufferMax && commandLine.Length >= bufferMax)
+                {
+                    commandLine = commandLine.Substring(0, bufferMax);
+                    payloadCommandLine = payloadCommandLine.Substring(0, bufferMax);
+                }
+                if (!commandLine.Trim().Equals(payloadCommandLine.Trim()))
+                {
+                    return CompareResult.Mismatch;
+                }
+            }
+            else
+            {
+                return CompareResult.NotApplicable;
+            }
+            // Match the command line as well because pids might be reused during the session
+            return CompareResult.Match;
+        }
+
+        public static bool MatchProcessName(TraceEvent evt, TraceSourceManager source, string processName)
+        {
+            if (source.IsWindows)
+            {
+                if (!processName.Equals(evt.ProcessName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return CompareResult.Mismatch;
+                }
+            }
+            else
+            {
+                // 15 characters is the maximum length of a process name in Linux kernel event payload
+                if (processName.Length < 15)
+                {
+                    if (!processName.Equals(evt.ProcessName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return CompareResult.Mismatch;
+                    }
+                }
+                else
+                {
+                    if (evt.PayloadByName("FileName") == null)
+                    {
+                        // match the first 15 characters only if FileName field is not present in the payload
+                        if (!processName.Substring(0, 15).Equals(evt.ProcessName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return CompareResult.Mismatch;
+                        }
+                    }
+                    else
+                    {
+                        // match the full process name by extracting the file name
+                        string filename = (string)GetPayloadValue(evt, "FileName");
+                        if (!processName.Equals(Path.GetFileName(filename)))
+                        {
+                            return CompareResult.Mismatch;
+                        }
+                    }
+                }
+            }
+            return CompareResult.Match;
+        }
+
+        public static bool MatchProcessID(TraceEvent evt, TraceSourceManager source, IList<int> pids)
+        {
+            if (!pids.Contains(evt.ProcessID))
+            {
+                return CompareResult.Mismatch;
+            }
+            if (!source.IsWindows)
+            {
+                // For Linux both pid and tid should match
+                // Check default payload value
+                if (!pids.Contains(evt.ThreadID))
+                {
+                    // Check event-specific payload value
+                    if (!pids.Contains((int)GetPayloadValue(evt, "PayloadThreadID")))
+                    {
+                        return CompareResult.Mismatch;
+                    }
+                }
+            }
+            return CompareResult.Match;
+        }
+
+        public static bool MatchSingleProcessID(TraceEvent evt, TraceSourceManager source, int pid)
+        {
+            return MatchProcessID(evt, source, new List<int> { pid });
+        }
+
+        private static object GetPayloadValue(TraceEvent evt, string payloadName)
+        {
+            var result = evt.PayloadByName(payloadName);
+            if (result == null)
+            {
+                throw new NoNullAllowedException($"Payload \"{payloadName}\" doesn't exist in event \"{evt.EventName}\" ");
+            }
+            return result;
+        }
+
+        public sealed class CompareResult
+        {
+            public static readonly bool Match = true;
+            public static readonly bool Mismatch = false;
+            public static readonly bool NotApplicable = CompareResult.Match;
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace ScenarioMeasurement
+{
+    public class PerfCollect : IDisposable
+    {
+        private readonly string startupDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        private ManagedProcessHelper perfCollectProcess;
+        public string TraceName { get; private set; }
+        public string TraceFileName { get; private set; }
+        public string TraceDirectory { get; private set; }
+        public string TraceFilePath { get; private set; }
+        private List<KernelKeyword> KernelEvents = new List<KernelKeyword>();
+        private List<ClrKeyword> ClrEvents = new List<ClrKeyword>();
+        public PerfCollect(string traceName, Logger logger) : this(traceName, Environment.CurrentDirectory, logger)
+        {
+        }
+
+        public PerfCollect(string traceName, string traceDirectory, Logger logger)
+        {
+            string perfCollectScript = Path.Combine(startupDirectory, "perfcollect");
+            if (!File.Exists(perfCollectScript))
+            {
+                throw new FileNotFoundException($"Pefcollect not found at {perfCollectScript}. Please rebuild the project to download it.");
+            }
+
+            if (String.IsNullOrEmpty(traceName))
+            {
+                throw new ArgumentException("Trace file name cannot be empty.");
+            }
+            TraceName = traceName.Replace(" ", "_");
+
+            if (!Directory.Exists(traceDirectory))
+            {
+                Directory.CreateDirectory(traceDirectory);
+            }
+
+            TraceDirectory = traceDirectory;
+            TraceFileName = $"{TraceName}.trace.zip";
+            TraceFilePath = Path.Combine(traceDirectory, TraceFileName);
+
+            perfCollectProcess = new ManagedProcessHelper(logger)
+            {
+                ProcessWillExit = true,
+                Executable = perfCollectScript,
+                Timeout = 1200,
+                RootAccess = true
+            };
+
+            if (Install() != Result.Success)
+            {
+                throw new Exception("Lttng installation failed. Please try manual install.");
+            }
+        }
+
+        public Result Start()
+        {
+            var arguments = new StringBuilder($"start {TraceName} -events ");
+
+            foreach (var keyword in KernelEvents)
+            {
+                arguments.Append(keyword.ToString());
+                arguments.Append(",");
+            }
+
+            foreach (var keyword in ClrEvents)
+            {
+                arguments.Append(keyword.ToString());
+                arguments.Append(",");
+            }
+
+            string args = arguments.Remove(arguments.Length - 1, 1).ToString();
+
+            perfCollectProcess.Arguments = args;
+            return perfCollectProcess.Run().Result;
+        }
+
+        public Result Stop()
+        {
+            string arguments = $"stop {TraceName} ";
+            perfCollectProcess.Arguments = arguments;
+            var result = perfCollectProcess.Run().Result;
+            // By default perfcollect saves traces in the current directory
+            if (!File.Exists(TraceFileName))
+            {
+                throw new FileNotFoundException($"Trace file not found at {Path.GetFullPath(TraceFileName)}.");
+            }
+            // Don't move file if destination directory is current directory
+            if (Path.GetFullPath(Path.GetDirectoryName(TraceFilePath)) != Environment.CurrentDirectory)
+            {
+                // Overwrite file at destination directory
+                if (File.Exists(TraceFilePath))
+                {
+                    Console.WriteLine($"Deleting existing file at {TraceFilePath}...");
+                    File.Delete(TraceFilePath);
+                }
+                File.Move(TraceFileName, TraceFilePath);
+            }
+            //TODO: move logs to appropriate location
+            return result;
+        }
+
+        public Result Install()
+        {
+            if (LttngInstalled())
+            {
+                Console.WriteLine("Lttng is already installed.");
+                return Result.Success;
+            }
+            perfCollectProcess.Arguments = "install -force";
+            perfCollectProcess.Run();
+
+            int retry = 10;
+            for(int i=0; i<retry; i++)
+            {
+                if (!LttngInstalled())
+                {
+                    Console.WriteLine($"Lttng not installed. Retry {i}...");
+                    perfCollectProcess.Run();
+                }
+                else
+                {
+                    return Result.Success;
+                }
+            }
+            return Result.CloseFailed;
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+
+        public void AddClrKeyword(ClrKeyword keyword)
+        {
+            ClrEvents.Add(keyword);
+        }
+
+        public void AddKernelKeyword(KernelKeyword keyword)
+        {
+            KernelEvents.Add(keyword);
+        }
+
+        private bool LttngInstalled()
+        {
+            ProcessStartInfo procStartInfo = new ProcessStartInfo("modinfo", "lttng_probe_writeback");
+            Process proc = new Process() { StartInfo = procStartInfo, };
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.Start();
+            string result = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit();
+            // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
+            return result.Contains("filename:");
+        }
+
+        public enum KernelKeyword
+        {
+            Empty,
+            LTTng_Kernel_ProcessLifetimeKeyword,
+            LTTng_Kernel_ThreadKeyword,
+            LTTng_Kernel_ContextSwitchKeyword
+        }
+
+        public enum ClrKeyword
+        {
+            Empty,
+            Threading,
+            DotNETRuntimePrivate_StartupKeyword,
+            EventSource
+        }
+
+
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
@@ -116,7 +116,7 @@ namespace ScenarioMeasurement
             perfCollectProcess.Run();
 
             int retry = 10;
-            for(int i=0; i<retry; i++)
+            for (int i = 0; i < retry; i++)
             {
                 if (!LttngInstalled())
                 {

--- a/src/tools/ScenarioMeasurement/PowerConsumption/PowerConsumption.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/PowerConsumption.cs
@@ -1,0 +1,391 @@
+﻿using Reporting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace ScenarioMeasurement
+{
+    enum PowerMetricType
+    {
+        AndroidPowerConsumption
+    }
+
+    class PowerConsumption
+    {
+        private static IProcessHelper TestProcess { get; set; }
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="appExe">Full path to test executable</param>
+        /// <param name="powerMetricType">Type of interval measurement</param>
+        /// <param name="scenarioName">Scenario name for reporting</param>
+        /// <param name="processWillExit">true: process exits on its own. False: process does not exit, send close.</param>
+        /// <param name="timeout">Max wait for process to exit</param>
+        /// <param name="measurementDelay">Time for the app to run window</param>
+        /// <param name="iterations">Number of measured iterations</param>
+        /// <param name="appArgs">optional arguments to test executable</param>
+        /// <param name="logFileName">optional log file. Default is appExe.powerconsumption.log</param>
+        /// <param name="workingDir">optional working directory</param>
+        /// <param name="warmup">enables/disables warmup iteration</param>
+        /// <param name="traceName">trace name</param>
+        /// <param name="guiApp">true: app under test is a GUI app, false: console</param>
+        /// <param name="skipProfileIteration">true: skip full results iteration</param>
+        /// <param name="reportJsonPath">path to save report json</param>
+        /// <param name="iterationSetup">command to set up before each iteration</param>
+        /// <param name="setupArgs">arguments of iterationSetup</param>
+        /// <param name="iterationCleanup">command to clean up after each iteration</param>
+        /// <param name="cleanupArgs">arguments of iterationCleanup</param>
+        /// <param name="traceDirectory">Directory to put files in (defaults to current directory)</param>
+        /// <param name="environmentVariables">Environment variables set for test processes (example: var1=value1;var2=value2)</param>
+        /// <param name="runWithoutExit">Run the main test process without handling shutdown</param>
+        /// <param name="skipMeasurementIteration">Don't run measurement collection</param>
+        /// <param name="parseOnly">Parse trace(s) without running app</param>
+        /// <param name="runWithDotnet">Run the app with dotnet</param>
+        /// <returns></returns>
+
+        static int Main(string appExe,
+                        PowerMetricType powerMetricType,
+                        string scenarioName,
+                        string traceName,
+                        bool processWillExit = false,
+                        int iterations = 5,
+                        string iterationSetup = "",
+                        string setupArgs = "",
+                        string iterationCleanup = "",
+                        string cleanupArgs = "",
+                        int timeout = 60,
+                        int measurementDelay = 15,
+                        string appArgs = "",
+                        string logFileName = "",
+                        string workingDir = "",
+                        bool warmup = true,
+                        bool guiApp = true,
+                        bool skipProfileIteration = false,
+                        string reportJsonPath = "",
+                        string traceDirectory = null,
+                        string environmentVariables = null,
+                        bool runWithoutExit = false,
+                        bool skipMeasurementIteration = false,
+                        bool parseOnly = false,
+                        bool runWithDotnet = false
+                        )
+        {
+            Logger logger = new Logger(String.IsNullOrEmpty(logFileName) ? $"{appExe}.powerconsumption.log" : logFileName);
+            static void checkArg(string arg, string name)
+            {
+                if (String.IsNullOrEmpty(arg))
+                    throw new ArgumentException(name);
+            };
+            checkArg(appExe, nameof(appExe));
+            checkArg(traceName, nameof(traceName));
+
+            string traceFilePath = "";
+
+
+            if (parseOnly == true)
+            {
+                skipMeasurementIteration = true;
+                skipProfileIteration = true;
+                traceFilePath = Path.Join(traceDirectory, traceName);
+            }
+
+            if (String.IsNullOrEmpty(traceDirectory))
+            {
+                traceDirectory = Environment.CurrentDirectory;
+            }
+            else
+            {
+                if (!Directory.Exists(traceDirectory))
+                {
+                    Directory.CreateDirectory(traceDirectory);
+                }
+            }
+
+            Dictionary<string, string> envVariables = new Dictionary<string, string>(ParseStringToDictionary(environmentVariables));
+
+            logger.Log($"Running {appExe} (args: \"{appArgs}\")");
+            logger.Log($"Working Directory: {workingDir}");
+            if (runWithoutExit)
+            {
+                TestProcess = new RawProcessHelper(logger)
+                {
+                    ProcessWillExit = processWillExit,
+                    Timeout = timeout,
+                    MeasurementDelay = measurementDelay,
+                    Executable = appExe,
+                    Arguments = appArgs,
+                    WorkingDirectory = workingDir,
+                    GuiApp = guiApp,
+                    EnvironmentVariables = envVariables
+                };
+            }
+            else
+            {
+                TestProcess = new ManagedProcessHelper(logger)
+                {
+                    ProcessWillExit = processWillExit,
+                    Timeout = timeout,
+                    MeasurementDelay = measurementDelay,
+                    Executable = appExe,
+                    Arguments = appArgs,
+                    WorkingDirectory = workingDir,
+                    GuiApp = guiApp,
+                    EnvironmentVariables = envVariables,
+                    RunWithDotnet = runWithDotnet
+                };
+            }
+
+            // create iteration setup process helper
+            logger.Log($"Iteration set up: {iterationSetup} (args: {setupArgs})");
+            IProcessHelper setupProcHelper = null;
+
+            if (!String.IsNullOrEmpty(iterationSetup))
+            {
+                setupProcHelper = CreateProcHelper(iterationSetup, setupArgs, true, logger);
+            }
+
+            // create iteration cleanup process helper
+            logger.Log($"Iteration clean up: {iterationCleanup} (args: {cleanupArgs})");
+            IProcessHelper cleanupProcHelper = null;
+            if (!String.IsNullOrEmpty(iterationCleanup))
+            {
+                cleanupProcHelper = CreateProcHelper(iterationCleanup, cleanupArgs, true, logger);
+            }
+
+            Util.Init();
+
+            // Warm up iteration
+            if (warmup && !skipMeasurementIteration)
+            {
+                logger.LogIterationHeader("Warm up");
+                if (!RunIteration(setupProcHelper, TestProcess, cleanupProcHelper, logger).Success)
+                {
+                    return -1;
+                }
+            }
+
+            IParser parser = null;
+            switch (powerMetricType)
+            {
+                case PowerMetricType.AndroidPowerConsumption:
+                    parser = new AndroidPowerParser();
+                    break;
+            }
+
+            var pids = new List<int>();
+            bool failed = false;
+
+            if (!skipMeasurementIteration)
+            {
+                // Run trace session
+                using (var traceSession = TraceSessionManager.CreateSession("PowerConsumptionSession", traceName, traceDirectory, logger))
+                {
+                    traceSession.EnableProviders(parser);
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        logger.LogIterationHeader($"Iteration {i}");
+                        (bool Success, List<int> Pids) iterationResult;
+
+                        iterationResult = RunIteration(setupProcHelper, TestProcess, cleanupProcHelper, logger);
+
+                        if (!iterationResult.Success)
+                        {
+                            failed = true;
+                            break;
+                        }
+                        pids.AddRange(iterationResult.Pids);
+                    }
+                    traceFilePath = traceSession.TraceFilePath;
+                }
+            }
+
+            // Parse trace files
+            if (!failed && !string.IsNullOrEmpty(traceFilePath))
+            {
+                logger.Log($"Parsing {traceFilePath}");
+
+                if (guiApp)
+                {
+                    appExe = Path.Join(workingDir, appExe);
+                }
+                string commandLine = $"\"{appExe}\"";
+                if (!String.IsNullOrEmpty(appArgs))
+                {
+                    commandLine = commandLine + " " + appArgs;
+                }
+
+                var processName = Path.GetFileNameWithoutExtension(appExe);
+                try
+                {
+                    var counters = parser.Parse(traceFilePath, processName, pids, commandLine);
+                    CreateTestReport(scenarioName, counters, reportJsonPath, logger);
+                }
+                catch
+                {
+                    logger.Log($"{nameof(parser)} = {parser.GetType().FullName}");
+                    logger.Log($"{nameof(processName)} = {processName}");
+                    logger.Log($"{nameof(pids)} = {string.Join(", ", pids)}");
+                    logger.Log($"{nameof(commandLine)} = {commandLine}");
+                    var destFileName = Path.Join(Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT"), Path.GetFileName(traceFilePath));
+                    File.Copy(traceFilePath, destFileName, true);
+                    logger.Log($"Copied {traceFilePath} to {destFileName}");
+                    throw;
+                }
+            }
+
+            // Skip unimplemented Linux profiling
+            skipProfileIteration = skipProfileIteration || !TraceSessionManager.IsWindows;
+            // Run profile session
+            if (!failed && !skipProfileIteration)
+            {
+                logger.LogIterationHeader("Profile Iteration");
+                ProfileParser profiler = new ProfileParser(parser);
+                (bool Success, List<int> Pids) iterationResult;
+                using (var profileSession = TraceSessionManager.CreateSession("ProfileSession", "profile_" + traceName, traceDirectory, logger))
+                {
+                    profileSession.EnableProviders(profiler);
+                    iterationResult = RunIteration(setupProcHelper, TestProcess, cleanupProcHelper, logger);
+
+                    if (!iterationResult.Success)
+                    {
+                        failed = true;
+                    }
+                }
+            }
+            return (failed ? -1 : 0);
+        }
+
+        private static IProcessHelper CreateProcHelper(string command, string args, bool runWithExit, Logger logger)
+        {
+            IProcessHelper procHelper;
+            if (runWithExit)
+            {
+                procHelper = new ManagedProcessHelper(logger)
+                {
+                    ProcessWillExit = true,
+                    Executable = command,
+                    Arguments = args,
+                    Timeout = 300
+                };
+            }
+            else
+            {
+                procHelper = new RawProcessHelper(logger)
+                {
+                    ProcessWillExit = true,
+                    Executable = command,
+                    Arguments = args,
+                    Timeout = 300
+                };
+            }
+            return procHelper;
+        }
+
+        private static (bool Success, List<int> Pids) RunIteration(IProcessHelper setupHelper, IProcessHelper testHelper,
+        IProcessHelper cleanupHelper, Logger logger)
+        {
+            (Process Proc, bool Success, int Pid) RunProcess(IProcessHelper helper)
+            {
+                var runResult = helper.Run();
+                if (runResult.Pid != -1)
+                {
+                    if (runResult.Result != Result.Success)
+                    {
+                        logger.Log($"Process {runResult.Pid} failed to run. Result: {runResult.Result}");
+                        return (null, false, runResult.Pid);
+                    }
+                    return (null, true, runResult.Pid);
+                }
+                else if (!runResult.Proc.HasExited)
+                {
+                    return (runResult.Proc, true, -1);
+                }
+                else
+                {
+                    return (runResult.Proc, false, -1);
+                }
+            }
+
+            List<int> pids = new List<int>();
+            bool failed = false;
+            (Process Proc, bool Success, int Pid) runResult = default((Process p, bool Success, int Pid));
+
+            if (setupHelper != null)
+            {
+                logger.LogStepHeader("Iteration Setup");
+                failed = !RunProcess(setupHelper).Success;
+            }
+
+            // no need to run test process if setup failed
+            if (!failed)
+            {
+                logger.LogStepHeader("Test");
+                runResult = RunProcess(testHelper);
+                failed = !runResult.Success;
+                if (runResult.Pid == -1)
+                {
+                    pids.Add(runResult.Proc.Id);
+                }
+                else
+                {
+                    pids.Add(runResult.Pid);
+                }
+            }
+
+            if (runResult.Proc != null)
+            {
+                logger.LogStepHeader("Stopping process");
+                runResult.Proc.Kill();
+                Thread.Sleep(2000);
+            }
+
+            // need to clean up despite the result of setup and test
+            if (cleanupHelper != null)
+            {
+                logger.LogStepHeader("Iteration Cleanup");
+                failed = failed || !RunProcess(cleanupHelper).Success;
+            }
+
+            return (!failed, pids);
+        }
+
+        private static Dictionary<string, string> ParseStringToDictionary(string s)
+        {
+            var dict = new Dictionary<string, string>();
+            if (!String.IsNullOrEmpty(s))
+            {
+                foreach (string substring in s.Split(';', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var pair = substring.Split('=');
+                    dict.Add(pair[0], pair[1]);
+                }
+            }
+            return dict;
+        }
+
+        private static void CreateTestReport(string scenarioName, IEnumerable<Counter> counters, string reportJsonPath, Logger logger)
+        {
+            var reporter = Reporter.CreateReporter();
+            var test = new Test();
+            test.Categories.Add("PowerConsumption");
+            test.Name = scenarioName;
+            test.AddCounter(counters);
+            reporter.AddTest(test);
+            if (reporter.InLab && !String.IsNullOrEmpty(reportJsonPath))
+            {
+                File.WriteAllText(reportJsonPath, reporter.GetJson());
+            }
+            logger.Log(reporter.WriteResultTable());
+        }
+
+        public static void AddTestProcessEnvironmentVariable(string name, string value)
+        {
+            TestProcess.AddEnvironmentVariable(name, value);
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/PowerConsumption.csproj
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/PowerConsumption.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFramework>
+    <!-- Supported target frameworks -->
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net7.0</TargetFramework>
+    <LangVersion>Preview</LangVersion>
+    <RootNamespace>ScenarioMeasurement</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.*" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Util\Util.csproj" />
+    <ProjectReference Include="..\..\Reporting\Reporting\Reporting.csproj" />
+  </ItemGroup>
+
+  <Target Name="DownloadPerfCollect" BeforeTargets="CoreCompile" Condition=" '$(OS)' != 'Windows_NT' ">
+    <PropertyGroup>
+      <PerfcollectUrl>https://aka.ms/perfcollect</PerfcollectUrl>
+    </PropertyGroup>
+    <DownloadFile SourceUrl="$(PerfcollectUrl)" 
+                  DestinationFolder="$(MSBuildProjectDirectory)"
+                  Retries="3"
+                  SkipUnchangedFiles="true">
+      <Output TaskParameter="DownloadedFile" ItemName="Content"/>
+    </DownloadFile>
+    <Exec Command="chmod +x perfcollect"/>
+    <Copy SourceFiles="perfcollect" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="perfcollect" DestinationFolder="$(OutDir)" />
+  </Target>
+</Project>

--- a/src/tools/ScenarioMeasurement/PowerConsumption/ProfileParser.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/ProfileParser.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using ScenarioMeasurement;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Reporting;
+
+namespace ScenarioMeasurement
+{
+    public class ProfileParser : IParser
+    {
+        IParser other;
+        public ProfileParser(IParser other) => this.other = other;
+
+        public void EnableKernelProvider(ITraceSession kernel)
+        {
+            TraceEventSession kernelSession = ((WindowsTraceSession)kernel).KernelSession;
+            kernelSession.StackCompression = true;
+            var keywords = KernelTraceEventParser.Keywords.Default;
+            kernelSession.EnableKernelProvider(keywords, keywords);
+        }
+
+        public void EnableUserProviders(ITraceSession user)
+        {
+            other.EnableUserProviders(user);
+            TraceEventSession userSession = ((WindowsTraceSession)user).UserSession;
+            // make sure we turn on whatever the user wanted so the start/stops are findable.
+            userSession.EnableProvider(ClrTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)ClrTraceEventParser.Keywords.Default);
+            userSession.EnableProvider(ClrPrivateTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)(ClrPrivateTraceEventParser.Keywords.GC
+                | ClrPrivateTraceEventParser.Keywords.Binding
+                | ClrPrivateTraceEventParser.Keywords.Fusion
+                | ClrPrivateTraceEventParser.Keywords.MulticoreJit
+                | ClrPrivateTraceEventParser.Keywords.Startup
+                | ClrPrivateTraceEventParser.Keywords.Stack));
+
+            // Microsoft-Windows-Kernel-File, for stacks on file creates etc.
+            var stacksEnabled = new TraceEventProviderOptions { StacksEnabled = true };
+            userSession.EnableProvider(new Guid("EDD08927-9CC4-4E65-B970-C2560FB5C289"), Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, 0x80, stacksEnabled);
+
+            //.NET Tasks
+            var options = new TraceEventProviderOptions { StacksEnabled = true };
+            if (TraceEventProviderOptions.FilteringSupported)
+            {
+                options.EventIDStacksToEnable = new List<int>() { 7, 10, 12 };
+            }
+            userSession.EnableProvider(TplEtwProviderTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)TplEtwProviderTraceEventParser.Keywords.Default, options);
+
+            // .NETFramework
+            userSession.EnableProvider(FrameworkEventSourceTraceEventParser.ProviderGuid, Microsoft.Diagnostics.Tracing.TraceEventLevel.Verbose, (ulong)(
+                                   FrameworkEventSourceTraceEventParser.Keywords.ThreadPool |
+                                   FrameworkEventSourceTraceEventParser.Keywords.ThreadTransfer |
+                                   FrameworkEventSourceTraceEventParser.Keywords.NetClient),
+                                   stacksEnabled);
+        }
+
+        public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+        {
+            throw new NotSupportedException("Parsing is not supported on ProfileParser");
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/TraceSessionManager.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/TraceSessionManager.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using System;
+
+namespace ScenarioMeasurement
+{
+    public interface ITraceSession : IDisposable
+    {
+        string TraceFilePath { get; }
+        void EnableProviders(IParser parser);
+        void EnableKernelProvider(params TraceSessionManager.KernelKeyword[] keywords);
+        void EnableUserProvider(params TraceSessionManager.ClrKeyword[] keywords);
+        void EnableUserProvider(string provider, TraceEventLevel verboseLevel);
+    }
+
+    public static class TraceSessionManager
+    {
+        public static bool IsWindows { get { return Util.IsWindows(); } }
+        public static ITraceSession CreateSession(string sessionName, string traceName, string traceDirectory, Logger logger)
+        {
+            if (IsWindows)
+            {
+                return new WindowsTraceSession(sessionName, traceName, traceDirectory, logger);
+            }
+            else
+            {
+                return new LinuxTraceSession(sessionName, traceName, traceDirectory, logger);
+            }
+        }
+
+        public enum KernelKeyword
+        {
+            Process,
+            Thread,
+            ContextSwitch
+        }
+
+        public enum ClrKeyword
+        {
+            Startup
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/TraceSourceManager.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/TraceSourceManager.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using System;
+
+namespace ScenarioMeasurement
+{
+    public class TraceSourceManager : IDisposable
+    {
+        public bool IsWindows { get { return Source?.GetType() == typeof(ETWTraceEventSource); } }
+        public TraceEventDispatcher Source;
+        private IKernelParser _kernel;
+        public IKernelParser Kernel
+        {
+            get
+            {
+                if (_kernel == null)
+                {
+                    if (IsWindows)
+                    {
+                        _kernel = new WindowsKernelParser((ETWTraceEventSource)Source);
+                    }
+                    else
+                    {
+                        _kernel = new LinuxKernelParser((CtfTraceEventSource)Source);
+                    }
+                }
+                return _kernel;
+            }
+        }
+
+        public TraceSourceManager(string fileName)
+        {
+            Source = TraceEventDispatcher.GetDispatcherFromFileName(fileName);
+        }
+
+        public void Process()
+        {
+            Source.Process();
+        }
+
+        public void Dispose()
+        {
+            Source.Dispose();
+        }
+    }
+
+    public interface IKernelParser
+    {
+        public event Action<TraceEvent> ProcessStart;
+        public event Action<TraceEvent> ProcessStop;
+        public event Action<TraceEvent> ContextSwitch;
+    }
+
+    public sealed class LinuxKernelParser : IKernelParser
+    {
+        LinuxKernelEventParser parser;
+        public event Action<TraceEvent> ProcessStart { add { parser.ProcessStart += value; } remove { parser.ProcessStart -= value; } }
+        public event Action<TraceEvent> ProcessStop { add { parser.ProcessStop += value; } remove { parser.ProcessStop -= value; } }
+        public event Action<TraceEvent> ContextSwitch { add { } remove { } } // not implemented
+        public LinuxKernelParser(CtfTraceEventSource source)
+        {
+            parser = new LinuxKernelEventParser(source);
+        }
+    }
+
+    public sealed class WindowsKernelParser : IKernelParser
+    {
+        KernelTraceEventParser parser;
+        public event Action<TraceEvent> ProcessStart { add { parser.ProcessStart += value; } remove { parser.ProcessStart -= value; } }
+        public event Action<TraceEvent> ProcessStop { add { parser.ProcessEndGroup += value; } remove { parser.ProcessEndGroup -= value; } }
+        public event Action<TraceEvent> ContextSwitch { add { parser.ThreadCSwitch += value; } remove { parser.ThreadCSwitch -= value; } }
+
+        public WindowsKernelParser(ETWTraceEventSource source)
+        {
+            parser = new KernelTraceEventParser(source);
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/WindowsTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/WindowsTraceSession.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Principal;
+
+namespace ScenarioMeasurement
+{
+    public class WindowsTraceSession : ITraceSession
+    {
+        private Logger logger;
+        public string TraceFilePath { get; }
+        public TraceEventSession KernelSession { get; set; }
+        public TraceEventSession UserSession { get; set; }
+        private Dictionary<TraceSessionManager.KernelKeyword, KernelTraceEventParser.Keywords> kernelKeywords;
+        private Dictionary<TraceSessionManager.ClrKeyword, ClrPrivateTraceEventParser.Keywords> clrKeywords;
+
+        public WindowsTraceSession(string sessionName, string traceName, string traceDirectory, Logger logger)
+        {
+            this.logger = logger;
+            if (!IsAdministrator())
+            {
+                Console.WriteLine("Admin mode is required to start ETW.");
+                Environment.Exit(1);
+            }
+            string kernelFileName = Path.ChangeExtension(traceName, "perflabkernel.etl");
+            string userFileName = Path.ChangeExtension(traceName, "perflabuser.etl");
+            TraceFilePath = Path.Combine(traceDirectory, Path.ChangeExtension(traceName, ".etl"));
+
+            KernelSession = new TraceEventSession(sessionName + "_kernel", Path.Combine(traceDirectory, kernelFileName));
+            UserSession = new TraceEventSession(sessionName + "_user", Path.Combine(traceDirectory, userFileName));
+            InitWindowsKeywordMaps();
+        }
+
+        public void EnableProviders(IParser parser)
+        {
+            // Enable both providers and start the session
+            parser.EnableKernelProvider(this);
+            parser.EnableUserProviders(this);
+        }
+
+        public void Dispose()
+        {
+            KernelSession.Dispose();
+            UserSession.Dispose();
+
+            MergeFiles(KernelSession.FileName, UserSession.FileName, TraceFilePath);
+
+            logger.Log($"Trace Saved to {TraceFilePath}");
+        }
+
+        private void MergeFiles(string kernelTraceFile, string userTraceFile, string traceFile)
+        {
+            var files = new List<string>();
+            if (!File.Exists(kernelTraceFile))
+            {
+                Console.WriteLine("Kernel trace file not found.");
+                Environment.Exit(1);
+            }
+            files.Add(kernelTraceFile);
+            if (File.Exists(userTraceFile))
+            {
+                files.Add(userTraceFile);
+            }
+
+            logger.Log($"Merging {string.Join(',', files)}... ");
+            try
+            {
+                TraceEventSession.Merge(files.ToArray(), traceFile);
+            }
+            catch (System.Runtime.InteropServices.COMException)
+            {
+                Console.WriteLine("Unable to merge the trace files due to insufficient system resources. Try freeing some memory.");
+                Environment.Exit(1);
+            }
+            if (File.Exists(traceFile))
+            {
+                File.Delete(userTraceFile);
+                File.Delete(kernelTraceFile);
+            }
+        }
+
+        public void EnableKernelProvider(params TraceSessionManager.KernelKeyword[] keywords)
+        {
+            // Create keyword flags for windows events
+            KernelTraceEventParser.Keywords flags = 0;
+            foreach (var keyword in keywords)
+            {
+                flags |= kernelKeywords[keyword];
+            }
+            bool enabled = false;
+            try
+            {
+                enabled = KernelSession.EnableKernelProvider(flags);
+            }
+            catch (System.Runtime.InteropServices.COMException)
+            {
+            }
+            finally
+            {
+                if (!enabled)
+                {
+                    Console.WriteLine("Unable to enable kernel provider. Try freeing some memory.");
+                    Environment.Exit(1);
+                }
+            }
+
+        }
+
+        public void EnableUserProvider(params TraceSessionManager.ClrKeyword[] keywords)
+        {
+            // Create keyword flags for windows events
+            ClrPrivateTraceEventParser.Keywords flags = 0;
+            foreach (var keyword in keywords)
+            {
+                flags |= clrKeywords[keyword];
+            }
+            bool enabled = false;
+            try
+            {
+                enabled = UserSession.EnableProvider(ClrPrivateTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)flags);
+            }
+            catch (System.Runtime.InteropServices.COMException)
+            {
+            }
+            finally{
+                if (!enabled)
+                {
+/*                    Console.WriteLine("Unable to enable user provider due to insufficient system resources. Try freeing some memory.");
+                    Environment.Exit(1);*/
+                }
+            }
+        }
+
+        private void InitWindowsKeywordMaps()
+        {
+            // initialize windows kernel keyword map
+            kernelKeywords = new Dictionary<TraceSessionManager.KernelKeyword, KernelTraceEventParser.Keywords>();
+            kernelKeywords[TraceSessionManager.KernelKeyword.Process] = KernelTraceEventParser.Keywords.Process;
+            kernelKeywords[TraceSessionManager.KernelKeyword.Thread] = KernelTraceEventParser.Keywords.Thread;
+            kernelKeywords[TraceSessionManager.KernelKeyword.ContextSwitch] = KernelTraceEventParser.Keywords.ContextSwitch;
+
+            // initialize windows clr keyword map
+            clrKeywords = new Dictionary<TraceSessionManager.ClrKeyword, ClrPrivateTraceEventParser.Keywords>();
+            clrKeywords[TraceSessionManager.ClrKeyword.Startup] = ClrPrivateTraceEventParser.Keywords.Startup;
+        }
+
+        public void EnableUserProvider(string provider, TraceEventLevel verboseLevel = TraceEventLevel.Verbose)
+        {
+            UserSession.EnableProvider(provider, verboseLevel);
+        }
+
+        public static bool IsAdministrator()
+        {
+#pragma warning disable CA1416 // WindowsTraceSession only called from TraceSessionManager if platform is windows
+            using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+            {
+                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+#pragma warning restore CA1416
+        }
+    }
+}

--- a/src/tools/ScenarioMeasurement/PowerConsumption/WindowsTraceSession.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/WindowsTraceSession.cs
@@ -125,11 +125,12 @@ namespace ScenarioMeasurement
             catch (System.Runtime.InteropServices.COMException)
             {
             }
-            finally{
+            finally
+            {
                 if (!enabled)
                 {
-/*                    Console.WriteLine("Unable to enable user provider due to insufficient system resources. Try freeing some memory.");
-                    Environment.Exit(1);*/
+                    /*                    Console.WriteLine("Unable to enable user provider due to insufficient system resources. Try freeing some memory.");
+                                        Environment.Exit(1);*/
                 }
             }
         }

--- a/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
+++ b/src/tools/ScenarioMeasurement/ScenarioMeasurement.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Startup.Tests", "Startup.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MemoryConsumption", "MemoryConsumption\MemoryConsumption.csproj", "{03F692B1-9290-447B-AECB-A3AFC8ECA944}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PowerConsumption", "PowerConsumption\PowerConsumption.csproj", "{192DB7E6-1263-4651-BC8C-BFF09AB2481F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{03F692B1-9290-447B-AECB-A3AFC8ECA944}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{03F692B1-9290-447B-AECB-A3AFC8ECA944}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03F692B1-9290-447B-AECB-A3AFC8ECA944}.Release|Any CPU.Build.0 = Release|Any CPU
+		{192DB7E6-1263-4651-BC8C-BFF09AB2481F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{192DB7E6-1263-4651-BC8C-BFF09AB2481F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{192DB7E6-1263-4651-BC8C-BFF09AB2481F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{192DB7E6-1263-4651-BC8C-BFF09AB2481F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Setup the ability to run android power consumption tests. This includes:
* Adding the devicepowerconsumption run type in runner.py.
* Creating the devicepowerconsumption wrapper that runs the android specific flow and builds the power consumption skeleton tool.
* Creating the PowerConsumption tool project with the minimal setup to get the device tests working (copied from the MemoryConsumption tool).
* Minor updates to androidhelper.py to enable immediate return after calling to start the app.