### PR TITLE
Added an override nuget feed for some packages that don't exist in our eng feeds

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/NuGet.config
+++ b/src/benchmarks/gc/GC.Infrastructure/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <packageSources>
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources />
+</configuration>


### PR DESCRIPTION
A few users have been reporting issues with installing required packages such as XPlot needed by the infra. This is a workaround to add the nuget feed for the GC.Infrastructure to prevent install errors.