### PR TITLE
Fix typo in metric name for BDN.Extensions Duration.

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -83,7 +83,7 @@ namespace BenchmarkDotNet.Extensions
                     TopCounter = false,
                     DefaultCounter = false,
                     HigherIsBetter = false,
-                    MetricName = "ms",
+                    MetricName = "ns",
                     Results = (from result in results
                                select result.Nanoseconds).ToList()
                 });


### PR DESCRIPTION
Fix typo in metric name for BDN.Extensions Duration. The MetricName was denoting that the value is in ms while we are actually returning ns. This was found while investigating why Duration was showing up as ms in PowerBI, made a note of this discrepancy in the PowerBI for now.

Starting as a draft so we can talk about this change as this seems like it may have impacts in our perfcommand code. Specifically CompareAggregate equals and potentially hashcode generation. Although I have not found any other obvious places were this change may cause breaks.


