### PR TITLE
Remove old JIT perf lab experiments; add block layout experiment

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -414,14 +414,12 @@ def main(args: Any):
     if args.r2r_status == 'nor2r':
         r2r_config = variable_format % ('DOTNET_ReadyToRun', '0')
 
-    if args.experiment_name == "crossblocklocalassertionprop":
-        experiment_config = variable_format % ('DOTNET_JitEnableCrossBlockLocalAssertionProp', '1')
-    elif args.experiment_name == "gdv3":
-        experiment_config = variable_format % ('DOTNET_JitGuardedDevirtualizationMaxTypeChecks', '3')
-    elif args.experiment_name == "rlcse":
+    if args.experiment_name == "rlcse":
         experiment_config = variable_format % ('DOTNET_JitRLCSEGreedy', '1')
     elif args.experiment_name == "jitoptrepeat":
         experiment_config = variable_format % ('DOTNET_JitOptRepeat', '*')
+    elif args.experiment_name == "rpolayout":
+        experiment_config = variable_format % ('DOTNET_JitDoReversePostOrderLayout', '*')
 
     output = ''
 


### PR DESCRIPTION
cc @AndyAyersMS @EgorBo, this retires the gdv3 and cross-block assertion prop experiments.
@DrewScoggins @caaavik-msft PTAL, thank you!

Requires https://github.com/dotnet/runtime/pull/101852