### PR TITLE
Add byte to TensorPrimitives BinaryInteger benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/System.Numerics.Tensors/Perf_BinaryIntegerTensorPrimitives.cs
+++ b/src/benchmarks/micro/libraries/System.Numerics.Tensors/Perf_BinaryIntegerTensorPrimitives.cs
@@ -9,6 +9,7 @@ using MicroBenchmarks;
 namespace System.Numerics.Tensors.Tests
 {
     [BenchmarkCategory(Categories.Libraries, Categories.SIMD, Categories.JIT)]
+    [GenericTypeArguments(typeof(byte))]
     [GenericTypeArguments(typeof(int))]
     public class Perf_BinaryIntegerTensorPrimitives<T>
         where T : unmanaged, IBinaryInteger<T>


### PR DESCRIPTION
Following up on https://github.com/dotnet/runtime/issues/99123 this adds `byte` testing to the BinaryInteger as the type represents an important category of the TensorPrimitives vectorized implementations.