### PR TITLE
GC PerfSim Infrastructure Improvements

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -57,11 +57,13 @@ environment:
   iterations: 1
 coreruns:
   baseline:
-    path: C:\CoreRuns\Test\corerun.exe
-    environment_variables: {} #COMPlus_GCName: clrgc.dll
+    path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
+    environment_variables:
+      COMPlus_GCName: clrgc.dll
   run:
-    path: C:\CoreRuns\Test\corerun.exe
-    environment_variables: {} #COMPlus_GCName: clrgc.dll
+    path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
+    environment_variables:
+      COMPlus_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\GCPerfSim\

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -1,5 +1,5 @@
 runs:
-    normal:
+  normal:
     override_parameters:
       sohsi: 50 
     environment_variables: {}

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -30,7 +30,7 @@ gcperfsim_configurations:
   parameters:
     tc: 36
     tagb: 540
-    tlgb: 0
+    tlgb: 2 
     lohar: 0
     pohar: 0
     sohsr: 100-4000
@@ -57,13 +57,11 @@ environment:
   iterations: 1
 coreruns:
   baseline:
-    path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
-    environment_variables:
-      COMPlus_GCName: clrgc.dll
+    path: C:\CoreRuns\Test\corerun.exe
+    environment_variables: {} #COMPlus_GCName: clrgc.dll
   run:
-    path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
-    environment_variables:
-      COMPlus_GCName: clrgc.dll
+    path: C:\CoreRuns\Test\corerun.exe
+    environment_variables: {} #COMPlus_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\GCPerfSim\

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -1,26 +1,31 @@
 runs:
-  0gb:
+    normal:
     override_parameters:
-      tlgb: 0
-    environment_variables: 
-  2gb:
+      sohsi: 50 
+    environment_variables: {}
+
+  soh_pinning:
     override_parameters:
-      tlgb: 2
+      sohsi: 50 
+      sohpi: 100 
+    environment_variables: {}
+
+  poh:
+    override_parameters:
       sohsi: 50
-    environment_variables: 
-  2gb_pinning:
+      pohsi: 100
+      pohar: 100
+      rpohsi: 50
+    environment_variables: {}
+
+  loh:
     override_parameters:
-      tlgb: 2
       sohsi: 50
-      sohpi: 50
-    environment_variables: 
-  20gb:
-    override_parameters:
-      tagb: 300
-      tlgb: 20
-      sohsi: 50
-      allocType: simple
-    environment_variables: 
+      lohar: 100
+      rlohsi: 50
+      lohsi: 50
+    environment_variables: {}
+
 gcperfsim_configurations:
   parameters:
     tc: 36
@@ -39,6 +44,8 @@ gcperfsim_configurations:
     sohfi: 0
     lohfi: 0
     pohfi: 0
+    ramb: 20 
+    rlmb: 2
     allocType: reference
     testKind: time
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
@@ -59,7 +66,7 @@ coreruns:
       COMPlus_GCName: clrgc.dll
 linux_coreruns: 
 output:
