### PR TITLE
Update urllib to 1.26.18

### DIFF
--- a/eng/performance/benchmark_jobs.yml
+++ b/eng/performance/benchmark_jobs.yml
@@ -110,10 +110,10 @@ jobs:
             value: 'official'
           - ${{ if eq(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: '$(PreservePythonPath);py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;py -3 -m pip install urllib3==1.26.15 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
+              value: '$(PreservePythonPath);py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0 --force-reinstall;py -3 -m pip install azure.storage.queue==12.0.0 --force-reinstall;py -3 -m pip install urllib3==1.26.18 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: '$(PreservePythonPath);$(SetAllowOpenSsl102);$(InstallPrerequisites);python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;pip3 install urllib3==1.26.15 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
+              value: '$(PreservePythonPath);$(SetAllowOpenSsl102);$(InstallPrerequisites);python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0 --force-reinstall;pip3 install azure.storage.queue==12.0.0 --force-reinstall;pip3 install urllib3==1.26.18 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
           - group: DotNet-HelixApi-Access
           # perflab upload tokens still exist in this variable group
           - group: dotnet-benchview

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -96,10 +96,10 @@ jobs:
             value: ''
           - ${{ if eq(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: '$(PreservePythonPath);py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;py -3 -m pip install urllib3==1.26.15 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
+              value: '$(PreservePythonPath);py -3 -m venv %HELIX_WORKITEM_PAYLOAD%\.venv;call %HELIX_WORKITEM_PAYLOAD%\.venv\Scripts\activate.bat;set PYTHONPATH=;py -3 -m pip install azure.storage.blob==12.0.0;py -3 -m pip install azure.storage.queue==12.0.0;py -3 -m pip install urllib3==1.26.18 --force-reinstall;set "PERFLAB_UPLOAD_TOKEN=$(PerfCommandUploadToken)";$(AdditionalHelixPreCommands)'
           - ${{ if ne(parameters.osName, 'windows') }}:
             - name: HelixPreCommand
-              value: '$(PreservePythonPath);$(SetAllowOpenSsl102);sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0;pip3 install azure.storage.queue==12.0.0;pip3 install urllib3==1.26.15 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
+              value: '$(PreservePythonPath);$(SetAllowOpenSsl102);sudo apt-get -y install python3-venv;python3 -m venv $HELIX_WORKITEM_PAYLOAD/.venv;. $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate;export PYTHONPATH=;python3 -m pip install -U pip;pip3 install azure.storage.blob==12.0.0;pip3 install azure.storage.queue==12.0.0;pip3 install urllib3==1.26.18 --force-reinstall;export PERFLAB_UPLOAD_TOKEN="$(PerfCommandUploadTokenLinux)";$(AdditionalHelixPreCommands)'
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
         workspace:
@@ -186,7 +186,7 @@ jobs:
               condition: ne('${{ parameters.architecture }}', 'x86')
           - powershell: |
               $(Python) -m pip install --upgrade pip
-              $(Python) -m pip install urllib3==1.26.15
+              $(Python) -m pip install urllib3==1.26.18
               $(Python) -m pip install requests
               .\src\scenarios\init.ps1 -DotnetDirectory $(CorrelationStaging)dotnet
               dotnet msbuild .\eng\performance\${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /p:RuntimeFlavor=${{ parameters.runtimeFlavor }} /p:HybridGlobalization=${{ parameters.hybridGlobalization }} /bl:.\artifacts\log\$(_BuildConfig)\PrepareWorkItemPayloads.binlog
@@ -225,7 +225,7 @@ jobs:
               PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
           - script: |
               $(Python) -m pip install --user --upgrade pip
-              $(Python) -m pip install --user urllib3==1.26.15
+              $(Python) -m pip install --user urllib3==1.26.18
               $(Python) -m pip install --user requests
               . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
               dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /p:RuntimeFlavor=${{ parameters.runtimeFlavor }} /p:HybridGlobalization=${{ parameters.hybridGlobalization }} /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog
@@ -260,7 +260,7 @@ jobs:
             condition: and(succeeded(), contains(variables['System.JobDisplayName'], '2204'))
           - script: |
               $(Python) -m pip install --user --upgrade pip
-              $(Python) -m pip install --user urllib3==1.26.15
+              $(Python) -m pip install --user urllib3==1.26.18
               $(Python) -m pip install --user requests
               . ./src/scenarios/init.sh -dotnetdir $(CorrelationStaging)dotnet
               dotnet msbuild ./eng/performance/${{ parameters.projectFile }} /restore /t:PreparePayloadWorkItems /p:RuntimeFlavor=${{ parameters.runtimeFlavor }} /p:HybridGlobalization=${{ parameters.hybridGlobalization }} /bl:./artifacts/log/$(_BuildConfig)/PrepareWorkItemPayloads.binlog

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -131,7 +131,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 "set PYTHONPATH=",
                 "py -3 -m pip install azure.storage.blob==12.0.0",
                 "py -3 -m pip install azure.storage.queue==12.0.0",
-                "py -3 -m pip install urllib3==1.26.15 --force-reinstall",
+                "py -3 -m pip install urllib3==1.26.18 --force-reinstall",
                 f"set \"PERFLAB_UPLOAD_TOKEN={args.perflab_upload_token}\"",
                 *additional_helix_pre_commands
             ]
@@ -146,7 +146,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 "python3 -m pip install -U pip",
                 "pip3 install azure.storage.blob==12.0.0",
                 "pip3 install azure.storage.queue==12.0.0",
-                "pip3 install urllib3==1.26.15 --force-reinstall",
+                "pip3 install urllib3==1.26.18 --force-reinstall",
                 f"export PERFLAB_UPLOAD_TOKEN=\"{args.perflab_upload_token}\"",
                 *additional_helix_pre_commands
             ]
@@ -159,7 +159,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 "call %HELIX_WORKITEM_PAYLOAD%\\.venv\\Scripts\\activate.bat",
                 "set PYTHONPATH=",
                 "py -3 -m pip install -U pip",
-                "py -3 -m pip install --user urllib3==1.26.15 --force-reinstall",
+                "py -3 -m pip install --user urllib3==1.26.18 --force-reinstall",
                 "py -3 -m pip install --user azure.storage.blob==12.0.0 --force-reinstall",
                 "py -3 -m pip install --user azure.storage.queue==12.0.0 --force-reinstall",
                 f'set "PERFLAB_UPLOAD_TOKEN={args.perflab_upload_token}"'
@@ -173,7 +173,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 "source $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate",
                 "export PYTHONPATH=",
                 "python3 -m pip install -U pip",
-                "pip3 install --user urllib3==1.26.15 --force-reinstall",
+                "pip3 install --user urllib3==1.26.18 --force-reinstall",
                 "pip3 install --user azure.storage.blob==12.7.1 --force-reinstall",
                 "pip3 install --user azure.storage.queue==12.1.5 --force-reinstall",
                 f'export PERFLAB_UPLOAD_TOKEN="{args.perflab_upload_token}"'
@@ -201,7 +201,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 "ls -l $HELIX_WORKITEM_PAYLOAD/.venv/bin/activate && "
                 "export PYTHONPATH= && "
                 "python3 -m pip install --user -U pip && "
-                "pip3 install --user urllib3==1.26.15 && "
+                "pip3 install --user urllib3==1.26.18 && "
                 "pip3 install --user azure.storage.blob==12.0.0 && "
                 "pip3 install --user azure.storage.queue==12.0.0 && "
                 "sudo apt-get update && "
@@ -365,7 +365,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         os.environ["Python"] = python
 
         RunCommand([*(python.split(" ")), "-m", "pip", "install", "--upgrade", "pip"]).run()
-        RunCommand([*(python.split(" ")), "-m", "pip", "install", "urllib3==1.26.15"]).run()
+        RunCommand([*(python.split(" ")), "-m", "pip", "install", "urllib3==1.26.18"]).run()
         RunCommand([*(python.split(" ")), "-m", "pip", "install", "requests"]).run()
 
         scenarios_path = os.path.join(args.performance_repo_dir, "src", "scenarios")


### PR DESCRIPTION
This updates our manual urllib3 install to version 1.26.18 from 1.26.15. This also makes it match our requirements.txt file. Potential follow-up would be to switch to exclusively using the requirements.txt file to install these requirements.

Test runs, both are generally succeeding like the normal runs for each pipeline:
perf pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2356196&view=results
perf-runtime: https://dev.azure.com/dnceng/internal/_build/results?buildId=2356226&view=results
