### PR TITLE
[Release/6.0] Remove out of support MAUI test runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -302,36 +302,38 @@ jobs:
       projectFile: scenarios.proj
       channels:
         - release/6.0
-      
-  # Maui Android scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: windows
-      architecture: x64
-      osVersion: 19H1
-      pool:
-        vmImage: 'windows-2022'
-      queue: Windows.10.Amd64.Pixel.Perf
-      machinePool: Pixel
-      kind: maui_scenarios_android
-      projectFile: maui_scenarios_android.proj
-      channels:
-        - release/6.0
+  
+  # Officially out of support for 6.0: https://aka.ms/maui-support-policy
+  # # Maui Android scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: windows
+  #     architecture: x64
+  #     osVersion: 19H1
+  #     pool:
+  #       vmImage: 'windows-2022'
+  #     queue: Windows.10.Amd64.Pixel.Perf
+  #     machinePool: Pixel
+  #     kind: maui_scenarios_android
+  #     projectFile: maui_scenarios_android.proj
+  #     channels:
+  #       - release/6.0
 
-  # Maui iOS scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: osx
-      architecture: x64
-      osVersion: 12
-      pool:
-        vmImage: 'macos-12'
-      queue: OSX.1015.Amd64.Iphone.Perf
-      machinePool: iPhoneMini12
-      kind: maui_scenarios_ios
-      projectFile: maui_scenarios_ios.proj
-      channels:
-        - release/6.0
+  # Officially out of support for 6.0: https://aka.ms/maui-support-policy
+  # # Maui iOS scenario benchmarks
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: osx
+  #     architecture: x64
+  #     osVersion: 12
+  #     pool:
+  #       vmImage: 'macos-12'
+  #     queue: OSX.1015.Amd64.Iphone.Perf
+  #     machinePool: iPhoneMini12
+  #     kind: maui_scenarios_ios
+  #     projectFile: maui_scenarios_ios.proj
+  #     channels:
+  #       - release/6.0
 
   # # Windows x64 micro benchmarks
   # - template: /eng/performance/benchmark_jobs.yml


### PR DESCRIPTION
Remove out of support MAUI test runs. The private runs for release/6.0 are red because the Android MAUI builds are causing red due to the following (run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2328586&view=results):
```
  [2023/12/04 13:25:55][INFO] D:\a\1\s\CorrelationStaging\dotnet\sdk\6.0.417\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5): warning NETSDK1202: The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy. [D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj]
  [2023/12/04 13:25:55][INFO] D:\a\1\s\CorrelationStaging\dotnet\sdk\6.0.417\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5): warning NETSDK1202: The workload 'ios' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy. [D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj]
  [2023/12/04 13:25:55][INFO] D:\a\1\s\CorrelationStaging\dotnet\sdk\6.0.417\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5): warning NETSDK1202: The workload 'maccatalyst' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy. [D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj]
  [2023/12/04 13:26:05][INFO]   Restored D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj (in 9.73 sec).
  [2023/12/04 13:26:05][INFO] $ popd
  [2023/12/04 13:26:05][INFO] $ pushd "D:\a\1\s\src\scenarios\mauiandroid"
  [2023/12/04 13:26:05][INFO] $ dotnet publish D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj --configuration Release --output D:\a\1\s\CorrelationStaging\scenarios_out\mauiandroid /p:NuGetPackageRoot=D:\a\1\s\artifacts\packages\ /p:UseSharedCompilation=false /p:BuildInParallel=false /m:1 --runtime android-arm64 --framework net6.0-android --no-restore --source MauiNuGet.config --self-contained
  [2023/12/04 13:26:05][INFO] MSBuild version 17.3.2+561848881 for .NET
  [2023/12/04 13:26:06][INFO] D:\a\1\s\CorrelationStaging\dotnet\sdk\6.0.417\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(35,5): warning NETSDK1202: The workload 'android' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/maui-support-policy for more information about the support policy. [D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj]
  [2023/12/04 13:26:11][INFO] D:\a\1\s\CorrelationStaging\dotnet\packs\Microsoft.Android.Sdk.Windows\32.0.509\targets\Microsoft.Android.Sdk.Tooling.targets(20,5): error XA0031: Java SDK 11.0 or above is required when using .NET 6 or higher. Download the latest JDK at: https://aka.ms/msopenjdk [D:\a\1\s\src\scenarios\mauiandroid\app\MauiAndroidDefault.csproj]
  [2023/12/04 13:26:11][INFO] $ popd

```

As such, this PR disables the Maui tests from running and explains that they are out of support.