### PR TITLE
Revert BDN version to one that works with wasm based on local testing.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <MicrosoftNETILLinkTasksVersion>9.0.0-preview.2.24123.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkPackageVersion>9.0.0-preview.2.24123.1</MicrosoftNETILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.13-nightly.20240213.132</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.13-nightly.20240114.129</BenchmarkDotNetVersion>
     <SystemThreadingChannelsPackageVersion>9.0.0-preview.2.24123.1</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>9.0.0-preview.2.24123.1</MicrosoftExtensionsLoggingPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
Revert BDN version to one that works with wasm based on local testing. This version still has the VS test adapter.
This will give us more time to work through: https://github.com/dotnet/performance/issues/3984
