### PR TITLE
Fix arm64 on Ubuntu build.

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -242,6 +242,13 @@ jobs:
               TargetsWindows: 'false'
               WorkItemDirectory: $(Build.SourcesDirectory)
               HelixTargetQueues: ${{ parameters.queue }}
+          - ${{ if eq(parameters.architecture, 'arm64') }}:
+            - script: killall -9 dotnet
+              displayName: Stop dotnet
+            - script: rm -rf $(CorrelationStaging)dotnet/*
+              displayName: Delete old dotnet
+            - script: cp -r tools/dotnet/arm64/* $(CorrelationStaging)dotnet/
+              displayName: Copy Arm64 Dotnet to Correlation Payload
         - template: /eng/performance/send-to-helix.yml
           parameters:
             HelixSource: '$(HelixSourcePrefix)/dotnet/performance/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/


### PR DESCRIPTION
Fixes arm64 scenarios build for Linux/Ubuntu. It was uploading x64 version of dotnet. Basically same [steps as on Windows](https://github.com/dotnet/performance/blob/main/eng/performance/scenarios.yml#L182-L188), where it was already handled.