### PR TITLE
Fix Wasm benchmark_local setup

### DIFF
--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -231,27 +231,26 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
         artifact_wasm_wasm = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmInterpreter, commit), "wasm_bundle")
         artifact_wasm_aot = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle")
         if force_regenerate or not os.path.exists(artifact_wasm_wasm) or not os.path.exists(artifact_wasm_aot):
+            dir_bin_wasm = os.path.join(repo_path, "artifacts", "bin", "wasm")
             build_runtime_dependency(parsed_args, repo_path, "mono+libs", os_override="browser", arch_override="wasm", additional_args=[f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
-            src_dir_dotnet_latest = os.path.join(repo_path, "artifacts", "BrowserWasm", "staging", "dotnet-latest")
-            dest_dir_wasm_dotnet = os.path.join(repo_path, "artifacts", "bin", "wasm", "dotnet")
+            src_dir_dotnet_latest = os.path.join(repo_path, "artifacts", "bin", "dotnet-latest")
+            dest_dir_wasm_dotnet = os.path.join(dir_bin_wasm, "dotnet")
             copy_directory_contents(src_dir_dotnet_latest, dest_dir_wasm_dotnet)
-            src_dir_built_nugets = os.path.join(repo_path, "artifacts", "BrowserWasm", "staging", "built-nugets")
-            dest_dir_bin_wasm = os.path.join(repo_path, "artifacts", "bin", "wasm")
-            copy_directory_contents(src_dir_built_nugets, dest_dir_bin_wasm)
+            src_dir_built_nugets = os.path.join(repo_path, "artifacts", "packages", "Release", "Shipping") # Goal is to copy Microsoft.NET.Sdk.WebAssembly.Pack*, Microsoft.NETCore.App.Ref*, either need to do the shipping folder or glob
+            copy_directory_contents(src_dir_built_nugets, dir_bin_wasm)
             # browser folder was extracted from wasm folder here: https://github.com/dotnet/runtime/pull/95940, so we need to check both locations for which to use (Dec, 2023)
             src_file_test_main = glob.glob(os.path.join(repo_path, "src", "mono", "*", "test-main.js"))[0]
-            dest_dir_wasm_data = os.path.join(repo_path, "artifacts", "bin", "wasm", "wasm-data")
+            dest_dir_wasm_data = os.path.join(dir_bin_wasm, "wasm-data")
             dest_file_test_main = os.path.join(dest_dir_wasm_data, "test-main.js")
             if not os.path.exists(dest_dir_wasm_data):
                 os.makedirs(dest_dir_wasm_data)
             shutil.copy2(src_file_test_main, dest_file_test_main)
 
             # Store the artifact in the artifact storage path
-            src_dir_dotnet_wasm = os.path.join(repo_path, "artifacts", "bin", "wasm")
             shutil.rmtree(artifact_wasm_wasm, ignore_errors=True)
-            copy_directory_contents(src_dir_dotnet_wasm, artifact_wasm_wasm)
+            copy_directory_contents(dir_bin_wasm, artifact_wasm_wasm)
             shutil.rmtree(artifact_wasm_aot, ignore_errors=True)
-            copy_directory_contents(src_dir_dotnet_wasm, artifact_wasm_aot)
+            copy_directory_contents(dir_bin_wasm, artifact_wasm_aot)
 
         else:
             getLogger().info("wasm_bundle already exists in %s and %s. Skipping generation.", artifact_wasm_wasm, artifact_wasm_aot)

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -262,6 +262,8 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
         else:
             getLogger().info("wasm_bundle already exists in %s and %s. Skipping generation.", artifact_wasm_wasm, artifact_wasm_aot)
 
+        getLogger().info("Finished generating dependencies for %s run types in %s and stored in %s.", ' '.join(map(str, parsed_args.run_type_names)), repo_path, parsed_args.artifact_storage_path)
+
 def generate_combined_benchmark_ci_args(parsed_args: Namespace, specific_run_type: RunType, all_commits: List[str]) -> List[str]:
     getLogger().info("Generating benchmark_ci.py arguments for %s run type using artifacts in %s.", specific_run_type.name, parsed_args.artifact_storage_path)
     bdn_args_unescaped: list[str] = []
@@ -406,6 +408,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--logBuildOutput',
             '--generateBinLog'
         ]
+        os.environ['RestoreAdditionalProjectSources'] = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmInterpreter, commit), "wasm_bundle")
 
     elif specific_run_type == RunType.WasmAOT:
         benchmark_ci_args += ['--wasm', '--dotnet-path', os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle", "dotnet")]
@@ -423,7 +426,6 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--generateBinLog',
         ]
         os.environ['RestoreAdditionalProjectSources'] = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle")
