### PR TITLE
Move runs to 22.04 queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        - ubuntu-x64
+        - ubuntu-x64-1804
       isPublic: true
       jobParameters:
         kind: scenarios
@@ -108,7 +108,7 @@ jobs:
       buildMachines:
         - win-x64
         - win-x86
-        - ubuntu-x64
+        - ubuntu-x64-1804
       isPublic: true
       jobParameters:
         kind: sdk_scenarios
@@ -276,7 +276,7 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        - ubuntu-x64
+        - ubuntu-x64-1804
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -394,7 +394,7 @@ jobs:
       buildMachines:
         - win-x64
         - win-x86
-        - ubuntu-x64
+        - ubuntu-x64-1804
       isPublic: false
       jobParameters:
         kind: sdk_scenarios

--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -68,7 +68,7 @@ jobs:
             value: 'export PYTHONPATH=$ORIGPYPATH'
           - name: Python
             value: python3
-          - ${{ if eq(parameters.osVersion, '1804')}}:
+          - ${{ if eq(parameters.osVersion, '2204')}}:
             - name: ArtifactsDirectory
               value: '$HELIX_WORKITEM_UPLOAD_ROOT/BenchmarkDotNet.Artifacts'
           - ${{ if or(eq(parameters.osVersion, '1604'), eq(parameters.architecture, 'arm64'))}}:

--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -55,6 +55,24 @@ jobs:
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osName: ubuntu
+      osVersion: 2204
+      architecture: x64
+      pool: 
+        vmImage: ubuntu-latest
+      container: ubuntu_x64_build_container
+      ${{ insert }}: ${{ parameters.jobParameters }}
+      ${{ if eq(parameters.isPublic, true) }}:
+        machinePool: Open
+        queue: Ubuntu.2204.Amd64.Open
+      ${{ else }}:
+        machinePool: Tiger
+        queue: Ubuntu.2204.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
+
+# While we wait for lttng updates on Ubuntu 22.04 we are going to use 18.04
+- ${{ if containsValue(parameters.buildMachines, 'ubuntu-x64-1804') }}:
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osName: ubuntu
       osVersion: 1804
       architecture: x64
       pool: 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->

This moves all of the runs, except our scenario runs from Ubuntu 18.04 to 22.04.
