### PR TITLE
Update BDN version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <MicrosoftNETILLinkTasksVersion>8.0.0-rc.2.23462.12</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkPackageVersion>8.0.0-rc.2.23462.12</MicrosoftNETILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.7-nightly.20230717.35</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.9-nightly.20230908.70</BenchmarkDotNetVersion>
     <SystemThreadingChannelsPackageVersion>8.0.0-rc.2.23462.12</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>8.0.0-rc.2.23462.12</MicrosoftExtensionsLoggingPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
This updates the BDN version to include this fix, https://github.com/dotnet/BenchmarkDotNet/pull/2375/files. This resolves an issue with filtering that was happening with the GC performance tests.