### PR TITLE
[wasm] Enable previously disabled benchmark

### DIFF
--- a/src/benchmarks/micro/libraries/System.Memory/MemoryMarshal.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/MemoryMarshal.cs
@@ -13,7 +13,7 @@ namespace System.Memory
 {
     [GenericTypeArguments(typeof(byte))]
     [GenericTypeArguments(typeof(int))]
-    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span, Categories.NoWASM)]
+    [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span)]
     public class MemoryMarshal<T>
         where T : struct
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/performance/issues/1948 .

This was disabled 2 years ago due to a build failure:

```
error: Invalid cast (Producer: 'LLVM11.1.0' Reader: 'LLVM 13.0.0git')
```

.. which is not hit any more.
