### PR TITLE
Fix 8.0 runs by replacing global.json with net8.0 compatible global.json

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,6 +315,22 @@ jobs:
 ###########################################
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
+    # Ubuntux64 Default and NativeAOT micro benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - ubuntu-x64
+      isPublic: false
+      jobParameters:
+        kind: micro
+        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+        runCategories: 'runtime libraries' 
+        channels:
+          - main
+          - nativeaot9.0
+          - nativeaot8.0
+          - 8.0 # Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
   # Scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -322,38 +338,38 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
+        #- ubuntu-x64
+        #- win-arm64
+        #- ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
         projectFile: scenarios.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0 # Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       #- win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -368,7 +384,7 @@ jobs:
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -385,53 +401,53 @@ jobs:
           # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
         runtimeFlavor: mono
 
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
-        runtimeFlavor: coreclr
+  # # Maui iOS Native AOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_ios
+  #       projectFile: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+  #         # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+  #       runtimeFlavor: coreclr
 
-  ## Maui scenario benchmarks
-  #- template: /eng/performance/build_machine_matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/performance/scenarios.yml
-  #    buildMachines:
-  #      - win-x64
-  #      - ubuntu-x64
-  #      - win-arm64
-  #      - ubuntu-arm64-ampere
-  #    isPublic: false
-  #    jobParameters:
-  #      kind: maui_scenarios
-  #      projectFile: maui_scenarios.proj
-  #      channels:
-  #        - main
-  # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  # ## Maui scenario benchmarks
+  # #- template: /eng/performance/build_machine_matrix.yml
+  # #  parameters:
+  # #    jobTemplate: /eng/performance/scenarios.yml
+  # #    buildMachines:
+  # #      - win-x64
+  # #      - ubuntu-x64
+  # #      - win-arm64
+  # #      - ubuntu-arm64-ampere
+  # #    isPublic: false
+  # #    jobParameters:
+  # #      kind: maui_scenarios
+  # #      projectFile: maui_scenarios.proj
+  # #      channels:
+  # #        - main
+  # # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: nativeaot_scenarios
+  #       projectFile: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
 ################################################
 # Scheduled Private jobs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
         projectFile: scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   ## MAUI scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
@@ -87,7 +87,7 @@ jobs:
   #      projectFile: maui_scenarios.proj
   #      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
   #        - main
-  # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  #        - 8.0
 
   # Blazor scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -102,7 +102,7 @@ jobs:
         projectFile: blazor_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # SDK scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -118,7 +118,7 @@ jobs:
         projectFile: sdk_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
   
   # micro benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -134,7 +134,7 @@ jobs:
         runCategories: 'runtime libraries' 
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Ubuntux64 Default and NativeAOT micro benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -151,7 +151,7 @@ jobs:
           - main
           - nativeaot9.0
           - nativeaot8.0
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # net462 micro benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -181,7 +181,7 @@ jobs:
         runCategories: 'mldotnet' 
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # F# benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -197,7 +197,7 @@ jobs:
         runCategories: 'fsharp'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # bepuphysics benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -213,7 +213,7 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # ImageSharp benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -229,7 +229,7 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Akade.IndexedSet benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -245,7 +245,7 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Roslyn benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -261,7 +261,7 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # ILLink benchmarks
   # disabled because of: https://github.com/dotnet/performance/issues/3569
@@ -292,7 +292,7 @@ jobs:
         projectFile: nativeaot_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Powershell benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -308,7 +308,7 @@ jobs:
         runCategories: 'Public'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
 ###########################################
 # Private Jobs
@@ -331,7 +331,7 @@ jobs:
         projectFile: scenarios.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Affinitized Scenario benchmarks (Initially just PDN)
   - template: /eng/performance/build_machine_matrix.yml
@@ -347,7 +347,7 @@ jobs:
         projectFile: scenarios_affinitized.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
         additionalJobIdentifier: 'Affinity_85'
         affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
         runEnvVars: 
@@ -415,7 +415,7 @@ jobs:
   #      projectFile: maui_scenarios.proj
   #      channels:
   #        - main
-  # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  #        - 8.0
 
   # NativeAOT scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -431,7 +431,7 @@ jobs:
         projectFile: nativeaot_scenarios.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
 ################################################
 # Scheduled Private jobs
