### PR TITLE
[doc] Updating prerequisites documentation

### DIFF
--- a/docs/scenarios-workflow.md
+++ b/docs/scenarios-workflow.md
@@ -17,6 +17,12 @@ This is a general guideline on how the scenario tests are arranged in this repo.
 ### Prerequisites
 
 - python3 or newer
+  - some of the scenarios require `requests` python module to be installed. To install the required module run:
+
+    ```bash
+    python3 -m pip install requests
+    ```
+
 - dotnet runtime 3.0 or newer
 - terminal/command prompt **in Admin Mode** (for collecting kernel traces)
 - clean state of the test machine (anti-virus scan is off and no other user program's running -- to minimize the influence of environment on the test)


### PR DESCRIPTION
A minor update to the documentation related to python3 prerequisites.

MAUI scenarios depend on `requests` module which does not come out-of-the-box with python3 installation, so running `pre.py` script can result with:
```
Traceback (most recent call last): 
File "/Users/ivan/repos/performance/src/scenarios/mauiios/pre.py", line 9, in <module> from shared.mauisharedpython import remove_aab_files, install_versioned_maui 
File "/Users/ivan/repos/performance/src/scenarios/shared/mauisharedpython.py", line 3, in <module> import requests 
ModuleNotFoundError: No module named 'requests'
```

To solve this problem `requests` module has to be installed manually, as described in the documentation.