### PR TITLE
Only use 8.0 and 9.0 for perf-ci runs on main

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -479,7 +479,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     ci_setup_arguments.build_number = args.build_number
 
-    if branch is not None and not args.performance_repo_ci:
+    if branch is not None and not (args.performance_repo_ci and branch == "refs/heads/main"):
         ci_setup_arguments.branch = branch
 
     if args.perf_repo_hash is not None and not args.performance_repo_ci:


### PR DESCRIPTION
Setup performance-ci runs to only use the 9.0 and 8.0 branch from channel map when running for main to ensure non-main runs don't get included in main runs.


