### PR TITLE
[wasm] Fix scripts to track change in BDN

### DIFF
--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -393,7 +393,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
             '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmInterpreter, commit), "wasm_bundle", "wasm-data"),
             '--wasmEngine', parsed_args.wasm_engine_path,
-            '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
+            '--wasmArgs', '\" --experimental-wasm-eh --expose_wasm --module\"',
             '--logBuildOutput',
             '--generateBinLog'
         ]
@@ -405,7 +405,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--category-exclusion-filter', 'NoInterpreter', 'NoWASM', 'NoMono',
             '--wasmDataDir', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle", "wasm-data"),
             '--wasmEngine', parsed_args.wasm_engine_path,
-            '--wasmArgs', '\"--experimental-wasm-eh --expose_wasm --module\"',
+            '--wasmArgs', '\" --experimental-wasm-eh --expose_wasm --module\"',
             '--aotcompilermode', 'wasm',
             '--logBuildOutput',
             '--generateBinLog'

--- a/scripts/performance_setup.py
+++ b/scripts/performance_setup.py
@@ -256,8 +256,10 @@ def run(args: PerformanceSetupArgs):
     if args.wasm_bundle_directory is not None:
         wasm_bundle_directory_path = payload_directory
         shutil.copytree(args.wasm_bundle_directory, wasm_bundle_directory_path)
-        
-        wasm_args = "--experimental-wasm-eh --expose_wasm"
+
+        # Ensure there is a space at the beginning, so BDN can correctly read them
+        # as arguments to `--wasmArgs`
+        wasm_args = " --experimental-wasm-eh --expose_wasm"
 
         if args.javascript_engine == "v8":
             wasm_args += " --module"


### PR DESCRIPTION
`dotnet/performance` got an update for `dotnet/BenchmarkDotNet` via
https://github.com/dotnet/performance/pull/3331 . And that bdn update
includes https://github.com/dotnet/BenchmarkDotNet/pull/2375, which
subtly changes how the arguments get parsed, and breaks the existing
scripts:

```
$ pushd "/home/helixbot/work/B807097D/w/AED609DF/e/performance/artifacts/bin/for-running/MicroBenchmarks"
$ dotnet exec MicroBenchmarks.dll --wasmArgs "--experimental-wasm-eh --expose_wasm --module" ...
MicroBenchmarks 1.0.0-dev
© Microsoft Corporation. All rights reserved.

ERROR(S):
  Option 'experimental-wasm-eh --expose_wasm --module' is unknown.
```

Related: https://github.com/dotnet/runtime/issues/92066 .
