### PR TITLE
Disallowing using COMPlus_ has the prefix for environment variables. 

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/ASPNetBenchmarks/ASPNetBenchmarks.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/ASPNetBenchmarks/ASPNetBenchmarks.yaml
@@ -2,12 +2,12 @@ runs:
   baseline:
     corerun: C:\CoreRuns\Empty\
     environment_variables:
-      COMPlus_GCServer: 1
+      DOTNET_gcServer: 1
     framework_version: net6.0
   run:
     corerun: C:\CoreRuns\Empty\
     environment_variables:
-      COMPlus_GCServer: 1
+      DOTNET_gcServer: 1
 environment:
   environment_variables: {}
   default_max_seconds: 300

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
@@ -5,14 +5,14 @@ coreruns:
   segments:
     path: C:\runtime_rc2\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   regions:
     path: C:\runtime_ga\artifacts\tests\coreclr\windows.x64.Release\Tests\Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgcexp.dll
+      DOTNET_GCName: clrgcexp.dll
 
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
+    DOTNET_gcServer: 1
 
 trace_configuration_type: none # Choose between: none, gc, verbose, cpu, cpu_managed, threadtime, join.

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/HighMemory.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/HighMemory.yaml
@@ -10,7 +10,7 @@ runs:
       tlgb: 3 
       sohsi: 50
     environment_variables:
-      COMPlus_GCServer: 0
+      DOTNET_gcServer: 0
 
 # Top level microbenchmark configuration.
 gcperfsim_configurations:
@@ -39,19 +39,19 @@ coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 18
-    COMPlus_GCName: clrgc.dll 
-    COMPlus_GCHeapHardLimit: "0x100000000"
-    COMPlus_GCTotalPhysicalMemory: "0x100000000"
+    DOTNET_gcServer: 1
+    DOTNET_GCHeapCount: 18
+    DOTNET_GCName: clrgc.dll 
+    DOTNET_GCHeapHardLimit: "0x100000000"
+    DOTNET_GCTotalPhysicalMemory: "0x100000000"
   default_max_seconds: 300 
   iterations: 1 
 

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_NormalServer.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_NormalServer.yaml
@@ -52,11 +52,11 @@
   
   environment:
     environment_variables:
-      COMPlus_GCServer: 1
-      COMPlus_GCLargePages: 1
-      COMPlus_GCHeapHardLimitSOH: 0x800000000
-      COMPlus_GCHeapHardLimitLOH: 0x400000000
-      COMPlus_GCHeapHardLimitPOH: 0x100000000
+      DOTNET_gcServer: 1
+      DOTNET_GCLargePages: 1
+      DOTNET_GCHeapHardLimitSOH: 0x800000000
+      DOTNET_GCHeapHardLimitLOH: 0x400000000
+      DOTNET_GCHeapHardLimitPOH: 0x100000000
     default_max_seconds: 300 
     iterations: 1 
   

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Server.yaml
@@ -44,23 +44,23 @@ gcperfsim_configurations:
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 12
-    COMPlus_GCLargePages: 1
-    COMPlus_GCHeapHardLimitSOH: 0x800000000
-    COMPlus_GCHeapHardLimitLOH: 0x400000000
-    COMPlus_GCHeapHardLimitPOH: 0x100000000
+    DOTNET_gcServer: 1
+    DOTNET_GCHeapCount: 12
+    DOTNET_GCLargePages: 1
+    DOTNET_GCHeapHardLimitSOH: 0x800000000
+    DOTNET_GCHeapHardLimitLOH: 0x400000000
+    DOTNET_GCHeapHardLimitPOH: 0x100000000
   default_max_seconds: 300
   iterations: 1
 coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\RunNew_All\GCPerfSim\LargePages_Server

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Workstation.yaml
@@ -44,22 +44,22 @@ gcperfsim_configurations:
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 environment:
   environment_variables:
