### PR TITLE
Add and fix up DependencyInjection CreateInstance() benchmarks

### DIFF
--- a/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
+++ b/src/benchmarks/micro/libraries/Microsoft.Extensions.DependencyInjection/ActivatorUtilitiesBenchmark.cs
@@ -26,19 +26,12 @@ namespace Microsoft.Extensions.DependencyInjection
         private object[] _factoryArguments2;
         private object[] _factoryArguments2_OutOfOrder;
         private object[] _factoryArguments3;
-        private object[] _factoryArguments4;
         private object[] _factoryArguments5;
 
         [GlobalSetup]
         public void SetUp()
         {
             ServiceCollection collection = new();
-            collection.AddTransient<TypeWith0ParametersToBeActivated>();
-            collection.AddTransient<TypeWith1ParameterToBeActivated>();
-            collection.AddTransient<TypeWith2ParametersToBeActivated>();
-            collection.AddTransient<TypeWith3ParametersToBeActivated>();
-            collection.AddTransient<TypeWith4ParametersToBeActivated>();
-            collection.AddTransient<TypeWith5ParametersToBeActivated>();
 
             collection.AddSingleton<DependencyA>();
             collection.AddSingleton<DependencyB>();
@@ -51,30 +44,22 @@ namespace Microsoft.Extensions.DependencyInjection
             _types2_OutOfOrder = new Type[] { typeof(DependencyB), typeof(DependencyC) };
             _types3 = new Type[] { typeof(DependencyA), typeof(DependencyB), typeof(DependencyC) };
 
-            _factory0 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types0);
-            _factory2 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2);
-            _factory2_OutOfOrder = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types2_OutOfOrder);
-            _factory3 = ActivatorUtilities.CreateFactory(typeof(TypeWith3ParametersToBeActivated), _types3);
+            _factory0 = ActivatorUtilities.CreateFactory(typeof(TypeWithVaryingIncomingParametersToBeActivated), _types0);
+            _factory2 = ActivatorUtilities.CreateFactory(typeof(TypeWithVaryingIncomingParametersToBeActivated), _types2);
+            _factory2_OutOfOrder = ActivatorUtilities.CreateFactory(typeof(TypeWithVaryingIncomingParametersToBeActivated), _types2_OutOfOrder);
+            _factory3 = ActivatorUtilities.CreateFactory(typeof(TypeWithVaryingIncomingParametersToBeActivated), _types3);
 
             _factoryArguments0 = Array.Empty<object>();
             _factoryArguments1 = new object[] { new DependencyA() };
             _factoryArguments2 = new object[] { new DependencyA(), new DependencyB() };
             _factoryArguments2_OutOfOrder = new object[] { new DependencyB(), new DependencyC() };
             _factoryArguments3 = new object[] { new DependencyA(), new DependencyB(), new DependencyC() };
-            _factoryArguments4 = new object[] { new DependencyA(), new DependencyB(), new DependencyC(), new DependencyD() };
             _factoryArguments5 = new object[] { new DependencyA(), new DependencyB(), new DependencyC(), new DependencyD(), new DependencyE() };
             _serviceProvider = collection.BuildServiceProvider();
         }
 
         [GlobalCleanup]
         public void Cleanup() => _serviceProvider.Dispose();
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith0ParametersToBeActivated GetService_0Injected()
-        {
-            return _serviceProvider.GetService<TypeWith0ParametersToBeActivated>();
-        }
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
@@ -85,23 +70,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith2ParametersToBeActivated GetService_2Injected()
-        {
-            return _serviceProvider.GetService<TypeWith2ParametersToBeActivated>();
-        }
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
         public TypeWith3ParametersToBeActivated GetService_3Injected()
         {
             return _serviceProvider.GetService<TypeWith3ParametersToBeActivated>();
-        }
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith4ParametersToBeActivated GetService_4Injected()
-        {
-            return _serviceProvider.GetService<TypeWith4ParametersToBeActivated>();
         }
 
         [Benchmark]
