### PR TITLE
[wasm] Replace hash with VERSION.

### DIFF
--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -153,7 +153,9 @@ class SizeOnDisk
         {
             var groups = Regex.Match(wasmFile, @"(?<path>\D+)\/(?<dotnet>\D+)(?<major>\d.)(?<minor>\d.\d)-(?<hash>.*)(?<jsExtension>.js)").Groups;
             // e.g. dotnet.native.8.0.0-rc.1.23375.3.trarwnmzt5.js -> rc.1.23375.3.trarwnmzt5
-            versions.Add(groups["hash"].Value);
+            string hash = groups["hash"].Value;
+            if (!string.IsNullOrEmpty(hash))
+                versions.Add(hash);
         }
     }
 

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -151,11 +151,11 @@ class SizeOnDisk
         var wasmFile = Directory.GetFiles(path, "dotnet.*.js.*", SearchOption.AllDirectories).FirstOrDefault();
         if (wasmFile != null)
         {
-            var groups = Regex.Match(wasmFile, @"(?<path>\D+)\/(?<dotnet>\D+)(?<major>\d.)(?<minor>\d.\d)-(?<hash>.*)(?<jsExtension>.js)").Groups;
+            var groups = Regex.Match(wasmFile, @"-(?<versionWithHash>.*).js").Groups;
             // e.g. dotnet.native.8.0.0-rc.1.23375.3.trarwnmzt5.js -> rc.1.23375.3.trarwnmzt5
-            string hash = groups["hash"].Value;
-            if (!string.IsNullOrEmpty(hash))
-                versions.Add(hash);
+            string versionWithHash = groups["versionWithHash"].Value;
+            if (!string.IsNullOrEmpty(versionWithHash))
+                versions.Add(versionWithHash);
         }
     }
 

--- a/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
+++ b/src/tools/ScenarioMeasurement/SizeOnDisk/SizeOnDisk.cs
@@ -151,8 +151,9 @@ class SizeOnDisk
         var wasmFile = Directory.GetFiles(path, "dotnet.*.js.*", SearchOption.AllDirectories).FirstOrDefault();
         if (wasmFile != null)
         {
-            var wasmVersion = Regex.Match(wasmFile, @"dotnet\.(.+)\.js").Groups[1].Value;
-            versions.Add(wasmVersion);
+            var groups = Regex.Match(wasmFile, @"(?<path>\D+)\/(?<dotnet>\D+)(?<major>\d.)(?<minor>\d.\d)-(?<hash>.*)(?<jsExtension>.js)").Groups;
+            // e.g. dotnet.native.8.0.0-rc.1.23375.3.trarwnmzt5.js -> rc.1.23375.3.trarwnmzt5
+            versions.Add(groups["hash"].Value);
         }
     }
 


### PR DESCRIPTION
All dotnet versions used to be squashed into the same name, e.g. `dotnet.VERSION.js.br`. This PR changes it to be `dotnet.8.0.0-VERSION.js.br`.