### PR TITLE
Update BDN Version to fix Wasm Wasm runs and remove Test Adapter to fix WasmAOT runs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <MicrosoftNETILLinkTasksVersion>9.0.0-preview.3.24128.2</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkPackageVersion>9.0.0-preview.3.24128.2</MicrosoftNETILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.13-nightly.20240114.129</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.13-nightly.20240228.135</BenchmarkDotNetVersion>
     <SystemThreadingChannelsPackageVersion>9.0.0-preview.3.24128.2</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>9.0.0-preview.3.24128.2</MicrosoftExtensionsLoggingPackageVersion>
   </PropertyGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -61,7 +61,6 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet.TestAdapter" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="Jil" Version="3.0.0-alpha2" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="MessagePackAnalyzer" Version="1.7.3.7" />


### PR DESCRIPTION
Potential replacement for https://github.com/dotnet/performance/pull/4013. 

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2390239&view=results

