### PR TITLE
Fix secret sync

### DIFF
--- a/.vault-config/dotnet-perf-keyvault.yaml
+++ b/.vault-config/dotnet-perf-keyvault.yaml
@@ -53,3 +53,9 @@ secrets:
       connectionString: pvscmdupload-connection-string
       service: blob|queue
       permissions: rwdlacup
+  SASWithoutURI:
+    type: azure-storage-account-sas-token
+    parameters:
+      connectionString: pvscmdupload-connection-string
+      service: blob
+      permissions: rwdlacup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -632,9 +632,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install .NET 6.0 runtime
-      inputs:
-        version: 6.x
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
 
     - script: dotnet tool restore
 
@@ -658,9 +658,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install .NET 6.0 runtime
-      inputs:
-        version: 6.x
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
 
     - script: dotnet tool restore
 
@@ -684,9 +684,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install .NET 6.0 runtime
-      inputs:
-        version: 6.x
+        displayName: Install Correct .NET Version
+        inputs:
+          useGlobalJson: true
 
     - script: dotnet tool restore
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -632,9 +632,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET 8.0 
       inputs:
-        version: 6.x
+        version: 8.x
 
     - task: DeleteFiles@1
       inputs:
@@ -662,9 +662,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET 8.0 
       inputs:
-        version: 6.x
+        version: 8.x
 
     - task: DeleteFiles@1
       inputs:
@@ -692,9 +692,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-      displayName: Install Correct .NET Version
+      displayName: Install .NET 8.0 
       inputs:
-        version: 6.x
+        version: 8.x
 
     - task: DeleteFiles@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -637,6 +637,10 @@ jobs:
         useGlobalJson: true
         includePreviewVersions: true
 
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
+
     - script: dotnet tool restore
 
     - task: AzureCLI@2
@@ -664,6 +668,10 @@ jobs:
         useGlobalJson: true
         includePreviewVersions: true
 
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
+
     - script: dotnet tool restore
 
     - task: AzureCLI@2
@@ -688,8 +696,11 @@ jobs:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version
       inputs:
-        useGlobalJson: true
-        includePreviewVersions: true
+        version: 6.x
+
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
 
     - script: dotnet tool restore
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -635,6 +635,7 @@ jobs:
       displayName: Install Correct .NET Version
       inputs:
         useGlobalJson: true
+        includePreviewVersions: true
 
     - script: dotnet tool restore
 
@@ -661,6 +662,7 @@ jobs:
       displayName: Install Correct .NET Version
       inputs:
         useGlobalJson: true
+        includePreviewVersions: true
 
     - script: dotnet tool restore
 
@@ -687,6 +689,7 @@ jobs:
       displayName: Install Correct .NET Version
       inputs:
         useGlobalJson: true
+        includePreviewVersions: true
 
     - script: dotnet tool restore
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -634,8 +634,7 @@ jobs:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version
       inputs:
-        useGlobalJson: true
-        includePreviewVersions: true
+        version: 6.x
 
     - task: DeleteFiles@1
       inputs:
@@ -665,8 +664,7 @@ jobs:
     - task: UseDotNet@2
       displayName: Install Correct .NET Version
       inputs:
-        useGlobalJson: true
-        includePreviewVersions: true
+        version: 6.x
 
     - task: DeleteFiles@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -632,9 +632,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-        displayName: Install Correct .NET Version
-        inputs:
-          useGlobalJson: true
+      displayName: Install Correct .NET Version
+      inputs:
+        useGlobalJson: true
 
     - script: dotnet tool restore
 
@@ -658,9 +658,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-        displayName: Install Correct .NET Version
-        inputs:
-          useGlobalJson: true
+      displayName: Install Correct .NET Version
+      inputs:
+        useGlobalJson: true
 
     - script: dotnet tool restore
 
@@ -684,9 +684,9 @@ jobs:
       demands: ImageOverride -equals 1es-windows-2019
     steps:
     - task: UseDotNet@2
-        displayName: Install Correct .NET Version
-        inputs:
-          useGlobalJson: true
+      displayName: Install Correct .NET Version
+      inputs:
+        useGlobalJson: true
 
     - script: dotnet tool restore
 


### PR DESCRIPTION
Updating the secret sync to grab the SDK from the global.json instead of a fixed version. We had to make this update to fix this run after https://github.com/dotnet/performance/pull/3737