-    COMPlus_GCServer: 0
-    COMPlus_GCLargePages: 1
-    COMPlus_GCHeapHardLimitSOH: 0x800000000
-    COMPlus_GCHeapHardLimitLOH: 0x400000000
-    COMPlus_GCHeapHardLimitPOH: 0x100000000
+    DOTNET_gcServer: 0
+    DOTNET_GCLargePages: 1
+    DOTNET_GCHeapHardLimitSOH: 0x800000000
+    DOTNET_GCHeapHardLimitLOH: 0x400000000
+    DOTNET_GCHeapHardLimitPOH: 0x100000000
   default_max_seconds: 300
   iterations: 1
 coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\RunNew_All\GCPerfSim\LargePages_Workstation

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowMemoryContainer.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowMemoryContainer.yaml
@@ -11,8 +11,8 @@ runs:
       tc: 2 
       tlgb: 0.5
     environment_variables:
-      COMPlus_GCServer: 0
-      COMPlus_GCHeapCount: 1 
+      DOTNET_gcServer: 0
+      DOTNET_GCHeapCount: 1 
       
 # Top level microbenchmark configuration.
 gcperfsim_configurations:
@@ -41,18 +41,18 @@ coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 4 
-    COMPlus_GCHeapHardLimit: "0x23C34600"
-    COMPlus_GCTotalPhysicalMemory: "0x23C34600"
+    DOTNET_gcServer: 1
+    DOTNET_GCHeapCount: 4 
+    DOTNET_GCHeapHardLimit: "0x23C34600"
+    DOTNET_GCTotalPhysicalMemory: "0x23C34600"
   default_max_seconds: 300 
   iterations: 1 
 

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -51,19 +51,19 @@ gcperfsim_configurations:
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 12
+    DOTNET_gcServer: 1
+    DOTNET_GCHeapCount: 12
   default_max_seconds: 300
   iterations: 1
 coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\GCPerfSim\

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
@@ -44,19 +44,19 @@ gcperfsim_configurations:
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
-    COMPlus_GCHeapCount: 12
+    DOTNET_gcServer: 1
+    DOTNET_GCHeapCount: 12
   default_max_seconds: 300
   iterations: 1
 coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\RunNew_All\GCPerfSim\Normal_Server_

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Workstation.yaml
@@ -44,18 +44,18 @@ gcperfsim_configurations:
   gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
 environment:
   environment_variables:
-    COMPlus_GCServer: 0
+    DOTNET_gcServer: 0
   default_max_seconds: 300
   iterations: 1
 coreruns:
   baseline:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
   run:
     path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 linux_coreruns: 
 output:
   path: C:\InfraRuns\RunNew_All\GCPerfSim\Normal_Workstation

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/SampleCrank.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/SampleCrank.yaml
@@ -5,7 +5,7 @@
 # - How to get custom corerun: both as commits and locally.
 #   --application.options.outputFiles c:\git\runtime\artifacts\bin\coreclr\windows.x64.Release\clrgc.dll
 # - How to get environment variables set.
-#   --application.environmentVariables COMPlus_GCName=clrgc.dll 
+#   --application.environmentVariables DOTNET_GCName=clrgc.dll 
 
 # crank --config C:\Users\musharm\source\repos\GC.Analysis.API\ExampleConfigurations\GCPerfSim\SampleCrank.yaml --scenario gcperfsim --profile aspnet-perf-win --application.variables.threadCount 2 --application.options.displayOutput true --application.framework net7.0 --profile pgo --application.cpuSet 1 --application.options.collectCounters true --chart --json Result_1.json --property cpu=2
 # crank --config C:\Users\musharm\source\repos\GC.Analysis.API\ExampleConfigurations\GCPerfSim\SampleCrank.yaml --scenario gcperfsim --application.variables.tc 2 --application.options.displayOutput true --application.framework net7.0 --profile aspnet-citrine-win --application.collect true --application.collectArguments GCCollectOnly --application.cpuSet 0-1 --application.options.collectCounters true --chart --application.options.downloadOutput true  --application.options.downloadOutputOutput ".\gc.etl.zip"  --application.options.traceOutput "./gc.etl.zip"
@@ -98,7 +98,7 @@ scenarios:
     application:
       job: gcperfsim
       environmentVariables:
-        COMPlus_GCServer: 1
+        DOTNET_gcServer: 1
       variables:
         threadCount: 1
 
