### PR TITLE
Remove blazorserver scenario runs

### DIFF
--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -43,10 +43,6 @@
       <ScenarioDirectoryName>aspwebtemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem>
-    <SDKWorkItem Include="SDK Blazor Server App Template">
-      <ScenarioDirectoryName>blazorservertemplate</ScenarioDirectoryName>
-      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-    </SDKWorkItem>
     <SDKWorkItem Include="SDK Class library Template">
       <ScenarioDirectoryName>classlibtemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
@@ -156,13 +152,6 @@
     </HelixWorkItem>
     <HelixWorkItem Include="Inner Loop MVC">
       <ScenarioDirectoryName>mvcinnerloop</ScenarioDirectoryName>
-      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
-      <Command>$(Python) test.py innerloop --scenario-name &quot;%(Identity)&quot;</Command>
-      <PostCommands>$(Python) post.py</PostCommands>
-    </HelixWorkItem>
-    <HelixWorkItem Include="Inner Loop Blazor Server">
-      <ScenarioDirectoryName>blazorserverinnerloop</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
       <Command>$(Python) test.py innerloop --scenario-name &quot;%(Identity)&quot;</Command>

--- a/src/scenarios/blazorserverinnerloop/pre.py
+++ b/src/scenarios/blazorserverinnerloop/pre.py
@@ -1,5 +1,7 @@
 '''
 pre-command
+WARNING: blazorserver is no longer a template in dotnet 8.0 (https://github.com/dotnet/performance/issues/3108)
+         runs have been removed but keeping the test folder for now
 '''
 import sys
 import shutil

--- a/src/scenarios/blazorservertemplate/pre.py
+++ b/src/scenarios/blazorservertemplate/pre.py
@@ -1,5 +1,7 @@
 '''
 pre-command
+WARNING: blazorserver is no longer a template in dotnet 8.0 (https://github.com/dotnet/performance/issues/3108)
+         runs have been removed but keeping the test folder for now
 '''
 import sys
 from performance.logger import setup_loggers


### PR DESCRIPTION
Remove blazorserver scenario runs per https://github.com/dotnet/performance/issues/3108.

Fixes https://github.com/dotnet/performance/issues/3108.
