### PR TITLE
Removed Redundant ASP.NET Scenario and Added The GCHeapCount Per The Machine For GCPerfSim

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/ASPNetBenchmarks.csv
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/ASPNetBenchmarks.csv
@@ -1,4 +1,3 @@
 Legend,Base CommandLine
 JsonMin_Windows, --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/json.benchmarks.yml --scenario mapaction --application.options.collectCounters true --property os=windows --property arch=x64 --profile aspnet-citrine-win
 FortunesEf_Windows, --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_ef --application.options.collectCounters true --property os=windows --property arch=x64 --profile aspnet-citrine-win
-Stage1Grpc_Windows, --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/goldilocks.benchmarks.yml --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/ci.profile.yml --scenario basicgrpcvanilla --profile intel-win-app --profile intel-lin-load --application.framework net8.0 --application.options.collectCounters true

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
@@ -51,7 +51,6 @@ gcperfsim_configurations:
 environment:
   environment_variables:
     COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 12
   default_max_seconds: 300
   iterations: 1
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
@@ -275,6 +275,9 @@ namespace GC.Infrastructure.Commands.RunCommand
             {
                 baseConfiguration.Environment.environment_variables = inputConfiguration.environment_variables;
             }
+            int logicalProcessors = GetAppropriateLogicalProcessors();
+            baseConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = logicalProcessors.ToString("X");
+            baseConfiguration.gcperfsim_configurations.Parameters["tc"] = (2 * logicalProcessors).ToString();
 
             return baseConfiguration;
         }


### PR DESCRIPTION
- Removed the Stage1Grpc Scenario that's AoT based.
- Adjusting the GCHeapCount based on the machine for the LowVolatility scenario.