@@ -116,6 +116,6 @@ scenarios:
     application:
       job: gcperfsim
       environmentVariables:
-        COMPlus_GCServer: 1
+        DOTNET_gcServer: 1
       variables:
         threadCount: 1

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Server.yaml
@@ -6,16 +6,16 @@ runs:
     corerun: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     is_baseline: true
     environment_variables:
-      COMPlus_GCName: clrgc.dll
-      COMPlus_GCServer: 1
+      DOTNET_GCName: clrgc.dll
+      DOTNET_gcServer: 1
   run:
     dotnet_installer: 
     name: run
     corerun: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     is_baseline: false
     environment_variables:
-      COMPlus_GCName: clrgc.dll
-      COMPlus_GCServer: 1
+      DOTNET_GCName: clrgc.dll
+      DOTNET_gcServer: 1
 microbenchmark_configurations:
   filter: 
   filter_path: C:\InfraRuns\RunNew_All\Suites\Microbenchmark\MicrobenchmarksToRun.txt

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Workstation.yaml
@@ -6,16 +6,16 @@ runs:
     corerun: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     is_baseline: true
     environment_variables:
-      COMPlus_GCName: clrgc.dll
-      COMPlus_GCServer: 0
+      DOTNET_GCName: clrgc.dll
+      DOTNET_gcServer: 0
   run:
     dotnet_installer: 
     name: run
     corerun: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
     is_baseline: false
     environment_variables:
-      COMPlus_GCName: clrgc.dll
-      COMPlus_GCServer: 0
+      DOTNET_GCName: clrgc.dll
+      DOTNET_gcServer: 0
 microbenchmark_configurations:
   filter: 
   filter_path: C:\InfraRuns\RunNew_All\Suites\Microbenchmark\MicrobenchmarksToRun.txt

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
@@ -6,11 +6,11 @@ coreruns:
     baseline: 
       path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
       environment_variables:
-          COMPlus_GCName: clrgc.dll
+          DOTNET_GCName: clrgc.dll
     run:
       path: C:\CoreRuns\EmitEvent_Core_Root\corerun.exe
       environment_variables:
-          COMPlus_GCName: clrgc.dll
+          DOTNET_GCName: clrgc.dll
 
 trace_configuration_type: gc # Choose between: none, gc, verbose, cpu, cpu_managed, threadtime, join.
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkConfigurationsSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkConfigurationsSpecified.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Configurations that involve capturing a trace.
 trace_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkFilterSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkFilterSpecified.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Top level microbenchmark configuration.
 microbenchmark_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkFrameworkVersionSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoMicrobenchmarkFrameworkVersionSpecified.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Top level microbenchmark configuration.
 microbenchmark_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoOutputSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoOutputSpecified.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Top level microbenchmark configuration.
 microbenchmark_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoTraceConfigurationTypeSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/NoTraceConfigurationTypeSpecified.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Top level microbenchmark configuration.
 microbenchmark_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration.yaml
@@ -1,28 +1,28 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
 
 # Top level microbenchmark configuration.
 microbenchmark_configurations:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration_BDNArgumentsSpecified.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration_BDNArgumentsSpecified.yaml
@@ -1,32 +1,32 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
     framework_version: net6.0
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
 # Top level microbenchmark configuration.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration_OverridingFramework.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/Microbenchmarks/Configurations/SimpleValidConfiguration_OverridingFramework.yaml
@@ -1,32 +1,32 @@
 ﻿runs:
   heapcount_1:
     environment_variables:
-      COMPLUS_GCHeapCount: 1 
-      COMPLUS_GCServer: 0 
+      DOTNET_GCHeapCount: 1 
+      DOTNET_gcServer: 0 
     framework_version: net6.0
 
   heapcount_2:
     environment_variables:
-      COMPLUS_GCHeapCount: 2 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 2 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_3:
     environment_variables:
-      COMPLUS_GCHeapCount: 3 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 3 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_4:
     environment_variables:
-      COMPLUS_GCHeapCount: 4 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 4 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
   heapcount_5:
     environment_variables:
