### PR TITLE
Clean up GCPerfSim Functional

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
@@ -2,7 +2,7 @@ output_path: C:\Outputs\GCPerfsimFunctionalTest
 gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 
 coreruns:
-  segments: 
+  segments:
     path: C:\runtime_rc2\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe
     environment_variables:
       COMPlus_GCName: clrgc.dll

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
@@ -5,14 +5,14 @@ coreruns:
   segments: 
     path: C:\runtime_rc2\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe
     environment_variables:
-        COMPlus_GCName: clrgc.dll
+      COMPlus_GCName: clrgc.dll
   regions:
     path: C:\runtime_ga\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe
     environment_variables:
-        COMPlus_GCName: clrgc.dll
+      COMPlus_GCName: clrgcexp.dll
 
 environment:
   environment_variables:
-    COMPlus_GCName: clrgc.dll 
+    COMPlus_GCServer: 1
 
-trace_configuration_type: gc # Choose between: none, gc, verbose, cpu, cpu_managed, threadtime, join.
+trace_configuration_type: none # Choose between: none, gc, verbose, cpu, cpu_managed, threadtime, join.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
@@ -23,7 +23,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
         {
             [Description("Path to Configuration.")]
             [CommandOption("-c|--configuration")]
-            public string? ConfigurationPath { get; init; }
+            public required string ConfigurationPath { get; init; }
 
             [Description("Crank Server to target.")]
             [CommandOption("-s|--server")]
@@ -377,8 +377,12 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             // modify trace_configurations
             gcPerfSimNormalWorkstationConfiguration.TraceConfigurations.Type = configuration.trace_configuration_type;
 
-            // load environment variables
-            gcPerfSimNormalWorkstationConfiguration.Environment.environment_variables = configuration.Environment.environment_variables;
+            // load environment variables by deep copying them.
+            gcPerfSimNormalWorkstationConfiguration.Environment.environment_variables = new Dictionary<string, string>();
+            foreach (var c in configuration.Environment.environment_variables)
+            {
+                gcPerfSimNormalWorkstationConfiguration.Environment.environment_variables[c.Key] = c.Value;
+            }
 
             return gcPerfSimNormalWorkstationConfiguration;
         }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
@@ -302,7 +302,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                 Path.Combine(configuration.output_path, "HighMemoryLoad");
 
             // modify name 
-            gcPerfSimHighMemoryLoadConfiguration.Name = "HighMemory_NormalServer";
+            gcPerfSimHighMemoryLoadConfiguration.Name = "HighMemoryLoad";
 
             SaveConfiguration(gcPerfSimHighMemoryLoadConfiguration, gcPerfSimSuitePath, "HighMemoryLoad.yaml");
         }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
@@ -1,19 +1,13 @@
-﻿using GC.Analysis.API;
-using GC.Infrastructure.Commands.RunCommand;
+﻿using GC.Infrastructure.Commands.RunCommand;
 using GC.Infrastructure.Core.Configurations;
 using GC.Infrastructure.Core.Configurations.GCPerfSim;
 using GC.Infrastructure.Core.Presentation;
 using Spectre.Console;
 using Spectre.Console.Cli;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Configuration;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 
 namespace GC.Infrastructure.Commands.GCPerfSim
@@ -53,9 +47,6 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             GCPerfSimFunctionalConfiguration configuration = GCPerfSimFunctionalConfigurationParser.Parse(configurationPath);
 
             // II. Create the test suite for gcperfsim functional tests.
-            string gcPerfSimOutputPath = Path.Combine(configuration.output_path, "GCPerfSim");
-            Core.Utilities.TryCreateDirectory(gcPerfSimOutputPath);
-
             string suitePath = Path.Combine(configuration.output_path, "Suites");
             string gcPerfSimSuitePath = Path.Combine(suitePath, "GCPerfSim_Functional");
 
@@ -108,8 +99,8 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                     yamlFileResultMap[yamlFileName] = gcperfsimResult;
 
                     sw.Stop();
-                    AnsiConsole.WriteLine($"Time to execute Msec: {sw.ElapsedMilliseconds}");
                 }
+
                 catch (Exception e)
                 {
                     Console.WriteLine(e.ToString());
@@ -152,16 +143,17 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                     string yamlFileName = yamlFileNameResultPair.Key;
                     GCPerfSimResults gcperfsimResult = yamlFileNameResultPair.Value;
 
-                    bool hasFailedTests = gcperfsimResult.ExecutionDetails.Any(
-                        executionDetail => executionDetail.Value.HasFailed == true);
+                    bool hasFailedTests = gcperfsimResult.ExecutionDetails.Any(executionDetail => executionDetail.Value.HasFailed);
 
-                    if (hasFailedTests == true)
+                    if (hasFailedTests)
                     {
                         resultWriter.AddIncompleteTestsSectionWithYamlFileName(
                             yamlFileName, new(gcperfsimResult.ExecutionDetails));
                     }
                 }
             }
+
+            AnsiConsole.MarkupLine($"[green bold] ({DateTime.Now}) Results written to: {markdownPath} [/]");
             return 0;
         }
 


### PR DESCRIPTION
- Some code clean up in GCPerfSim Functional.
- Fix an issue with deep copying environment variables. 
- Updated configuration to highlight all the features.
- Fixed cleaning up of the artifacts.