-  path: C:\InfraRuns\RunNew_All\GCPerfSim\Normal_Server_
+  path: C:\InfraRuns\GCPerfSim\
   columns:
   - Count
   - total allocated (mb)

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Common.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Common.cs
@@ -26,7 +26,7 @@ namespace GC.Infrastructure.Core.Configurations
             // Parse configuration + Precondition checks.
             if (string.IsNullOrEmpty(configurationPath) || !File.Exists(configurationPath))
             {
-                throw new ArgumentNullException($"{prefix}: The provided path to yaml file {nameof(configurationPath)} is null or empty or doesn't exist.");
+                throw new ArgumentNullException($"{prefix}: The provided path to yaml file {nameof(configurationPath)} doesn't exist or is empty - please ensure you are passing in a valid .yaml file.");
             }
 
             if (Path.GetExtension(configurationPath) != ".yaml")

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
@@ -5,12 +5,12 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
 {
     public sealed class GCPerfSimConfiguration : ConfigurationBase
     {
-        public Dictionary<string, Run> Runs { get; set; }
-        public GCPerfSimConfigurations gcperfsim_configurations { get; set; }
+        public Dictionary<string, Run>? Runs { get; set; }
+        public GCPerfSimConfigurations? gcperfsim_configurations { get; set; }
         public Environment Environment { get; set; } = new();
-        public Dictionary<string, CoreRunInfo> coreruns { get; set; }
+        public Dictionary<string, CoreRunInfo>? coreruns { get; set; }
         public Dictionary<string, CoreRunInfo>? linux_coreruns { get; set; }
-        public Output Output { get; set; }
+        public Output? Output { get; set; }
     }
 
     public sealed class Run : RunBase 
@@ -23,13 +23,13 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
     public class GCPerfSimConfigurations
     {
         public Dictionary<string, string> Parameters { get; set; } = new();
-        public string gcperfsim_path { get; set; }
+        public string? gcperfsim_path { get; set; }
     }
 
     public class ClrGcRunInfo
     {
         public Dictionary<string, string>? paths { get; set; }
-        public string corerun { get; set; }
+        public string? corerun { get; set; }
     }
 
     public class Environment
@@ -50,6 +50,8 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
 
             string serializedConfiguration = File.ReadAllText(path);
             GCPerfSimConfiguration? configuration = null; 
+
+            // This try catch is here because the exception from the YamlDotNet isn't helpful and must be imbued with more details.
             try
             {
                 configuration = _deserializer.Deserialize<GCPerfSimConfiguration>(serializedConfiguration);
@@ -60,12 +62,19 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
                 throw new ArgumentException($"{nameof(GCPerfSimConfiguration)}: Unable to parse the yaml file because of an error in the syntax. Please use the configurations under: Configuration/GCPerfSim/*.yaml in as example to ensure the file is formatted correctly. Exception: {ex.Message} \n Call Stack: {ex.StackTrace}");
             }
 
+            // Check to make sure we get a valid configuration.
             if (configuration == null)
             {
                 throw new ArgumentNullException($"{nameof(GCPerfSimConfigurationParser)}: {nameof(configuration)} is null. Check the syntax of the configuration.");
             }
 
-            // Check to ensure the path to GCPerfSim exists / is valid.
+            // Check to ensure gcperfsim_configurations field exists.
+            if (configuration.gcperfsim_configurations == null)
+            {
+                throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: The configuration is missing the `gcperfsim_configuration` field in the yaml. Please add it following the example: Configuration/GCPerfSim/*.yaml.");
+            }
+
+            // Check to ensure the GCPerfSim configuration binaries exist.
             if (string.IsNullOrEmpty(configuration.gcperfsim_configurations.gcperfsim_path) || !File.Exists(configuration.gcperfsim_configurations.gcperfsim_path))
             {
                 throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: The GCPerfSim binary either doesn't exist or the path provided is incorrect. Please ensure the path is valid; the path provided: {configuration.gcperfsim_configurations.gcperfsim_path}");
@@ -77,8 +86,14 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
                 throw new ArgumentNullException($"{nameof(GCPerfSimConfigurationParser)}: {nameof(configuration.Runs)} are null or empty. 1 or more runs should be specified.");
             }
 
+            // Check to ensure there are some coreruns passed in.
+            if (configuration.coreruns == null || configuration.coreruns?.Count == 0)
+            {
+                throw new ArgumentNullException($"{nameof(GCPerfSimConfigurationParser)}: {nameof(configuration.coreruns)} are null or empty. 1 or more builds should be specified.");
+            }
+
             // Check to ensure the builds are valid i.e., have an existent path to corerun.
-            foreach (var build in configuration.coreruns)
+            foreach (var build in configuration.coreruns!)
             {
                 if (string.IsNullOrEmpty(build.Value.Path) || !File.Exists(build.Value.Path))
                 {
@@ -89,13 +104,19 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
             // Parameters.
             if (configuration.gcperfsim_configurations.Parameters == null || configuration.gcperfsim_configurations.Parameters.Count == 0)
             {
-                throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: {nameof(configuration.gcperfsim_configurations.Parameters)} are null or empty. GC PerfSim Parameters must be specified."); 
+                throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: {nameof(configuration.gcperfsim_configurations.Parameters)} are null or empty. GC PerfSim Parameters must be specified.");
             }
 
             // Trace Configurations if specified, must have a type specified.
             if (configuration.TraceConfigurations != null && string.IsNullOrEmpty(configuration.TraceConfigurations.Type))
             {
                 throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: Please ensure a trace configuration type is specified. If you don't want to collect a trace, simply don't include the trace_configuration type or choose either: gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed.");
+            }
+
+            // If the user passes in a null output path, default to the current directory.
+            if (string.IsNullOrEmpty(configuration.Output?.Path))
+            {
+                configuration.Output!.Path = Directory.GetCurrentDirectory();
             }
 
             return configuration;

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
@@ -62,7 +62,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 metric1_Comparand = comparandResultItem.PauseDurationMSec_95PWhereIsBackground;
                 metric2_Comparand = comparandResultItem.PauseDurationMSec_95PWhereIsBlockingGen2;
 
-                sw.WriteLine($"| {metric1_Base:N2} | {metric1_Comparand:N2} | {((metric1_Comparand - metric1_Comparand) / metric1_Base) * 100:N2} | {metric2_Base} |  {metric2_Comparand:N2} | {((metric2_Comparand - metric2_Base) / metric2_Base * 100):N2}| ");
+                sw.WriteLine($"| {metric1_Base:N2} | {metric1_Comparand:N2} | {((metric1_Comparand - metric1_Comparand) / metric1_Base) * 100:N2} | {metric2_Base:N2} |  {metric2_Comparand:N2} | {((metric2_Comparand - metric2_Base) / metric2_Base * 100):N2}| ");
                 sb.AppendLine();
 
                 sb.AppendLine("# Individual Results");

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItem.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItem.cs
@@ -9,7 +9,9 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
             new ResultItem(runName, corerun);
 
         private ResultItem(string runName, string corerun) 
-        { 
+        {
+            ConfigurationName                         = corerun;
+            RunName                                   = runName;
             PctTimePausedInGC                         = double.NaN;
             FirstToLastGCSeconds                      = double.NaN;
             HeapSizeBeforeMB_Mean                     = double.NaN;
@@ -38,7 +40,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
         {
             RunName = runName;
             ConfigurationName = configurationName;
-            ExecutionTimeMSec = processData.DurationMSec;
+            ExecutionTimeMSec = processData.DurationMSec; 
 
             PctTimePausedInGC = processData.Stats.GetGCPauseTimePercentage();
             FirstToLastGCSeconds = ( processData.GCs.Last().StartRelativeMSec - processData.GCs.First().StartRelativeMSec ) / 1000;
@@ -54,7 +56,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 }
 
                 string propertyName = property.Name;
-                double propertyValue = (double)property.GetValue(processData.Stats);
+                double propertyValue = (double)(property.GetValue(processData.Stats) ?? double.NaN);
                 StatsData[propertyName] = propertyValue;
             }
 
@@ -67,7 +69,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 }
 
                 string name = field.Name;
-                double value = (double)field.GetValue(processData.Stats);
+                double value = (double)(field.GetValue(processData.Stats) ?? double.NaN);
                 StatsData[name] = value;
             }
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
@@ -78,7 +78,7 @@ namespace GC.Infrastructure.Core.TraceCollection
             if (_collectType != CollectType.none)
             {
                 _sessionName = Guid.NewGuid();
-                foreach(var invalid in Path.InvalidPathChars)
+                foreach(var invalid in Path.GetInvalidPathChars())
                 {
                     name = name.Replace(invalid.ToString(), string.Empty);
                 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimAnalyzeCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimAnalyzeCommand.cs
@@ -15,7 +15,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
         {
             [Description("Path to Configuration.")]
             [CommandOption("-c|--configuration")]
-            public string? ConfigurationPath { get; init; }
+            public required string ConfigurationPath { get; init; }
         }
 
         public override int Execute([NotNull] CommandContext context, [NotNull] GCPerfSimAnalyzeSettings settings)
@@ -26,15 +26,16 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             ConfigurationChecker.VerifyFile(settings.ConfigurationPath, nameof(GCPerfSimAnalyzeSettings));
             GCPerfSimConfiguration configuration = GCPerfSimConfigurationParser.Parse(settings.ConfigurationPath);
 
-            Core.Utilities.TryCreateDirectory(configuration.Output.Path);
+            Core.Utilities.TryCreateDirectory(configuration.Output!.Path);
 
+            // TODO: Fill in at least the repro steps if you are simply analyzing the results.
             ExecuteAnalysis(configuration, new Dictionary<string, ProcessExecutionDetails>());
             return 0;
         }
 
         public static IReadOnlyList<ComparisonResult> ExecuteAnalysis(GCPerfSimConfiguration configuration, Dictionary<string, ProcessExecutionDetails> executionDetails)
         {
-            string outputPath = Path.Combine(configuration.Output.Path, "Results.md");
+            string outputPath = Path.Combine(configuration.Output!.Path, "Results.md");
             IReadOnlyList<ComparisonResult> results = Markdown.GenerateTable(configuration, executionDetails, outputPath); 
             AnsiConsole.MarkupLine($"[green bold] ({DateTime.Now}) Results written to {outputPath} [/]");
             return results;

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
@@ -58,8 +58,6 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             AnsiConsole.Write(new Rule("GCPerfSim Orchestrator"));
             AnsiConsole.WriteLine();
 
-            ConfigurationChecker.VerifyFile(settings.ConfigurationPath, nameof(GCPerfSimCommand));
-
             GCPerfSimConfiguration configuration = GCPerfSimConfigurationParser.Parse(settings.ConfigurationPath);
             GCPerfSimResults _ = RunGCPerfSim(configuration, settings.Server);
 
@@ -68,7 +66,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             return 0;
         }
 
-        public static GCPerfSimResults RunGCPerfSim(GCPerfSimConfiguration configuration, string server)
+        public static GCPerfSimResults RunGCPerfSim(GCPerfSimConfiguration configuration, string? server)
         {
             Core.Utilities.TryCreateDirectory(configuration.Output.Path);
 
@@ -100,7 +98,6 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             return new GCPerfSimResults(executionDetails, GCPerfSimAnalyzeCommand.ExecuteAnalysis(configuration, executionDetails));
         }
 
-        // Trace Path -> Markdown file.
         internal static Dictionary<string, ProcessExecutionDetails> ExecuteLocally(GCPerfSimConfiguration configuration, IReadOnlyList<RunInfo> runInfos)
         {
             Dictionary<string, ProcessExecutionDetails> executionDetails = new();
@@ -126,7 +123,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                         gcperfsimProcess.StartInfo.RedirectStandardOutput = true;
                         gcperfsimProcess.StartInfo.CreateNoWindow = true;
 
-                        AnsiConsole.MarkupLine($"[green bold] ({DateTime.Now}) Running {Path.GetFileNameWithoutExtension(configuration.Name)}: {runInfo.CorerunDetails.Key} for {runInfo.RunDetails.Key} [/]");
+                        AnsiConsole.MarkupLine($"[green bold] ({DateTime.Now}) Running {Path.GetFileNameWithoutExtension(configuration.Name)}: {runInfo.CorerunDetails.Key} for {runInfo.RunDetails.Key} - Iteration: {iterationIdx} [/]");
 
                         // Environment Variables.
                         Dictionary<string, string> environmentVariables = new();
@@ -168,17 +165,25 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                         string error = null;
 
                         string key = $"{runInfo.RunDetails.Key}.{runInfo.CorerunDetails.Key}.{iterationIdx}";
-                        using (TraceCollector traceCollector = new TraceCollector($"{runInfo.RunDetails.Key}.{runInfo.CorerunDetails.Key}.{iterationIdx}", collectType, outputPath))
+                        string traceName = $"{runInfo.RunDetails.Key}.{runInfo.CorerunDetails.Key}.{iterationIdx}";
+                        using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, outputPath))
                         {
                             gcperfsimProcess.Start();
                             output = gcperfsimProcess.StandardOutput.ReadToEnd();
                             error = gcperfsimProcess.StandardError.ReadToEnd(); 
-
                             gcperfsimProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);
                             File.WriteAllText(Path.Combine(outputPath, key + ".txt"), "Standard Out: \n" + output + "\n Standard Error: \n" + error);
                         }
 
-                        // TODO: Another check here could be to check for the existence of the trace.. if not, we got a problem specifically if the configuration wasn't passed.
+                        // If a trace is requested, ensure the file exists. If not, there is was an error and alert the user.
+                        if (configuration.TraceConfigurations?.Type != "none")
+                        {
+                            // Not checking Linux here since the local run only allows for Windows.
+                            if (!File.Exists(Path.Combine(outputPath, traceName + ".etl.zip")))
+                            {
+                                AnsiConsole.MarkupLine($"[yellow bold] ({DateTime.Now}) The trace for the run wasn't successfully captured. Please check the log file for more details: {output} Full run details: {Path.GetFileNameWithoutExtension(configuration.Name)}: {runInfo.CorerunDetails.Key} for {runInfo.RunDetails.Key} [/]");
+                            }
+                        }
                         
                         int exitCode = gcperfsimProcess.ExitCode;
                         ProcessExecutionDetails details = new(key: key,
@@ -225,16 +230,15 @@ namespace GC.Infrastructure.Commands.GCPerfSim
 
                         crankProcess.OutputDataReceived += (s, d) =>
                         {
-                            Console.WriteLine(d.Data?.ToString());
                             output.AppendLine(d.Data);
                         };
                         crankProcess.ErrorDataReceived += (s, d) =>
                         {
-                            Console.WriteLine(d.Data?.ToString());
                             error.Append(d.Data);
                         };
 
                         Console.WriteLine($"Executing: {processAndParameters.Item1} {processAndParameters.Item2}");
+                        AnsiConsole.MarkupLine($"[green bold] ({DateTime.Now}) Running {Path.GetFileNameWithoutExtension(configuration.Name)}: {run.CorerunDetails.Key} for {run.RunDetails.Key} - Iteration: {iterationIdx} [/]");
                         crankProcess.Start();
                         crankProcess.BeginOutputReadLine();
                         crankProcess.BeginErrorReadLine();

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCompare.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCompare.cs
@@ -13,15 +13,15 @@ namespace GC.Infrastructure.Commands.GCPerfSim
         {
             [Description("Path to Baseline Trace")]
             [CommandOption("-b|--baseline")]
-            public string BaselinePath { get; set; }
+            public required string BaselinePath { get; set; }
 
             [Description("Path to Comparand Trace")]
             [CommandOption("-c|--comparand")]
-            public string ComparandPath { get; set; }
+            public required string ComparandPath { get; set; }
 
             [Description("Path to Output")]
             [CommandOption("-o|--output")]
-            public string OutputPath { get; set; }
+            public required string OutputPath { get; set; }
 
         }
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/CrankConfiguration.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/CrankConfiguration.yaml
@@ -6,7 +6,7 @@ jobs:
     source:
       repository: https://github.com/dotnet/performance
       branchOrCommit: main
-      project: src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
+      project: src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
     readyStateText: "GCPerfSim"
     waitForExit: true
     variables:
@@ -26,9 +26,14 @@ jobs:
       sohfi: 0
       lohfi: 0
       pohfi: 0
+      ramb: 0
+      rlmb: 0
+      rsohsi: 3 # Defaults from GCPerfSim
+      rlohsi: 2 # Defaults from GCPerfSim
+      rpohsi: 0 # Defaults from GCPerfSim
       allocType: reference
       testKind: time
-    arguments: "-tc {{ tc }} -tagb {{ tagb }} -tlgb {{ tlgb }} -lohar {{ lohar }} -lohsr {{ lohsr }} -sohsi {{ sohsi }} -lohsi {{ lohsi }} -sohpi {{ sohpi }} -lohpi {{ lohpi }} -sohfi {{ sohfi }} -lohfi {{ lohfi }} -allocType {{ allocType }} -testKind {{ testKind }}"
+    arguments: "-tc {{ tc }} -tagb {{ tagb }} -tlgb {{ tlgb }} -lohar {{ lohar }} -lohsr {{ lohsr }} -sohsi {{ sohsi }} -lohsi {{ lohsi }} -sohpi {{ sohpi }} -lohpi {{ lohpi }} -sohfi {{ sohfi }} -lohfi {{ lohfi }} -ramb {{ ramb }} -rlmb {{ rlmb }} -rsohsi {{ rsohsi }} -rlohsi {{ rlohsi }} -rpohsi {{ rpohsi }} -allocType {{ allocType }} -testKind {{ testKind }}"
 
 scenarios:
   gcperfsim:


### PR DESCRIPTION
- Improved the robustness of the GCPerfSim runs. 
- Added a configuration covering the Low Volatility Runs.
- Reduced the number of warnings.
- Fixed up the crank-based configuration to include the request based parameters.
- Fixed the location of the new GCPerfSim path after the old infra deprecation.