### PR TITLE
Add device restart in pre.py for android instrumentation runs

### DIFF
--- a/src/scenarios/bdnandroid/pre.py
+++ b/src/scenarios/bdnandroid/pre.py
@@ -1,14 +1,16 @@
 '''
 pre-command
 '''
-import sys
 import os
-from zipfile import ZipFile
-from performance.logger import setup_loggers, getLogger
-from shutil import copyfile
-from shared.precommands import PreCommands
-from shared.const import PUBDIR
+import time
 from argparse import ArgumentParser
+from zipfile import ZipFile
+from shutil import copyfile
+from shared.const import PUBDIR
+from shared.util import xharnesscommand
+
+from performance.common import RunCommand
+from performance.logger import setup_loggers, getLogger
 
 setup_loggers(True)
 
@@ -20,6 +22,7 @@ parser.add_argument(
         required=True,
         type=str,
         help='Name of the APK to setup (with .apk)')
+parser.add_argument('--restart-device', help='Restart the device before running the tests', action='store_true', default=False)
 args = parser.parse_args()
 
 if not os.path.exists(PUBDIR):
@@ -44,4 +47,43 @@ if args.unzip:
     os.remove(assets_zip)
 else:
     copyfile(apkname, os.path.join(PUBDIR, apkname))
+
+if args.restart_device:
+    cmdline = xharnesscommand() + ['android', 'state', '--adb']
+    adb = RunCommand(cmdline, verbose=True)
+    adb.run()
+
+    # Do not remove, XHarness install seems to fail without an adb command called before the xharness command
+    getLogger().info("Preparing ADB")
+    adbpath = adb.stdout.strip()
+    waitForDeviceCmd = [
+        adbpath,
+        'wait-for-device'
+    ]
+
+    checkDeviceBootCmd = [
+        adbpath,
+        'shell',
+        'getprop',
+        'sys.boot_completed'
+    ]
+
+    getLogger().info("Waiting for device to come back online")
+    RunCommand(waitForDeviceCmd, verbose=True).run()
+    
+    # Wait for the device to boot
+    getLogger().info("Waiting for device to boot")
+    boot_completed = False
+    boot_attempts = 0
+    while not boot_completed and boot_attempts < 10:
+        time.sleep(5)
+        boot_check = RunCommand(checkDeviceBootCmd, verbose=True)
+        boot_check.run()
+        boot_completed = boot_check.stdout.strip() == '1'
+        boot_attempts += 1
+        getLogger().info("Device not booted yet, waiting 5 seconds")
+
+    if not boot_completed:
+        getLogger().error("Android device did not boot in a reasonable time")
+        raise TimeoutError("Android device did not boot in a reasonable time")
 

--- a/src/scenarios/bdnandroid/pre.py
+++ b/src/scenarios/bdnandroid/pre.py
@@ -56,20 +56,29 @@ if args.restart_device:
     # Do not remove, XHarness install seems to fail without an adb command called before the xharness command
     getLogger().info("Preparing ADB")
     adbpath = adb.stdout.strip()
