### PR TITLE
Update IPAName for iOS Podcast to fix unzipped tests.

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -54,7 +54,7 @@
     <MAUIiOSScenario Include="Maui iOS Podcast $(RunConfigsString)">
       <ScenarioDirectoryName>mauiiospodcast</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <IPAName>MauiiOSPodcast</IPAName>
+      <IPAName>Microsoft.NetConf2021.Maui</IPAName>
       <PackageName>net.dot.netconf2021.maui</PackageName>
     </MAUIiOSScenario>
   </ItemGroup>


### PR DESCRIPTION
Update IPAName for iOS Podcast to fix unzipped tests. The specific update is MauiiOSPodcast->Microsoft.NetConf2021.Maui.

Fixes: https://github.com/dotnet/performance/issues/3454
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2304644&view=results


