### PR TITLE
Don't always write MAUI_VERSION and ensure version env vars have value

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -323,37 +323,37 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        # - win-arm64
-        # - ubuntu-arm64-ampere
+        - win-arm64
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
         projectFile: scenarios.proj
         channels:
           - main
-          # - 8.0
+          - 8.0
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -361,14 +361,14 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        # - win-x64-android-arm64-galaxy
+        - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -382,23 +382,23 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
 
-  # # Maui iOS Native AOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_ios
-  #       projectFile: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-  #         # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
-  #       runtimeFlavor: coreclr
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+        runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
@@ -417,21 +417,21 @@ jobs:
   #        - main
   #        - 8.0
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: nativeaot_scenarios
-  #       projectFile: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 8.0
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 8.0
 
 ################################################
 # Scheduled Private jobs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -323,37 +323,37 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
+        # - win-arm64
+        # - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         kind: scenarios
         projectFile: scenarios.proj
         channels:
           - main
-          - 8.0
+          # - 8.0
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -361,14 +361,14 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
+        # - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -382,23 +382,23 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
 
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
-        runtimeFlavor: coreclr
+  # # Maui iOS Native AOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_ios
+  #       projectFile: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+  #         # 8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+  #       runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
@@ -417,21 +417,21 @@ jobs:
   #        - main
   #        - 8.0
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 8.0
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: nativeaot_scenarios
+  #       projectFile: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 8.0
 
 ################################################
 # Scheduled Private jobs

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -489,7 +489,8 @@ def main(args: Any):
             out_file.write(variable_format % ('DOTNET_MULTILEVEL_LOOKUP', '0'))
             out_file.write(variable_format % ('UseSharedCompilation', 'false'))
             out_file.write(variable_format % ('DOTNET_ROOT', dotnet_path))
-            out_file.write(variable_format % ('MAUI_VERSION', args.maui_version))
+            if args.maui_version:
+                out_file.write(variable_format % ('MAUI_VERSION', args.maui_version))
             if run_name is not None:
                 out_file.write(variable_format % ('PERFLAB_RUNNAME', run_name))
             out_file.write(path_variable % dotnet_path)

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -5,19 +5,21 @@ import json
 import os
 import subprocess
 
-def versions_write_json(versiondict: dict, outputfile = 'versions.json'):
-    with open(outputfile, 'w') as file:
+from typing import Dict
+
+def versions_write_json(versiondict: Dict[str, str], outputfile: str = 'versions.json'):
+    with open(outputfile, 'w', encoding='utf-8') as file:
         json.dump(versiondict, file)
 
-def versions_read_json(inputfile = 'versions.json'):
-    with open(inputfile, 'r') as file:
+def versions_read_json(inputfile: str = 'versions.json'):
+    with open(inputfile, 'r', encoding='utf-8') as file:
         return json.load(file)
 
-def versions_write_env(versiondict: dict):
+def versions_write_env(versiondict: Dict[str, str]):
     for key, value in versiondict.items():
-        os.environ[key] = value
+        os.environ[key.upper()] = value # Windows automatically converts environment variables to uppercase, match this behavior everywhere
 
-def versions_read_json_file_save_env(inputfile = 'versions.json'):
+def versions_read_json_file_save_env(inputfile: str = 'versions.json'):
     versions = versions_read_json(inputfile)
     print(f"Versions: {versions}")
     versions_write_env(versions)

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -103,7 +103,7 @@ public class Reporter
                 if(entry.Key.ToString().Equals("DOTNET_VERSION", StringComparison.InvariantCultureIgnoreCase)){
                     build.AdditionalData["productVersion"] = entry.Value.ToString();
                 } else if(entry.Key.ToString().Equals("MAUI_VERSION", StringComparison.InvariantCultureIgnoreCase)){
-                    build.AdditionalData["mauiVersion"] = entry.Value.ToString();
+                    build.AdditionalData["MAUIVERSION"] = entry.Value.ToString();
                 } else if(!string.IsNullOrWhiteSpace(entry.Value.ToString())){
                     build.AdditionalData[entry.Key.ToString()] = entry.Value.ToString();
                 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -104,7 +104,7 @@ public class Reporter
                     build.AdditionalData["productVersion"] = entry.Value.ToString();
                 } else if(entry.Key.ToString().Equals("MAUI_VERSION", StringComparison.InvariantCultureIgnoreCase)){
                     build.AdditionalData["mauiVersion"] = entry.Value.ToString();
-                } else {
+                } else if(!string.IsNullOrWhiteSpace(entry.Value.ToString())){
                     build.AdditionalData[entry.Key.ToString()] = entry.Value.ToString();
                 }
             }


### PR DESCRIPTION
Don't always write MAUI_VERSION and ensure version env vars have value. Only add entries to Additional data if they have values and don't write MAUI_VERSION env var in ci_setup if maui_version is not passed.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2388245&view=results
Will also need to update the ADX MauiVersion column generation.

