### PR TITLE
Update 2004 -> 2204

### DIFF
--- a/helix.yml
+++ b/helix.yml
@@ -143,7 +143,7 @@ profiles:
         variables:
           osGroup: linux
           architecture: arm64
-          queue: Ubuntu.2004.Arm64.Perf
+          queue: Ubuntu.2204.Arm64.Perf
 
   osx-x64-ios-arm64:
     jobs:


### PR DESCRIPTION
We have been submitting jobs to the 2004 queue, which has been dead for a while. This updates the Arm64 Ubuntu jobs to point to the right queue.

