### PR TITLE
comment out output.path check logic for aspnetbenchmarks

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
@@ -62,10 +62,11 @@
                 throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Output)} is null. Check the syntax of the configuration.");
             }
 
-            if (string.IsNullOrEmpty(configuration.Output.Path))
-            {
-                throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Output.Path)} is null or empty. Please specify an output path.");
-            }
+            // configuration.Output.Path can be null when creating suites for ene to end run. 
+            //if (string.IsNullOrEmpty(configuration.Output.Path))
+            //{
+            //    throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Output.Path)} is null or empty. Please specify an output path.");
+            //}
 
             if (configuration.Environment == null)
             {

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/ASPNetBenchmark.Configuration.cs
@@ -62,12 +62,6 @@
                 throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Output)} is null. Check the syntax of the configuration.");
             }
 
-            // configuration.Output.Path can be null when creating suites for ene to end run. 
-            //if (string.IsNullOrEmpty(configuration.Output.Path))
-            //{
-            //    throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Output.Path)} is null or empty. Please specify an output path.");
-            //}
-
             if (configuration.Environment == null)
             {
                 throw new ArgumentNullException($"{nameof(ASPNetBenchmarksConfigurationParser)}: {nameof(configuration.Environment)} is null. Please add the environment item in the configuration.");


### PR DESCRIPTION
In an end-to-end run, "output.path" can be null when creating suites for aspnetbenchmarks. We can comment out the logic for this case.