### PR TITLE
.NET 6 & 7 build fix

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Sockets/Perf.Socket.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Sockets/Perf.Socket.cs
@@ -139,6 +139,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+#if NET8_0_OR_GREATER // APIs introduced in .NET 8: https://github.com/dotnet/runtime/issues/30797
         [Benchmark]
         public async Task ReceiveFromAsyncThenSendToAsync_SocketAddress()
         {
@@ -160,6 +161,7 @@ namespace System.Net.Sockets.Tests
                 await r;
             }
         }
+#endif
 
         [Benchmark]
         public void SendToThenReceiveFrom()


### PR DESCRIPTION
.NET 8 introduced new APIs for Sockets: https://github.com/dotnet/runtime/issues/30797

I don't blame @wfurt who added new benchmarks in #3211, because our CI does not run for all supported tfms (#2732)

![image](https://github.com/dotnet/performance/assets/6011991/1ac3ae3a-f3fb-4e24-b560-a71a93e3346e)