-
 
     if parsed_args.bdn_arguments:
         bdn_args_unescaped += [parsed_args.bdn_arguments]

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -423,7 +423,7 @@ def generate_single_benchmark_ci_args(parsed_args: Namespace, specific_run_type:
             '--wasmArgs', '\" --expose_wasm --module\"',
             '--aotcompilermode', 'wasm',
             '--logBuildOutput',
-            '--generateBinLog',
+            '--generateBinLog'
         ]
         os.environ['RestoreAdditionalProjectSources'] = os.path.join(get_run_artifact_path(parsed_args, RunType.WasmAOT, commit), "wasm_bundle")
 

--- a/scripts/benchmarks_local.py
+++ b/scripts/benchmarks_local.py
@@ -117,6 +117,12 @@ def build_runtime_dependency(parsed_args: Namespace, repo_path: str, subset: str
             ] + additional_args
     RunCommand(build_libs_and_corerun_command, verbose=True).run(os.path.join(repo_path, "eng"))
 
+def run_runtime_dotnet(repo_path: str, args: Optional[List[str]] = None):
+    if args is None:
+        args = []
+    dotnet_command = ["dotnet.sh"] + args
+    RunCommand(dotnet_command, verbose=True).run(repo_path)
+
 def generate_layout(parsed_args: Namespace, repo_path: str, additional_args: Optional[List[str]] = None):
     if additional_args is None:
         additional_args = []
@@ -233,7 +239,7 @@ def generate_all_runtype_dependencies(parsed_args: Namespace, repo_path: str, co
         if force_regenerate or not os.path.exists(artifact_wasm_wasm) or not os.path.exists(artifact_wasm_aot):
             dir_bin_wasm = os.path.join(repo_path, "artifacts", "bin", "wasm")
             build_runtime_dependency(parsed_args, repo_path, "mono+libs", os_override="browser", arch_override="wasm", additional_args=[f'/p:AotHostArchitecture={parsed_args.architecture}', f'/p:AotHostOS={parsed_args.os}'])
-            build_runtime_dependency(parsed_args, repo_path, subset="", os_override="browser", arch_override="wasm", additional_args=['/t:InstallWorkloadUsingArtifacts', os.path.join(repo_path, "src", "mono", "wasm", "Wasm.Build.Tests", "Wasm.Build.Tests.csproj")])
+            run_runtime_dotnet(repo_path, [ 'build', '-p:TargetOS=browser', '-p:TargetArchitecture=wasm', '/nr:false', '/p:TreatWarningsAsErrors=true', '/p:Configuration=Release', '-bl', '/t:InstallWorkloadUsingArtifacts', os.path.join(repo_path, "src", "mono", "wasm", "Wasm.Build.Tests", "Wasm.Build.Tests.csproj")])
             src_dir_dotnet_latest = os.path.join(repo_path, "artifacts", "bin", "dotnet-latest")
             dest_dir_wasm_dotnet = os.path.join(dir_bin_wasm, "dotnet")
             copy_directory_contents(src_dir_dotnet_latest, dest_dir_wasm_dotnet)


### PR DESCRIPTION
Fix Wasm benchmark_local setup. This includes changing to using the correct *-dev packages, calling the InstallWorkloadUsingArtifacts target, using the built dotnet rather than the passed default dotnet, and match the build paths to the latest build flow.