### PR TITLE
Benchmark Parse/ToString with Large number

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime.Numerics/Perf.BigInteger.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Numerics/Perf.BigInteger.cs
@@ -17,6 +17,8 @@ namespace System.Numerics.Tests
             yield return new BigIntegerData("123");
             yield return new BigIntegerData(int.MinValue.ToString());
             yield return new BigIntegerData(string.Concat(Enumerable.Repeat("1234567890", 20)));
+            yield return new BigIntegerData(string.Concat(Enumerable.Repeat("1234567890", 2000)));
+            yield return new BigIntegerData(string.Concat(Enumerable.Repeat("1234567890", 1000)) + new string('0', 10000));
         }
 
         [Benchmark]


### PR DESCRIPTION
When a number of input digits is large, BigInteger.Parse works in a divide-and-conquer algorithm. https://github.com/dotnet/runtime/pull/55121
Therefore, I added two cases with a large number of digits.
The input with lots of trailing zeros is for https://github.com/dotnet/runtime/pull/97589.


## Related issues

- https://github.com/dotnet/runtime/pull/55121
- https://github.com/dotnet/runtime/pull/97101
- https://github.com/dotnet/runtime/pull/97589