-      COMPLUS_GCHeapCount: 5 
-      COMPLUS_GCServer: 1 
+      DOTNET_GCHeapCount: 5 
+      DOTNET_gcServer: 1 
     framework_version: net6.0
 
 # Top level microbenchmark configuration.

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/ASPNetBenchmarks.CommandBuilder.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/ASPNetBenchmarks.CommandBuilder.cs
@@ -37,8 +37,7 @@ namespace GC.Infrastructure.Core.CommandBuilders
 
                 // Check if the log file is specified, also add the fact that we want to retrieve the log file back.
                 // This log file should be named in concordance with the name of the run and the benchmark.
-                if (string.CompareOrdinal(env.Key, "DOTNET_GCLogFile") == 0 ||
-                    string.CompareOrdinal(env.Key, "COMPlus_GCLogFile") == 0)
+                if (string.CompareOrdinal(env.Key, "DOTNET_GCLogFile") == 0)
                 {
                     string fileNameOfLog = Path.GetFileName(env.Value);
                     commandStringBuilder.Append( $" --application.options.downloadFiles \"*{fileNameOfLog}.log\" " );

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
@@ -59,6 +59,19 @@
                 throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration)} is null. Check the syntax of the configuration.");
             }
 
+            // Check for any COMPlus_ environment variables.
+            if (configuration.Environment != null)
+            {
+                ConfigurationChecker.VerifyEnvironmentVariables(configuration.Environment.environment_variables, $"{nameof(ASPNetBenchmarksConfigurationParser)}");
+            }
+            if (configuration.Runs != null)
+            {
+                foreach (var run in configuration.Runs)
+                {
+                    ConfigurationChecker.VerifyEnvironmentVariables(run.Value.environment_variables, $"{nameof(ASPNetBenchmarksConfigurationParser)} for Run: {run.Key}");
+                }
+            }
+
             return configuration;
         }
     }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Common.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Common.cs
@@ -34,5 +34,25 @@ namespace GC.Infrastructure.Core.Configurations
                 throw new ArgumentNullException($"{prefix}: A yaml file wasn't provided as the configuration.");
             }
         }
+
+        public static void VerifyEnvironmentVariables(Dictionary<string, string>? environmentVariables, string prefix)
+        {
+            // If there are no environment variables set, ignore.
+            if (environmentVariables == null)
+            {
+                return;
+            }
+
+            else
+            {
+                foreach (var env in environmentVariables)
+                {
+                    if (env.Key.ToLower().StartsWith("complus_"))
+                    {
+                        throw new ArgumentException($"{prefix}: COMPlus Environment variables are disallowed. Please replace it with it's DOTNET equivalent.");
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSim.Configuration.cs
@@ -125,6 +125,18 @@ namespace GC.Infrastructure.Core.Configurations.GCPerfSim
                 configuration.Output!.Path = Directory.GetCurrentDirectory();
             }
 
+            // Check if the user passes any COMPlus environment variables.
+            ConfigurationChecker.VerifyEnvironmentVariables(configuration.Environment.environment_variables, $"{nameof(GCPerfSimConfigurationParser)}");
+            foreach (var corerun in configuration.coreruns)
+            {
+                ConfigurationChecker.VerifyEnvironmentVariables(corerun.Value.environment_variables, $"{nameof(GCPerfSimConfigurationParser)} for Corerun: {corerun.Key}");
+            }
+
+            foreach (var run in configuration.Runs!)
+            {
+                ConfigurationChecker.VerifyEnvironmentVariables(run.Value.environment_variables, $"{nameof(GCPerfSimConfigurationParser)} for Run: {run.Key}");
+            }
+
             return configuration;
         }
     }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSimFunctional.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/GCPerfSimFunctional.Configuration.cs
@@ -1,4 +1,5 @@
 using GC.Infrastructure.Core.Configurations.GCPerfSim;
+using GC.Infrastructure.Core.Configurations.Microbenchmarks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -57,6 +58,13 @@ namespace GC.Infrastructure.Core.Configurations
             {
                 throw new ArgumentException($"{nameof(GCPerfSimFunctionalConfigurationParser)}: Please provide the trace_configuration type");
             }
+
+            // Check if COMPlus_ environment variables.
+            foreach (var run in configuration.coreruns!)
+            {
+                ConfigurationChecker.VerifyEnvironmentVariables(run.Value.environment_variables, $"{nameof(GCPerfSimFunctionalConfigurationParser)} for Run: {run.Key}");
+            }
+            ConfigurationChecker.VerifyEnvironmentVariables(configuration.Environment.environment_variables, $"{nameof(GCPerfSimFunctionalConfigurationParser)}");  
 
             return configuration;
         }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/InputConfiguration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/InputConfiguration.cs
