### PR TITLE
Re-enable 8.0 device Maui tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -368,7 +368,7 @@ jobs:
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -382,7 +382,7 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
 
   # Maui iOS Native AOT scenario benchmarks
@@ -397,7 +397,7 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json # 8.0 build flow is failing, disable temporarily https://github.com/dotnet/performance/issues/3655
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks

--- a/global.net8.json
+++ b/global.net8.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.101",
+    "version": "8.0.100",
     "allowPrerelease": true,
     "rollForward": "latestMinor"
   },


### PR DESCRIPTION
Part of finishing https://github.com/dotnet/performance/issues/3655. Re-enables 8.0 Maui device testing.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2367893&view=results. Shows all device apps building correctly and any errors are directly device related and being seen in other unrelated runs.

