### PR TITLE
Add `-bl:` argument to the restore command line

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -294,7 +294,8 @@ class CSharpProject:
     def restore(self, 
                 packages_path: str, 
                 verbose: bool,
-                runtime_identifier: str = None) -> None:
+                runtime_identifier: str = None,
+                args: list = None) -> None:
         '''
         Calls dotnet to restore the dependencies and tools of the specified
         project.
@@ -317,7 +318,10 @@ class CSharpProject:
 
         if runtime_identifier:
             cmdline += ['--runtime', runtime_identifier]
-            
+
+        if args:
+            cmdline = cmdline + args
+
         RunCommand(cmdline, verbose=verbose, retry=1).run(
             self.working_directory)
 

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -296,7 +296,9 @@ class PreCommands:
                              *build_args)
 
     def _restore(self):
-        self.project.restore(packages_path=get_packages_directory(), verbose=True)
+        self.project.restore(packages_path=get_packages_directory(),
+                             verbose=True,
+                             args=['-bl:%s-restore.binlog' % self.binlog] if self.binlog else [])
 
     def _build(self, configuration: str, framework: str = None, output: str = None, build_args: list = []):
         self.project.build(configuration,


### PR DESCRIPTION
This utilizes the `binlog` path passed in, and appends `-restore.binlog`
to the string, which could be a full path. So the filename can be like
`foo.binlog-restore.binlog`.
