### PR TITLE
Don't set branch on performance CI runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -479,7 +479,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     ci_setup_arguments.build_number = args.build_number
 
-    if branch is not None:
+    if branch is not None and not args.performance_repo_ci:
         ci_setup_arguments.branch = branch
 
     if args.perf_repo_hash is not None and not args.performance_repo_ci:


### PR DESCRIPTION
With the python pipelines changes, a bug was introduced that would set the branch for dotnet/performance CI runs when instead it should not be passed and then ci_setup will fill the branch value with data from the ChannelMap