### PR TITLE
Update core-sdk url to point at sdk instead.

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -345,7 +345,7 @@ def main(args: Any):
     verbose = not args.quiet
     setup_loggers(verbose=verbose)
 
-    # if repository is not set, then we are doing a core-sdk in performance repo run
+    # if repository is not set, then we are doing a sdk in performance repo run
     # if repository is set, user needs to supply the commit_sha
     use_core_sdk = args.repository is None
     if not ((args.commit_sha is None) == use_core_sdk):
@@ -397,7 +397,7 @@ def main(args: Any):
     path_variable = 'set PATH=%s;%%PATH%%\n' if args.target_windows else 'export PATH=%s:$PATH\n'
     which = 'where dotnet\n' if args.target_windows else 'which dotnet\n'
     dotnet_path = '%HELIX_CORRELATION_PAYLOAD%\\dotnet' if args.target_windows else '$HELIX_CORRELATION_PAYLOAD/dotnet'
-    owner, repo = ('dotnet', 'core-sdk') if repo_url is None else (dotnet.get_repository(repo_url))
+    owner, repo = ('dotnet', 'sdk') if repo_url is None else (dotnet.get_repository(repo_url))
     config_string = ';'.join(args.build_configs) if args.target_windows else "%s" % ';'.join(args.build_configs)
     pgo_config = ''
     physical_promotion_config = ''

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -631,7 +631,7 @@ def get_commit_date(
         # The origin of the repo where the commit belongs to has changed
         # between release. Here we attempt to naively guess the repo.
         core_sdk_frameworks = ChannelMap.get_supported_frameworks()
-        repo = 'core-sdk' if framework  in core_sdk_frameworks else 'cli'
+        repo = 'sdk' if framework in core_sdk_frameworks else 'cli'
         url = f'https://github.com/dotnet/{repo}/commit/{commit_sha}.patch'
     else:
         owner, repo = get_repository(repository)


### PR DESCRIPTION
[dotnet/installer](https://github.com/dotnet/installer) (core-sdk) recently moved to [dotnet/sdk](https://github.com/dotnet/sdk). This updates so we check from [dotnet/sdk](https://github.com/dotnet/sdk) instead of [dotnet/installer](https://github.com/dotnet/installer)