### PR TITLE
Add benchmarks for DI activation

### DIFF
--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
@@ -5,6 +5,7 @@
 using System;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
+using ProtoBuf.Serializers;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -12,22 +13,54 @@ namespace Microsoft.Extensions.DependencyInjection
     public class ActivatorUtilitiesBenchmark
     {
         private ServiceProvider _serviceProvider;
-        private ObjectFactory _factory;
-        private object[] _factoryArguments;
+        private Type[] _types2;
+        private Type[] _types2_OutOfOrder;
+        private Type[] _types3;
+
+        private ObjectFactory _factory2;
+        private ObjectFactory _factory2_OutOfOrder;
+        private ObjectFactory _factory3;
+        private object[] _factoryArguments0;
+        private object[] _factoryArguments1;
+        private object[] _factoryArguments2;
+        private object[] _factoryArguments2_OutOfOrder;
+        private object[] _factoryArguments3;
+        private object[] _factoryArguments4;
+        private object[] _factoryArguments5;
 
         [GlobalSetup]
         public void SetUp()
         {
-            var collection = new ServiceCollection();
-            collection.AddTransient<TypeToBeActivated>();
+            ServiceCollection collection = new();
+            collection.AddTransient<TypeWith0ParametersToBeActivated>();
+            collection.AddTransient<TypeWith1ParameterToBeActivated>();
+            collection.AddTransient<TypeWith2ParametersToBeActivated>();
+            collection.AddTransient<TypeWith3ParametersToBeActivated>();
+            collection.AddTransient<TypeWith4ParametersToBeActivated>();
+            collection.AddTransient<TypeWith5ParametersToBeActivated>();
+
             collection.AddSingleton<DependencyA>();
             collection.AddSingleton<DependencyB>();
             collection.AddSingleton<DependencyC>();
-            collection.AddTransient<TypeToBeActivated>();
+            collection.AddSingleton<DependencyD>();
+            collection.AddSingleton<DependencyE>();
 
+            _types2 = new Type[] { typeof(DependencyA), typeof(DependencyB) };
+            _types2_OutOfOrder = new Type[] { typeof(DependencyB), typeof(DependencyC) };
+            _types3 = new Type[] { typeof(DependencyA), typeof(DependencyB), typeof(DependencyC) };
+
+            _factory2 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2);
+            _factory2_OutOfOrder = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2_OutOfOrder);
+            _factory3 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types3);
+
+            _factoryArguments0 = Array.Empty<object>();
+            _factoryArguments1 = new object[] { new DependencyA() };
+            _factoryArguments2 = new object[] { new DependencyA(), new DependencyB() };
+            _factoryArguments2_OutOfOrder = new object[] { new DependencyB(), new DependencyC() };
+            _factoryArguments3 = new object[] { new DependencyA(), new DependencyB(), new DependencyC() };
+            _factoryArguments4 = new object[] { new DependencyA(), new DependencyB(), new DependencyC(), new DependencyD() };
+            _factoryArguments5 = new object[] { new DependencyA(), new DependencyB(), new DependencyC(), new DependencyD(), new DependencyE() };
             _serviceProvider = collection.BuildServiceProvider();
-            _factory = ActivatorUtilities.CreateFactory(typeof(TypeToBeActivated), new Type[] { typeof(DependencyB), typeof(DependencyC) });
-            _factoryArguments = new object[] { new DependencyB(), new DependencyC() };
         }
 
         [GlobalCleanup]
