### PR TITLE
Build only .NET7 for GCPerfSim

### DIFF
--- a/src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
+++ b/src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- For a desktop build, you could add e.g. `net472;` here. -->
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;netcoreapp5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>gcperfsim_core</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Other framework versions can be added manually but for now, only build GCPerfSim with .NET 7. 