### PR TITLE
Cleanup benchmarks_local.py script

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -241,7 +241,7 @@ def __process_arguments(args: List[str]):
     add_arguments(parser)
     return parser.parse_args(args)
 
-def __main(argv: List[str]):
+def main(argv: List[str]):
     validate_supported_runtime()
     args = __process_arguments(argv)
     verbose = not args.quiet
@@ -358,4 +358,4 @@ def __main(argv: List[str]):
             sys.exit(1)
 
 if __name__ == "__main__":
-    __main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -200,7 +200,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]):
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else None, f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
+            if parsed_args.mono_libclang_path:
+                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}') 
+            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -62,6 +62,18 @@ class RunType(Enum):
 def is_windows(parsed_args: Namespace):
     return parsed_args.os == "windows"
 
+def get_os_short_name(os_name: str):
+    if os_name == "windows":
+        return "win"
+    elif os_name == "linux":
+        return "linux"
+    elif os_name == "osx":
+        return "osx"
+    elif os_name == "browser":
+        return "browser"
+    else:
+        raise ValueError(f"Unknown OS {os_name}")
+
 def is_running_as_admin(parsed_args: Namespace):
     if is_windows(parsed_args):
         return ctypes.windll.shell32.IsUserAnAdmin()
@@ -206,10 +218,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location
-            src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")
+            src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{get_os_short_name(parsed_args.os)}-{parsed_args.architecture}")
             dest_dir_aot = os.path.join(repo_path, "artifacts", "bin", "aot")
             copy_directory_contents(src_dir_aot, dest_dir_aot)
-            src_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", f"microsoft.netcore.app.runtime.{parsed_args.os}-{parsed_args.architecture}", "Release")
+            src_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", f"microsoft.netcore.app.runtime.{get_os_short_name(parsed_args.os)}-{parsed_args.architecture}", "Release")
             dest_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", "aot", "pack")
             copy_directory_contents(src_dir_aot_pack, dest_dir_aot_pack)
             
@@ -365,7 +377,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--anyCategories', 'Libraries', 'Runtime',
             '--category-exclusion-filter', 'NoAOT', 'NoWASM',
             '--runtimes', "monoaotllvm",
-            '--aotcompilerpath', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", "mono-aot-cross"),
+            '--aotcompilerpath', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", f"mono-aot-cross{'.exe' if is_windows(parsed_args) else ''}"),
             '--customruntimepack', os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot", "pack"),
             '--aotcompilermode', 'llvm',
             '--logBuildOutput',

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -24,7 +24,6 @@
 # Wasm need jsvu installed and setup (No need to setup EMSDK, the tool does that automatically when building)
 
 
-import ctypes
 import glob
 import os
 import platform
@@ -33,7 +32,7 @@ import sys
 import xml.etree.ElementTree as xmlTree
 from argparse import ArgumentParser, ArgumentTypeError, Namespace
 from datetime import datetime
-from enum import Enum
+from enum import Enum, EnumMeta
 from logging import getLogger
 from subprocess import CalledProcessError
 
@@ -76,11 +75,12 @@ def get_os_short_name(os_name: str):
     else:
         raise ValueError(f"Unknown OS {os_name}")
 
-def is_running_as_admin(parsed_args: Namespace):
+def is_running_as_admin(parsed_args: Namespace) -> bool:
     if is_windows(parsed_args):
+        import ctypes
         return ctypes.windll.shell32.IsUserAnAdmin()
     else:
-        return os.getuid() == 0
+        return os.getuid() == 0 # type: ignore os.getuid() returns an int on Unix-like systems
 
 def kill_dotnet_processes(parsed_args: Namespace):
     if is_windows(parsed_args):
@@ -88,16 +88,17 @@ def kill_dotnet_processes(parsed_args: Namespace):
     else:
         os.system('killall -9 dotnet 2> /dev/null || killall -9 VSTest.Console 2> /dev/null || killall -9 msbuild 2> /dev/null || killall -9 ".NET Host" 2> /dev/null') # Always kill dotnet so it isn't left with handles on its files
 
-def enum_name_to_enum(EnumType, enum_name: str):
-    for enum in EnumType:
-        if enum.name == enum_name:
-            return enum
-    raise ValueError(f"Enum name {enum_name} not found in {EnumType}.")
+# Use EnumMeta until set to using python 3.11 or greater, where the name is switched to EnumType (although EnumMeta should still work as an alias)
+def enum_name_to_enum(enum_type: EnumMeta, enum_name: str):
+    try:
+        return enum_type[enum_name]
+    except KeyError:
+        raise ArgumentTypeError(f"Invalid run type name {enum_name}.")
 
