### PR TITLE
Avoid benchmarking cached IPAddress ToString

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Primitives/IPAddressPerformanceTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Primitives/IPAddressPerformanceTests.cs
@@ -38,9 +38,9 @@ namespace System.Net.Primitives.Tests
             => new IPAddress(address);
 
         [Benchmark]
-        [ArgumentsSource(nameof(Addresses))]
-        public string ToString(IPAddress address)
-            => address.ToString();
+        [ArgumentsSource(nameof(ByteAddresses))]
+        public string CtorAndToString(byte[] address)
+            => new IPAddress(address).ToString();
 
         private static readonly long s_addr = IPAddress.Loopback.Address;
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/88671#issuecomment-1658081776

Alternatively, we could delete this one given that we already have benchmarks covering `ctor` and `TryFormat`, which are almost the same.