### PR TITLE
Add CountBy and AggregateBy benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/Linq/Linq.cs
+++ b/src/benchmarks/micro/runtime/Linq/Linq.cs
@@ -118,7 +118,8 @@ public class LinqBenchmarks
     public const int IterationsWhere01 = 250000;
     public const int IterationsCount00 = 1000000;
     public const int IterationsOrder00 = 25000;
-    
+    public const int IterationsCountBy00 = 1000000;
+
     #region Where00
 
     [Benchmark]
@@ -354,6 +355,56 @@ public class LinqBenchmarks
         }
 
         return (medianPricedProduct.ProductID == 57);
+    }
+    #endregion
+
+    #region CountBy00
+
+#if NET9_0_OR_GREATER
+    [Benchmark]
+    public bool CountBy00LinqMethodX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products.CountBy(p => p.Category).Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
+    }
+#endif
+
+    [Benchmark]
+    public bool CountBy00GroupByX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products
+                .GroupBy(p => p.Category)
+                .ToDictionary(c => c, g => g.Count())
+                .Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
+    }
+
+    [Benchmark]
+    public bool CountBy00LookupX()
+    {
+        List<Product> products = Product.GetProductList();
+        int count = 0;
+        for (int i = 0; i < IterationsCount00; i++)
+        {
+            count += products
+                .ToLookup(p => p.Category)
+                .ToDictionary(c => c, g => g.Count())
+                .Count();
+        }
+
+        return (count == 5 * IterationsCountBy00);
     }
     #endregion
 }

--- a/src/benchmarks/micro/runtime/Linq/Linq.cs
+++ b/src/benchmarks/micro/runtime/Linq/Linq.cs
@@ -434,33 +434,33 @@ public class LinqBenchmarks
     public bool AggregateBy00LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
-        int sum = 0;
+        decimal sum = 0;
         for (int i = 0; i < IterationsAggregateBy00; i++)
         {
             sum += products
-                .AggregateBy(p => p.Category, 0, (total, p) => total + p.UnitsInStock * p.UnitPrice)
-                .Sum();
+                .AggregateBy(p => p.Category, decimal.Zero, (total, p) => total + p.UnitsInStock * p.UnitPrice)
+                .Sum(kvp => kvp.Value);
         }
 
         return (sum == 5 * IterationsAggregateBy00);
     }
+#endif
 
     [Benchmark]
     public bool AggregateBy00GroupByX()
     {
         List<Product> products = Product.GetProductList();
-        int count = 0;
+        decimal count = 0;
         for (int i = 0; i < IterationsAggregateBy00; i++)
         {
             count += products
                 .GroupBy(p => p.Category)
-                .ToDictionary(c => c, g => g.Aggregate(0, (total, p) => total + p.UnitsInStock * p.UnitPrice)
-                .Sum();
+                .ToDictionary(c => c, g => g.Aggregate(decimal.Zero, (total, p) => total + p.UnitsInStock * p.UnitPrice))
+                .Sum(kvp => kvp.Value);
         }
 
         return (count == 5 * IterationsAggregateBy00);
     }
-#endif
 
     #endregion
 
@@ -490,7 +490,7 @@ public class LinqBenchmarks
         for (int i = 0; i < IterationsGroupBy00; i++)
         {
             count += products
-                .AggregateBy(p => p.Category, _ => new List<string>(), (group, element) => { group.Add(element); return group;})
+                .AggregateBy(p => p.Category, _ => new List<Product>(), (group, element) => { group.Add(element); return group;})
                 .Count();
         }
 


### PR DESCRIPTION
Adding benchmarks for the new CountBy and AggregateBy Linq methods.
See https://github.com/dotnet/runtime/pull/91507 and https://github.com/dotnet/runtime/pull/92089

I have tried to add support for the net9.0 TFM as it is now the one used in the main branch of the [dotnet/runtime](https://github.com/dotnet/runtime) repo but I don't know what I'm getting into...