### PR TITLE
Update the Illink Sample benchmark to support the PERFLAB_TARGET_FRAMEWORKS

### DIFF
--- a/src/benchmarks/real-world/ILLink/SampleProject/HelloWorld.template.csproj
+++ b/src/benchmarks/real-world/ILLink/SampleProject/HelloWorld.template.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net9.0</TargetFrameworks>
 		<PublishTrimmed>false</PublishTrimmed>
 		<TrimMode>partial</TrimMode>
 		<SelfContained>true</SelfContained>

--- a/src/benchmarks/real-world/ILLink/SampleProject/HelloWorld.template.csproj
+++ b/src/benchmarks/real-world/ILLink/SampleProject/HelloWorld.template.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<OutputType>exe</OutputType>
 		<TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
+		<!-- Update PublishSampleProject in Utilities default framework when updating default framework below -->
 		<TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net9.0</TargetFrameworks>
 		<PublishTrimmed>false</PublishTrimmed>
 		<TrimMode>partial</TrimMode>

--- a/src/benchmarks/real-world/ILLink/Utilities.cs
+++ b/src/benchmarks/real-world/ILLink/Utilities.cs
@@ -61,7 +61,7 @@ namespace ILLinkBenchmarks
         {
             string outputDirectory = GenerateTempFolder();
             Directory.CreateDirectory(outputDirectory);
-            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", $"publish {projectFilePath} -r {CurrentRID} --self-contained -o {outputDirectory} {extraArgs.Aggregate("", (agg, val) => agg + " " + val)}");
+            ProcessStartInfo processStartInfo = new ProcessStartInfo("dotnet", $"publish {projectFilePath} -f {Environment.GetEnvironmentVariable("PERFLAB_TARGET_FRAMEWORKS") ?? "net9.0"} -r {CurrentRID} --self-contained -o {outputDirectory} {extraArgs.Aggregate("", (agg, val) => agg + " " + val)}");
             processStartInfo.RedirectStandardError = false;
             processStartInfo.RedirectStandardOutput = true;
             var p = Process.Start(processStartInfo);


### PR DESCRIPTION
Update the Illink Sample real-world benchmark to support the PERFLAB_TARGET_FRAMEWORKS. Per https://github.com/dotnet/performance/pull/3511#issuecomment-1828709348. 



