### PR TITLE
Added warning disables for the newly added CA2022

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.Context.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.Context.cs
@@ -54,9 +54,11 @@ namespace System.Net.Security.Tests
                 // In Tls1.3 part of handshake happens with data exchange.
                 // To be consistent we do this extra step for all protocol versions
                 await sslClient.WriteAsync(_clientBuffer, default);
+#pragma warning disable CA2022 // Avoid inexact read
                 await sslServer.ReadAsync(_serverBuffer, default);
                 await sslServer.WriteAsync(_serverBuffer, default);
                 await sslClient.ReadAsync(_clientBuffer, default);
+#pragma warning restore CA2022
             }
         }
 

--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.cs
@@ -151,9 +151,11 @@ namespace System.Net.Security.Tests
                 {
                     // In Tls1.3 part of handshake happens with data exchange.
                     await sslClient.WriteAsync(_clientBuffer, cts.Token);
+#pragma warning disable CA2022 // Avoid inexact read
                     await sslServer.ReadAsync(_serverBuffer, cts.Token);
                     await sslServer.WriteAsync(_serverBuffer, cts.Token);
                     await sslClient.ReadAsync(_clientBuffer, cts.Token);
+#pragma warning restore CA2022
                 }
             }
         }
@@ -189,11 +191,12 @@ namespace System.Net.Security.Tests
                         sslServer.AuthenticateAsServerAsync(serverOptions, cts.Token));
 
                 byte[] clientBuffer = new byte[1], serverBuffer = new byte[1];
-
                 await sslClient.WriteAsync(clientBuffer, cts.Token);
+#pragma warning disable CA2022 // Avoid inexact read
                 await sslServer.ReadAsync(serverBuffer, cts.Token);
                 await sslServer.WriteAsync(serverBuffer, cts.Token);
                 await sslClient.ReadAsync(clientBuffer, cts.Token);
+#pragma warning restore CA2022
             }
         }
 
@@ -208,7 +211,9 @@ namespace System.Net.Security.Tests
             for (int i = 0; i < ReadWriteIterations; i++)
             {
                 await _sslClient.WriteAsync(clientBuffer, default);
+#pragma warning disable CA2022 // Avoid inexact read
                 await _sslServer.ReadAsync(serverBuffer, default);
+#pragma warning restore CA2022
             }
         }
 
@@ -219,7 +224,9 @@ namespace System.Net.Security.Tests
             Memory<byte> clientBuffer = _largeClientBuffer;
             Memory<byte> serverBuffer = _largeServerBuffer;
             await _sslClient.WriteAsync(clientBuffer, default);
+#pragma warning disable CA2022 // Avoid inexact read
             await _sslServer.ReadAsync(serverBuffer, default);
+#pragma warning restore CA2022
         }
 
         [Benchmark(OperationsPerInvoke = ReadWriteIterations)]
@@ -256,6 +263,7 @@ namespace System.Net.Security.Tests
             Memory<byte> buffer1 = _clientBuffer;
             Memory<byte> buffer2 = _serverBuffer;
 
+#pragma warning disable CA2022 // Avoid inexact read
             Task other = Task.Run(async delegate
             {
                 _twoParticipantBarrier.SignalAndWait();
@@ -272,6 +280,7 @@ namespace System.Net.Security.Tests
                 await _sslClient.WriteAsync(buffer2, default);
                 await _sslServer.ReadAsync(buffer2, default);
             }
+#pragma warning restore CA2022 
 
             await other;
         }


### PR DESCRIPTION
Added warning disables for the newly added CA2022 warning about not reading SSL streams inexactly. This warning was added here: https://github.com/dotnet/roslyn-analyzers/pull/7208, but since we are just doing microbenchmarks, we should be clear to disable it.

This seems to fix the error based on locally testing before/after.



