### PR TITLE
Don't include AzureCLI for PDN if running a public or PR build

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -82,15 +82,16 @@ jobs:
         steps:
         - checkout: self
           clean: true
-        - task: AzureCLI@2
-          condition: ne(variables.PdnPathParameter, '')
-          displayName: 'Download PDN'
-          inputs:
-            azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
-            scriptType: 'pscore'
-            scriptLocation: 'inlineScript'
-            inlineScript: |
-              az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file $(Build.ArtifactStagingDirectory)/PDN.zip 
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - task: AzureCLI@2
+            condition: ne(variables.PdnPathParameter, '')
+            displayName: 'Download PDN'
+            inputs:
+              azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name paint.net.5.0.3.portable.${{ parameters.architecture }}.zip --file $(Build.ArtifactStagingDirectory)/PDN.zip 
         - script: $(Python) scripts/run_performance_job.py --performance-repo-ci --is-scenario --queue ${{ parameters.queue }} --channel $(_Channel) --architecture ${{ parameters.architecture }} --run-kind ${{ parameters.kind }} --affinity ${{ parameters.affinity }} $(runEnvVarsParam) --os-group ${{ parameters.osName }} $(runtimeFlavorParam) $(hybridGlobalizationParam) $(PdnPathParameter) --os-version ${{ parameters.osVersion }} $(_DotnetVersionParam) $(internalParam) --project-file $(Build.SourcesDirectory)/eng/performance/${{ parameters.projectFile }}
           displayName: Run run_performance_job.py
           env:


### PR DESCRIPTION
Fix public runs not running due to attempting to instantiate a service connection that does not exist on our public runs.