### PR TITLE
Fix microbenchmarks build

### DIFF
--- a/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
+++ b/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
@@ -41,7 +41,7 @@ namespace Interop
         }
 
         [Benchmark]
-        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.ARM64)]
+        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.Arm64)]
         public async Task ParallelRCWLookUp()
         {
             await Task.WhenAll(


### PR DESCRIPTION
```
src/benchmarks/micro/runtime/Interop/ComWrappers.cs(44,74): error CS0117: 'Architecture' does not contain a definition for 'ARM64' [/datadisks/disk1/work/B4E8099E/w/A21C0899/e/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net9.0]
```

https://github.com/dotnet/performance/pull/3450 got merged on red with the above failure, causing `dotnet-runtime-perf` to break.