### PR TITLE
Add nativeaot9.0 runs and some other 9.0 framework parsing support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,6 +149,7 @@ jobs:
         runCategories: 'runtime libraries' 
         channels:
           - main
+          - nativeaot9.0
           - nativeaot8.0
           - 8.0
 

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -12,6 +12,11 @@ class ChannelMap():
             'branch': '9.0',
             'quality': 'daily'
         },
+        'nativeaot9.0': {
+            'tfm': 'nativeaot9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
         '8.0': {
             'tfm': 'net8.0',
             'branch': '8.0',

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -10,7 +10,7 @@ from argparse import Action, ArgumentParser, ArgumentTypeError
 from glob import iglob
 from logging import getLogger
 from os import chmod, environ, listdir, makedirs, path, pathsep, system
-from re import match, search, MULTILINE
+from re import search, MULTILINE
 from shutil import rmtree
 from stat import S_IRWXU
 from subprocess import CalledProcessError, check_output
@@ -78,10 +78,14 @@ class FrameworkAction(Action):
         To run NativeAOT benchmarks we need to run the host BDN process as latest
         .NET the host process will build and run AOT benchmarks
         '''
-        pattern = r'^nativeaot(\d+)\.0$'
-        match_found = match(pattern, framework)
-        if match_found:
-            return f"net{match_found.group(1)}.0"
+        if framework == 'nativeaot6.0':
+            return 'net6.0'
+        if framework == 'nativeaot7.0':
+            return 'net7.0'
+        if framework == 'nativeaot8.0':
+            return 'net8.0'
+        if framework == 'nativeaot9.0':
+            return 'net9.0'
         else:
             return framework
 

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -10,7 +10,7 @@ from argparse import Action, ArgumentParser, ArgumentTypeError
 from glob import iglob
 from logging import getLogger
 from os import chmod, environ, listdir, makedirs, path, pathsep, system
-from re import search, MULTILINE
+from re import match, search, MULTILINE
 from shutil import rmtree
 from stat import S_IRWXU
 from subprocess import CalledProcessError, check_output
@@ -78,12 +78,10 @@ class FrameworkAction(Action):
         To run NativeAOT benchmarks we need to run the host BDN process as latest
         .NET the host process will build and run AOT benchmarks
         '''
-        if framework == 'nativeaot6.0':
-            return 'net6.0'
-        if framework == 'nativeaot7.0':
-            return 'net7.0'
-        if framework == 'nativeaot8.0':
-            return 'net8.0'
+        pattern = r'^nativeaot(\d+)\.0$'
+        match_found = match(pattern, framework)
+        if match_found:
+            return f"net{match_found.group(1)}.0"
         else:
             return framework
 

--- a/src/tools/ResultsComparer/Data.cs
+++ b/src/tools/ResultsComparer/Data.cs
@@ -150,6 +150,14 @@ namespace ResultsComparer
                 return "nativeaot8.0-preview" + key[key.IndexOf("nativeaot8.0-preview") + "nativeaot8.0-preview".Length];
             if (key.Contains("net8.0"))
                 return "net8.0";
+            if (key.Contains("net9.0-preview"))
+                return "net9.0-preview" + key[key.IndexOf("net9.0-preview") + "net9.0-preview".Length];
+            if (key.Contains("net9.0-rc"))
+                return "net9.0-rc" + key[key.IndexOf("net9.0-rc") + "net9.0-rc".Length];
+            if (key.Contains("nativeaot9.0-preview"))
+                return "nativeaot9.0-preview" + key[key.IndexOf("nativeaot9.0-preview") + "nativeaot9.0-preview".Length];
+            if (key.Contains("net9.0"))
+                return "net9.0";
 
             return null;
         }
@@ -167,7 +175,7 @@ namespace ResultsComparer
                 if (segment[0] == 'i' || segment[0] == 'E') // things like i7-8700 or E5530
                     return segment.Replace("-", "");
                 if (segment.EndsWith("CL")
-                    || segment.EndsWith("X") // things like AMD 3945WX or 5900X 
+                    || segment.EndsWith("X") // things like AMD 3945WX or 5900X
                     || segment.StartsWith("SQ") // things like SQ1
                     || segment.StartsWith("M1")
                     || segment.StartsWith("ARM")) // things like ARMv7


### PR DESCRIPTION
Added net9.0 support to moniker retrieval in ResultsComparer, generalized NativeAOT framework correction, and added run for nativeaot9.0.
