### PR TITLE
Make sure the DynamicEvent unit tests are compiled only when using custom trace event

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/DynamicEventTests.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/DynamicEventTests.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿// TODO, andrewau, remove this condition when new TraceEvent is available through Nuget.
+#if CUSTOM_TRACE_EVENT
+
+using FluentAssertions;
 using Microsoft.Diagnostics.Tracing.Analysis.GC;
 using Microsoft.Diagnostics.Tracing.Parsers.GCDynamic;
 using GC.Analysis.API.DynamicEvents;
@@ -321,3 +324,5 @@ TimeStamp : *
         }
     }
 }
+
+#endif


### PR DESCRIPTION
This will prevent the code to fail the build in case we are not using the latest TraceEvent.