### PR TITLE
Add microbenchmark for core UnmanagedMemoryStream scenario

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
@@ -41,7 +41,7 @@ namespace System.IO.Tests
         [Benchmark]
         public void ReadAsArrays()
         {
-            var array = new byte[1];
+            var array = new byte[128];
             using (var ums = new UnmanagedMemoryStream(_buffer, Length))
             {
                 while (ums.Read(array, 0, array.Length) != 0)

--- a/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
@@ -13,24 +13,24 @@ namespace System.IO.Tests
     public unsafe class UnmanagedMemoryStreamTests
     {
         private const int Length = 10000;
-        private byte* buffer;
+        private byte* _buffer;
 
         [GlobalSetup]
         public void Setup()
         {
-            buffer = (byte*)Marshal.AllocCoTaskMem(Length);
+            _buffer = (byte*)Marshal.AllocCoTaskMem(Length);
         }
 
         [GlobalCleanup]
         public void Cleanup()
         {
-            Marshal.FreeCoTaskMem((IntPtr)buffer);
+            Marshal.FreeCoTaskMem((IntPtr)_buffer);
         }
 
         [Benchmark]
         public void ReadAsBytes()
         {
-            using (var ums = new UnmanagedMemoryStream(buffer, Length))
+            using (var ums = new UnmanagedMemoryStream(_buffer, Length))
             {
                 while (ums.ReadByte() >= 0)
                 {
@@ -42,7 +42,7 @@ namespace System.IO.Tests
         public void ReadAsArrays()
         {
             var array = new byte[1];
-            using (var ums = new UnmanagedMemoryStream(buffer, Length))
+            using (var ums = new UnmanagedMemoryStream(_buffer, Length))
             {
                 while (ums.Read(array, 0, array.Length) != 0)
                 {

--- a/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.IO/UnmanagedMemoryStreamTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.IO.Tests
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public unsafe class UnmanagedMemoryStreamTests
+    {
+        private const int Length = 10000;
+        private byte* buffer;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            buffer = (byte*)Marshal.AllocCoTaskMem(Length);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            Marshal.FreeCoTaskMem((IntPtr)buffer);
+        }
+
+        [Benchmark]
+        public void ReadAsBytes()
+        {
+            using (var ums = new UnmanagedMemoryStream(buffer, Length))
+            {
+                while (ums.ReadByte() >= 0)
+                {
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ReadAsArrays()
+        {
+            var array = new byte[1];
+            using (var ums = new UnmanagedMemoryStream(buffer, Length))
+            {
+                while (ums.Read(array, 0, array.Length) != 0)
+                {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/93766

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