@@ -45,6 +45,13 @@
                 throw new ArgumentException($"{nameof(InputConfigurationParser)}: A path to the microbenchmarks must be provided or exist.");
             }
 
+            // Check if the user passes any COMPlus environment variables.
+            ConfigurationChecker.VerifyEnvironmentVariables(configuration.environment_variables, $"{nameof(InputConfigurationParser)}");
+            foreach (var run in configuration.coreruns)
+            {
+                ConfigurationChecker.VerifyEnvironmentVariables(run.Value.environment_variables, $"{nameof(InputConfigurationParser)} with Run {run.Key}");
+            }
+
             return configuration;
         }
     }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Microbenchmarks.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Microbenchmarks.Configuration.cs
@@ -80,6 +80,15 @@ namespace GC.Infrastructure.Core.Configurations.Microbenchmarks
                 throw new ArgumentNullException($"{nameof(MicrobenchmarkConfigurationParser)}: {nameof(configuration.TraceConfigurations.Type)} is null or empty. This value should be specified if the a 'trace_configurations' node is added");
             }
 
+            // Check if COMPlus_ environment variables.
+            if (configuration.Runs != null)
+            {
+                foreach (var run in configuration.Runs!)
+                {
+                    ConfigurationChecker.VerifyEnvironmentVariables(run.Value.environment_variables, $"{nameof(MicrobenchmarkConfigurationParser)} for Run: {run.Key}");
+                }
+            }
+
             return configuration;
         }
     }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimFunctionalCommand.cs
@@ -166,8 +166,8 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             gcPerfSimNormalServerConfiguration.gcperfsim_configurations.Parameters["tagb"] = "100";
 
             // modify environment
-            gcPerfSimNormalServerConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            gcPerfSimNormalServerConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = _logicalProcessors.ToString("X");
+            gcPerfSimNormalServerConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            gcPerfSimNormalServerConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = _logicalProcessors.ToString("X");
 
             // modify output
             gcPerfSimNormalServerConfiguration.Output.Path =
@@ -224,8 +224,8 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                 },
                 environment_variables = new Dictionary<string, string>()
                 {
-                    {"COMPlus_GCServer", "0" },
-                    {"COMPlus_GCHeapCount", "1" },
+                    {"DOTNET_gcServer", "0" },
+                    {"DOTNET_GCHeapCount", "1" },
                 }
             };
 
@@ -238,10 +238,10 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                 configuration.gcperfsim_path;
 
             // modify environment
-            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = "4";
-            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x23C34600";
-            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["COMPlus_GCTotalPhysicalMemory"] = "0x23C34600";
+            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = "4";
+            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x23C34600";
+            gcPerfSimLowMemoryContainerConfiguration.Environment.environment_variables["DOTNET_GCTotalPhysicalMemory"] = "0x23C34600";
 
             // modify output
             gcPerfSimLowMemoryContainerConfiguration.Output.Path =
@@ -278,7 +278,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                 },
                 environment_variables = new Dictionary<string, string>()
                 {
-                    {"COMPlus_GCServer", "0" },
+                    {"DOTNET_gcServer", "0" },
                 }
             };
 
@@ -290,12 +290,12 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                 configuration.gcperfsim_path;
 
             // modify environment
-            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = _logicalProcessors.ToString("X");
+            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = _logicalProcessors.ToString("X");
 
             // add environment variables in GCPerfSimFunctionalRun.yaml
