### PR TITLE
[perf] Fix hybrid globalization command line parameter

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -13,6 +13,7 @@
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
     
     <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
+    <HybridGlobalizationCommandProps Condition="'$(HybridGlobalization)' == 'true'">--hybrid-globalization true</HybridGlobalizationCommandProps>
     <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise didn't add anything.
     This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
     <HybridGlobalizationString></HybridGlobalizationString>
@@ -61,7 +62,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --hybrid-globalization $(HybridGlobalization) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) $(HybridGlobalizationCommandProps) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>


### PR DESCRIPTION
This PR modifies the command line arguments to include `--hybrid-globalization` only when the feature is enabled. Otherwise, it is always enabled.