### PR TITLE
Update ComWrapper.ParallelRCWLookup loop count

### DIFF
--- a/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
+++ b/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
@@ -41,7 +41,6 @@ namespace Interop
         }
 
         [Benchmark]
-        [OperatingSystemsArchitectureFilter(allowed: false, Architecture.Arm64)]
         public async Task ParallelRCWLookUp()
         {
             var iterationsPerTask = 3_000_000/Environment.ProcessorCount;

--- a/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
+++ b/src/benchmarks/micro/runtime/Interop/ComWrappers.cs
@@ -44,13 +44,14 @@ namespace Interop
         [OperatingSystemsArchitectureFilter(allowed: false, Architecture.Arm64)]
         public async Task ParallelRCWLookUp()
         {
+            var iterationsPerTask = 3_000_000/Environment.ProcessorCount;
             await Task.WhenAll(
                 Enumerable.Range(0, Environment.ProcessorCount)
                     .Select(_ =>
                         Task.Run(delegate
                         {
                             // Define a large number of iterations for parallel action.
-                            for (int i = 0; i < 3_000_000; i++)
+                            for (int i = 0; i < iterationsPerTask; i++)
                             {
                                 s_instance.GetOrCreateObjectForComInstance(_ptr, CreateObjectFlags.None);
                             }


### PR DESCRIPTION
Update ComWrapper.ParallelRCWLookup loop count to be 3 mil per iteration, not per ProcessorCount in the iteration. Manual test using this setup resulted in a mean time of ~3s per op and total runtime of ~70s, a time we can manage. 

Mitigates: https://github.com/dotnet/performance/issues/3448 by setting a consistent loop count that will not cause issues on high core count machines. There may still be some investigation to be done on windows vs linux runtimes and Arm vs x64 runtimes.

From my understanding of https://github.com/dotnet/runtime/pull/91120, this seems like it should still catch any potential regressions similar to the previous setup while ensuring high-core machines don't get hit harder than expected. @AaronRobinsonMSFT does my understanding above make sense?




