### PR TITLE
Add a ReadWriteIterationsLarge for the large SSLStreamTests

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
@@ -198,13 +198,15 @@ namespace System.Net.Security.Tests
         }
 
         private const int ReadWriteIterations = 50_000;
+        private const int ReadWriteIterationsLarge = 500;
+
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
         [BenchmarkCategory(Categories.NoAOT)]
         public Task WriteReadAsync() => WriteReadAsync(_clientBuffer, _serverBuffer);
 
 
-        [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
+        [Benchmark(OperationsPerInvoke = ReadWriteIterationsLarge)]
         [BenchmarkCategory(Categories.NoAOT)]
         public Task LargeWriteReadAsync() => WriteReadAsync(_largeClientBuffer, _largeServerBuffer);
 
@@ -223,7 +225,7 @@ namespace System.Net.Security.Tests
         [BenchmarkCategory(Categories.NoAOT)]
         public Task ReadWriteAsync() => ReadWriteAsync(_clientBuffer, _serverBuffer);
 
-        [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
+        [Benchmark(OperationsPerInvoke = ReadWriteIterationsLarge)]
         [BenchmarkCategory(Categories.NoAOT)]
         public Task LargeReadWriteAsync() => ReadWriteAsync(_largeClientBuffer, _largeServerBuffer);
 

--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
@@ -200,11 +200,9 @@ namespace System.Net.Security.Tests
         private const int ReadWriteIterations = 50_000;
         private const int ReadWriteIterationsLarge = 500;
 
-
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
         [BenchmarkCategory(Categories.NoAOT)]
         public Task WriteReadAsync() => WriteReadAsync(_clientBuffer, _serverBuffer);
-
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterationsLarge)]
         [BenchmarkCategory(Categories.NoAOT)]


### PR DESCRIPTION
Add a ReadWriteIterationsLarge for the large tests so they don't cause the pipeline to timeout.
@wfurt FYI about this update. Please let me know if this may cause problems one your end.

Fixes: https://github.com/dotnet/performance/issues/3387