-def enum_name_list_to_enum_list(EnumType, enum_name_list: list):
-    return [enum_name_to_enum(EnumType, enum_name) for enum_name in enum_name_list]
+def enum_name_list_to_enum_list(enum_type: EnumMeta, enum_name_list: list[str]):
+    return [enum_name_to_enum(enum_type, enum_name) for enum_name in enum_name_list]
 
-def check_for_runtype_specified(parsed_args: Namespace, run_types_to_check: list) -> bool:
+def check_for_runtype_specified(parsed_args: Namespace, run_types_to_check: list[RunType]) -> bool:
     for run_type in run_types_to_check:
         if run_type.name in parsed_args.run_type_names:
             return True
@@ -105,7 +106,7 @@ def check_for_runtype_specified(parsed_args: Namespace, run_types_to_check: list
 
 # Uses python copy, to copy the contents of a directory to another directory while overwriting any existing files
 def copy_directory_contents(src_dir: str, dest_dir: str):
-    for src_dirpath, src_dirnames, src_filenames in os.walk(src_dir):
+    for src_dirpath, _, src_filenames in os.walk(src_dir):
         dest_dirpath = os.path.join(dest_dir, os.path.relpath(src_dirpath, src_dir))
         if not os.path.exists(dest_dirpath):
             os.makedirs(dest_dirpath)
@@ -115,7 +116,7 @@ def copy_directory_contents(src_dir: str, dest_dir: str):
             shutil.copy2(os.path.join(src_dirpath, src_filename), dest_dirpath)
         
 # Builds libs and corerun by default
-def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str = "clr+libs", configuration: str = "Release", os_override = "", arch_override = "", additional_args: list = []):    
+def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str = "clr+libs", configuration: str = "Release", os_override = "", arch_override = "", additional_args: list[str] = []):    
     if is_windows(parsed_args):
         build_libs_and_corerun_command = [
                 "powershell",
@@ -136,7 +137,7 @@ def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str
             ] + additional_args
     RunCommand(build_libs_and_corerun_command, verbose=True).run(os.path.join(repo_path, "eng"))
 
-def generate_layout(parsed_args: Namespace, repo_path: str, additional_args: list = []):
+def generate_layout(parsed_args: Namespace, repo_path: str, additional_args: list[str] = []):
     # Run the command
     if is_windows(parsed_args):
         generate_layout_command = ["build.cmd"]
@@ -275,9 +276,9 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
 
     getLogger().info(f"Finished generating dependencies for {' '.join(map(str, parsed_args.run_type_names))} run types in {repo_path} and stored in {parsed_args.artifact_storage_path}.")
 
-def generate_combined_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunType, all_commits: list[str]) -> list:
+def generate_combined_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunType, all_commits: list[str]) -> list[str]:
     getLogger().info(f"Generating benchmark_ci.py arguments for {specific_run_type.name} run type using artifacts in {parsed_args.artifact_storage_path}.")
-    bdn_args_unescaped = []
+    bdn_args_unescaped: list[str] = []
     benchmark_ci_args = [
         '--architecture', parsed_args.architecture,
         '--frameworks', parsed_args.framework,
@@ -353,9 +354,9 @@ def generate_combined_benchmark_ci_args(parsed_args: Namespace, specific_run_typ
     getLogger().info(f"Finished generating benchmark_ci.py arguments for {specific_run_type.name} run type using artifacts in {parsed_args.artifact_storage_path}.")
     return benchmark_ci_args
 
-def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunType, commit: str) -> list:
+def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunType, commit: str) -> list[str]:
     getLogger().info(f"Generating benchmark_ci.py arguments for {specific_run_type.name} run type using artifacts in {parsed_args.artifact_storage_path}.")
