### PR TITLE
Add benchmarks for GetCurrentHashAsUInt32 and GetCurrentHashAsUInt64.

### DIFF
--- a/src/benchmarks/micro/libraries/System.IO.Hashing/Crc32_GetCurrentHashPerf.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Hashing/Crc32_GetCurrentHashPerf.cs
@@ -8,5 +8,12 @@ namespace System.IO.Hashing.Tests
 {
     public class Crc32_GetCurrentHashPerf : Crc_GetCurrentHashPerf<Crc32>
     {
+#if NET8_0_OR_GREATER
+        [Benchmark]
+        public uint GetCurrentHashAsUInt32()
+        {
+            return Crc.GetCurrentHashAsUInt32();
+        }
+#endif
     }
 }

--- a/src/benchmarks/micro/libraries/System.IO.Hashing/Crc64_GetCurrentHashPerf.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Hashing/Crc64_GetCurrentHashPerf.cs
@@ -8,5 +8,12 @@ namespace System.IO.Hashing.Tests
 {
     public class Crc64_GetCurrentHashPerf : Crc_GetCurrentHashPerf<Crc64>
     {
+#if NET8_0_OR_GREATER
+        [Benchmark]
+        public ulong GetCurrentHashAsUInt64()
+        {
+            return Crc.GetCurrentHashAsUInt64();
+        }
+#endif
     }
 }


### PR DESCRIPTION
Addition to #3035.