@@ -454,7 +454,7 @@ jobs:
         projectFile: sdk_scenarios.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Blazor 3.2 scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -468,7 +468,7 @@ jobs:
         projectFile: blazor_scenarios.proj
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # F# benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -486,7 +486,7 @@ jobs:
         runCategories: 'fsharp'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # bepuphysics benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -504,7 +504,7 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # ImageSharp benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -522,7 +522,7 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Akade.IndexedSet benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -558,7 +558,7 @@ jobs:
         runCategories: 'mldotnet'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
         runEnvVars: 
           - DOTNET_GCgen0size=410000 # ~4MB
@@ -582,7 +582,7 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
         runEnvVars: 
           - DOTNET_GCgen0size=410000 # ~4MB
@@ -605,7 +605,7 @@ jobs:
   #       runCategories: 'illink'
   #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
   #         - main
-  # #         - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  #         - 8.0
 
   # Powershell benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -623,7 +623,7 @@ jobs:
         runCategories: 'Public Internal'
         channels:
           - main
-          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          - 8.0
 
   # Secret Sync
   - job: Synchronize

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,22 +315,6 @@ jobs:
 ###########################################
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
-    # Ubuntux64 Default and NativeAOT micro benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - ubuntu-x64
-      isPublic: false
-      jobParameters:
-        kind: micro
-        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-        runCategories: 'runtime libraries' 
-        channels:
-          - main
-          - nativeaot9.0
-          - nativeaot8.0
-          - 8.0 # Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
   # Scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -338,38 +322,38 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64
-        #- ubuntu-x64
-        #- win-arm64
-        #- ubuntu-arm64-ampere
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
         projectFile: scenarios.proj
         channels:
           - main
-          - 8.0 # Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       #- win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -384,7 +368,7 @@ jobs:
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -401,53 +385,53 @@ jobs:
           # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
         runtimeFlavor: mono
 
-  # # Maui iOS Native AOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_ios
-  #       projectFile: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-  #         # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
-  #       runtimeFlavor: coreclr
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+        runtimeFlavor: coreclr
 
-  # ## Maui scenario benchmarks
-  # #- template: /eng/performance/build_machine_matrix.yml
-  # #  parameters:
-  # #    jobTemplate: /eng/performance/scenarios.yml
-  # #    buildMachines:
-  # #      - win-x64
-  # #      - ubuntu-x64
-  # #      - win-arm64
-  # #      - ubuntu-arm64-ampere
-  # #    isPublic: false
-  # #    jobParameters:
-  # #      kind: maui_scenarios
-  # #      projectFile: maui_scenarios.proj
-  # #      channels:
-  # #        - main
-  # # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  ## Maui scenario benchmarks
+  #- template: /eng/performance/build_machine_matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/performance/scenarios.yml
+  #    buildMachines:
+  #      - win-x64
+  #      - ubuntu-x64
+  #      - win-arm64
+  #      - ubuntu-arm64-ampere
+  #    isPublic: false
+  #    jobParameters:
+  #      kind: maui_scenarios
+  #      projectFile: maui_scenarios.proj
+  #      channels:
+  #        - main
+  # #        - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: nativeaot_scenarios
-  #       projectFile: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
+          # - 8.0 Temp disabled per (2023/12/18): https://github.com/dotnet/performance/issues/3655
 
 ################################################
 # Scheduled Private jobs

--- a/global.net8.json
+++ b/global.net8.json
@@ -1,0 +1,12 @@
+{
+  "tools": {
+    "dotnet": "8.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23580.7",
+    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.23580.7"
+  },
+  "native-tools": {
+    "python3": "3.7.1"
+  }
+}

