### PR TITLE
3153 perf scenarios startup tool build failing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,9 +276,9 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        # - ubuntu-x64
+        - ubuntu-x64
         - win-arm64
-        # - ubuntu-arm64-ampere
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -286,84 +286,84 @@ jobs:
         channels:
           - main
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-  # # Maui Android scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_android
-  #       projectFile: maui_scenarios_android.proj
-  #       dotnetVersionsLinks:
-  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # Maui Android scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_android
+        projectFile: maui_scenarios_android.proj
+        dotnetVersionsLinks:
+          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # # Maui iOS scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_ios
-  #       projectFile: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # Maui iOS scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # ## Maui scenario benchmarks
-  # #- template: /eng/performance/build_machine_matrix.yml
-  # #  parameters:
-  # #    jobTemplate: /eng/performance/scenarios.yml
-  # #    buildMachines:
-  # #      - win-x64
-  # #      - ubuntu-x64
-  # #      - win-arm64
-  # #      - ubuntu-arm64-ampere
-  # #    isPublic: false
-  # #    jobParameters:
-  # #      kind: maui_scenarios
-  # #      projectFile: maui_scenarios.proj
-  # #      channels:
-  # #        - main
+  ## Maui scenario benchmarks
+  #- template: /eng/performance/build_machine_matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/performance/scenarios.yml
+  #    buildMachines:
+  #      - win-x64
+  #      - ubuntu-x64
+  #      - win-arm64
+  #      - ubuntu-arm64-ampere
+  #    isPublic: false
+  #    jobParameters:
+  #      kind: maui_scenarios
+  #      projectFile: maui_scenarios.proj
+  #      channels:
+  #        - main
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: nativeaot_scenarios
-  #       projectFile: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
 
 ################################################
 # Scheduled Private jobs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,9 +276,9 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        - ubuntu-x64
+        # - ubuntu-x64
         - win-arm64
-        - ubuntu-arm64-ampere
+        # - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -286,84 +286,84 @@ jobs:
         channels:
           - main
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-  # Maui Android scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_android
-        projectFile: maui_scenarios_android.proj
-        dotnetVersionsLinks:
-          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # # Maui Android scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_android
+  #       projectFile: maui_scenarios_android.proj
+  #       dotnetVersionsLinks:
+  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  # Maui iOS scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          main: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  # # Maui iOS scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_ios
+  #       projectFile: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         main: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
-  ## Maui scenario benchmarks
-  #- template: /eng/performance/build_machine_matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/performance/scenarios.yml
-  #    buildMachines:
-  #      - win-x64
-  #      - ubuntu-x64
-  #      - win-arm64
-  #      - ubuntu-arm64-ampere
-  #    isPublic: false
-  #    jobParameters:
-  #      kind: maui_scenarios
-  #      projectFile: maui_scenarios.proj
-  #      channels:
-  #        - main
+  # ## Maui scenario benchmarks
+  # #- template: /eng/performance/build_machine_matrix.yml
+  # #  parameters:
+  # #    jobTemplate: /eng/performance/scenarios.yml
+  # #    buildMachines:
+  # #      - win-x64
+  # #      - ubuntu-x64
+  # #      - win-arm64
+  # #      - ubuntu-arm64-ampere
+  # #    isPublic: false
+  # #    jobParameters:
+  # #      kind: maui_scenarios
+  # #      projectFile: maui_scenarios.proj
+  # #      channels:
+  # #        - main
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: nativeaot_scenarios
+  #       projectFile: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
 
 ################################################
 # Scheduled Private jobs

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -129,8 +129,16 @@ jobs:
           - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam)
             displayName: Run ci_setup.py with dotnetVersionsLinks
         - powershell: |
