### PR TITLE
[wasm] Explicitly enable JsonSerializerIsReflectionEnabledByDefault

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.props
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.props
@@ -3,5 +3,6 @@
     <WasmGenerateRunV8Script>true</WasmGenerateRunV8Script>
     <WasmMainJSPath>$(WasmDataDir)\test-main.js</WasmMainJSPath>
     <TrimMode>partial</TrimMode>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 </Project>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -16,6 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <LangVersion>latest</LangVersion>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
 
     <!-- Allow building with one major version, and running using a sdk with a higher major version -->
     <RollForward Condition="'$(BuildingForWasm)' == 'true'">LatestMajor</RollForward>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -16,7 +16,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <LangVersion>latest</LangVersion>
-    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
 
     <!-- Allow building with one major version, and running using a sdk with a higher major version -->
     <RollForward Condition="'$(BuildingForWasm)' == 'true'">LatestMajor</RollForward>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/88480 changed the default for `$(JsonSerializerIsReflectionEnabledByDefault)` to `false`, which breaks wasm benchmarks using STJ serializer with reflection.

Fixes https://github.com/dotnet/runtime/issues/88610