### PR TITLE
Add 9.0 TFM to Microbenchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -4,8 +4,8 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -38,6 +38,13 @@
         </PropertyGroup>
     </When>
     <When Condition="'$(TargetFramework)' == 'net8.0'">
+        <PropertyGroup>
+            <LangVersion>preview</LangVersion>
+            <ExtensionsVersion>8.0.0</ExtensionsVersion>
+            <SystemVersion>8.0.0</SystemVersion>
+        </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net9.0'">
         <PropertyGroup>
             <LangVersion>preview</LangVersion>
             <ExtensionsVersion>$(MicrosoftExtensionsLoggingPackageVersion)</ExtensionsVersion>

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,38 +12,38 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net462`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net8.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net9.0|net462`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net9.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 
 ```cmd
-dotnet run -c Release -f net8.0
+dotnet run -c Release -f net9.0
 ```
 
 To list all available benchmarks ([read more](../../../docs/benchmarkdotnet.md#Listing-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net8.0 --list flat|tree
+dotnet run -c Release -f net9.0 --list flat|tree
 ```
 
 To filter the benchmarks using a glob pattern applied to namespace.typeName.methodName ([read more](../../../docs/benchmarkdotnet.md#Filtering-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net8.0 --filter *Span*
+dotnet run -c Release -f net9.0 --filter *Span*
 ```
 
 To profile the benchmarked code and produce an ETW Trace file ([read more](../../../docs/benchmarkdotnet.md#Profiling)):
 
 ```cmd
-dotnet run -c Release -f net8.0 --filter $YourFilter --profiler ETW
+dotnet run -c Release -f net9.0 --filter $YourFilter --profiler ETW
 ```
 
 To run the benchmarks for multiple runtimes ([read more](../../../docs/benchmarkdotnet.md#Multiple-Runtimes)):
 
 ```cmd
-dotnet run -c Release -f net7.0 --filter * --runtimes net7.0 net8.0
+dotnet run -c Release -f net8.0 --filter * --runtimes net8.0 net9.0
 ```
 
 ## Private Runtime Builds
@@ -51,19 +51,19 @@ dotnet run -c Release -f net7.0 --filter * --runtimes net7.0 net8.0
 If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests - so a command similar to `build clr+libs+libs.tests -rc release -lc release`) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
 
 ```cmd
-dotnet run -c Release -f net8.0 --filter $YourFilter \
-    --corerun C:\git\runtime\artifacts\bin\testhost\net8.0-windows-Release-x64\shared\Microsoft.NETCore.App\8.0.0\CoreRun.exe
+dotnet run -c Release -f net9.0 --filter $YourFilter \
+    --corerun C:\git\runtime\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe
 ```
 
 To make sure that your changes don't introduce any regressions, you can provide paths to CoreRuns with and without your changes and use the Statistical Test feature to detect regressions/improvements ([read more](../../../docs/benchmarkdotnet.md#Regressions)):
 
 ```cmd
-dotnet run -c Release -f net8.0 \
+dotnet run -c Release -f net9.0 \
     --filter BenchmarksGame* \
     --statisticalTest 3ms \
     --coreRun \
-        "C:\git\runtime_upstream\artifacts\bin\testhost\net8.0-windows-Release-x64\shared\Microsoft.NETCore.App\8.0.0\CoreRun.exe" \
-        "C:\git\runtime_fork\artifacts\bin\testhost\net8.0-windows-Release-x64\shared\Microsoft.NETCore.App\8.0.0\CoreRun.exe"
+        "C:\git\runtime_upstream\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe" \
+        "C:\git\runtime_fork\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe"
 ```
 
 If you **prefer to use dotnet cli** instead of CoreRun, you need to pass the path to cli via the `--cli` argument.


### PR DESCRIPTION
This is an attempt to add `net9.0` TFM to microbenchmarks csproj, otherwise it is impossible to run them for .NET 9 in the way it's suggested by [src/benchmarks/micro/README.md](https://github.com/dotnet/performance/blob/7e86feb33c5d27c668ba291d35d03210dd295231/src/benchmarks/micro/README.md):
```
➜ dotnet run -c release -f net9.0

C:\Users\knatalia\dev\git\tmp\performance\.dotnet\sdk\9.0.100-alpha.1.23572.8\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(266,5): error NETSDK1005: Assets file
 'C:\Users\knatalia\dev\git\tmp\performance\artifacts\obj\MicroBenchmarks\project.assets.json' doesn't have a target for 'net9.0'. Ensure that restore has run and that you have included 'net9.
0' in the TargetFrameworks for your project. [C:\Users\knatalia\dev\git\tmp\performance\src\benchmarks\micro\MicroBenchmarks.csproj::TargetFramework=net9.0]

The build failed. Fix the build errors and run again.
```

Contributes to https://github.com/dotnet/crank/issues/662