### PR TITLE
Added the new benchmark based types that enable the Benchmark provider

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -140,4 +140,4 @@ output:
   - json
 name: Normal_Server
 trace_configurations:
-  type: gc # gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed, join.
+  type: gc # none, gc, gc_benchmarks, verbose, cpu, cpu_benchmarks, cpu_managed, cpu_managed_benchmarks, threadtime, join.

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
@@ -133,4 +133,4 @@ output:
   - json
 name: Normal_Server
 trace_configurations:
-  type: gc # gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed, join.
+  type: gc # none, gc, gc_benchmarks, verbose, cpu, cpu_benchmarks, cpu_managed, cpu_managed_benchmarks, threadtime, join.

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
@@ -12,7 +12,7 @@ coreruns:
       environment_variables:
           COMPlus_GCName: clrgc.dll
 
-trace_configuration_type: gc # Choose between: none, gc, verbose, cpu, cpu_managed, threadtime, join.
+trace_configuration_type: gc # Choose between: none, gc, gc_benchmarks, verbose, cpu, cpu_benchmarks, cpu_managed, cpu_managed_benchmarks, threadtime, join.
 
 # Optional fields: the contents of both the symbol_path and the source_path will be copied over to the output path.
 symbol_path:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
@@ -116,7 +116,7 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
             // Trace Configurations if specified, must have a type specified.
             if (configuration.TraceConfigurations != null && string.IsNullOrEmpty(configuration.TraceConfigurations.Type))
             {
-                throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: Please ensure a trace configuration type is specified. If you don't want to collect a trace, simply don't include the trace_configuration type or choose either: gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed.");
+                throw new ArgumentException($"{nameof(GCPerfSimConfigurationParser)}: Please ensure a trace configuration type is specified. If you don't want to collect a trace, simply don't include the trace_configuration type or choose either: gc, gc_benchmarks, verbose, cpu, cpu_benchmarks, cpu_managed, cpu_managed_benchmarks, threadtime, threadtime_managed.");
             }
 
             // If the user passes in a null output path, default to the current directory.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
@@ -7,9 +7,12 @@ namespace GC.Infrastructure.Core.TraceCollection
     {
         none,
         gc,
+        gc_benchmarks,
         verbose,
         cpu,
+        cpu_benchmarks,
         cpu_managed,
+        cpu_managed_benchmarks,
         threadtime,
         threadtime_managed,
         join
@@ -28,9 +31,12 @@ namespace GC.Infrastructure.Core.TraceCollection
         internal static readonly Dictionary<CollectType, string> WindowsCollectTypeMap = new()
         {
             { CollectType.gc, "/GCCollectOnly" },
+            { CollectType.gc_benchmarks, "/GCCollectOnly /Providers:Benchmarks" },
             { CollectType.verbose, "/ClrEventLevel:Verbose /ClrEvents:GC+Stack" },
             { CollectType.cpu,  "/KernelEvents=Process+Thread+ImageLoad+Profile /ClrEventLevel:Informational /ClrEvents:GC+Stack /BufferSize:3000 /CircularMB:3000"  },
+            { CollectType.cpu_benchmarks,  "/KernelEvents=Process+Thread+ImageLoad+Profile /Providers:Benchmarks /ClrEventLevel:Informational /ClrEvents:GC+Stack /BufferSize:3000 /CircularMB:3000"  },
             { CollectType.cpu_managed,  "/KernelEvents=Process+Thread+ImageLoad+Profile /ClrEventLevel:Informational /ClrEvents:GC+Stack+Codesymbols+JitSymbols+Compilation+Type+GCHeapAndTypeNames /BufferSize:3000 /CircularMB:3000"  },
+            { CollectType.cpu_managed_benchmarks,  "/KernelEvents=Process+Thread+ImageLoad+Profile /Providers:Benchmarks /ClrEventLevel:Informational /ClrEvents:GC+Stack+Codesymbols+JitSymbols+Compilation+Type+GCHeapAndTypeNames /BufferSize:3000 /CircularMB:3000"  },
             { CollectType.threadtime_managed, "/KernelEvents=Process+Thread+ImageLoad+Profile+ContextSwitch+Dispatcher /ClrEvents:GC+Stack+Codesymbols+JitSymbols+Compilation+Type+GCHeapAndTypeNames /BufferSize:3000 /CircularMB:3000 /ClrEventLevel=Verbose" },
             { CollectType.threadtime, "/KernelEvents=Process+Thread+ImageLoad+Profile+ContextSwitch+Dispatcher /ClrEvents:GC /ClrEventLevel=Verbose /BufferSize:3000 /CircularMB:3000 " },
             { CollectType.join, " /BufferSizeMB:4096 /CircularMB:4096 /KernelEvents:Process+Thread+ImageLoad  /ClrEvents:GC+Threading /ClrEventLevel=Verbose " },
@@ -46,9 +52,12 @@ namespace GC.Infrastructure.Core.TraceCollection
         internal static readonly Dictionary<string, CollectType> StringToCollectTypeMap = new(StringComparer.OrdinalIgnoreCase)
         {
             { "gc", CollectType.gc },
+            { "gc_benchmarks", CollectType.gc_benchmarks },
             { "verbose", CollectType.verbose },
             { "cpu", CollectType.cpu },
+            { "cpu_benchmarks", CollectType.cpu_benchmarks },
             { "cpu_managed", CollectType.cpu_managed },
+            { "cpu_managed_benchmarks", CollectType.cpu_managed_benchmarks },
             { "threadtime", CollectType.threadtime },
             { "threadtime_managed", CollectType.threadtime_managed },
             { "join", CollectType.join },

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
@@ -128,4 +128,4 @@ output:
   - json
 name: Normal_Server
 trace_configurations:
-  type: gc # gc, verbose, cpu, cpu_managed, threadtime, threadtime_managed, join.
+  type: gc # none, gc, gc_benchmarks, verbose, cpu, cpu_benchmarks, cpu_managed, cpu_managed_benchmarks, threadtime, join.


### PR DESCRIPTION
The benchmark provider gives the ability to observe the Startup events in the trace that are helpful for Startup Regressions.