### PR TITLE
Add DI Factory_3Injected to measure against Factory_3Explicit

### DIFF
--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
@@ -12,10 +12,12 @@ namespace Microsoft.Extensions.DependencyInjection
     public class ActivatorUtilitiesBenchmark
     {
         private ServiceProvider _serviceProvider;
+        private Type[] _types0;
         private Type[] _types2;
         private Type[] _types2_OutOfOrder;
         private Type[] _types3;
 
+        private ObjectFactory _factory0;
         private ObjectFactory _factory2;
         private ObjectFactory _factory2_OutOfOrder;
         private ObjectFactory _factory3;
@@ -44,10 +46,12 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.AddSingleton<DependencyD>();
             collection.AddSingleton<DependencyE>();
 
+            _types0 = new Type[] { };
             _types2 = new Type[] { typeof(DependencyA), typeof(DependencyB) };
             _types2_OutOfOrder = new Type[] { typeof(DependencyB), typeof(DependencyC) };
             _types3 = new Type[] { typeof(DependencyA), typeof(DependencyB), typeof(DependencyC) };
 
+            _factory0 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types0);
             _factory2 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2);
             _factory2_OutOfOrder = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2_OutOfOrder);
             _factory3 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types3);
@@ -152,9 +156,16 @@ namespace Microsoft.Extensions.DependencyInjection
             return (TypeWith3ParametersToBeActivated)_factory3(_serviceProvider, _factoryArguments3);
         }
 
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated Factory_3Injected()
+        {
+            return (TypeWith3ParametersToBeActivated)_factory0(_serviceProvider, _factoryArguments0);
+        }
+
         public class TypeWith0ParametersToBeActivated
         {
-            // DI  picks these over the correct one below and throws TargetInvocationException.
+            // DI picks these over the correct one below and throws TargetInvocationException.
             //public TypeWith0ParametersToBeActivated(int i)
             //{
             //    throw new NotImplementedException();
@@ -234,20 +245,21 @@ namespace Microsoft.Extensions.DependencyInjection
             public DependencyB _b;
             public DependencyC _c;
 
-            public TypeWith3ParametersToBeActivated(int i)
-            {
-                throw new NotImplementedException();
-            }
+            // DI picks these over the correct one below and throws InvalidOperation.
+            //public TypeWith3ParametersToBeActivated(int i)
+            //{
+            //    throw new NotImplementedException();
+            //}
 
-            public TypeWith3ParametersToBeActivated(string s)
-            {
-                throw new NotImplementedException();
-            }
+            //public TypeWith3ParametersToBeActivated(string s)
+            //{
+            //    throw new NotImplementedException();
+            //}
 
-            public TypeWith3ParametersToBeActivated(object o)
-            {
-                throw new NotImplementedException();
-            }
+            //public TypeWith3ParametersToBeActivated(object o)
+            //{
+            //    throw new NotImplementedException();
+            //}
 
             public TypeWith3ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c)
             {


### PR DESCRIPTION
This helps comparing the case when GetService() needs to be called for injected services.

Local results for new bechmark `Factory_3Injected` compared to existing `Factory_3Explicit` (using the default behavior on my local machine that uses compiled expressions):
 ```
|                                 Method |        Job |              Toolchain |       Mean |      Error |     StdDev |     Median |        Min |        Max | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|--------------------------------------- |----------- |----------------------- |-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|------:|--------:|-------:|----------:|------------:|
|                      Factory_3Explicit | Job-GYQEFS | \DI_BEFORE\corerun.exe |   9.322 ns |  0.1178 ns |  0.1102 ns |   9.277 ns |   9.151 ns |   9.538 ns |  0.54 |    0.01 | 0.0038 |      40 B |        1.00 |
|                      Factory_3Injected | Job-GYQEFS | \DI_BEFORE\corerun.exe |  35.648 ns |  0.3830 ns |  0.3395 ns |  35.623 ns |  35.209 ns |  36.312 ns |  0.91 |    0.01 | 0.0037 |      40 B |        1.00 |
```