-            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x100000000";
-            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["COMPlus_GCTotalPhysicalMemory"] = "0x100000000";
+            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x100000000";
+            gcPerfSimHighMemoryLoadConfiguration.Environment.environment_variables["DOTNET_GCTotalPhysicalMemory"] = "0x100000000";
 
             // modify output
             gcPerfSimHighMemoryLoadConfiguration.Output.Path =
@@ -316,12 +316,12 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             gcPerfSimLargePages_ServerConfiguration.gcperfsim_configurations.Parameters["tagb"] = "100";
 
             // modify environment
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = _logicalProcessors.ToString("X");
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCLargePages"] = "1";
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitSOH"] = "0x800000000";
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitLOH"] = "0x400000000";
-            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitPOH"] = "0x100000000";
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = _logicalProcessors.ToString("X");
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_GCLargePages"] = "1";
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitSOH"] = "0x800000000";
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitLOH"] = "0x400000000";
+            gcPerfSimLargePages_ServerConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitPOH"] = "0x100000000";
 
             // modify output
             gcPerfSimLargePages_ServerConfiguration.Output.Path =
@@ -342,12 +342,12 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             gcPerfSimLargePages_WorkstationConfiguration.gcperfsim_configurations.Parameters["tagb"] = "100";
 
             // modify environment
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = _logicalProcessors.ToString("X");
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCLargePages"] = "1";
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitSOH"] = "0x800000000";
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitLOH"] = "0x400000000";
-            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimitPOH"] = "0x100000000";
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = _logicalProcessors.ToString("X");
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_GCLargePages"] = "1";
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitSOH"] = "0x800000000";
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitLOH"] = "0x400000000";
+            gcPerfSimLargePages_WorkstationConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimitPOH"] = "0x100000000";
 
             // modify output
             gcPerfSimLargePages_WorkstationConfiguration.Output.Path =

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/GCPerfSim_Normal_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/GCPerfSim_Normal_Workstation.yaml
@@ -46,7 +46,7 @@ gcperfsim_configurations:
 
 environment:
   environment_variables:
-    COMPlus_GCServer: 0 
+    DOTNET_gcServer: 0 
   default_max_seconds: 300
   iterations: 1
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/LowVolatilityRuns.yaml
@@ -50,7 +50,7 @@ gcperfsim_configurations:
     testKind: time
 environment:
   environment_variables:
-    COMPlus_GCServer: 1
+    DOTNET_gcServer: 1
   default_max_seconds: 300
   iterations: 1
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
@@ -130,7 +130,7 @@ namespace GC.Infrastructure.Commands.RunCommand
                 // ASPNET benchmarks is any file that gets uploaded to the servers
                 foreach (var envVars in r.Value.environment_variables)
                 {
-                    if (string.CompareOrdinal(envVars.Key, "COMPlus_GCName") == 0 ||
+                    if (string.CompareOrdinal(envVars.Key, "DOTNET_GCName") == 0 ||
                         string.CompareOrdinal(envVars.Key, "DOTNET_GCName") == 0 )
                     {
                         string directoryOfCorerun = Path.GetDirectoryName(r.Value.Path)!;
@@ -182,7 +182,7 @@ namespace GC.Infrastructure.Commands.RunCommand
                     r.Value.environment_variables = new();
                 }
 
-                r.Value.environment_variables["COMPlus_GCServer"] = "0";
+                r.Value.environment_variables["DOTNET_gcServer"] = "0";
             }
 
             workstation.Name = "Workstation";
@@ -200,7 +200,7 @@ namespace GC.Infrastructure.Commands.RunCommand
                     r.Value.environment_variables = new();
                 }
 
-                r.Value.environment_variables["COMPlus_GCServer"] = "1";
+                r.Value.environment_variables["DOTNET_gcServer"] = "1";
             }
             server.microbenchmarks_path = inputConfiguration.microbenchmark_path;
             server.Output.Path = Path.Combine(microbenchmarkOutputPath, "Server");
@@ -309,8 +309,8 @@ namespace GC.Infrastructure.Commands.RunCommand
             normalServerCase.gcperfsim_configurations.Parameters["tagb"] = (30 * logicalProcessors).ToString();
 
             // Set the environment variables appropriately.
