### PR TITLE
Revert https://github.com/dotnet/performance/commit/860d6a17d0c17592e2f4d803038d99969f3d8778

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,8 +277,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
+        #- win-arm64
+        #- ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -286,26 +286,26 @@ jobs:
         channels:
           - main
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,8 +277,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        #- win-arm64
-        #- ubuntu-arm64-ampere
+        - win-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
@@ -286,26 +286,26 @@ jobs:
         channels:
           - main
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -129,6 +129,20 @@ jobs:
             displayName: Get dotnetVersion to use
           - script: $(Python) scripts/ci_setup.py --channel $(_Channel) --dotnet-versions $(DotnetVersion) --architecture ${{parameters.architecture}} --perf-hash $(Build.SourceVersion) --queue ${{parameters.queue}} --build-number $(Build.BuildNumber) --build-configs $(_Configs) --output-file $(CorrelationStaging)machine-setup$(ScriptExtension) --install-dir $(CorrelationStaging)dotnet $(runEnvVarsParam) $(AffinityParam)
             displayName: Run ci_setup.py with dotnetVersionsLinks
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=DOTNET_ROOT;]$(CorrelationStaging)dotnet"
+            Write-Host "Set DOTNET_ROOT to $(CorrelationStaging)dotnet"
+          displayName: Explicitly set DOTNET_ROOT
+        - script: |
+            echo "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT):$(PATH)"
+            echo "Set PATH to $(DOTNET_ROOT):$(PATH)"
+          displayName: Explicitly set PATH (Non-Windows)
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=PATH;]$(DOTNET_ROOT);$(PATH)"
+            Write-Host "Set PATH to $(DOTNET_ROOT);$(PATH)"
+          displayName: Explicitly set PATH (Windows)
+          condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
         - ${{ if eq(parameters.osName, 'windows') }}:
           - script: xcopy .\NuGet.config $(CorrelationStaging) && xcopy .\scripts $(CorrelationStaging)scripts\/e && xcopy .\src\scenarios\shared $(CorrelationStaging)shared\/e && xcopy .\src\scenarios\staticdeps $(CorrelationStaging)staticdeps\/e
             displayName: Copy python libraries and NuGet.config


### PR DESCRIPTION
Reverts: https://github.com/dotnet/performance/pull/3179 (https://github.com/dotnet/performance/commit/860d6a17d0c17592e2f4d803038d99969f3d8778) as the tool build is still broken on the iOS builds. 

Test of proper building of tools (each scenario made it past building tools): https://dev.azure.com/dnceng/internal/_build/results?buildId=2235822&view=results