@@ -35,40 +68,309 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeToBeActivated ServiceProvider() => _serviceProvider.GetService<TypeToBeActivated>();
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeToBeActivated Factory() => (TypeToBeActivated)_factory(_serviceProvider, _factoryArguments);
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeToBeActivated CreateInstance() => ActivatorUtilities.CreateInstance<TypeToBeActivated>(_serviceProvider, _factoryArguments);
-
-        public class TypeToBeActivated
+        public TypeWith0ParametersToBeActivated GetService_0Injected()
         {
-            public TypeToBeActivated(int i)
+            return _serviceProvider.GetService<TypeWith0ParametersToBeActivated>();
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith1ParameterToBeActivated GetService_1Injected()
+        {
+            TypeWith1ParameterToBeActivated obj = _serviceProvider.GetService<TypeWith1ParameterToBeActivated>();
+            if (obj._a is null)
+            {
+                throw new Exception("Not expected.");
+            }
+
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith2ParametersToBeActivated GetService_2Injected()
+        {
+            TypeWith2ParametersToBeActivated obj = _serviceProvider.GetService<TypeWith2ParametersToBeActivated>();
+            if (obj._a is null || obj._b is null)
+            {
+                throw new Exception("Not expected.");
+            }
+
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated GetService_3Injected()
+        {
+            TypeWith3ParametersToBeActivated obj = _serviceProvider.GetService<TypeWith3ParametersToBeActivated>();
+            if (obj._a is null || obj._b is null || obj._c is null)
+            {
+                throw new Exception("Not expected.");
+            }
+
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith4ParametersToBeActivated GetService_4Injected()
+        {
+            TypeWith4ParametersToBeActivated obj = _serviceProvider.GetService<TypeWith4ParametersToBeActivated>();
+            if (obj._a is null || obj._b is null || obj._c is null || obj._d is null)
+            {
+                throw new Exception("Not expected.");
+            }
+
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith5ParametersToBeActivated GetService_5Injected()
+        {
+            TypeWith5ParametersToBeActivated obj = _serviceProvider.GetService<TypeWith5ParametersToBeActivated>();
+            if (obj._a is null || obj._b is null || obj._c is null || obj._d is null || obj._e is null)
+            {
+                throw new Exception("Not expected.");
+            }
+
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith0ParametersToBeActivated CreateInstance_0() => ActivatorUtilities.CreateInstance<TypeWith0ParametersToBeActivated>(_serviceProvider, _factoryArguments0);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith1ParameterToBeActivated CreateInstance_1() => ActivatorUtilities.CreateInstance<TypeWith1ParameterToBeActivated>(_serviceProvider, _factoryArguments1);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith2ParametersToBeActivated CreateInstance_2() => ActivatorUtilities.CreateInstance<TypeWith2ParametersToBeActivated>(_serviceProvider, _factoryArguments2);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated CreateInstance_3() => ActivatorUtilities.CreateInstance<TypeWith3ParametersToBeActivated>(_serviceProvider, _factoryArguments3);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith4ParametersToBeActivated CreateInstance_4() => ActivatorUtilities.CreateInstance<TypeWith4ParametersToBeActivated>(_serviceProvider, _factoryArguments4);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith5ParametersToBeActivated CreateInstance_5() => ActivatorUtilities.CreateInstance<TypeWith5ParametersToBeActivated>(_serviceProvider, _factoryArguments5);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated Factory_1Injected_2Explicit()
+        {
+            TypeWith3ParametersToBeActivated obj = (TypeWith3ParametersToBeActivated)_factory2(_serviceProvider, _factoryArguments2);
+            if (obj is null || obj._a is null || obj._b is null || obj._c is null)
+            {
+                throw new Exception("Not expected.");
+            }
+            return obj;
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated Factory_1Injected_2Explicit_OutOfOrder()
+        {
+            TypeWith3ParametersToBeActivated obj = (TypeWith3ParametersToBeActivated)_factory2_OutOfOrder(_serviceProvider, _factoryArguments2_OutOfOrder);
+            if (obj is null || obj._a is null || obj._b is null || obj._c is null)
+            {
+                throw new Exception("Not expected.");
+            }
+            return obj;
+        }
+       
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated Factory_3Explicit()
+        {
+            TypeWith3ParametersToBeActivated obj = (TypeWith3ParametersToBeActivated)_factory3(_serviceProvider, _factoryArguments3);
+            if (obj is null || obj._a is null || obj._b is null || obj._c is null)
+            {
+                throw new Exception("Not expected.");
+            }
+            return obj;
+        }
+
+        public class TypeWith0ParametersToBeActivated
+        {
+            // DI  picks these over the correct one below and throws TargetInvocationException.
+            //public TypeWith0ParametersToBeActivated(int i)
+            //{
+            //    throw new NotImplementedException();
+            //}
+
+            //public TypeWith0ParametersToBeActivated(string s)
+            //{
+            //    throw new NotImplementedException();
+            //}
+
+            //public TypeWith0ParametersToBeActivated(object o)
+            //{
+            //    throw new NotImplementedException();
+            //}
+
+            public TypeWith0ParametersToBeActivated()
+            {
+            }
+        }
+
+        public class TypeWith1ParameterToBeActivated
+        {
+            public DependencyA _a;
+
+            public TypeWith1ParameterToBeActivated(int i)
             {
                 throw new NotImplementedException();
             }
 
-            public TypeToBeActivated(string s)
+            public TypeWith1ParameterToBeActivated(string s)
             {
                 throw new NotImplementedException();
             }
 
-            public TypeToBeActivated(object o)
+            // DI picks this over the one below and calls it.
+            //public TypeWith1ParameterToBeActivated(object o)
+            //{
+            //    throw new NotImplementedException();
+            //}
+
+            public TypeWith1ParameterToBeActivated(DependencyA a)
+            {
+                _a = a;
+            }
+        }
+
+        public class TypeWith2ParametersToBeActivated
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+
+            public TypeWith2ParametersToBeActivated(int i)
             {
                 throw new NotImplementedException();
             }
 
-            public TypeToBeActivated(DependencyA a, DependencyB b, DependencyC c)
+            public TypeWith2ParametersToBeActivated(string s)
             {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith2ParametersToBeActivated(object o)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith2ParametersToBeActivated(DependencyA a, DependencyB b)
+            {
+                _a = a;
+                _b = b;
+            }
+        }
+
+        public class TypeWith3ParametersToBeActivated
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+
+            public TypeWith3ParametersToBeActivated(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated(string s)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated(object o)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
+            }
+        }
+
+        public class TypeWith4ParametersToBeActivated
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+            public DependencyD _d;
+
+            public TypeWith4ParametersToBeActivated(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith4ParametersToBeActivated(string s)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith4ParametersToBeActivated(object o)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith4ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c, DependencyD d)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
+                _d = d;
+            }
+        }
+
+        public class TypeWith5ParametersToBeActivated
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+            public DependencyD _d;
+            public DependencyE _e;
+
+            public TypeWith5ParametersToBeActivated(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated(string s)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated(object o)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c, DependencyD d, DependencyE e)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
+                _d = d;
+                _e = e;
             }
         }
 
         public class DependencyA {}
         public class DependencyB {}
         public class DependencyC {}
+        public class DependencyD { }
+        public class DependencyE { }
     }
 }