@@ -114,15 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith0ParametersToBeActivated CreateInstance_0() => ActivatorUtilities.CreateInstance<TypeWith0ParametersToBeActivated>(_serviceProvider, _factoryArguments0);
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
         public TypeWith1ParameterToBeActivated CreateInstance_1() => ActivatorUtilities.CreateInstance<TypeWith1ParameterToBeActivated>(_serviceProvider, _factoryArguments1);
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith2ParametersToBeActivated CreateInstance_2() => ActivatorUtilities.CreateInstance<TypeWith2ParametersToBeActivated>(_serviceProvider, _factoryArguments2);
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
@@ -130,82 +93,68 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith4ParametersToBeActivated CreateInstance_4() => ActivatorUtilities.CreateInstance<TypeWith4ParametersToBeActivated>(_serviceProvider, _factoryArguments4);
-
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
         public TypeWith5ParametersToBeActivated CreateInstance_5() => ActivatorUtilities.CreateInstance<TypeWith5ParametersToBeActivated>(_serviceProvider, _factoryArguments5);
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith3ParametersToBeActivated Factory_1Injected_2Explicit()
+        public TypeWith1ParameterToBeActivated_WithAttrFirst CreateInstance_1_WithAttrFirst() => ActivatorUtilities.CreateInstance<TypeWith1ParameterToBeActivated_WithAttrFirst>(_serviceProvider, _factoryArguments1);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated_WithAttrFirst CreateInstance_3_WithAttrFirst() => ActivatorUtilities.CreateInstance<TypeWith3ParametersToBeActivated_WithAttrFirst>(_serviceProvider, _factoryArguments3);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith5ParametersToBeActivated_WithAttrFirst CreateInstance_5_WithAttrFirst() => ActivatorUtilities.CreateInstance<TypeWith5ParametersToBeActivated_WithAttrFirst>(_serviceProvider, _factoryArguments5);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith1ParameterToBeActivated_WithAttrLast CreateInstance_1_WithAttrLast() => ActivatorUtilities.CreateInstance<TypeWith1ParameterToBeActivated_WithAttrLast>(_serviceProvider, _factoryArguments1);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith3ParametersToBeActivated_WithAttrLast CreateInstance_3_WithAttrLast() => ActivatorUtilities.CreateInstance<TypeWith3ParametersToBeActivated_WithAttrLast>(_serviceProvider, _factoryArguments3);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWith5ParametersToBeActivated_WithAttrLast CreateInstance_5_WithAttrLast() => ActivatorUtilities.CreateInstance<TypeWith5ParametersToBeActivated_WithAttrLast>(_serviceProvider, _factoryArguments5);
+
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWithVaryingIncomingParametersToBeActivated Factory_1Injected_2Explicit()
         {
-            return (TypeWith3ParametersToBeActivated)_factory2(_serviceProvider, _factoryArguments2);
+            return (TypeWithVaryingIncomingParametersToBeActivated)_factory2(_serviceProvider, _factoryArguments2);
         }
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith3ParametersToBeActivated Factory_1Injected_2Explicit_OutOfOrder()
+        public TypeWithVaryingIncomingParametersToBeActivated Factory_1Injected_2Explicit_OutOfOrder()
         {
-            return (TypeWith3ParametersToBeActivated)_factory2_OutOfOrder(_serviceProvider, _factoryArguments2_OutOfOrder);
-        }
-       
-        [Benchmark]
-        [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith3ParametersToBeActivated Factory_3Explicit()
-        {
-            return (TypeWith3ParametersToBeActivated)_factory3(_serviceProvider, _factoryArguments3);
+            return (TypeWithVaryingIncomingParametersToBeActivated)_factory2_OutOfOrder(_serviceProvider, _factoryArguments2_OutOfOrder);
         }
 
         [Benchmark]
         [BenchmarkCategory(Categories.NoAOT)]
-        public TypeWith3ParametersToBeActivated Factory_3Injected()
+        public TypeWithVaryingIncomingParametersToBeActivated Factory_3Explicit()
         {
-            return (TypeWith3ParametersToBeActivated)_factory0(_serviceProvider, _factoryArguments0);
+            return (TypeWithVaryingIncomingParametersToBeActivated)_factory3(_serviceProvider, _factoryArguments3);
         }
 
-        public class TypeWith0ParametersToBeActivated
+        [Benchmark]
+        [BenchmarkCategory(Categories.NoAOT)]
+        public TypeWithVaryingIncomingParametersToBeActivated Factory_3Injected()
         {
-            // DI picks these over the correct one below and throws TargetInvocationException.
-            //public TypeWith0ParametersToBeActivated(int i)
-            //{
-            //    throw new NotImplementedException();
-            //}
-
-            //public TypeWith0ParametersToBeActivated(string s)
-            //{
-            //    throw new NotImplementedException();
-            //}
-
-            //public TypeWith0ParametersToBeActivated(object o)
-            //{
-            //    throw new NotImplementedException();
-            //}
-
-            public TypeWith0ParametersToBeActivated()
-            {
-            }
+            return (TypeWithVaryingIncomingParametersToBeActivated)_factory0(_serviceProvider, _factoryArguments0);
         }
 
         public class TypeWith1ParameterToBeActivated
         {
             public DependencyA _a;
 
-            public TypeWith1ParameterToBeActivated(int i)
+            public TypeWith1ParameterToBeActivated()
             {
                 throw new NotImplementedException();
             }
-
-            public TypeWith1ParameterToBeActivated(string s)
-            {
-                throw new NotImplementedException();
-            }
-
-            // DI picks this over the one below and calls it.
-            //public TypeWith1ParameterToBeActivated(object o)
-            //{
-            //    throw new NotImplementedException();
-            //}
 
             public TypeWith1ParameterToBeActivated(DependencyA a)
             {
@@ -213,30 +162,35 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        public class TypeWith2ParametersToBeActivated
+        public class TypeWith1ParameterToBeActivated_WithAttrFirst
         {
             public DependencyA _a;
-            public DependencyB _b;
 
-            public TypeWith2ParametersToBeActivated(int i)
+            public TypeWith1ParameterToBeActivated_WithAttrFirst()
             {
                 throw new NotImplementedException();
             }
 
-            public TypeWith2ParametersToBeActivated(string s)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TypeWith2ParametersToBeActivated(object o)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TypeWith2ParametersToBeActivated(DependencyA a, DependencyB b)
+            [ActivatorUtilitiesConstructor]
+            public TypeWith1ParameterToBeActivated_WithAttrFirst(DependencyA a)
             {
                 _a = a;
-                _b = b;
+            }
+        }
+
+        public class TypeWith1ParameterToBeActivated_WithAttrLast
+        {
+            public DependencyA _a;
+
+            public TypeWith1ParameterToBeActivated_WithAttrLast()
+            {
+                throw new NotImplementedException();
+            }
+
+            [ActivatorUtilitiesConstructor]
+            public TypeWith1ParameterToBeActivated_WithAttrLast(DependencyA a)
+            {
+                _a = a;
             }
         }
 
@@ -246,21 +200,20 @@ namespace Microsoft.Extensions.DependencyInjection
             public DependencyB _b;
             public DependencyC _c;
 
-            // DI picks these over the correct one below and throws InvalidOperation.
-            //public TypeWith3ParametersToBeActivated(int i)
-            //{
-            //    throw new NotImplementedException();
-            //}
+            public TypeWith3ParametersToBeActivated()
+            {
+                throw new NotImplementedException();
+            }
 
-            //public TypeWith3ParametersToBeActivated(string s)
-            //{
-            //    throw new NotImplementedException();
-            //}
+            public TypeWith3ParametersToBeActivated(int i)
+            {
+                throw new NotImplementedException();
+            }
 
-            //public TypeWith3ParametersToBeActivated(object o)
-            //{
-            //    throw new NotImplementedException();
-            //}
+            public TypeWith3ParametersToBeActivated(int i, int i2)
+            {
+                throw new NotImplementedException();
+            }
 
             public TypeWith3ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c)
             {
@@ -270,34 +223,63 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        public class TypeWith4ParametersToBeActivated
+        public class TypeWith3ParametersToBeActivated_WithAttrFirst
         {
             public DependencyA _a;
             public DependencyB _b;
             public DependencyC _c;
-            public DependencyD _d;
 
-            public TypeWith4ParametersToBeActivated(int i)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TypeWith4ParametersToBeActivated(string s)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TypeWith4ParametersToBeActivated(object o)
-            {
-                throw new NotImplementedException();
-            }
-
-            public TypeWith4ParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c, DependencyD d)
+            [ActivatorUtilitiesConstructor]
+            public TypeWith3ParametersToBeActivated_WithAttrFirst(DependencyA a, DependencyB b, DependencyC c)
             {
                 _a = a;
                 _b = b;
                 _c = c;
-                _d = d;
+            }
+
+            public TypeWith3ParametersToBeActivated_WithAttrFirst()
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated_WithAttrFirst(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated_WithAttrFirst(int i, int i2)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TypeWith3ParametersToBeActivated_WithAttrLast
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+
+            public TypeWith3ParametersToBeActivated_WithAttrLast()
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated_WithAttrLast(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith3ParametersToBeActivated_WithAttrLast(int i, int i2)
+            {
+                throw new NotImplementedException();
+            }
+
+            [ActivatorUtilitiesConstructor]
+            public TypeWith3ParametersToBeActivated_WithAttrLast(DependencyA a, DependencyB b, DependencyC c)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
             }
         }
 
@@ -309,17 +291,27 @@ namespace Microsoft.Extensions.DependencyInjection
             public DependencyD _d;
             public DependencyE _e;
 
+            public TypeWith5ParametersToBeActivated()
+            {
+                throw new NotImplementedException();
+            }
+
             public TypeWith5ParametersToBeActivated(int i)
             {
                 throw new NotImplementedException();
             }
 
-            public TypeWith5ParametersToBeActivated(string s)
+            public TypeWith5ParametersToBeActivated(int i, int i2)
             {
                 throw new NotImplementedException();
             }
 
-            public TypeWith5ParametersToBeActivated(object o)
+            public TypeWith5ParametersToBeActivated(int i, int i2, int i3)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated(int i, int i2, int i3, int i4)
             {
                 throw new NotImplementedException();
             }
@@ -332,6 +324,99 @@ namespace Microsoft.Extensions.DependencyInjection
                 _d = d;
                 _e = e;
             }
+        }
+
+        public class TypeWith5ParametersToBeActivated_WithAttrFirst
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+            public DependencyD _d;
+            public DependencyE _e;
+
+            [ActivatorUtilitiesConstructor]
+            public TypeWith5ParametersToBeActivated_WithAttrFirst(DependencyA a, DependencyB b, DependencyC c, DependencyD d, DependencyE e)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
+                _d = d;
+                _e = e;
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrFirst()
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrFirst(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrFirst(int i, int i2)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrFirst(int i, int i2, int i3)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrFirst(int i, int i2, int i3, int i4)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class TypeWith5ParametersToBeActivated_WithAttrLast
+        {
+            public DependencyA _a;
+            public DependencyB _b;
+            public DependencyC _c;
+            public DependencyD _d;
+            public DependencyE _e;
+
+            public TypeWith5ParametersToBeActivated_WithAttrLast()
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrLast(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrLast(int i, int i2)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrLast(int i, int i2, int i3)
+            {
+                throw new NotImplementedException();
+            }
+
+            public TypeWith5ParametersToBeActivated_WithAttrLast(int i, int i2, int i3, int i4)
+            {
+                throw new NotImplementedException();
+            }
+
+            [ActivatorUtilitiesConstructor]
+            public TypeWith5ParametersToBeActivated_WithAttrLast(DependencyA a, DependencyB b, DependencyC c, DependencyD d, DependencyE e)
+            {
+                _a = a;
+                _b = b;
+                _c = c;
+                _d = d;
+                _e = e;
+            }
+        }
+
+        public class TypeWithVaryingIncomingParametersToBeActivated
+        {
+            public TypeWithVaryingIncomingParametersToBeActivated(DependencyA a, DependencyB b, DependencyC c) { }
         }
 
         public class DependencyA { }


### PR DESCRIPTION
- Fixed up the benchmarks that said "DI picks this over the one below and calls". This will do a slight reset on these, but that is desired since they can't be compared against each other very well.
- Added benchmarks that use `[ActivatorUtilitiesConstructor]`. There is current work in DI that will improve perf here.
- Removed some unnecessary benchmarks that are either never used (0 args) or can be inferred by others (removed 2,4 args since they can be calculated by 1,3,5 args).

