### PR TITLE
Update BDN version to fix MonoAOT runs.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <MicrosoftNETILLinkTasksVersion>9.0.0-preview.3.24128.10</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkPackageVersion>9.0.0-preview.3.24128.10</MicrosoftNETILLinkPackageVersion>
-    <BenchmarkDotNetVersion>0.13.13-nightly.20240228.135</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.13-nightly.20240311.145</BenchmarkDotNetVersion>
     <SystemThreadingChannelsPackageVersion>9.0.0-preview.3.24128.10</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>9.0.0-preview.3.24128.10</MicrosoftExtensionsLoggingPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
Update BDN to include the https://github.com/dotnet/BenchmarkDotNet/pull/2541 fix.

