### PR TITLE
Add MicrosoftDotNetXHarnessCLIVersion to the maui iOS test proj.

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <MicrosoftDotNetXHarnessCLIVersion>8.0.0-prerelease.23401.3</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Add MicrosoftDotNetXHarnessCLIVersion to the maui iOS test proj as it is now required. This version is known working from the runtime repo for the startup tests. Same change was made to other branch I am testing getting a successful send to helix in this test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2241031&view=results.