### PR TITLE
Add MonoAOTLLVM to local script

### DIFF
--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -200,7 +200,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]):
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else None, f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
+            if parsed_args.mono_libclang_path:
+                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}') 
+            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -62,6 +62,18 @@ class RunType(Enum):
 def is_windows(parsed_args: Namespace):
     return parsed_args.os == "windows"
 
+def get_os_short_name(os_name: str):
+    if os_name == "windows":
+        return "win"
+    elif os_name == "linux":
+        return "linux"
+    elif os_name == "osx":
+        return "osx"
+    elif os_name == "browser":
+        return "browser"
+    else:
+        raise ValueError(f"Unknown OS {os_name}")
+
 def is_running_as_admin(parsed_args: Namespace):
     if is_windows(parsed_args):
         return ctypes.windll.shell32.IsUserAnAdmin()
@@ -206,10 +218,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location
-            src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")
+            src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{get_os_short_name(parsed_args.os)}-{parsed_args.architecture}")
             dest_dir_aot = os.path.join(repo_path, "artifacts", "bin", "aot")
             copy_directory_contents(src_dir_aot, dest_dir_aot)
-            src_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", f"microsoft.netcore.app.runtime.{parsed_args.os}-{parsed_args.architecture}", "Release")
+            src_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", f"microsoft.netcore.app.runtime.{get_os_short_name(parsed_args.os)}-{parsed_args.architecture}", "Release")
             dest_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", "aot", "pack")
             copy_directory_contents(src_dir_aot_pack, dest_dir_aot_pack)
             
@@ -365,7 +377,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--anyCategories', 'Libraries', 'Runtime',
             '--category-exclusion-filter', 'NoAOT', 'NoWASM',
             '--runtimes', "monoaotllvm",
-            '--aotcompilerpath', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", "mono-aot-cross"),
+            '--aotcompilerpath', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", f"mono-aot-cross{'.exe' if is_windows(parsed_args) else ''}"),
             '--customruntimepack', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", "pack"),
             '--aotcompilermode', 'llvm',
             '--logBuildOutput',

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,8 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else '', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path)
+            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else None, f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else '', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")
@@ -562,7 +562,8 @@ def add_arguments(parser):
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework to run the benchmarks against.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
-    parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') 
+    parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') # TODO: Setup required arguments
+    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.') # TODO: Setup required arguments
 
 def get_default_os():
     system = platform.system().lower()

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -216,7 +216,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
             build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
             if parsed_args.mono_libclang_path:
-                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}') 
+                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}')
+            if parsed_args.architecture == "arm64":
+                build_args.append('/p:MonoAOTEnableLLVM=true')
+                build_args.append('/p:MonoBundleLLVMOptimizer=true')
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -563,8 +563,8 @@ def add_arguments(parser):
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework used to build the microbenchmarks.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
+    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.')
     parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') # TODO: Setup required arguments
-    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.') # TODO: Setup required arguments
 
 def get_default_os():
     system = platform.system().lower()

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -214,12 +214,9 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]):
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
+            build_args = ['/p:MonoEnableLLVM=True', '/p:MonoAOTEnableLLVM=true', '/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
             if parsed_args.mono_libclang_path:
                 build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}')
-            if parsed_args.architecture == "arm64":
-                build_args.append('/p:MonoAOTEnableLLVM=true')
-                build_args.append('/p:MonoBundleLLVMOptimizer=true')
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -213,7 +213,6 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             dest_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", "aot", "pack")
             copy_directory_contents(src_dir_aot_pack, dest_dir_aot_pack)
             
-            generate_layout(parsed_args, repo_path, ["/p:LibrariesConfiguration=Release"])
             src_dir_aot_final = os.path.join(repo_path, "artifacts", "bin", "aot")
             shutil.rmtree(artifact_mono_aot_llvm, ignore_errors=True)
             copy_directory_contents(src_dir_aot_final, artifact_mono_aot_llvm)

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -18,7 +18,9 @@
 # Prereqs:
 # Normal prereqs for building the target runtime: https://github.com/dotnet/runtime/blob/main/docs/workflow/README.md#Build_Requirements
 # Python 3
-# gitpython (pip install gitpython)
+# gitpython (pip install --global gitpython)
+# Ubuntu Version 22.04 if using Ubuntu
+# May need llvm+clang 16 for MonoAOTLLVM (https://apt.llvm.org/)
 # Wasm need jsvu installed and setup (No need to setup EMSDK, the tool does that automatically when building)
 
 
@@ -571,7 +573,7 @@ def add_arguments(parser):
     # Arguments specifically for dependency generation and BDN
     parser.add_argument('--bdn-arguments', type=str, default="", help='Command line arguments to be passed to BenchmarkDotNet, wrapped in quotes')
     parser.add_argument('--architecture', choices=['x64', 'x86', 'arm64', 'arm'], default=get_machine_architecture(), help='Specifies the SDK processor architecture')
-    parser.add_argument('--os', choices=['windows', 'linux', 'osx'], default=get_default_os(), help='Specifies the operating system of the system')
+    parser.add_argument('--os', choices=['windows', 'linux', 'osx'], default=get_default_os(), help='Specifies the operating system of the system. Darwin is OSX.')
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework used to build the microbenchmarks.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
@@ -582,7 +584,7 @@ def get_default_os():
     system = platform.system().lower()
     if system == 'darwin':
         return 'osx'
-    elif system in ['windows', 'linux']:
+    elif system in ['windows', 'linux', 'osx']:
         return system
     else:
         raise Exception("Unsupported operating system: {system}.")

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,6 +7,16 @@ class ChannelMap():
             'branch': '8.0',
             'quality': 'daily'
         },
+        '9.0': {
+            'tfm': 'net9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
+        'release/9.0': {
+            'tfm': 'net9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,16 +7,6 @@ class ChannelMap():
             'branch': '8.0',
             'quality': 'daily'
         },
-        '9.0': {
-            'tfm': 'net9.0',
-            'branch': '9.0',
-            'quality': 'daily'
-        },
-        'release/9.0': {
-            'tfm': 'net9.0',
-            'branch': '9.0',
-            'quality': 'daily'
-        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',


### PR DESCRIPTION
Adds MonoAOTLLVM scenario support to the local testing script. Because the MonoAOTLLVM toolchain is only setup to run one BDN test set per invocation, the tool runs multiple which then can be compared using the ResultsComparer tool.