-    waitForDeviceCmd = [
+
+    reboot_cmd = [
+        adbpath,
+        'reboot'
+    ]
+
+    wait_for_device_cmd = [
         adbpath,
         'wait-for-device'
     ]
 
-    checkDeviceBootCmd = [
+    check_device_boot_cmd = [
         adbpath,
         'shell',
         'getprop',
         'sys.boot_completed'
     ]
 
+    getLogger().info("Rebooting device to ensure we don't hit issue with being unable to install APK")
+    RunCommand(reboot_cmd, verbose=True).run()
+
     getLogger().info("Waiting for device to come back online")
-    RunCommand(waitForDeviceCmd, verbose=True).run()
+    RunCommand(wait_for_device_cmd, verbose=True).run()
     
     # Wait for the device to boot
     getLogger().info("Waiting for device to boot")
@@ -77,7 +86,7 @@ if args.restart_device:
     boot_attempts = 0
     while not boot_completed and boot_attempts < 10:
         time.sleep(5)
-        boot_check = RunCommand(checkDeviceBootCmd, verbose=True)
+        boot_check = RunCommand(check_device_boot_cmd, verbose=True)
         boot_check.run()
         boot_completed = boot_check.stdout.strip() == '1'
         boot_attempts += 1
@@ -86,4 +95,3 @@ if args.restart_device:
     if not boot_completed:
         getLogger().error("Android device did not boot in a reasonable time")
         raise TimeoutError("Android device did not boot in a reasonable time")
-

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -29,11 +29,6 @@ class AndroidInstrumentationHelper(object):
             getLogger().info("Preparing ADB")
             adbpath = adb.stdout.strip()
             try:
-                rebootCmd = [
-                    adbpath,
-                    'reboot'
-                ]
-
                 installCmd = [
                     adbpath,
                     'install',
@@ -65,9 +60,6 @@ class AndroidInstrumentationHelper(object):
                     '-s',
                     '"DOTNET,MAUI"'
                 ]
-
-                getLogger().info("Rebooting device to ensure we don't hit issue with being unable to install APK")
-                RunCommand(rebootCmd, verbose=True).run()
 
                 getLogger().info("Installing APK")
                 RunCommand(installCmd, verbose=True).run()

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -1,6 +1,7 @@
 '''
 Helper/Runner for Android Instrumentation Scenarios tool.
 '''
+import time
 import sys
 import os
 import json
@@ -75,6 +76,7 @@ class AndroidInstrumentationHelper(object):
 
                 getLogger().info("Waiting for device to come back online")
                 RunCommand(waitForDeviceCmd, verbose=True).run()
+                time.sleep(30)
 
                 getLogger().info("Installing APK")
                 RunCommand(installCmd, verbose=True).run()

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -39,6 +39,13 @@ class AndroidInstrumentationHelper(object):
                     'wait-for-device'
                 ]
 
+                checkDeviceBootCmd = [
+                    adbpath,
+                    'shell',
+                    'getprop',
+                    'sys.boot_completed'
+                ]
+
                 installCmd = [
                     adbpath,
                     'install',
@@ -76,7 +83,22 @@ class AndroidInstrumentationHelper(object):
 
                 getLogger().info("Waiting for device to come back online")
                 RunCommand(waitForDeviceCmd, verbose=True).run()
-                time.sleep(30)
+                
+                # Wait for the device to boot
+                getLogger().info("Waiting for device to boot")
+                boot_completed = False
+                boot_attempts = 0
+                while not boot_completed and boot_attempts < 10:
+                    time.sleep(5)
+                    boot_check = RunCommand(checkDeviceBootCmd, verbose=True)
+                    boot_check.run()
+                    boot_completed = boot_check.stdout.strip() == '1'
+                    boot_attempts += 1
+                    getLogger().info("Device not booted yet, waiting 5 seconds")
+
+                if not boot_completed:
+                    getLogger().error("Android device did not boot in a reasonable time")
+                    raise TimeoutError("Android device did not boot in a reasonable time")
 
                 getLogger().info("Installing APK")
                 RunCommand(installCmd, verbose=True).run()

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -1,7 +1,6 @@
 '''
 Helper/Runner for Android Instrumentation Scenarios tool.
 '''
-import time
 import sys
 import os
 import json

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -34,18 +34,6 @@ class AndroidInstrumentationHelper(object):
                     'reboot'
                 ]
 
-                waitForDeviceCmd = [
-                    adbpath,
-                    'wait-for-device'
-                ]
-
-                checkDeviceBootCmd = [
-                    adbpath,
-                    'shell',
-                    'getprop',
-                    'sys.boot_completed'
-                ]
-
                 installCmd = [
                     adbpath,
                     'install',
@@ -80,25 +68,6 @@ class AndroidInstrumentationHelper(object):
 
                 getLogger().info("Rebooting device to ensure we don't hit issue with being unable to install APK")
                 RunCommand(rebootCmd, verbose=True).run()
-
-                getLogger().info("Waiting for device to come back online")
-                RunCommand(waitForDeviceCmd, verbose=True).run()
-                
-                # Wait for the device to boot
-                getLogger().info("Waiting for device to boot")
-                boot_completed = False
-                boot_attempts = 0
-                while not boot_completed and boot_attempts < 10:
-                    time.sleep(5)
-                    boot_check = RunCommand(checkDeviceBootCmd, verbose=True)
-                    boot_check.run()
-                    boot_completed = boot_check.stdout.strip() == '1'
-                    boot_attempts += 1
-                    getLogger().info("Device not booted yet, waiting 5 seconds")
-
-                if not boot_completed:
-                    getLogger().error("Android device did not boot in a reasonable time")
-                    raise TimeoutError("Android device did not boot in a reasonable time")
 
                 getLogger().info("Installing APK")
                 RunCommand(installCmd, verbose=True).run()

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -28,6 +28,16 @@ class AndroidInstrumentationHelper(object):
             getLogger().info("Preparing ADB")
             adbpath = adb.stdout.strip()
             try:
+                rebootCmd = [
+                    adbpath,
+                    'reboot'
+                ]
+
+                waitForDeviceCmd = [
+                    adbpath,
+                    'wait-for-device'
+                ]
+
                 installCmd = [
                     adbpath,
                     'install',
@@ -59,6 +69,12 @@ class AndroidInstrumentationHelper(object):
                     '-s',
                     '"DOTNET,MAUI"'
                 ]
+
+                getLogger().info("Rebooting device to ensure we don't hit issue with being unable to install APK")
+                RunCommand(rebootCmd, verbose=True).run()
+
+                getLogger().info("Waiting for device to come back online")
+                RunCommand(waitForDeviceCmd, verbose=True).run()
 
                 getLogger().info("Installing APK")
                 RunCommand(installCmd, verbose=True).run()


### PR DESCRIPTION
We recently had to disable PerfBDN runs in runtime testing due to the app failing to install: https://github.com/dotnet/performance/issues/3662. A single device reboot would only temporarily fix the issue, quickly getting back into a failing state. By restarting the device each time before trying to run the test we ensure that we are able to download the app. This must be merged before the usage is added to the runtime runs.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2383951&view=results


