### PR TITLE
Update Helix Sender docker file to use CBL Mariner

### DIFF
--- a/eng/performance/helix_sender.Dockerfile
+++ b/eng/performance/helix_sender.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bookworm
+FROM mcr.microsoft.com/cbl-mariner/base/python:3.9
 
 WORKDIR /performance
 


### PR DESCRIPTION
Change is needed for compliance reasons