-            Write-Host "##vso[task.setvariable variable=PATH;]$(CorrelationStaging)dotnet;$(PATH))"
-            Write-Host "Prepend PATH with $(CorrelationStaging)dotnet"
+            Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"
+            Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
+          displayName: Explicitly set DOTNET_ROOT
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=PERFLAB_TARGET_FRAMEWORKS;]net8.0"
+            Write-Host "Set PERFLAB_TARGET_FRAMEWORKS to net8.0"
+          displayName: Explicitly set PERFLAB_TARGET_FRAMEWORKS
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH))"
+            Write-Host "Prepend PATH with $(DOTNET_ROOT)"
           displayName: Explicitly set PATH
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -136,6 +136,10 @@ jobs:
             Write-Host "##vso[task.setvariable variable=PERFLAB_TARGET_FRAMEWORKS;]net8.0"
             Write-Host "Set PERFLAB_TARGET_FRAMEWORKS to net8.0"
           displayName: Explicitly set PERFLAB_TARGET_FRAMEWORKS
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH))"
+            Write-Host "Prepend PATH with $(DOTNET_ROOT)"
+          displayName: Explicitly set PATH
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -132,13 +132,15 @@ jobs:
             Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"
             Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
           displayName: Explicitly set DOTNET_ROOT
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=PERFLAB_TARGET_FRAMEWORKS;]net8.0"
+            Write-Host "Set PERFLAB_TARGET_FRAMEWORKS to net8.0"
+          displayName: Explicitly set PERFLAB_TARGET_FRAMEWORKS
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config
-          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_TARGET_FRAMEWORKS) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
             displayName: Build startup tool
-            env:
-              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
           - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
             displayName: Build SOD tool
             env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -129,16 +129,8 @@ jobs:
           - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam)
             displayName: Run ci_setup.py with dotnetVersionsLinks
         - powershell: |
-            Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"
-            Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
-          displayName: Explicitly set DOTNET_ROOT
-        - powershell: |
-            Write-Host "##vso[task.setvariable variable=PERFLAB_TARGET_FRAMEWORKS;]net8.0"
-            Write-Host "Set PERFLAB_TARGET_FRAMEWORKS to net8.0"
-          displayName: Explicitly set PERFLAB_TARGET_FRAMEWORKS
-        - powershell: |
-            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH))"
-            Write-Host "Prepend PATH with $(DOTNET_ROOT)"
+            Write-Host "##vso[task.setvariable variable=PATH;]$(CorrelationStaging)dotnet;$(PATH))"
+            Write-Host "Prepend PATH with $(CorrelationStaging)dotnet"
           displayName: Explicitly set PATH
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -133,18 +133,16 @@ jobs:
             Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
           displayName: Explicitly set DOTNET_ROOT
         - powershell: |
-            Write-Host "##vso[task.setvariable variable=PERFLAB_TARGET_FRAMEWORKS;]net8.0"
-            Write-Host "Set PERFLAB_TARGET_FRAMEWORKS to net8.0"
-          displayName: Explicitly set PERFLAB_TARGET_FRAMEWORKS
-        - powershell: |
-            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH))"
+            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH)"
             Write-Host "Prepend PATH with $(DOTNET_ROOT)"
           displayName: Explicitly set PATH
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config
-          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_TARGET_FRAMEWORKS) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
+          - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)startup -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\Startup\Startup.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
             displayName: Build startup tool
+            env:
+              PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
           - script: $(CorrelationStaging)dotnet\dotnet publish -c Release -o $(CorrelationStaging)SOD -f $(PERFLAB_Framework) -r win-${{parameters.architecture}} --self-contained $(Build.SourcesDirectory)\src\tools\ScenarioMeasurement\SizeOnDisk\SizeOnDisk.csproj -p:DisableTransitiveFrameworkReferenceDownloads=true
             displayName: Build SOD tool
             env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -132,10 +132,17 @@ jobs:
             Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"
             Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
           displayName: Explicitly set DOTNET_ROOT
+        # Set PATH
+        - script: |
+            echo "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT):$(PATH)"
+            echo "Set PATH to $(DOTNET_ROOT):$(PATH)"
+          displayName: Explicitly set PATH (Non-Windows)
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
         - powershell: |
             Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH)"
-            Write-Host "Prepend PATH with $(DOTNET_ROOT)"
-          displayName: Explicitly set PATH
+            Write-Host "Set PATH to $(DOTNET_ROOT);$(PATH)"
+          displayName: Explicitly set PATH (Windows)
+          condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config


### PR DESCRIPTION
Add dotnet root to the beginning of the path to ensure that it is the dotnet being used throughout the rest of the yaml pipeline steps.

Test run showing successful tool build (Windows, Ubuntu, and OSX): https://dev.azure.com/dnceng/internal/_build/results?buildId=2227096&view=results
Fixes #3153 for performance repo runs

These changes may be temporary depending on how the underlying issue is resolved, but this gets us results until then.