### PR TITLE
Fix default repo_storage_path with os.getcwd

### DIFF
--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -514,7 +514,7 @@ def add_arguments(parser):
     parser.add_argument('--repo-url', type=str, default='https://github.com/dotnet/runtime.git', help='The runtime repo to test from, used to get data for a fork.')
     parser.add_argument('--local-test-repo', type=str, help='Path to a local repo with the runtime source code to test from.') 
     parser.add_argument('--separate-repos', action='store_true', help='Whether to test each runtime version from their own separate repo directory.') # TODO: Do we want to have this as an actual option? It made sense before a shared build cache was added
-    parser.add_argument('--repo-storage-path', type=str, default='.', help='The path to store the cloned repositories in.')
+    parser.add_argument('--repo-storage-path', type=str, default=os.getcwd(), help='The path to store the cloned repositories in.')
     parser.add_argument('--artifact-storage-path', type=str, default=os.path.join(os.getcwd(), "runtime-testing-artifacts"), help=f'The path to store the artifacts in (builds, results, etc). Default is {os.path.join(os.getcwd(), "runtime-testing-artifacts")}')
     parser.add_argument('--rebuild-artifacts', action='store_true', help='Whether to rebuild the artifacts for the specified commits before benchmarking.')
     parser.add_argument('--reinstall-dotnet', action='store_true', help='Whether to reinstall dotnet for use in building the benchmarks before running the benchmarks.')


### PR DESCRIPTION
Fix default repo_storage_path with os.getcwd rather than . to ensure full path usage. Fixes the error: https://github.com/dotnet/performance/pull/3338#issuecomment-1731548399.


