### PR TITLE
Disable the ComWrapper.ParallelRCWLookup test on ARM64.

### DIFF
--- a/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
+++ b/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
@@ -41,6 +41,7 @@ namespace Interop
         }
 
         [Benchmark]
+        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.ARM64)]
         public async Task ParallelRCWLookUp()
         {
             await Task.WhenAll(


### PR DESCRIPTION
Disable the ComWrapper.ParallelRCWLookup test on ARM64 while we investigate: https://github.com/dotnet/performance/issues/3448.
