### PR TITLE
Surround obsolete X509Certificate2 load in tests with warning disable.

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
@@ -27,6 +27,7 @@ namespace System.Net.Test.Common
             {
                 try
                 {
+                    #pragma warning disable SYSLIB0057 // Warning disabled per https://github.com/dotnet/docs/issues/41662, TODO: Update to use X509CertificateLoader.LoadPkcs12FromFile we are able to use it (will need to version block with this regardless).
                     return new X509Certificate2(
                          File.ReadAllBytes(
                              Path.Combine(
@@ -36,6 +37,7 @@ namespace System.Net.Test.Common
                                  certificateFileName)),
                          CertificatePassword,
                          X509KeyStorageFlags.DefaultKeySet);
+                    #pragma warning restore SYSLIB0057
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
Surround obsolete X509Certificate2 load in tests with warning disable. We started hitting errors when building the microbenchmarks due to the changes made for https://github.com/dotnet/runtime/issues/91763 making their way through to the daily SDK we use to build the benchmarks. Disabling the warning will get the benchmarks running again as we figure out how we want to update the certificate retrieval as the X509CertificateLoader is new and not available on versions < net9.0-preview.7 AFAICT.

First runtime-perf build that hit the issue: https://dev.azure.com/dnceng/internal/_build/results?buildId=2490580&view=results

