### PR TITLE
Normalize the dictionary order and values for Reporter Run Configs

### DIFF
--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -67,7 +67,7 @@ public class Reporter
             foreach (var kvp in configs.Split(';'))
             {
                 var split = kvp.Split('=');
-                run.Configurations.Add(split[0], split[1]);
+                run.Configurations.Add(split[0], split[1].ToLower());
             } 
         }
 

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -67,7 +67,7 @@ public class Reporter
             foreach (var kvp in configs.Split(';'))
             {
                 var split = kvp.Split('=');
-                run.Configurations.Add(split[0], split[1].ToLower());
+                run.Configurations.Add(split[0], split[1]);
             } 
         }
 

--- a/src/tools/Reporting/Reporting/Run.cs
+++ b/src/tools/Reporting/Reporting/Run.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Reporting;
 
@@ -21,5 +20,6 @@ public class Run
     public string Queue { get; set; }
 
     public string WorkItemName { get; set; }
-    public IDictionary<string, string> Configurations { get; set; } = new Dictionary<string, string>();
+
+    public IDictionary<string, string> Configurations { get; set; } = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
Normalize the dictionary order and values in the run configurations for the Reporter.cs generation. Also fixed some spacing. This will ensure that the RunConfiguration strings uploaded to the ADX will be consistent in ordering.

The OrdinalCaseInsensitive string comparer was chosen based on use of the default stringcomparer sort in other places and the values of the RunConfigs in our run information tables like "CompilationMode:tiered;iOSLlvmBuild:true;iOSStripSymbols:true;RunKind:ios_scenarios;RuntimeType:mono". Either Invariant or ordinal cultures with CaseInsensitivity would result in this for my testing, but using ordinal culture should ensure no potential machine to machine differences as the individual character code values are evaluated. 