### PR TITLE
Properly fix ssl stream tests timeout per: https://github.com/dotnet/performance/issues/3387

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
@@ -198,22 +198,21 @@ namespace System.Net.Security.Tests
         }
 
         private const int ReadWriteIterations = 50_000;
-        private const int ReadWriteIterationsLarge = 500;
+        private const int ReadWriteIterationsLarge = 5;
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
         [BenchmarkCategory(Categories.NoAOT)]
-        public Task WriteReadAsync() => WriteReadAsync(_clientBuffer, _serverBuffer);
+        public Task WriteReadAsync() => WriteReadAsync(_clientBuffer, _serverBuffer, ReadWriteIterations);
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterationsLarge)]
-        [OperatingSystemsFilter(allowed: false, platforms: OS.Linux)] // Currently timing out on Linux: https://github.com/dotnet/performance/issues/3387
         [BenchmarkCategory(Categories.NoAOT)]
-        public Task LargeWriteReadAsync() => WriteReadAsync(_largeClientBuffer, _largeServerBuffer);
+        public Task LargeWriteReadAsync() => WriteReadAsync(_largeClientBuffer, _largeServerBuffer, ReadWriteIterationsLarge);
 
-        private async Task WriteReadAsync(byte[] clientArray, byte[] serverArray)
+        private async Task WriteReadAsync(byte[] clientArray, byte[] serverArray, int iterations)
         {
             Memory<byte> clientBuffer = clientArray;
             Memory<byte> serverBuffer = serverArray;
-            for (int i = 0; i < ReadWriteIterations; i++)
+            for (int i = 0; i < iterations; i++)
             {
                 await _sslClient.WriteAsync(clientBuffer, default);
                 await _sslServer.ReadAsync(serverBuffer, default);
@@ -222,18 +221,17 @@ namespace System.Net.Security.Tests
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
         [BenchmarkCategory(Categories.NoAOT)]
-        public Task ReadWriteAsync() => ReadWriteAsync(_clientBuffer, _serverBuffer);
+        public Task ReadWriteAsync() => ReadWriteAsync(_clientBuffer, _serverBuffer, ReadWriteIterations);
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterationsLarge)]
-        [OperatingSystemsFilter(allowed: false, platforms: OS.Linux)] // Currently timing out on Linux: https://github.com/dotnet/performance/issues/3387
         [BenchmarkCategory(Categories.NoAOT)]
-        public Task LargeReadWriteAsync() => ReadWriteAsync(_largeClientBuffer, _largeServerBuffer);
+        public Task LargeReadWriteAsync() => ReadWriteAsync(_largeClientBuffer, _largeServerBuffer, ReadWriteIterationsLarge);
 
-        private async Task ReadWriteAsync(byte[] clientArray, byte[] serverArray)
+        private async Task ReadWriteAsync(byte[] clientArray, byte[] serverArray, int iterations)
         {
             Memory<byte> clientBuffer = clientArray;
             Memory<byte> serverBuffer = serverArray;
-            for (int i = 0; i < ReadWriteIterations; i++)
+            for (int i = 0; i < iterations; i++)
             {
                 ValueTask<int> read = _sslServer.ReadAsync(serverBuffer, default);
                 await _sslClient.WriteAsync(clientBuffer, default);

--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
@@ -198,7 +198,7 @@ namespace System.Net.Security.Tests
         }
 
         private const int ReadWriteIterations = 50_000;
-        private const int ReadWriteIterationsLarge = 5;
+        private const int ReadWriteIterationsLarge = 50;
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
         [BenchmarkCategory(Categories.NoAOT)]


### PR DESCRIPTION
Found out OperationsPerInvoke is essentially just a metadata update. Refactored the test methods to take the number of iterations as a parameter and setup them up to be used properly.