### PR TITLE
Fixed up the run command and replaced the GCPerfSim Suite with the LowVolatility Run

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
@@ -43,7 +43,7 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
         private static readonly IDeserializer _deserializer = 
             new DeserializerBuilder().WithNamingConvention(UnderscoredNamingConvention.Instance).Build();
 
-        public static GCPerfSimConfiguration Parse(string path)
+        public static GCPerfSimConfiguration Parse(string path, bool isIncompleteConfiguration = false)
         {
             // Preconditions.
             ConfigurationChecker.VerifyFile(path, nameof(GCPerfSimConfigurationParser)); 
@@ -72,6 +72,12 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
             if (configuration.gcperfsim_configurations == null)
             {
                 throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: The configuration is missing the `gcperfsim_configuration` field in the yaml. Please add it following the example: Configuration/GCPerfSim/*.yaml.");
+            }
+
+            // The rest of the items aren't filled for the incomplete configuration that's programmatically filled by the infrastructure.
+            if (isIncompleteConfiguration)
+            {
+                return configuration;
             }
 
             // Check to ensure the GCPerfSim configuration binaries exist.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
@@ -1,0 +1,132 @@
+runs:
+  normal:
+    override_parameters:
+      sohsi: 50 
+    environment_variables: {}
+
+  soh_pinning:
+    override_parameters:
+      sohsi: 50 
+      sohpi: 100 
+    environment_variables: {}
+
+  poh:
+    override_parameters:
+      sohsi: 50
+      pohsi: 100
+      pohar: 100
+      rpohsi: 50
+    environment_variables: {}
+
+  loh:
+    override_parameters:
+      sohsi: 50
+      lohar: 100
+      rlohsi: 50
+      lohsi: 50
+    environment_variables: {}
+
+gcperfsim_configurations:
+  parameters:
+    tc: 36
+    tagb: 540
+    tlgb: 2 
+    lohar: 0
+    pohar: 0
+    sohsr: 100-4000
+    lohsr: 102400-204800
+    pohsr: 100-204800
+    sohsi: 0
+    lohsi: 0
+    pohsi: 0
+    sohpi: 0
+    lohpi: 0
+    sohfi: 0
+    lohfi: 0
+    pohfi: 0
+    ramb: 20 
+    rlmb: 2
+    allocType: reference
+    testKind: time
+environment:
+  environment_variables:
+    COMPlus_GCServer: 1
+    COMPlus_GCHeapCount: 12
+  default_max_seconds: 300
+  iterations: 1
+
+output:
+  columns:
+  - Count
+  - total allocated (mb)
+  - total pause time (msec)
+  - PctTimePausedInGC
+  - FirstToLastGCSeconds
+  - HeapSizeAfter_Mean
+  - HeapSizeBeforeMB_Mean
+  - PauseDurationMSec_95PWhereIsGen0
+  - PauseDurationMSec_95PWhereIsGen1
+  - PauseDurationMSec_95PWhereIsBackground
+  - PauseDurationMSec_95PWhereIsBlockingGen2
+  - CountIsBlockingGen2
+  - HeapCount
+  - TotalNumberGCs
+  - TotalAllocatedMB
+  - Speed
+  - PauseDurationMSec_MeanWhereIsEphemeral
+  - PauseDurationMSec_MeanWhereIsBackground
+  - PauseDurationMSec_MeanWhereIsBlockingGen2
+  - PauseDurationSeconds_SumWhereIsGen1
+  - PauseDurationSeconds_Sum
+  - CountIsGen1
+  - ExecutionTimeMSec
+  percentage_disk_remaining_to_stop_per_run: 0
+  all_columns:
+  - Count
+  - total allocated (mb)
+  - total pause time (msec)
+  - PctTimePausedInGC
+  - FirstToLastGCSeconds
+  - HeapSizeAfter_Mean
+  - HeapSizeBeforeMB_Mean
+  - PauseDurationMSec_95PWhereIsGen0
+  - PauseDurationMSec_95PWhereIsGen1
+  - PauseDurationMSec_95PWhereIsBackground
+  - PauseDurationMSec_95PWhereIsBlockingGen2
+  - CountIsBlockingGen2
+  - HeapCount
+  - TotalNumberGCs
+  - TotalAllocatedMB
+  - Speed
+  - PauseDurationMSec_MeanWhereIsEphemeral
+  - PauseDurationMSec_MeanWhereIsBackground
+  - PauseDurationMSec_MeanWhereIsBlockingGen2
+  - PauseDurationSeconds_SumWhereIsGen1
+  - PauseDurationSeconds_Sum
+  - CountIsGen1
+  - ExecutionTimeMSec
+  - Count
+  - PctTimePausedInGC
+  - FirstToLastGCSeconds
+  - HeapSizeAfter_Mean
+  - HeapSizeBeforeMB_Mean
+  - PauseDurationMSec_95PWhereIsGen0
+  - PauseDurationMSec_95PWhereIsGen1
+  - PauseDurationMSec_95PWhereIsBackground
+  - PauseDurationMSec_95PWhereIsBlockingGen2
+  - CountIsBlockingGen2
+  - HeapCount
+  - TotalNumberGCs
+  - TotalAllocatedMB
+  - Speed
+  - PauseDurationMSec_MeanWhereIsEphemeral
+  - PauseDurationSeconds_SumWhereIsGen1
+  - PauseDurationSeconds_Sum
+  - CountIsGen1
+  - ExecutionTimeMSec
+  formats:
+  - markdown
+  - json
+name: Normal_Server
+trace_configurations:
+  type: gc # gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed, join.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
@@ -13,7 +13,9 @@ namespace GC.Infrastructure.Commands.RunCommand
     public sealed class CreateSuitesCommand : Command<CreateSuitesCommand.CreateSuitesSettings>
     {
         private static readonly string _baseSuitePath      = Path.Combine("Commands", "RunCommand", "BaseSuite"); 
-        private static readonly string _gcPerfSimBase      = Path.Combine(_baseSuitePath, "GCPerfSim_Normal_Workstation.yaml");
+        // Removed the high volatility configuration.  
+        //private static readonly string _gcPerfSimBase      = Path.Combine(_baseSuitePath, "GCPerfSim_Normal_Workstation.yaml");
+        private static readonly string _gcPerfSimBaseLowVolatility = Path.Combine(_baseSuitePath, "LowVolatilityRuns.yaml");
         private static readonly string _microbenchmarkBase = Path.Combine(_baseSuitePath, "Microbenchmarks.yaml");
         private static readonly string _aspNetBase         = Path.Combine(_baseSuitePath, "ASPNetBenchmarks.yaml");
         private static readonly ISerializer _serializer    = Common.Serializer;
@@ -236,14 +238,18 @@ namespace GC.Infrastructure.Commands.RunCommand
 
             string gcPerfSimOutputPath = Path.Combine(inputConfiguration.output_path, "GCPerfSim");
             Core.Utilities.TryCreateDirectory(gcPerfSimOutputPath);
+            SaveConfiguration(GetBaseConfiguration(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "LowVolatilityRun")), gcPerfSimSuitePath, "LowVolatilityRun.yaml");
 
             // Base Configuration = Workstation.
+            /*
+            These old configurations are commented out because of high volatility in results.
             SaveConfiguration(GetBaseConfiguration(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "Normal_Workstation")), gcPerfSimSuitePath, "Normal_Workstation.yaml");
             SaveConfiguration(CreateNormalServerCase(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "Normal_Server")), gcPerfSimSuitePath, "Normal_Server.yaml");
             SaveConfiguration(CreateLargePagesWithWorkstation(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "LargePages_Workstation")), gcPerfSimSuitePath, "LargePages_Workstation.yaml");
             SaveConfiguration(CreateLargePagesWithServer(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "LargePages_Server")), gcPerfSimSuitePath, "LargePages_Server.yaml");
             SaveConfiguration(CreateHighMemoryCase(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "HighMemory")), gcPerfSimSuitePath, "HighMemory.yaml");
             SaveConfiguration(CreateLowMemoryContainerCase(inputConfiguration, Path.Combine(gcPerfSimOutputPath, "LowMemoryContainer")), gcPerfSimSuitePath, "LowMemoryContainer.yaml");
+            */
 
             return gcPerfSimSuitePath;
         }
@@ -256,7 +262,7 @@ namespace GC.Infrastructure.Commands.RunCommand
 
         internal static GCPerfSimConfiguration GetBaseConfiguration(InputConfiguration inputConfiguration, string name)
         {
-            GCPerfSimConfiguration baseConfiguration = GCPerfSimConfigurationParser.Parse(_gcPerfSimBase);
+            GCPerfSimConfiguration baseConfiguration = GCPerfSimConfigurationParser.Parse(_gcPerfSimBaseLowVolatility, isIncompleteConfiguration: true);
             baseConfiguration.Output.Path = Path.Combine(inputConfiguration.output_path, name); 
             baseConfiguration.TraceConfigurations.Type = inputConfiguration.trace_configuration_type.ToLower();
             baseConfiguration.gcperfsim_configurations.gcperfsim_path = inputConfiguration.gcperfsim_path;

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
@@ -38,6 +38,9 @@
     <None Update="Commands\RunCommand\BaseSuite\ASPNetBenchmarks - All.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Commands\RunCommand\BaseSuite\LowVolatilityRuns.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Commands\RunCommand\BaseSuite\MicrobenchmarkInvocationCounts.psv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
- The run command now doesn't impose strict checks for incomplete GC PerfSim scenarios.
- Replaced the GCPerfSim suite with the LowVolatilityRun to not drown the signal from the noise of high volatility.