### PR TITLE
Perf: Workaround a nuget restore issue for MicroBenchmarks.csproj

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -87,7 +87,7 @@
   <!--
     Workaround for https://github.com/dotnet/performance/issues/3164
   -->
-  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))">
+  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '8.0'))">
     <PackageReference Include="System.Text.Json" Version="$(SystemVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemVersion)" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -84,6 +84,15 @@
     <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '8.0')" />
   </ItemGroup>
 
+  <!--
+    Workaround for https://github.com/dotnet/performance/issues/3164
+  -->
+  <ItemGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))">
+    <PackageReference Include="System.Text.Json" Version="$(SystemVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
```
error NU1102: Unable to find package System.Text.Json with version (>= 8.0.0-rc.1.23375.7)
error NU1102:   - Found 1290 version(s) in dotnet8 [ Nearest version: 8.0.0-rc.1.23375.4 ]
error NU1102: Unable to find package System.Security.Cryptography.Xml with version (>= 8.0.0-rc.1.23375.7)
error NU1102:   - Found 1290 version(s) in dotnet8 [ Nearest version: 8.0.0-rc.1.23375.4 ]
```

Note the difference between the referenced version, and the one
available in the feed.

These packages are getting added as transitive references.

The hypothesis is that the direct package references have version string
as `8.0.*-*` which select the latest available version.
    - but those packages transitively reference others for whom the
      latest version might not have been published to nuget yet.

To work around this, we add explicit references to such packages, so
they can get the versions selected from the ones in the feed.

Issue: https://github.com/dotnet/performance/issues/3164
