### PR TITLE
Fixed the path of the GCPerfSim in the scenarios

### DIFF
--- a/src/benchmarks/gc/scenarios/CrankConfiguration.yaml
+++ b/src/benchmarks/gc/scenarios/CrankConfiguration.yaml
@@ -6,7 +6,7 @@ jobs:
     source:
       repository: https://github.com/dotnet/performance
       branchOrCommit: main
-      project: src/benchmarks/gc/src/exec/GCPerfSim/GCPerfSim.csproj
+      project: src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
     waitForExit: true
     readyStateText: GCPerfSim
     variables:


### PR DESCRIPTION
Added a fix for broken ASP.NET scenarios that reference the said file. Since we moved around the structure of the infra, the path to GCPerfSim was different.