### PR TITLE
Add WasmWasm and WasmAOT to local testing script

### DIFF
--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -389,27 +389,27 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
     elif specific_run_type == RunType.WasmInterpreter:
         benchmark_ci_args += ['--wasm']
         bdn_args_unescaped += [
-                                '--anyCategories', 'Libraries', 'Runtime',
-                                '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
-                                '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmInterpreter, commit), "wasm_bundle", "wasm-data"),
-                                '--wasmEngine', parsed_args.wasm_engine_path,
-                                '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
-                                '--logBuildOutput',
-                                '--generateBinLog'
-                            ]
+            '--anyCategories', 'Libraries', 'Runtime',
+            '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
+            '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmInterpreter, commit), "wasm_bundle", "wasm-data"),
+            '--wasmEngine', parsed_args.wasm_engine_path,
+            '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
+            '--logBuildOutput',
+            '--generateBinLog'
+        ]
 
     elif specific_run_type == RunType.WasmAOT:
         benchmark_ci_args += ['--wasm']
         bdn_args_unescaped += [
-                                '--anyCategories', 'Libraries', 'Runtime',
-                                '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
-                                '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle", "wasm-data"),
-                                '--wasmEngine', parsed_args.wasm_engine_path,
-                                '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
-                                '--aotcompilermode', 'wasm',
-                                '--logBuildOutput',
-                                '--generateBinLog'
-                            ]
+            '--anyCategories', 'Libraries', 'Runtime',
+            '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
+            '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle", "wasm-data"),
+            '--wasmEngine', parsed_args.wasm_engine_path,
+            '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
+            '--aotcompilermode', 'wasm',
+            '--logBuildOutput',
+            '--generateBinLog'
+        ]
 
     if parsed_args.bdn_arguments:
         bdn_args_unescaped += [parsed_args.bdn_arguments]

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -96,7 +96,7 @@ def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str
     # Run the command
     if is_windows(parsed_args):
         build_libs_and_corerun_command = [
-                "pwsh",
+                "powershell",
                 "-File",
                 "build.ps1"
         ]

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -310,11 +310,12 @@ def generate_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunTyp
             bdn_args_unescaped += [ corerun_path ]
 
     elif specific_run_type == RunType.WasmWasm:
+        # TODO: Fail or print somewhere that we only support one commit for WasmWasm.
         benchmark_ci_args += [ '--wasm' ]
         bdn_args_unescaped += [
                                 '--anyCategories', 'Libraries', 'Runtime',
                                 '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
-                                '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmWasm, commit), "wasm_bundle", "wasm-data"),
+                                '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmWasm, all_commits[0]), "wasm_bundle", "wasm-data"),
                                 '--wasmEngine', parsed_args.wasm_engine_path,
                                 '--wasmArgs', '--experimental-wasm-eh --expose_wasm --module',
                                 # '--cli', '',

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -240,8 +240,8 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             shutil.rmtree(dest_dir_wasm_aot, ignore_errors=True)
             copy_directory_contents(dotnet_wasm_path, dest_dir_wasm_aot)
 
-            # Add wasm-tools to dotnet instance:
-            RunCommand([parsed_args.dotnet_dir_path, "workload", "install", "wasm-tools"], verbose=True).run()
+            # Add wasm-tools to dotnet instance: # TODO: Check if dotnet.exe is windows
+            RunCommand([os.path.join(parsed_args.dotnet_dir_path, f'dotnet{".exe" if is_windows(parsed_args) else ""}'), "workload", "install", "wasm-tools"], verbose=True).run()
         else:
             getLogger().info(f"wasm_bundle already exists in {dest_dir_wasm_wasm} and {dest_dir_wasm_aot}. Skipping generation.")
 
@@ -337,7 +337,7 @@ def generate_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunTyp
                                 '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, all_commits[0]), "wasm_bundle", "wasm-data"),
                                 '--wasmEngine', parsed_args.wasm_engine_path,
                                 '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
-                                '--aotcompilermode', 'wasm'
+                                '--aotcompilermode', 'wasm',
                                 '--logBuildOutput',
                                 '--generateBinLog'
                             ]

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -221,7 +221,6 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             os.environ["EMSDK_PATH"] =os.path.join(repo_path, 'src', 'mono', 'wasm', 'emsdk')
 
             build_runtime_dependency(parsed_args, repo_path, "mono+libs", os_override="browser", arch_override="wasm", additional_args=[f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
-
             src_dir = os.path.join(repo_path, "artifacts", "BrowserWasm", "staging", "dotnet-latest")
             dest_dir = os.path.join(repo_path, "artifacts", "bin", "wasm", "dotnet")
             copy_directory_contents(src_dir, dest_dir)
@@ -229,7 +228,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             dest_dir = os.path.join(repo_path, "artifacts", "bin", "wasm")
             copy_directory_contents(src_dir, dest_dir)
             src_file = os.path.join(repo_path, "src", "mono", "wasm", "test-main.js")
-            dest_file = os.path.join(repo_path, "artifacts", "bin", "wasm", "wasm-data", "test-main.js")
+            dest_dir = os.path.join(repo_path, "artifacts", "bin", "wasm", "wasm-data")
+            dest_file = os.path.join(dest_dir, "test-main.js")
+            if not os.path.exists(dest_dir):
+                os.makedirs(dest_dir)
             shutil.copy2(src_file, dest_file)
 
             # Store the dotnet_mono in the artifact storage path

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -16,10 +16,10 @@
 #   * Add the BDN run arguments to the generate_combined_benchmark_ci_args function
 #
 # Prereqs:
-# Normal prereqs for building the target runtime: https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/linux-requirements.md
+# Normal prereqs for building the target runtime: https://github.com/dotnet/runtime/blob/main/docs/workflow/README.md#Build_Requirements
 # Python 3
 # gitpython (pip install gitpython)
-# Wasm need jsvu and https://github.com/dotnet/runtime/blob/main/docs/workflow/building/libraries/webassembly-instructions.md
+# Wasm need jsvu installed and setup (No need to setup EMSDK, the tool does that automatically when building)
 
 
 import ctypes
@@ -255,7 +255,7 @@ def generate_combined_benchmark_ci_args(parsed_args: Namespace, specific_run_typ
     benchmark_ci_args += ['--dotnet-path', parsed_args.dotnet_dir_path]
     benchmark_ci_args += ['--csproj', parsed_args.csproj]
     benchmark_ci_args += ['--incremental', "no"]
-    benchmark_ci_args += ['--bdn-artifacts', os.path.join(parsed_args.artifact_storage_path, f"BenchmarkDotNet.Artifacts.{specific_run_type.name}.{start_time.strftime('%y%m%d_%H%M%S')}")]
+    benchmark_ci_args += ['--bdn-artifacts', os.path.join(parsed_args.artifact_storage_path, f"BenchmarkDotNet.Artifacts.{specific_run_type.name}.{start_time.strftime('%y%m%d_%H%M%S')}")] # We don't include the commit hash in the artifact path because we are combining multiple runs into one
 
     if specific_run_type == RunType.CoreRun:
         bdn_args_unescaped += [
@@ -334,7 +334,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
     benchmark_ci_args += ['--dotnet-path', parsed_args.dotnet_dir_path]
     benchmark_ci_args += ['--csproj', parsed_args.csproj]
     benchmark_ci_args += ['--incremental', "no"]
-    benchmark_ci_args += ['--bdn-artifacts', os.path.join(parsed_args.artifact_storage_path, f"BenchmarkDotNet.Artifacts.{specific_run_type.name}.{start_time.strftime('%y%m%d_%H%M%S')}")]
+    benchmark_ci_args += ['--bdn-artifacts', os.path.join(parsed_args.artifact_storage_path, f"BenchmarkDotNet.Artifacts.{specific_run_type.name}.{commit}.{start_time.strftime('%y%m%d_%H%M%S')}")] # We add the commit hash to the artifact path because we are only running one commit at a time and they would clobber if running more than one commit perf type
 
     if specific_run_type == RunType.CoreRun:
         bdn_args_unescaped += [

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -100,7 +100,6 @@ def copy_directory_contents(src_dir: str, dest_dir: str):
         
 # Builds libs and corerun by default
 def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str = "clr+libs", configuration: str = "Release", os_override = "", arch_override = "", additional_args: list = []):    
-    # Run the command
     if is_windows(parsed_args):
         build_libs_and_corerun_command = [
                 "powershell",
@@ -154,7 +153,6 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             core_root_path = os.path.join(repo_path, "artifacts", "tests", "coreclr", f"{parsed_args.os}.{parsed_args.architecture}.Release", "Tests", "Core_Root")
             shutil.rmtree(dest_dir, ignore_errors=True)
             copy_directory_contents(core_root_path, dest_dir)
-            # shutil.rmtree(os.path.join(repo_path, "artifacts"), ignore_errors=True)
         else:
             getLogger().info(f"CoreRun already exists in {dest_dir}. Skipping generation.")
 
@@ -196,20 +194,18 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             copy_directory_contents(dotnet_mono_path, dest_dir_mono_interpreter)
             shutil.rmtree(dest_dir_mono_jit, ignore_errors=True)
             copy_directory_contents(dotnet_mono_path, dest_dir_mono_jit)
-            # shutil.rmtree(os.path.join(repo_path, "artifacts"), ignore_errors=True)
         else:
             getLogger().info(f"dotnet_mono already exists in {dest_dir_mono_interpreter} and {dest_dir_mono_jit}. Skipping generation.")
 
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]):
         raise NotImplementedError("MonoAOTLLVM is not yet implemented.") # TODO: Finish MonoAOTLLVM Build stuff
         build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['/p:CrossBuild=false' '/p:MonoLLVMUseCxx11Abi=false'])
-        # TODO: Finish MonoAOTLLVM Build stuff
         # Clean up the build results
         shutil.rmtree(os.path.join(repo_path, "artifacts"), ignore_errors=True) # TODO: Can we trust the build system to update these when necessary or do we need to clean them up ourselves?
 
     if check_for_runtype_specified(parsed_args, [RunType.WasmWasm]):
-        ## TODO: Figure out prereq check flow
-        # Must have jsvu installed
+        # TODO: Figure out prereq check flow
+        # Must have jsvu installed also
         dest_dir_wasm = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmWasm, commit), "wasm_bundle")
         if force_regenerate or not os.path.exists(dest_dir_wasm):
             provision_wasm = [
@@ -315,7 +311,6 @@ def generate_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunTyp
             bdn_args_unescaped += [ corerun_path ]
 
     elif specific_run_type == RunType.WasmWasm:
-        # TODO: Fail or print somewhere that we only support one commit for WasmWasm.
         benchmark_ci_args += [ '--wasm' ]
         bdn_args_unescaped += [
                                 '--anyCategories', 'Libraries', 'Runtime',
@@ -323,7 +318,6 @@ def generate_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunTyp
                                 '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmWasm, all_commits[0]), "wasm_bundle", "wasm-data"),
                                 '--wasmEngine', parsed_args.wasm_engine_path,
                                 '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
-                                # '--cli', '',
                                 '--logBuildOutput',
                                 '--generateBinLog'
                             ]
@@ -531,7 +525,7 @@ def __main(args: list):
         
     finally:
         kill_dotnet_processes(parsed_args)
-    # TODO: Compare the results of the benchmarks || This is doable with just BDN as a start for now
+    # TODO: Compare the results of the benchmarks with results comparer (Currently will need to be done manually)
 
 if __name__ == "__main__":
     __main(sys.argv[1:])

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -215,7 +215,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
                 "provision-wasm"
             ]
             RunCommand(provision_wasm, verbose=True).run(os.path.join(repo_path))
-            os.environ["EMSDK_PATH"] =os.path.join(repo_path, 'src', 'mono', 'wasm', 'emsdk')
+            os.environ["EMSDK_PATH"] = os.path.join(repo_path, 'src', 'mono', 'wasm', 'emsdk')
 
             build_runtime_dependency(parsed_args, repo_path, "mono+libs", os_override="browser", arch_override="wasm", additional_args=[f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             src_dir = os.path.join(repo_path, "artifacts", "BrowserWasm", "staging", "dotnet-latest")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -237,7 +237,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             copy_directory_contents(dotnet_wasm_path, dest_dir_wasm)
 
             # Add wasm-tools to dotnet instance:
-            RunCommand([parsed_args.dotnet_dir_path, "workload", "install", "wasmsdk"], verbose=True).run()
+            RunCommand([parsed_args.dotnet_dir_path, "workload", "install", "wasm-tools"], verbose=True).run()
         else:
             getLogger().info(f"wasm_bundle already exists in {dest_dir_wasm}. Skipping generation.")
 


### PR DESCRIPTION
This adds WasmWasm and WasmAOT to the local benchmarking script. Among the changes is the addition of a dotnet sdk download that can be specified to be redownloaded (supporting wasm-tools install). 