### PR TITLE
Fix MonoAOT runs failing to compile

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -75,7 +75,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion)" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '8.0'" />


### PR DESCRIPTION
With the Microsoft.NET.Test.Sdk now implicitly referenced based on this warning:
```
Microsoft.NET.Sdk.DefaultItems.Shared.targets(152,5): warning NETSDK1023: A PackageReference for 'Microsoft.NET.Test.Sdk' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs [/home/pbibus/performance/src/benchmarks/micro/MicroBenchmarks.csproj::TargetFramework=net9.0]
```

Some sort of dll interaction was casuing the issue: https://stackoverflow.com/questions/62447717/system-typeloadexception-vtable-setup-of-type-xamarin-forms-formsandroidplatf. Removing the package reference from the MicroBenchmarks.csproj file fixes the issue. 

This should fix: https://github.com/dotnet/runtime/issues/98967
Tested locally using benchmarks_local.py.
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2389129&view=results

Open to other suggestions for the exact change.


