### PR TITLE
Fixed the reporting of the GCPerfSim runs in the Repro Steps

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
@@ -296,7 +296,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                         metric2_Comparand = Math.Round(comparandResultItem.PauseDurationMSec_MeanWhereIsBlockingGen2, 2);
                     }
 
-                    sw.WriteLine($"| {runName} | {metric1_Base:N2} | {metric1_Comparand:N2} | {((metric1_Comparand - metric1_Comparand) / metric1_Base) * 100:N2} | {metric2_Base} |  {metric2_Comparand:N2} | {((metric1_Comparand - metric1_Base) / metric1_Base * 100):N2}| ");
+                    sw.WriteLine($"| {runName} | {metric1_Base:N2} | {metric1_Comparand:N2} | {((metric1_Comparand - metric1_Base) / metric1_Base) * 100:N2} | {metric2_Base} |  {metric2_Comparand:N2} | {((metric2_Comparand - metric2_Base) / metric2_Base * 100):N2}| ");
                 }
                 sb.AppendLine();
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
@@ -340,7 +340,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                         string runKey = GetExecutionDetailKey(run.Key, corerun.Key);
                         if (executionDetails.TryGetValue(runKey, out var bped))
                         {
-                            ProcessExecutionDetails runDetails = executionDetails[$"{run.Key}.{baseCoreRun}.0"];
+                            ProcessExecutionDetails runDetails = executionDetails[$"{run.Key}.{corerun.Key}.0"];
                             foreach (var env in runDetails.EnvironmentVariables)
                             {
                                 sb.AppendLine($" ```set {env.Key}={env.Value}```\n");


### PR DESCRIPTION
Currently, the repro steps report _just_ the corerun of the baseline and not any other runs. This PR fixes this - note: there is no issue with the collection of the results just the presentation. 

Also, fixed the columns associated with the BGCs and Gen2 Blocking GCs.