-            normalServerCase.Environment.environment_variables["COMPlus_GCServer"]    = "1";
-            normalServerCase.Environment.environment_variables["COMPlus_GCHeapCount"] = logicalProcessors.ToString("x");
+            normalServerCase.Environment.environment_variables["DOTNET_gcServer"]    = "1";
+            normalServerCase.Environment.environment_variables["DOTNET_GCHeapCount"] = logicalProcessors.ToString("x");
             normalServerCase.Name = Path.GetFileNameWithoutExtension(name);
 
             return normalServerCase;
@@ -335,16 +335,16 @@ namespace GC.Infrastructure.Commands.RunCommand
             workstationRun.override_parameters["tlgb"] = "3";
             workstationRun.override_parameters["sohsi"] = "50";
             workstationRun.environment_variables = new();
-            workstationRun.environment_variables["COMPlus_GCServer"] = "0";
+            workstationRun.environment_variables["DOTNET_gcServer"] = "0";
             highMemoryConfiguration.Runs.Add("workstation", workstationRun);
 
-            highMemoryConfiguration.Environment.environment_variables["COMPlus_GCServer"] = "1";
+            highMemoryConfiguration.Environment.environment_variables["DOTNET_gcServer"] = "1";
             int logicalProcessors = GetAppropriateLogicalProcessors();
-            highMemoryConfiguration.Environment.environment_variables["COMPlus_GCHeapCount"] = logicalProcessors.ToString("x");
+            highMemoryConfiguration.Environment.environment_variables["DOTNET_GCHeapCount"] = logicalProcessors.ToString("x");
 
             // Add the appropriate environment variables.
-            highMemoryConfiguration.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x100000000";
-            highMemoryConfiguration.Environment.environment_variables["COMPlus_GCTotalPhysicalMemory"] = "0x100000000";
+            highMemoryConfiguration.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x100000000";
+            highMemoryConfiguration.Environment.environment_variables["DOTNET_GCTotalPhysicalMemory"] = "0x100000000";
             highMemoryConfiguration.Name = name;
             return highMemoryConfiguration;
         }
@@ -370,15 +370,15 @@ namespace GC.Infrastructure.Commands.RunCommand
             workstationRun.override_parameters["tagb"] = "100";
             workstationRun.override_parameters["tlgb"] = "0.5";
             workstationRun.environment_variables = new();
-            workstationRun.environment_variables["COMPlus_GCServer"] = "0";
+            workstationRun.environment_variables["DOTNET_gcServer"] = "0";
             lowMemoryConfigurationCase.Runs.Add("workstation", workstationRun);
 
-            lowMemoryConfigurationCase.Environment.environment_variables["COMPlus_GCServer"] = "1";
-            lowMemoryConfigurationCase.Environment.environment_variables["COMPlus_GCHeapCount"] = "4";
+            lowMemoryConfigurationCase.Environment.environment_variables["DOTNET_gcServer"] = "1";
+            lowMemoryConfigurationCase.Environment.environment_variables["DOTNET_GCHeapCount"] = "4";
 
             // Add the appropriate environment variables.
-            lowMemoryConfigurationCase.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x23C34600";
-            lowMemoryConfigurationCase.Environment.environment_variables["COMPlus_GCTotalPhysicalMemory"] = "0x23C34600";
+            lowMemoryConfigurationCase.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x23C34600";
+            lowMemoryConfigurationCase.Environment.environment_variables["DOTNET_GCTotalPhysicalMemory"] = "0x23C34600";
             lowMemoryConfigurationCase.Name = name;
             return lowMemoryConfigurationCase;
         }
@@ -386,9 +386,9 @@ namespace GC.Infrastructure.Commands.RunCommand
         internal static GCPerfSimConfiguration CreateLargePagesWithServer(InputConfiguration inputConfiguration, string name)
         {
             GCPerfSimConfiguration largePagesServer = CreateNormalServerCase(inputConfiguration, name);
-            largePagesServer.Environment.environment_variables["COMPlus_GCLargePages"] = "1";
+            largePagesServer.Environment.environment_variables["DOTNET_GCLargePages"] = "1";
             // This is a particularly memory intensive test that needs to be revisited. (~40 GB needed)
-            largePagesServer.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x960000000";
+            largePagesServer.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x960000000";
             largePagesServer.Name = name;
             return largePagesServer;
         }
