### PR TITLE
New TimeToMain2 measurement for LTTng on Ubuntu 22.04 workaround (future work).

### DIFF
--- a/src/scenarios/emptyconsolenativeaot/pre.py
+++ b/src/scenarios/emptyconsolenativeaot/pre.py
@@ -17,6 +17,7 @@ precommands.new(template='console',
 args = ['/p:PublishAot=true', '/p:StripSymbols=true', '/p:IlcGenerateMstatFile=true']
 if not iswin():
     args.extend(['/p:ObjCopyName=objcopy'])
+precommands.add_onmain_logging("Program.cs", "// See https://aka.ms/new-console-template for more information")
 precommands.execute(args)
 
 src = os.path.join(const.APPDIR, 'obj', precommands.configuration, precommands.framework, precommands.runtime_identifier, 'native', f'{EXENAME}.mstat')

--- a/src/scenarios/emptyconsolenativeaot/test.py
+++ b/src/scenarios/emptyconsolenativeaot/test.py
@@ -4,7 +4,7 @@ EXENAME = 'emptyconsolenativeaot'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME,
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/emptyconsoletemplate/pre.py
+++ b/src/scenarios/emptyconsoletemplate/pre.py
@@ -14,4 +14,5 @@ precommands.new(template='console',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
+precommands.add_onmain_logging("Program.cs", "// See https://aka.ms/new-console-template for more information")
 precommands.execute()

--- a/src/scenarios/emptyconsoletemplate/test.py
+++ b/src/scenarios/emptyconsoletemplate/test.py
@@ -7,7 +7,7 @@ EXENAME = 'emptycsconsoletemplate'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME, 
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/emptyvbconsoletemplate/pre.py
+++ b/src/scenarios/emptyvbconsoletemplate/pre.py
@@ -15,4 +15,5 @@ precommands.new(template='console',
                 exename=EXENAME,
                 working_directory=sys.path[0],
                 language='vb')
+precommands.add_onmain_logging("Program.vb", "    Sub Main(args As String())", language_file_extension="vb")
 precommands.execute()

--- a/src/scenarios/emptyvbconsoletemplate/test.py
+++ b/src/scenarios/emptyvbconsoletemplate/test.py
@@ -7,7 +7,7 @@ EXENAME = 'emptyvbconsoletemplate'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME, 
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -243,7 +243,6 @@ class PreCommands:
             trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.OnMain()"
         elif language_file_extension == 'fs':
             trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.OnMain()"
-        #print(f"{' ' * 10}Hello world")
         else:
             raise Exception(f"{language_file_extension} not supported.")
         self.add_event_source(file, line, trace_statement, language_file_extension)

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -225,10 +225,30 @@ class PreCommands:
             startup_args += self.crossgen_arguments.get_crossgen2_command_line()
             RunCommand(startup_args, verbose=True).run(self.crossgen_arguments.coreroot)
 
-    def add_startup_logging(self, file: str, line: str):
-        self.add_event_source(file, line, "PerfLabGenericEventSource.Log.Startup();")
+    def add_startup_logging(self, file: str, line: str, language_file_extension: str = 'cs', indent: int = 0):
+        if language_file_extension == 'cs':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.Startup();"
+        elif language_file_extension == 'vb':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.Startup()"
+        elif language_file_extension == 'fs':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.Startup()"
+        else:
+            raise Exception(f"{language_file_extension} not supported.")
+        self.add_event_source(file, line, trace_statement, language_file_extension)
 
-    def add_event_source(self, file: str, line: str, trace_statement: str):
+    def add_onmain_logging(self, file: str, line: str, language_file_extension: str = 'cs', indent: int = 0):
+        if language_file_extension == 'cs':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.OnMain();"
+        elif language_file_extension == 'vb':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.OnMain()"
+        elif language_file_extension == 'fs':
+            trace_statement = f"{' ' * indent}PerfLabGenericEventSource.Log.OnMain()"
+        #print(f"{' ' * 10}Hello world")
+        else:
+            raise Exception(f"{language_file_extension} not supported.")
+        self.add_event_source(file, line, trace_statement, language_file_extension)
+
+    def add_event_source(self, file: str, line: str, trace_statement: str, language_file_extension: str = 'cs'):
         '''
         Adds a copy of the event source to the project and inserts the correct call
         file: relative path to the root of the project (where the project file lives)
@@ -236,17 +256,17 @@ class PreCommands:
         trace_statement: Statement to insert
         '''
 
-        self.add_perflab_file()
+        self.add_perflab_file(language_file_extension)
         projpath = os.path.dirname(self.project.csproj_file)
         filepath = os.path.join(projpath, file)
         insert_after(filepath, line, trace_statement)
 
-    def add_perflab_file(self):
+    def add_perflab_file(self, language_file_extension: str = 'cs'):
         projpath = os.path.dirname(self.project.csproj_file)
         staticpath = os.path.join(get_repo_root_path(), "src", "scenarios", "staticdeps")
         if helixpayload():
             staticpath = os.path.join(helixpayload(), "staticdeps")
-        shutil.copyfile(os.path.join(staticpath, "PerfLab.cs"), os.path.join(projpath, "PerfLab.cs"))
+        shutil.copyfile(os.path.join(staticpath, f"PerfLab.{language_file_extension}"), os.path.join(projpath, f"PerfLab.{language_file_extension}"))
 
     def install_workload(self, workloadid: str, install_args: list = ["--skip-manifest-update"]):
         'Installs the workload, if needed'

--- a/src/scenarios/staticconsoletemplate/pre.py
+++ b/src/scenarios/staticconsoletemplate/pre.py
@@ -11,4 +11,5 @@ from test import EXENAME
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing(os.path.join(sys.path[0], const.SRCDIR), ('%s.csproj' % EXENAME))
+precommands.add_onmain_logging("Program.cs", "        {")
 precommands.execute()

--- a/src/scenarios/staticconsoletemplate/test.py
+++ b/src/scenarios/staticconsoletemplate/test.py
@@ -7,7 +7,7 @@ EXENAME = 'staticconsoletemplate'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME, 
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/staticdeps/PerfLab.cs
+++ b/src/scenarios/staticdeps/PerfLab.cs
@@ -7,7 +7,9 @@ class PerfLabGenericEventSource : EventSource
 
     public static PerfLabGenericEventSource Log { get; } = new PerfLabGenericEventSource();
 
+    [Event(MagicConstant + 1)]
     public void Startup() => WriteEvent(MagicConstant + 1);
 
+    [Event(MagicConstant + 2)]
     public void OnMain() => WriteEvent(MagicConstant + 2);
 }

--- a/src/scenarios/staticdeps/PerfLab.cs
+++ b/src/scenarios/staticdeps/PerfLab.cs
@@ -3,6 +3,9 @@ using System.Diagnostics.Tracing;
 [EventSource(Guid = "9bb228bd-1033-5cf0-1a56-c2dbbe0ebc86")]
 class PerfLabGenericEventSource : EventSource
 {
-    public static PerfLabGenericEventSource Log = new PerfLabGenericEventSource();
+    public static PerfLabGenericEventSource Log { get; } = new PerfLabGenericEventSource();
+
     public void Startup() => WriteEvent(1);
+
+    public void OnMain() => WriteEvent(2);
 }

--- a/src/scenarios/staticdeps/PerfLab.cs
+++ b/src/scenarios/staticdeps/PerfLab.cs
@@ -3,9 +3,11 @@ using System.Diagnostics.Tracing;
 [EventSource(Guid = "9bb228bd-1033-5cf0-1a56-c2dbbe0ebc86")]
 class PerfLabGenericEventSource : EventSource
 {
+    private const int MagicConstant = 6666;
+
     public static PerfLabGenericEventSource Log { get; } = new PerfLabGenericEventSource();
 
-    public void Startup() => WriteEvent(1);
+    public void Startup() => WriteEvent(MagicConstant + 1);
 
-    public void OnMain() => WriteEvent(2);
+    public void OnMain() => WriteEvent(MagicConstant + 2);
 }

--- a/src/scenarios/staticdeps/PerfLab.fs
+++ b/src/scenarios/staticdeps/PerfLab.fs
@@ -6,8 +6,11 @@ open System.Diagnostics.Tracing
 type PerfLabGenericEventSource() =
     inherit EventSource()
 
+    [<Literal>]
+    let MagicConstant = 6666
+
     static member val Log = new PerfLabGenericEventSource()
 
-    member this.Startup() = this.WriteEvent(1)
+    member this.Startup() = this.WriteEvent(MagicConstant + 1)
 
-    member this.OnMain() = this.WriteEvent(2)
+    member this.OnMain() = this.WriteEvent(MagicConstant + 2)

--- a/src/scenarios/staticdeps/PerfLab.fs
+++ b/src/scenarios/staticdeps/PerfLab.fs
@@ -1,0 +1,13 @@
+namespace global
+
+open System.Diagnostics.Tracing
+
+[<EventSource(Guid = "9bb228bd-1033-5cf0-1a56-c2dbbe0ebc86")>]
+type PerfLabGenericEventSource() =
+    inherit EventSource()
+
+    static member val Log = new PerfLabGenericEventSource()
+
+    member this.Startup() = this.WriteEvent(1)
+
+    member this.OnMain() = this.WriteEvent(2)

--- a/src/scenarios/staticdeps/PerfLab.fs
+++ b/src/scenarios/staticdeps/PerfLab.fs
@@ -11,6 +11,8 @@ type PerfLabGenericEventSource() =
 
     static member val Log = new PerfLabGenericEventSource()
 
+    [<Event(6667)>] // MagicConstant + 1
     member this.Startup() = this.WriteEvent(MagicConstant + 1)
 
+    [<Event(6668)>] // MagicConstant + 2
     member this.OnMain() = this.WriteEvent(MagicConstant + 2)

--- a/src/scenarios/staticdeps/PerfLab.vb
+++ b/src/scenarios/staticdeps/PerfLab.vb
@@ -4,13 +4,15 @@ Imports System.Diagnostics.Tracing
 Class PerfLabGenericEventSource
     Inherits EventSource
 
+    Private Const MagicConstant As Integer = 6666
+
     Public Shared ReadOnly Property Log As PerfLabGenericEventSource = New PerfLabGenericEventSource()
 
     Public Sub Startup()
-        WriteEvent(1)
+        WriteEvent(MagicConstant + 1)
     End Sub
 
     Public Sub OnMain()
-        WriteEvent(2)
+        WriteEvent(MagicConstant + 2)
     End Sub
 End Class

--- a/src/scenarios/staticdeps/PerfLab.vb
+++ b/src/scenarios/staticdeps/PerfLab.vb
@@ -1,0 +1,16 @@
+Imports System.Diagnostics.Tracing
+
+<EventSource(Guid:="9bb228bd-1033-5cf0-1a56-c2dbbe0ebc86")>
+Class PerfLabGenericEventSource
+    Inherits EventSource
+
+    Public Shared ReadOnly Property Log As PerfLabGenericEventSource = New PerfLabGenericEventSource()
+
+    Public Sub Startup()
+        WriteEvent(1)
+    End Sub
+
+    Public Sub OnMain()
+        WriteEvent(2)
+    End Sub
+End Class

--- a/src/scenarios/staticdeps/PerfLab.vb
+++ b/src/scenarios/staticdeps/PerfLab.vb
@@ -8,10 +8,12 @@ Class PerfLabGenericEventSource
 
     Public Shared ReadOnly Property Log As PerfLabGenericEventSource = New PerfLabGenericEventSource()
 
+    <[Event](MagicConstant + 1)>
     Public Sub Startup()
         WriteEvent(MagicConstant + 1)
     End Sub
 
+    <[Event](MagicConstant + 2)>
     Public Sub OnMain()
         WriteEvent(MagicConstant + 2)
     End Sub

--- a/src/scenarios/staticfsconsoletemplate/pre.py
+++ b/src/scenarios/staticfsconsoletemplate/pre.py
@@ -11,4 +11,5 @@ from test import EXENAME
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing(os.path.join(sys.path[0], const.SRCDIR), ('%s.fsproj' % EXENAME))
+precommands.add_onmain_logging("Program.fs", "let main _ =", language_file_extension="fs", indent=4)
 precommands.execute()

--- a/src/scenarios/staticfsconsoletemplate/src/staticfsconsoletemplate.fsproj
+++ b/src/scenarios/staticfsconsoletemplate/src/staticfsconsoletemplate.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Program.fs" />
+    <Compile Include="*.fs" />
   </ItemGroup>
 
 </Project>

--- a/src/scenarios/staticfsconsoletemplate/test.py
+++ b/src/scenarios/staticfsconsoletemplate/test.py
@@ -7,7 +7,7 @@ EXENAME = 'staticfsconsoletemplate'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME, 
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/scenarios/staticvbconsoletemplate/pre.py
+++ b/src/scenarios/staticvbconsoletemplate/pre.py
@@ -11,4 +11,5 @@ from test import EXENAME
 setup_loggers(True)
 precommands = PreCommands()
 precommands.existing(os.path.join(sys.path[0], const.SRCDIR), ('%s.vbproj' % EXENAME))
+precommands.add_onmain_logging("Program.vb", "    Sub Main(args As String())", language_file_extension="vb")
 precommands.execute()

--- a/src/scenarios/staticvbconsoletemplate/test.py
+++ b/src/scenarios/staticvbconsoletemplate/test.py
@@ -7,7 +7,7 @@ EXENAME = 'staticvbconsoletemplate'
 
 if __name__ == "__main__":
     traits = TestTraits(exename=EXENAME, 
-                        startupmetric='TimeToMain',
+                        startupmetric='TimeToMain2',
                         guiapp='false',
                         )
     Runner(traits).run()

--- a/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
+++ b/src/tools/ScenarioMeasurement/PowerConsumption/PerfCollect.cs
@@ -149,13 +149,15 @@ namespace ScenarioMeasurement
         private bool LttngInstalled()
         {
             ProcessStartInfo procStartInfo = new ProcessStartInfo("modinfo", "lttng_probe_writeback");
-            Process proc = new Process() { StartInfo = procStartInfo, };
-            proc.StartInfo.RedirectStandardOutput = true;
-            proc.Start();
-            string result = proc.StandardOutput.ReadToEnd();
-            proc.WaitForExit();
-            // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
-            return result.Contains("filename:");
+            using (Process proc = new Process() { StartInfo = procStartInfo })
+            {
+                proc.StartInfo.RedirectStandardOutput = true;
+                proc.Start();
+                string result = proc.StandardOutput.ReadToEnd();
+                proc.WaitForExit();
+                // If the lttng_probe_writeback module is installed, the modinfo output will include the filename field
+                return result.Contains("filename:");
+            }
         }
 
         public enum KernelKeyword

--- a/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/GenericStartupParser.cs
@@ -7,9 +7,8 @@ namespace ScenarioMeasurement;
 
 public class GenericStartupParser : IParser
 {
-    // see src\scenarios\staticdeps\PerfLab.cs
-    public const string PerfLabGenericEventSourceName = "PerfLabGenericEventSource";
-    public const string StartupEventName = "Startup";
+    private const string EventSourceName = PerfLabValues.EventSourceName;
+    private const string StartupEventName = PerfLabValues.StartupEventName;
 
     public void EnableKernelProvider(ITraceSession kernel)
     {
@@ -18,7 +17,7 @@ public class GenericStartupParser : IParser
 
     public void EnableUserProviders(ITraceSession user)
     {
-        user.EnableUserProvider(PerfLabGenericEventSourceName, TraceEventLevel.Verbose);
+        user.EnableUserProvider(EventSourceName, TraceEventLevel.Verbose);
     }
 
     public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
@@ -68,7 +67,7 @@ public class GenericStartupParser : IParser
                 }
             };
 
-            source.Dynamic.AddCallbackForProviderEvent(PerfLabGenericEventSourceName, StartupEventName, evt =>
+            source.Dynamic.AddCallbackForProviderEvent(EventSourceName, StartupEventName, evt =>
             {
                 if (pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/tools/ScenarioMeasurement/Startup/PerfLabValues.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfLabValues.cs
@@ -1,0 +1,11 @@
+﻿namespace ScenarioMeasurement;
+
+class PerfLabValues
+{
+    // see src\scenarios\staticdeps\PerfLab.cs
+    public const string EventSourceName = "PerfLabGenericEventSource";
+    public const string StartupEventName = "Startup";
+    public const int StartupEventId = 1;
+    public const string OnMainEventName = "OnMain";
+    public const int OnMainEventId = 2;
+}

--- a/src/tools/ScenarioMeasurement/Startup/PerfLabValues.cs
+++ b/src/tools/ScenarioMeasurement/Startup/PerfLabValues.cs
@@ -1,11 +1,13 @@
 ﻿namespace ScenarioMeasurement;
 
+// see src\scenarios\staticdeps\PerfLab.cs
 class PerfLabValues
 {
-    // see src\scenarios\staticdeps\PerfLab.cs
+    // to "prevent" event id collisions
+    private const int MagicConstant = 6666;
     public const string EventSourceName = "PerfLabGenericEventSource";
     public const string StartupEventName = "Startup";
-    public const int StartupEventId = 1;
+    public const int StartupEventId = MagicConstant + 1;
     public const string OnMainEventName = "OnMain";
-    public const int OnMainEventId = 2;
+    public const int OnMainEventId = MagicConstant + 2;
 }

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -23,7 +23,8 @@ enum MetricType
     DeviceTimeToMain,
     PDN,
     WinUI,
-    WinUIBlazor
+    WinUIBlazor,
+    TimeToMain2,
 }
 
 public class InnerLoopMarkerEventSource : EventSource
@@ -271,46 +272,23 @@ class Startup
             }
         }
 
-        IParser parser = null;
-        switch (metricType)
+        IParser parser = metricType switch
         {
-            case MetricType.TimeToMain:
-                parser = new TimeToMainParser();
-                break;
-            case MetricType.GenericStartup:
-                parser = new GenericStartupParser();
-                break;
-            case MetricType.ProcessTime:
-                parser = new ProcessTimeParser();
-                break;
-            case MetricType.Crossgen2:
-                parser = new Crossgen2Parser();
-                break;
-            case MetricType.InnerLoop:
-                parser = new InnerLoopParser(processWillExit);
-                break;
-            case MetricType.InnerLoopMsBuild:
-                parser = new InnerLoopMsBuildParser();
-                break;
-            case MetricType.DotnetWatch:
-                parser = new DotnetWatchParser();
-                break;
-            case MetricType.DeviceTimeToMain:
-                parser = new DeviceTimeToMain();
-                break;
-            case MetricType.WPF:
-                parser = new WPFParser();
-                break;
-            case MetricType.PDN:
-                parser = new PDNStartupParser();
-                break;
-            case MetricType.WinUI:
-                parser = new WinUIParser();
-                break;
-            case MetricType.WinUIBlazor:
-                parser = new WinUIBlazorParser();
-                break;
-        }
+            MetricType.TimeToMain => new TimeToMainParser(),
+            MetricType.GenericStartup => new GenericStartupParser(),
+            MetricType.ProcessTime => new ProcessTimeParser(),
+            MetricType.Crossgen2 => new Crossgen2Parser(),
+            MetricType.WPF => new WPFParser(),
+            MetricType.InnerLoop => new InnerLoopParser(processWillExit),
+            MetricType.InnerLoopMsBuild => new InnerLoopMsBuildParser(),
+            MetricType.DotnetWatch => new DotnetWatchParser(),
+            MetricType.DeviceTimeToMain => new DeviceTimeToMain(),
+            MetricType.PDN => new PDNStartupParser(),
+            MetricType.WinUI => new WinUIParser(),
+            MetricType.WinUIBlazor => new WinUIBlazorParser(),
+            MetricType.TimeToMain2 => new TimeToMain2Parser(),
+            _ => throw new ArgumentOutOfRangeException(),
+        };
 
         var pids = new List<int>();
         var failed = false;

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMain2Parser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMain2Parser.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Reporting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ScenarioMeasurement;
+
+public class TimeToMain2Parser : IParser
+{
+    private const string EventSourceName = PerfLabValues.EventSourceName;
+    private const string OnMainEventName = PerfLabValues.OnMainEventName;
+    private const int OnMainEventId = PerfLabValues.OnMainEventId;
+
+    public void EnableKernelProvider(ITraceSession kernel)
+    {
+        kernel.EnableKernelProvider(TraceSessionManager.KernelKeyword.Process, TraceSessionManager.KernelKeyword.Thread, TraceSessionManager.KernelKeyword.ContextSwitch);
+    }
+
+    public void EnableUserProviders(ITraceSession user)
+    {
+        user.EnableUserProvider(EventSourceName, TraceEventLevel.Verbose);
+    }
+
+    public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
+    {
+        var results = new List<double>();
+        var threadTimes = new List<double>();
+        double threadTime = 0;
+        var ins = new Dictionary<int, double>();
+        double start = -1;
+        int? pid = null;
+        using (var source = new TraceSourceManager(mergeTraceFile))
+        {
+            source.Kernel.ProcessStart += evt =>
+            {
+                if (!pid.HasValue && ParserUtility.MatchProcessStart(evt, source, processName, pids, commandLine))
+                {
+                    pid = evt.ProcessID;
+                    start = evt.TimeStampRelativeMSec;
+                }
+            };
+
+            source.Source.Kernel.ThreadCSwitch += evt =>
+            {
+                if (!pid.HasValue) // we're currently in a measurement interval
+                    return;
+
+                if (evt.NewProcessID != pid && evt.OldProcessID != pid)
+                    return; // but this isn't our process
+
+                if (evt.OldProcessID == pid) // this is a switch out from our process
+                {
+                    if (ins.TryGetValue(evt.OldThreadID, out var value)) // had we ever recorded a switch in for this thread?
+                    {
+                        threadTime += evt.TimeStampRelativeMSec - value;
+                        ins.Remove(evt.OldThreadID);
+                    }
+                }
+                else // this is a switch in to our process
+                {
+                    ins[evt.NewThreadID] = evt.TimeStampRelativeMSec;
+                }
+            };
+
+            if (source.IsWindows)
+            {
+                source.Source.Dynamic.AddCallbackForProviderEvent(EventSourceName, OnMainEventName, evt =>
+                {
+                    if (pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        results.Add(evt.TimeStampRelativeMSec - start);
+                        threadTimes.Add(threadTime);
+                        pid = null;
+                        threadTime = 0;
+                        start = 0;
+                    }
+                });
+            }
+            else
+            {
+                source.Source.Clr.EventSourceEvent += evt =>
+                {
+                    if (pid.HasValue && evt.ProcessID == pid && evt.EventID == OnMainEventId)
+                    {
+                        results.Add(evt.TimeStampRelativeMSec - start);
+                        threadTimes.Add(threadTime);
+                        pid = null;
+                        threadTime = 0;
+                        start = 0;
+                    }
+                };
+            }
+
+            source.Process();
+        }
+
+        var result = new List<Counter>();
+        result.Add(new Counter() { Name = "Time To Main", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = results.ToArray() });
+        // below is supported only on Windows, other platform will have 0s
+        if (threadTimes.All(x => x != 0))
+        {
+            result.Add(new Counter() { Name = "Time on Thread", MetricName = "ms", TopCounter = true, Results = threadTimes.ToArray() });
+        };
+        return result;
+    }
+}

--- a/src/tools/ScenarioMeasurement/Startup/TimeToMain2Parser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/TimeToMain2Parser.cs
@@ -99,7 +99,7 @@ public class TimeToMain2Parser : IParser
         var result = new List<Counter>();
         result.Add(new Counter() { Name = "Time To Main", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = results.ToArray() });
         // below is supported only on Windows, other platform will have 0s
-        if (threadTimes.All(x => x != 0))
+        if (!threadTimes.All(x => x == 0))
         {
             result.Add(new Counter() { Name = "Time on Thread", MetricName = "ms", TopCounter = true, Results = threadTimes.ToArray() });
         };

--- a/src/tools/ScenarioMeasurement/Startup/WinUIBlazorParser.cs
+++ b/src/tools/ScenarioMeasurement/Startup/WinUIBlazorParser.cs
@@ -17,7 +17,7 @@ public class WinUIBlazorParser : IParser
     public void EnableUserProviders(ITraceSession user)
     {
         user.EnableUserProvider(WinUIProvider, TraceEventLevel.Verbose);
-        user.EnableUserProvider(GenericStartupParser.PerfLabGenericEventSourceName, TraceEventLevel.Verbose);
+        user.EnableUserProvider(PerfLabValues.EventSourceName, TraceEventLevel.Verbose);
     }
 
     public IEnumerable<Counter> Parse(string mergeTraceFile, string processName, IList<int> pids, string commandLine)
@@ -77,7 +77,7 @@ public class WinUIBlazorParser : IParser
                 }
             });
 
-            source.Dynamic.AddCallbackForProviderEvent(GenericStartupParser.PerfLabGenericEventSourceName, GenericStartupParser.StartupEventName, evt =>
+            source.Dynamic.AddCallbackForProviderEvent(PerfLabValues.EventSourceName, PerfLabValues.StartupEventName, evt =>
             {
                 if (pid.HasValue && evt.ProcessID == pid && evt.ProcessName.Equals(processName, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
This switches _scenarios_ to use our own "OnMain" from using event from runtime to get "Time to Main". We can't use the runtime one, because currently we'll not be able to capture it on Ubuntu 22.04 and LTTng. 

The workaround for LTTng and 22.04 is future PR.