### PR TITLE
Update PowerShell benchmarks to use net8.0

### DIFF
--- a/src/benchmarks/real-world/PowerShell.Benchmarks/PowerShell.Benchmarks.csproj
+++ b/src/benchmarks/real-world/PowerShell.Benchmarks/PowerShell.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartArguments>--filter *</StartArguments>


### PR DESCRIPTION
We are wanting to use SuperPMI collections for the PowerShell benchmarks but we have to update the targetframework to net8 for it to work.


