### PR TITLE
Don't run PDN scenarios on x86 systems 

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -47,7 +47,7 @@
       <ScenarioDirectoryName>wpfsfc</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </UIScenario>
-    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(BUILD_REPOSITORY_PROVIDER) == 'TfsGit'">
+    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(BUILD_REPOSITORY_PROVIDER) == 'TfsGit' And '$(Architecture)' != 'x86'">
       <ScenarioDirectoryName>paintdotnet</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <ExplicitPrepareCommand>$(Python) pre.py extract -p $(CorrelationPayloadDirectory)PDN\PDN.zip -o $(PreparePayloadWorkItemBaseDirectory)%(ScenarioDirectoryName)_fdd</ExplicitPrepareCommand>

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -152,6 +152,7 @@ jobs:
                 mkdir $(CorrelationStaging)PDN
                 curl "https://pvscmdupload.blob.core.windows.net/assets/paint.net.5.0.3.portable.${{parameters.architecture}}.zip$(PerfCommandUploadTokenNonEscaped)" -OutFile $(CorrelationStaging)PDN\PDN.zip
               displayName: Download PDN
+              condition: ne('${{ parameters.architecture }}', 'x86')
           - powershell: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install urllib3==1.26.15

--- a/eng/performance/scenarios_affinitized.proj
+++ b/eng/performance/scenarios_affinitized.proj
@@ -13,7 +13,7 @@
 
   <!-- Scenario definitions -->
   <ItemGroup>
-    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(BUILD_REPOSITORY_PROVIDER) == 'TfsGit'">
+    <UIScenario Include="PaintDotNet" Condition="'$(TargetsWindows)' == 'true' And $(BUILD_REPOSITORY_PROVIDER) == 'TfsGit' And '$(Architecture)' != 'x86'">
       <ScenarioDirectoryName>paintdotnet</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <ExplicitPrepareCommand>$(Python) pre.py extract -p $(CorrelationPayloadDirectory)PDN\PDN.zip -o $(PreparePayloadWorkItemBaseDirectory)%(ScenarioDirectoryName)_fdd</ExplicitPrepareCommand>


### PR DESCRIPTION
Don't run PDN scenarios on x86 systems as there is no portable.zip available for x86, only arm64 and x64. Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2223768&view=results

The error is occuring on the sdk_scenarios runs because we download PDN for all the scenarios, not just scenarios.proj, and the sdk_scenarios is the only one to run for x86. This also means the architecture condition on the PaintDotNet is not strictly needed but was added to ensure clarity if x86 was added for scenarios.proj in the future.