### PR TITLE
Add benchmark for Base64.IsValid(int)

### DIFF
--- a/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
+++ b/src/benchmarks/micro/libraries/System.Buffers/Base64Tests.cs
@@ -81,6 +81,17 @@ namespace System.Buffers.Text.Tests
         [Benchmark]
         public bool ConvertTryFromBase64Chars() => Convert.TryFromBase64Chars(_encodedChars, _decodedBytes, out _);
 #endif
+
+#if NET8_0_OR_GREATER // API added in .NET 8.0
+        [GlobalSetup(Target = nameof(Base64IsValid))]
+        public void SetupBase64IsValid()
+        {
+            _encodedBytes = ValuesGenerator.ArrayBase64EncodingBytes(NumberOfBytes);
+        }
+
+        [Benchmark]
+        public bool Base64IsValid() => Base64.IsValid(_encodedBytes);
+#endif
     }
 
     // We want to test InPlace methods, which require fresh input for every benchmark invocation.


### PR DESCRIPTION
Add benchmark for `Base64.IsValid(int)` as its being updated and implementation will be shared with the new `Base64Url.IsValid(int)` API


