### PR TITLE
[perf][ios] Use precommands.framework var instead of explicit framework

### DIFF
--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -72,8 +72,8 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Copy the MauiVersion to a file so we have it on the machine
-maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.Maui.dll")
+maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
 version_dict = { "mauiVersion": maui_version }
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.Maui.dll")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
 

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -35,7 +35,7 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Copy the MauiVersion to a file so we have it on the machine
-maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.Maui.dll")
+maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
 version_dict = { "mauiVersion": maui_version }
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.Maui.dll")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")

--- a/src/scenarios/xamarinios/pre.py
+++ b/src/scenarios/xamarinios/pre.py
@@ -35,7 +35,7 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Copy the XamarinVersion to a file so we have it on the machine
-xamarin_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.iOS.dll")
+xamarin_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.iOS.dll")
 version_dict = { "xamarinVersion": xamarin_version }
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/net8.0-ios/ios-arm64/linked/Microsoft.iOS.dll")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.iOS.dll")


### PR DESCRIPTION
This PR updates iOS scenarios to use `{precommands.framework}` var instead of explicit framework.