@@ -396,9 +396,9 @@ namespace GC.Infrastructure.Commands.RunCommand
         internal static GCPerfSimConfiguration CreateLargePagesWithWorkstation(InputConfiguration inputConfiguration, string name)
         {
             GCPerfSimConfiguration largePagesWorkstation = GetBaseConfiguration(inputConfiguration, name);
-            largePagesWorkstation.Environment.environment_variables["COMPlus_GCLargePages"] = "1";
+            largePagesWorkstation.Environment.environment_variables["DOTNET_GCLargePages"] = "1";
             // This is a particularly memory intensive test that needs to be revisited. (~40 GB needed)
-            largePagesWorkstation.Environment.environment_variables["COMPlus_GCHeapHardLimit"] = "0x960000000";
+            largePagesWorkstation.Environment.environment_variables["DOTNET_GCHeapHardLimit"] = "0x960000000";
             largePagesWorkstation.Name = name;
             return largePagesWorkstation;
         }

--- a/src/benchmarks/gc/GC.Infrastructure/README.md
+++ b/src/benchmarks/gc/GC.Infrastructure/README.md
@@ -148,7 +148,7 @@ The ASP.NET benchmarks can be run without any of the users changes however, if t
 This can be accomplished by specifying either a file or a directory as the corerun path of a particular run:
 
 As an example, if I were to only update ``gc.cpp`` and build a standalone ``clrgc.dll``, specifically set the ``corerun`` field of the said run to the path of the ``clrgc.dll``.
-NOTE: the environment variable ``COMPlus_GCName`` must be set in this case:
+NOTE: the environment variable ``DOTNET_GCName`` must be set in this case:
 
 1. Assume your ``clrgc.dll`` is placed in ``C:\ASPNETUpload``:  
 
@@ -164,10 +164,10 @@ runs:
   run:
     corerun: C:\ASPNetUpload\clrgc.dll
     environment_variables:
-      COMPlus_GCName: clrgc.dll # This environment variable was set.
+      DOTNET_GCName: clrgc.dll # This environment variable was set.
 ```
 
-NOTE: For this case, ensure the environment variable ``COMPlus_GCName`` or ``DOTNET_GCName`` is set to clrgc.dll.
+NOTE: For this case, ensure the environment variable ``DOTNET_GCName`` or ``DOTNET_GCName`` is set to clrgc.dll.
 
 On the other hand, if you want upload the entire directory, say ``C:\ASPNETUpload2``, simply set the path to the directory in the corerun of a corerun:
 
@@ -176,7 +176,7 @@ runs:
   run:
     corerun: C:\ASPNetUpload2
     environment_variables:
-      COMPlus_GCName: clrgc.dll
+      DOTNET_GCName: clrgc.dll
 ```
 
 ###### Updating Which Benchmarks to Run

--- a/src/benchmarks/gc/GC.Infrastructure/README.md
+++ b/src/benchmarks/gc/GC.Infrastructure/README.md
@@ -167,7 +167,7 @@ runs:
       DOTNET_GCName: clrgc.dll # This environment variable was set.
 ```
 
-NOTE: For this case, ensure the environment variable ``DOTNET_GCName`` or ``DOTNET_GCName`` is set to clrgc.dll.
+NOTE: For this case, ensure the environment variable ``DOTNET_GCName`` is set to clrgc.dll.
 
 On the other hand, if you want upload the entire directory, say ``C:\ASPNETUpload2``, simply set the path to the directory in the corerun of a corerun:
 


### PR DESCRIPTION
Disallowing using COMPlus_ has the prefix for environment variables and therefore, this PR entails:

1. Updating all instances in the configurations. 
2. Adding checks that throw an exception in case COMPlus env vars are used. 
3. Updated readme. 

The reason for this PR is to ensure we aren't losing out on the application of environment variables for NativeAoT and ensuring some degree of consistency of how we set environment variables.

Replacing https://github.com/dotnet/performance/pull/3815 