### PR TITLE
Update Pixel Windows 10 queues to Windows 11 queues.

### DIFF
--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -98,10 +98,10 @@ jobs:
     parameters:
       osName: windows
       architecture: x64
-      osVersion: 19H1
+      osVersion: 22H2
       pool:
         vmImage: 'windows-2022'
-      queue: Windows.10.Amd64.Pixel.Perf
+      queue: Windows.11.Amd64.Pixel.Perf
       machinePool: Pixel
       ${{ insert }}: ${{ parameters.jobParameters }}
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/performance/pull/3547, although only the Pixel update as the Galaxy devices are not in the release/7.0 machine matrix.
