### PR TITLE
Download PDN with Managed Identity

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -52,7 +52,7 @@ jobs:
             value: "--internal"
           - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
             - name: PdnPathParameter
-              value: "--pdn-path '$(System.DefaultWorkingDirectory)/PDN.zip'"
+              value: "--pdn-path '$(System.DefaultWorkingDirectory)\PDN.zip'"
           - ${{ else }}:
             - name: PdnPathParameter
               value: ''

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -52,7 +52,7 @@ jobs:
             value: "--internal"
           - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
             - name: PdnPathParameter
-              value: "--pdn-path '$(System.DefaultWorkingDirectory)\\PDN.zip'"
+              value: "--pdn-path '$(Build.ArtifactStagingDirectory)\\PDN.zip'"
           - ${{ else }}:
             - name: PdnPathParameter
               value: ''
@@ -82,15 +82,15 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - task: AzureCLI@2
-          displayName: 'Download PDN'
-          condition: ne(variables.PdnPathParameter, '')
-          inputs:
-            azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
-            scriptType: 'pscore'
-            scriptLocation: 'inlineScript'
-            inlineScript: |
-              az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file PDN.zip 
+        - ${{ if ne(variables.PdnPathParameter, '') }}:
+          - task: AzureCLI@2
+            displayName: 'Download PDN'
+            inputs:
+              azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file $(Build.ArtifactStagingDirectory)/PDN.zip 
         - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(PdnPathParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
           displayName: Run run_performance_job.py
           env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -52,7 +52,7 @@ jobs:
             value: "--internal"
           - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
             - name: PdnPathParameter
-              value: "--pdn-path '$(Build.ArtifactStagingDirectory)\\PDN.zip'"
+              value: '--pdn-path "$(Build.ArtifactStagingDirectory)\\PDN.zip"'
           - ${{ else }}:
             - name: PdnPathParameter
               value: ''

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -52,7 +52,7 @@ jobs:
             value: "--internal"
           - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
             - name: PdnPathParameter
-              value: "--pdn-path '$(System.DefaultWorkingDirectory)\PDN.zip'"
+              value: "--pdn-path '$(System.DefaultWorkingDirectory)\\PDN.zip'"
           - ${{ else }}:
             - name: PdnPathParameter
               value: ''

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -50,14 +50,18 @@ jobs:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           - name: internalParam
             value: "--internal"
-          - name: DownloadPdnParameter
-            value: --download-pdn
+            - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
+              - name: PdnPathParameter
+                value: "--pdn-path '$(System.DefaultWorkingDirectory)/assets/PDN.zip'"
+            - ${{ else }}:
+              - name: PdnPathParameter
+                value: ''
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
         - ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))) }}:
           - name: internalParam
             value: ''
-          - name: DownloadPdnParameter
+          - name: PdnPathParameter
             value: ''
         workspace:
           clean: all
@@ -78,7 +82,16 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(DownloadPdnParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
+        - task: AzureCLI@2
+          displayName: 'Download PDN'
+          condition: ne(variables.PdnPathParameter, '')
+          inputs:
+            azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+            scriptType: 'pscore'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              az storage blob download --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file assets/PDN.zip 
+        - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(PdnPathParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
           displayName: Run run_performance_job.py
           env:
             HelixAccessToken: '$(HelixApiAccessToken)'

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -82,15 +82,15 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - ${{ if ne(variables.PdnPathParameter, '') }}:
-          - task: AzureCLI@2
-            displayName: 'Download PDN'
-            inputs:
-              azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
-              scriptType: 'pscore'
-              scriptLocation: 'inlineScript'
-              inlineScript: |
-                az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file $(Build.ArtifactStagingDirectory)/PDN.zip 
+        - task: AzureCLI@2
+          condition: ne(variables.PdnPathParameter, '')
+          displayName: 'Download PDN'
+          inputs:
+            azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+            scriptType: 'pscore'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file $(Build.ArtifactStagingDirectory)/PDN.zip 
         - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(PdnPathParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
           displayName: Run run_performance_job.py
           env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -52,7 +52,7 @@ jobs:
             value: "--internal"
           - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
             - name: PdnPathParameter
-              value: "--pdn-path '$(System.DefaultWorkingDirectory)/assets/PDN.zip'"
+              value: "--pdn-path '$(System.DefaultWorkingDirectory)/PDN.zip'"
           - ${{ else }}:
             - name: PdnPathParameter
               value: ''
@@ -90,7 +90,7 @@ jobs:
             scriptType: 'pscore'
             scriptLocation: 'inlineScript'
             inlineScript: |
-              az storage blob download --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file assets/PDN.zip 
+              az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file PDN.zip 
         - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(PdnPathParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
           displayName: Run run_performance_job.py
           env:

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -50,12 +50,12 @@ jobs:
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           - name: internalParam
             value: "--internal"
-            - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
-              - name: PdnPathParameter
-                value: "--pdn-path '$(System.DefaultWorkingDirectory)/assets/PDN.zip'"
-            - ${{ else }}:
-              - name: PdnPathParameter
-                value: ''
+          - ${{ if and(eq(parameters.osName, 'windows'), ne(parameters.architecture, 'x86')) }}:
+            - name: PdnPathParameter
+              value: "--pdn-path '$(System.DefaultWorkingDirectory)/assets/PDN.zip'"
+          - ${{ else }}:
+            - name: PdnPathParameter
+              value: ''
           - group: DotNet-HelixApi-Access
           - group: dotnet-benchview
         - ${{ if not(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))) }}:


### PR DESCRIPTION
Will need to make these changes in the 6.0 and 7.0 branches too after this goes in. This is done by downloading PDN in a separate Azure Pipelines build step and the copying it into the helix upload directories during the performance setup scripts.