--- a/global.net8.json
+++ b/global.net8.json
@@ -1,10 +1,15 @@
 {
+  "sdk": {
+    "version": "8.0.101",
+    "allowPrerelease": true,
+    "rollForward": "latestMinor"
+  },
   "tools": {
-    "dotnet": "8.0.100"
+    "dotnet": "8.0.101"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23580.7",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.23580.7"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24059.4",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.24059.4"
   },
   "native-tools": {
     "python3": "3.7.1"

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -141,7 +141,8 @@ class ChannelMap():
         },
         'net462': {
             'tfm': 'net462',
-            'branch': '8.0'
+            'branch': '9.0',
+            'quality': 'daily'
         },
         'net48': {
             'tfm': 'net48', # For Full Framework download the LTS for dotnet cli.

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -349,7 +349,7 @@ def main(args: Any):
     # if repository is set, user needs to supply the commit_sha
     if not ((args.commit_sha is None) == (args.repository is None)):
         raise ValueError('Either both commit_sha and repository should be set or neither')
-    
+   
     # for CI pipelines, use the agent OS
     if not args.local_build:
         args.target_windows = sys.platform == 'win32'
@@ -368,7 +368,7 @@ def main(args: Any):
                 channel=args.channel,
                 verbose=verbose
             )
-            
+           
         init_tools(
             architecture=architecture,
             dotnet_versions=args.dotnet_versions,
@@ -380,14 +380,11 @@ def main(args: Any):
         dotnet.setup_dotnet(args.dotnet_path)
 
     framework = ChannelMap.get_target_framework_moniker(args.channel)
-    if framework == 'net8.0' or framework == 'nativeaot8.0':
-        # Copy the global.json file to global.bak.json
+    if framework in ('net8.0', 'nativeaot8.0'):
         global_json_path = os.path.join(get_repo_root_path(), 'global.json')
-        shutil.copy(global_json_path, os.path.join(get_repo_root_path(), 'global.net9.json'))
-        print('Copied global.json to global.net9.json')
         shutil.copy(os.path.join(get_repo_root_path(), 'global.net8.json'), global_json_path)
-        print('Copied global.net8.json to global.json')
-              
+        print('Overwrote global.json with global.net8.json')
+             
     # dotnet --info
     dotnet.info(verbose=verbose)
 

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -445,7 +445,7 @@ def main(args: Any):
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
         dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
-        
+
         if args.local_build:
             source_timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
         elif(args.commit_time is not None):

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -433,10 +433,22 @@ def main(args: Any):
         extension = ".cmd" if args.target_windows else ".sh"
         output_file += extension
 
+    target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
+    dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
+    commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
+    # If there is a global.json file, update the version in the file to the version we are using
+    global_json_path = os.path.join(get_repo_root_path(), 'global.json')
+    if os.path.isfile(global_json_path):
+        # read the global.json file as json
+        import json
+        with open(global_json_path, 'r') as global_json_file:
+            global_json = json.load(global_json_file)
+            
+        global_json['sdk']['version'] = dotnet_version
+        with open(global_json_path, 'w') as global_json_file:
+            json.dump(global_json, global_json_file, indent=4)
+
     if not framework.startswith('net4'):
-        target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
-        dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
-        commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
 
         if args.local_build:
             source_timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -382,9 +382,10 @@ def main(args: Any):
     framework = ChannelMap.get_target_framework_moniker(args.channel)
     if framework == 'net8.0':
         # Copy the global.json file to global.bak.json
-        shutil.copy('global.json', 'global.net9.json')
+        global_json_path = os.path.join(get_repo_root_path(), 'global.json')
+        shutil.copy(global_json_path, os.path.join(get_repo_root_path(), 'global.net9.json'))
         print('Copied global.json to global.net9.json')
-        shutil.copy('global.net8.json', 'global.json')
+        shutil.copy(os.path.join(get_repo_root_path(), 'global.net8.json'), global_json_path)
         print('Copied global.net8.json to global.json')
               
     # dotnet --info

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -380,7 +380,7 @@ def main(args: Any):
         dotnet.setup_dotnet(args.dotnet_path)
 
     framework = ChannelMap.get_target_framework_moniker(args.channel)
-    if framework == 'net8.0':
+    if framework == 'net8.0' or framework == 'nativeaot8.0':
         # Copy the global.json file to global.bak.json
         global_json_path = os.path.join(get_repo_root_path(), 'global.json')
         shutil.copy(global_json_path, os.path.join(get_repo_root_path(), 'global.net9.json'))
@@ -445,6 +445,7 @@ def main(args: Any):
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
         dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if args.commit_sha is None else args.commit_sha
+        
         if args.local_build:
             source_timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
         elif(args.commit_time is not None):


### PR DESCRIPTION
Adds global.net8.json file that replaces the normal global.json file when ci_setup is ran and setting up for a net8.0/nativeaot8.0 framework run. This will fix our pipeline and make 8.0 testing work again (to enable in a different PR).


Test runs:
Performance (pre-nativeaot fix but with multiple 8.0 runs): https://dev.azure.com/dnceng/internal/_build/results?buildId=2364393&view=results 
Release/8.0 runtime: https://dev.azure.com/dnceng/internal/_build/results?buildId=2364454&view=results
Main runtime: https://dev.azure.com/dnceng/internal/_build/results?buildId=2365843&view=results