-    bdn_args_unescaped = []
+    bdn_args_unescaped: list[str] = []
     benchmark_ci_args = [
         '--architecture', parsed_args.architecture,
         '--frameworks', parsed_args.framework,
@@ -473,8 +474,7 @@ def generate_artifacts_for_commit(parsed_args: Namespace, repo_url: str, repo_di
         getLogger().info(f"Running for {repo_path} at {commit}.")
 
         if not os.path.exists(repo_path):
-            Repo.clone_from(repo_url, repo_path)
-            repo = Repo(repo_path)
+            repo = Repo.clone_from(repo_url, repo_path) # type: ignore 'Type of "clone_from" is partially unknown', we know it is a method and returns a Repo
             repo.git.checkout(commit)
             repo.git.show('HEAD')
         else:
@@ -487,22 +487,23 @@ def generate_artifacts_for_commit(parsed_args: Namespace, repo_url: str, repo_di
     generate_all_runtype_dependencies(parsed_args, repo_path, commit, (is_local and not parsed_args.skip_local_rebuild) or parsed_args.rebuild_artifacts)
 
 # Run tests on the local machine
-def run_benchmarks(parsed_args: Namespace, commits: list) -> None:
+def run_benchmarks(parsed_args: Namespace, commits: list[str]) -> None:
     # Generate the correct benchmarks_ci.py arguments for the run type
-    for run_type in enum_name_list_to_enum_list(RunType, parsed_args.run_type_names):
+    for run_type_meta in enum_name_list_to_enum_list(RunType, parsed_args.run_type_names):
         # Run the benchmarks_ci.py test and save results
+        run_type = RunType(run_type_meta)
         try:
             if run_type in [RunType.CoreRun, RunType.MonoInterpreter, RunType.MonoJIT]:
                 benchmark_ci_args = generate_combined_benchmark_ci_args(parsed_args, run_type, commits)
                 getLogger().info(f"Running benchmarks_ci.py for {run_type} at {commits} with arguments \"{' '.join(benchmark_ci_args)}\".")
                 kill_dotnet_processes(parsed_args)
-                benchmarks_ci.__main(benchmark_ci_args) # Build the runtime includes a download of dotnet at this location
+                benchmarks_ci.main(benchmark_ci_args) # Build the runtime includes a download of dotnet at this location
             elif run_type in [RunType.MonoAOTLLVM, RunType.WasmInterpreter, RunType.WasmAOT]:
                 for commit in commits:
                     benchmark_ci_args = generate_single_benchmark_ci_args(parsed_args, run_type, commit)
                     getLogger().info(f"Running single benchmarks_ci.py for {run_type} at {commit} with arguments \"{' '.join(benchmark_ci_args)}\".")
                     kill_dotnet_processes(parsed_args)
-                    benchmarks_ci.__main(benchmark_ci_args)
+                    benchmarks_ci.main(benchmark_ci_args)
             else:
                 raise TypeError(f"Run type {run_type} is not supported. Please check the run type and try again.")
         except CalledProcessError:
@@ -526,14 +527,14 @@ def install_dotnet(parsed_args: Namespace) -> None:
 # - repo_dir (str): The name of the directory where the cloned repository is stored.
 #
 # Returns: None
-def check_references_exist_and_add_branch_commits(repo_url: str, references: list, repo_storage_path: str, repo_dir: str):
+def check_references_exist_and_add_branch_commits(repo_url: str, references: list[str], repo_storage_path: str, repo_dir: str):
     getLogger().debug(f"Inside check_references_exist_and_add_branch_commits: Checking if references {references} exist in {repo_url}.")
     
     # Initialize a new Git repository in the specified directory
     repo_combined_path = os.path.join(repo_storage_path, repo_dir)
     if not os.path.exists(repo_combined_path):
         getLogger().debug(f"Cloning {repo_url} to {repo_combined_path}.")
-        repo = Repo.clone_from(repo_url, repo_combined_path)
+        repo = Repo.clone_from(repo_url, repo_combined_path) # type: ignore 'Type of "clone_from" is partially unknown', we know it is a method and returns a Repo
     else:
         repo = Repo(repo_combined_path)
         repo.remotes.origin.fetch()
@@ -545,7 +546,7 @@ def check_references_exist_and_add_branch_commits(repo_url: str, references: lis
         except GitCommandError:
             raise Exception(f"Reference {reference} does not exist in {repo_url}.")
 
-def add_arguments(parser):
+def add_arguments(parser: ArgumentParser):
     dotnet.add_arguments(parser)
 
     # Arguments for the local runner script
@@ -561,7 +562,7 @@ def add_arguments(parser):
     parser.add_argument('--build-only', action='store_true', help='Whether to only build the artifacts for the specified commits and not run the benchmarks.')
     parser.add_argument('--skip-local-rebuild', action='store_true', help='Whether to skip rebuilding the local repo and use the already built version (if already built). Useful if you need to run against local changes again.')
     parser.add_argument('--allow-non-admin-execution', action='store_true', help='Whether to allow non-admin execution of the script. Admin execution is highly recommended as it minimizes the chance of encountering errors, but may not be possible in all cases.')
-    def __is_valid_run_type(value):
+    def __is_valid_run_type(value: str):
         try:
             RunType[value]
         except KeyError:
@@ -589,7 +590,7 @@ def get_default_os():
     else:
         raise Exception("Unsupported operating system: {system}.")
 
-def __main(args: list):
+def __main(args: list[str]):
     # Define the ArgumentParser
     parser = ArgumentParser(description='Run local benchmarks for the Performance repo.', conflict_handler='resolve')
     add_arguments(parser)
@@ -607,9 +608,9 @@ def __main(args: list):
 
     # If list cached builds is specified, list the cached builds and exit
     if parsed_args.list_cached_builds:
-        for folder in os.listdir(parsed_args.artifact_storage_path):
-            if any([run_type.name in folder for run_type in RunType]):
-                getLogger().info(folder)
+        for folder in os.listdir(parsed_args.artifact_storage_path): # type: ignore warning about folder type being unknown, we know it is a string
+            if any([run_type.name in folder for run_type in RunType]): 
+                getLogger().info(folder) # type: ignore We know folder is a string
         return
 
     # Check to make sure we have something specified to test
@@ -623,7 +624,7 @@ def __main(args: list):
 
     getLogger().debug(f"Input arguments: {parsed_args}")
 
-    repo_dirs = []
+    repo_dirs: list[str] = []
     repo_url = parsed_args.repo_url
     if parsed_args.commits:
         getLogger().info(f"Checking if references {parsed_args.commits} exist in {repo_url}.")
@@ -653,7 +654,7 @@ def __main(args: list):
 
         if not parsed_args.build_only:
             # Run the benchmarks
-            commitsToRun = []
+            commitsToRun: list[str] = []
             if parsed_args.commits:
                 commitsToRun = parsed_args.commits
             if parsed_args.local_test_repo:

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,8 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else '', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path)
+            build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else None, f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -201,7 +201,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]): # TODO: Is all the cross stuff needed?
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', '/p:MonoLibClang="/usr/local/lib/libclang.so.16"', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
+            build_runtime_dependency(parsed_args, repo_path, "clr+mono+libs+host+packs", additional_args=['-cross', '/p:BuildMonoAOTCrossCompiler=true', f'/p:MonoLibClang={parsed_args.mono_libclang_path}' if parsed_args.mono_libclang_path else '', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
             
             # Move to the bin/aot location
             src_dir_aot = os.path.join(repo_path, "artifacts", "bin", "mono", f"{parsed_args.os}.{parsed_args.architecture}.Release", "cross", f"{parsed_args.os}-{parsed_args.architecture}")
@@ -562,7 +562,8 @@ def add_arguments(parser):
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework to run the benchmarks against.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
-    parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') 
+    parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') # TODO: Setup required arguments
+    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.') # TODO: Setup required arguments
 
 def get_default_os():
     system = platform.system().lower()

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -216,7 +216,10 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
             build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
             if parsed_args.mono_libclang_path:
-                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}') 
+                build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}')
+            if parsed_args.architecture == "arm64":
+                build_args.append('/p:MonoAOTEnableLLVM=true')
+                build_args.append('/p:MonoBundleLLVMOptimizer=true')
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -563,8 +563,8 @@ def add_arguments(parser):
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework used to build the microbenchmarks.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
+    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.')
     parser.add_argument('--wasm-engine-path', type=str, help='The full path to the wasm engine to use for the benchmarks. e.g. /usr/local/bin/v8') # TODO: Setup required arguments
-    parser.add_argument('--mono-libclang-path', type=str, help='The full path to the clang compiler to use for the benchmarks. e.g. "/usr/local/lib/libclang.so.16", used for "MonoLibClang" build property.') # TODO: Setup required arguments
 
 def get_default_os():
     system = platform.system().lower()

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -214,12 +214,9 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
     if check_for_runtype_specified(parsed_args, [RunType.MonoAOTLLVM]):
         artifact_mono_aot_llvm = os.path.join(get_run_artifact_path(parsed_args, RunType.MonoAOTLLVM, commit), "monoaot")
         if force_regenerate or not os.path.exists(artifact_mono_aot_llvm):
-            build_args = ['/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
+            build_args = ['/p:MonoEnableLLVM=True', '/p:MonoAOTEnableLLVM=true', '/p:BuildMonoAOTCrossCompiler=true', f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}']
             if parsed_args.mono_libclang_path:
                 build_args.append(f'/p:MonoLibClang={parsed_args.mono_libclang_path}')
-            if parsed_args.architecture == "arm64":
-                build_args.append('/p:MonoAOTEnableLLVM=true')
-                build_args.append('/p:MonoBundleLLVMOptimizer=true')
             build_runtime_dependency(parsed_args, repo_path, "mono+libs+host+packs", additional_args=build_args)
             
             # Move to the bin/aot location

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -213,7 +213,6 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
             dest_dir_aot_pack = os.path.join(repo_path, "artifacts", "bin", "aot", "pack")
             copy_directory_contents(src_dir_aot_pack, dest_dir_aot_pack)
             
-            generate_layout(parsed_args, repo_path, ["/p:LibrariesConfiguration=Release"])
             src_dir_aot_final = os.path.join(repo_path, "artifacts", "bin", "aot")
             shutil.rmtree(artifact_mono_aot_llvm, ignore_errors=True)
             copy_directory_contents(src_dir_aot_final, artifact_mono_aot_llvm)

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -80,7 +80,7 @@ def is_running_as_admin(parsed_args: Namespace) -> bool:
         import ctypes
         return ctypes.windll.shell32.IsUserAnAdmin()
     else:
-        return os.getuid() == 0 # type: ignore os.getuid() returns an int on Unix-like systems
+        return os.getuid() == 0 # type: ignore We know that os.getuid() is a method on Unix-like systems, ignore the pylance unknown type error for getuid.
 
 def kill_dotnet_processes(parsed_args: Namespace):
     if is_windows(parsed_args):

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -18,7 +18,9 @@
 # Prereqs:
 # Normal prereqs for building the target runtime: https://github.com/dotnet/runtime/blob/main/docs/workflow/README.md#Build_Requirements
 # Python 3
-# gitpython (pip install gitpython)
+# gitpython (pip install --global gitpython)
+# Ubuntu Version 22.04 if using Ubuntu
+# May need llvm+clang 16 for MonoAOTLLVM (https://apt.llvm.org/)
 # Wasm need jsvu installed and setup (No need to setup EMSDK, the tool does that automatically when building)
 
 
@@ -571,7 +573,7 @@ def add_arguments(parser):
     # Arguments specifically for dependency generation and BDN
     parser.add_argument('--bdn-arguments', type=str, default="", help='Command line arguments to be passed to BenchmarkDotNet, wrapped in quotes')
     parser.add_argument('--architecture', choices=['x64', 'x86', 'arm64', 'arm'], default=get_machine_architecture(), help='Specifies the SDK processor architecture')
-    parser.add_argument('--os', choices=['windows', 'linux', 'osx'], default=get_default_os(), help='Specifies the operating system of the system')
+    parser.add_argument('--os', choices=['windows', 'linux', 'osx'], default=get_default_os(), help='Specifies the operating system of the system. Darwin is OSX.')
     parser.add_argument('--filter', type=str, default='*', help='Specifies the benchmark filter to pass to BenchmarkDotNet')
     parser.add_argument('-f', '--framework', choices=ChannelMap.get_supported_frameworks(), default='net8.0', help='The target framework used to build the microbenchmarks.') # Can and should this accept multiple frameworks?
     parser.add_argument('--csproj', type=str, default=os.path.join("..", "src", "benchmarks", "micro", "MicroBenchmarks.csproj"), help='The path to the csproj file to run benchmarks against.')   
@@ -582,7 +584,7 @@ def get_default_os():
     system = platform.system().lower()
     if system == 'darwin':
         return 'osx'
-    elif system in ['windows', 'linux']:
+    elif system in ['windows', 'linux', 'osx']:
         return system
     else:
         raise Exception("Unsupported operating system: {system}.")

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,6 +7,16 @@ class ChannelMap():
             'branch': '8.0',
             'quality': 'daily'
         },
+        '9.0': {
+            'tfm': 'net9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
+        'release/9.0': {
+            'tfm': 'net9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,16 +7,6 @@ class ChannelMap():
             'branch': '8.0',
             'quality': 'daily'
         },
-        '9.0': {
-            'tfm': 'net9.0',
-            'branch': '9.0',
-            'quality': 'daily'
-        },
-        'release/9.0': {
-            'tfm': 'net9.0',
-            'branch': '9.0',
-            'quality': 'daily'
-        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',


### PR DESCRIPTION
This cleans up the benchmarks_local.py script based on the Pylance recommendations. This mostly consisted of adding type specifications. It also included refactoring how the enum string methods interact with the enum types and updating the benchmarks_ci.py __main method to main so it could be properly called from the local script.