### PR TITLE
Use full dotnet version instead of the version in file path

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -447,7 +447,7 @@ def main(args: Any):
 
     if not framework.startswith('net4'):
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
-        dotnet_version = dotnet.get_dotnet_sdk_version_precise(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
+        dotnet_version = dotnet.get_dotnet_version_precise(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if use_core_sdk else args.commit_sha
 
         if args.local_build:

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -447,7 +447,7 @@ def main(args: Any):
 
     if not framework.startswith('net4'):
         target_framework_moniker = dotnet.FrameworkAction.get_target_framework_moniker(framework)
-        dotnet_version = dotnet.get_dotnet_version(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
+        dotnet_version = dotnet.get_dotnet_sdk_version_precise(target_framework_moniker, args.cli) if args.dotnet_versions == [] else args.dotnet_versions[0]
         commit_sha = dotnet.get_dotnet_sdk(target_framework_moniker, args.cli) if use_core_sdk else args.commit_sha
 
         if args.local_build:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -555,7 +555,7 @@ def get_dotnet_path() -> str:
     return dotnet_path
 
 
-def get_dotnet_version(
+def get_dotnet_version_path(
         framework: str,
         dotnet_path: Optional[str] = None,
         sdk_path: Optional[str] = None) -> str:
@@ -586,29 +586,28 @@ def get_dotnet_version(
 
     return sdk
 
+def get_dotnet_version_precise(
+        framework: str,
+        dotnet_path: Optional[str] = None,
+        sdk: Optional[str] = None) -> str:
+    sdk_path = get_sdk_path(dotnet_path)
+    sdk = get_dotnet_version_path(framework, dotnet_path,
+                             sdk_path) if sdk is None else sdk
+
+    # Use the precise version if it exists. https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/version-file-entries
+    with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
+        return sdk_version_file.readlines()[3].strip()
 
 def get_dotnet_sdk(
         framework: str,
         dotnet_path: Optional[str] = None,
         sdk: Optional[str] = None) -> str:
     sdk_path = get_sdk_path(dotnet_path)
-    sdk = get_dotnet_version(framework, dotnet_path,
+    sdk = get_dotnet_version_path(framework, dotnet_path,
                              sdk_path) if sdk is None else sdk
 
     with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
         return sdk_version_file.readline().strip()
-
-def get_dotnet_sdk_version_precise(
-        framework: str,
-        dotnet_path: Optional[str] = None,
-        sdk: Optional[str] = None) -> str:
-    sdk_path = get_sdk_path(dotnet_path)
-    sdk = get_dotnet_version(framework, dotnet_path,
-                             sdk_path) if sdk is None else sdk
-
-    # Use the precise version if it exists. https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/version-file-entries
-    with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
-        return sdk_version_file.readlines()[3].strip()
 
 def get_repository(repository: str) -> Tuple[str, str]:
     url_path = urlparse(repository).path

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -555,7 +555,7 @@ def get_dotnet_path() -> str:
     return dotnet_path
 
 
-def get_dotnet_version_path(
+def get_dotnet_version_from_path(
         framework: str,
         dotnet_path: Optional[str] = None,
         sdk_path: Optional[str] = None) -> str:
@@ -591,8 +591,8 @@ def get_dotnet_version_precise(
         dotnet_path: Optional[str] = None,
         sdk: Optional[str] = None) -> str:
     sdk_path = get_sdk_path(dotnet_path)
-    sdk = get_dotnet_version_path(framework, dotnet_path,
-                             sdk_path) if sdk is None else sdk
+    if sdk is None:
+        sdk = get_dotnet_version_from_path(framework, dotnet_path, sdk_path)
 
     # Use the precise version if it exists. https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/version-file-entries
     with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
@@ -603,7 +603,7 @@ def get_dotnet_sdk(
         dotnet_path: Optional[str] = None,
         sdk: Optional[str] = None) -> str:
     sdk_path = get_sdk_path(dotnet_path)
-    sdk = get_dotnet_version_path(framework, dotnet_path,
+    sdk = get_dotnet_version_from_path(framework, dotnet_path,
                              sdk_path) if sdk is None else sdk
 
     with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -597,8 +597,18 @@ def get_dotnet_sdk(
 
     with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
         return sdk_version_file.readline().strip()
-    raise RuntimeError("Unable to retrieve information about the .NET SDK.")
 
+def get_dotnet_sdk_version_precise(
+        framework: str,
+        dotnet_path: Optional[str] = None,
+        sdk: Optional[str] = None) -> str:
+    sdk_path = get_sdk_path(dotnet_path)
+    sdk = get_dotnet_version(framework, dotnet_path,
+                             sdk_path) if sdk is None else sdk
+
+    # Use the precise version if it exists. https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/version-file-entries
+    with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
+        return sdk_version_file.readlines()[3].strip()
 
 def get_repository(repository: str) -> Tuple[str, str]:
     url_path = urlparse(repository).path


### PR DESCRIPTION
Fixes 8.0 runs where the file path for the dotnet sdk contains the short version of the dotnet sdk rather than the full version, this switches to using the full version located in the sdks .version file instead. This will allow the dotnet-install script to redownload the correct dotnet version for running the tests.

Fixes: https://github.com/dotnet/performance/issues/4027