### PR TITLE
Update Android Windows 10 queues to Windows 11 queues.

### DIFF
--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -127,10 +127,10 @@ jobs:
     parameters:
       osName: windows
       architecture: x64
-      osVersion: 19H1
+      osVersion: 22H2
       pool:
         vmImage: 'windows-2022'
-      queue: Windows.10.Amd64.Pixel.Perf
+      queue: Windows.11.Amd64.Pixel.Perf
       machinePool: Pixel
       ${{ insert }}: ${{ parameters.jobParameters }}
 
@@ -139,10 +139,10 @@ jobs:
     parameters:
       osName: windows
       architecture: x64
-      osVersion: 19H1
+      osVersion: 22H2
       pool:
         vmImage: 'windows-2022'
-      queue: Windows.10.Amd64.Galaxy.Perf
+      queue: Windows.11.Amd64.Galaxy.Perf
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
 


### PR DESCRIPTION
Update Android Windows 10 queues to Windows 11 queues.
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2328807 
Galaxy failures for memory consumption are known and are usually disabled, this PR ensures that it is setup to not run correctly: https://github.com/dotnet/performance/pull/3529.
