### PR TITLE
Include the tzinfo in the start time argument when getting the logs from iOS devices

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -698,7 +698,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     'log',
                     'collect',
                     '--device',
-                    '--start', runCmdTimestamp.strftime("%Y-%m-%d %H:%M:%S"),
+                    '--start', runCmdTimestamp.strftime("%Y-%m-%d %H:%M:%S%z"),
                     '--output', logarchive_filename,
                 ]
                 RunCommand(collectCmd, verbose=True).run()


### PR DESCRIPTION
Include the tzinfo in the start time argument when getting the logs from iOS devices. This will fix an error where not having the timezone info is causing more logs then expected to be grabbed.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2354941&view=results