### PR TITLE
Increase Sorting invocations per iteration

### DIFF
--- a/src/benchmarks/micro/runtime/Span/Sorting.cs
+++ b/src/benchmarks/micro/runtime/Span/Sorting.cs
@@ -16,7 +16,7 @@ namespace Span
     [MinWarmupCount(6, forceAutoWarmup: true)] // when InvocationCount is set, BDN does not run Pilot Stage, so to get the code promoted to Tier 1 before Actual Workload, we enforce more Warmups
     public class Sorting
     {
-        private const int InvocationsPerIteration = 1000;
+        private const int InvocationsPerIteration = 10_000;
 
         [Params(Utils.DefaultCollectionSize)]
         public int Size;


### PR DESCRIPTION
Increase by 10x, since the benchmark currently runs each iteration
in 10ms or so, and we'd prefer 100ms.