### PR TITLE
Add SDK entry to require min SDK version when building

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100-alpha.1.23615.4",
     "allowPrerelease": true,
     "rollForward": "major"
   },

--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "8.0.100",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  },
   "tools": {
     "dotnet": "9.0.100-alpha.1.23615.4"
   },


### PR DESCRIPTION
Repos like runtime have this setting to require a min version of the .NET SDK to build the repo: https://github.com/dotnet/runtime/blob/main/global.json

This is necessary as Arcade requires a specific min version of .NET.