### PR DESCRIPTION
These will support the perf impact of refactoring DI based on https://github.com/dotnet/runtime/issues/66153 which depends on new APIs from https://github.com/dotnet/runtime/issues/85539.

Some existing benchmarks were renamed here for consistency\understandability, but since there are no planned changes doing a reset is ok.

Local results:
```
|                                 Method |      Mean |    Error |   StdDev |    Median |       Min |       Max |   Gen0 | Allocated |
|--------------------------------------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|----------:|
|                   GetService_0Injected |  10.69 ns | 0.166 ns | 0.155 ns |  10.62 ns |  10.51 ns |  11.00 ns | 0.0023 |      24 B |
|                   GetService_1Injected |  12.56 ns | 0.097 ns | 0.081 ns |  12.55 ns |  12.44 ns |  12.69 ns | 0.0022 |      24 B |
|                   GetService_2Injected |  12.52 ns | 0.107 ns | 0.100 ns |  12.47 ns |  12.40 ns |  12.67 ns | 0.0030 |      32 B |
|                   GetService_3Injected |  13.67 ns | 0.078 ns | 0.070 ns |  13.64 ns |  13.57 ns |  13.78 ns | 0.0038 |      40 B |
|                   GetService_4Injected |  16.45 ns | 0.072 ns | 0.060 ns |  16.46 ns |  16.29 ns |  16.50 ns | 0.0045 |      48 B |
|                   GetService_5Injected |  17.79 ns | 0.093 ns | 0.087 ns |  17.76 ns |  17.70 ns |  17.98 ns | 0.0053 |      56 B |
|                       CreateInstance_0 |  84.44 ns | 0.386 ns | 0.322 ns |  84.42 ns |  83.94 ns |  85.18 ns | 0.0076 |      80 B |
|                       CreateInstance_1 | 302.51 ns | 3.503 ns | 3.276 ns | 300.79 ns | 299.42 ns | 308.73 ns | 0.0242 |     264 B |
|                       CreateInstance_2 | 417.45 ns | 6.568 ns | 6.143 ns | 413.95 ns | 411.27 ns | 428.41 ns | 0.0334 |     360 B |
|                       CreateInstance_3 | 416.45 ns | 0.879 ns | 0.779 ns | 416.44 ns | 415.28 ns | 418.19 ns | 0.0353 |     384 B |
|                       CreateInstance_4 | 453.16 ns | 1.138 ns | 0.888 ns | 453.28 ns | 451.79 ns | 454.46 ns | 0.0385 |     408 B |
|                       CreateInstance_5 | 504.89 ns | 3.007 ns | 2.813 ns | 503.84 ns | 501.33 ns | 510.85 ns | 0.0457 |     496 B |
|            Factory_1Injected_2Explicit |  18.95 ns | 0.123 ns | 0.115 ns |  18.94 ns |  18.75 ns |  19.13 ns | 0.0038 |      40 B |
| Factory_1Injected_2Explicit_OutOfOrder |  18.00 ns | 0.152 ns | 0.135 ns |  18.01 ns |  17.72 ns |  18.24 ns | 0.0038 |      40 B |
|                      Factory_3Explicit |  10.69 ns | 0.103 ns | 0.092 ns |  10.69 ns |  10.53 ns |  10.81 ns | 0.0038 |      40 B |
```