### PR TITLE
Add strength reduction benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
+++ b/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
@@ -22,8 +22,6 @@ namespace Loops
         private long[] _arrayLongs;
 
         private S3[] _arrayS3;
-        private S5[] _arrayS5;
-        private S6[] _arrayS6;
         private S8[] _arrayS8;
         private S12[] _arrayS12;
         private S16[] _arrayS16;
@@ -37,8 +35,6 @@ namespace Loops
             _arrayLongs = Enumerable.Range(0, 10000).Select(i => (long)i).ToArray();
 
             _arrayS3 = Enumerable.Range(0, 10000).Select(i => new S3 { A = (byte)i, B = (byte)i, C = (byte)i }).ToArray();
-            _arrayS5 = Enumerable.Range(0, 10000).Select(i => new S5 { A = (byte)i, B = (byte)i, C = (byte)i, D = (byte)i, E = (byte)i }).ToArray();
-            _arrayS6 = Enumerable.Range(0, 10000).Select(i => new S6 { A = (ushort)i, B = (ushort)i, C = (ushort)i, }).ToArray();
             _arrayS8 = Enumerable.Range(0, 10000).Select(i => new S8 { A = i, B = i, }).ToArray();
             _arrayS12 = Enumerable.Range(0, 10000).Select(i => new S12 { A = i, B = i, C = i, }).ToArray();
             _arrayS16 = Enumerable.Range(0, 10000).Select(i => new S16 { A = i, B = i, }).ToArray();
@@ -259,118 +255,6 @@ namespace Loops
                 do
                 {
                     S3 s = p;
-                    result += s.A | 1;
-                    p = ref Unsafe.Add(ref p, 1);
-                    length--;
-                } while (length != 0);
-            }
-
-            return result;
-        }
-
-        [Benchmark(Baseline = true), BenchmarkCategory("S5")]
-        public int SumS5Array()
-        {
-            return SumS5WithArray(_arrayS5);
-        }
-
-        [Benchmark, BenchmarkCategory("S5")]
-        public int SumS5Span()
-        {
-            return SumS5WithSpan(_arrayS5);
-        }
-
-        [Benchmark, BenchmarkCategory("S5")]
-        public int SumS5ArrayStrengthReduced()
-        {
-            return SumS5StrengthReducedWithArray(_arrayS5);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS5WithArray(S5[] input)
-        {
-            int result = 0;
-            foreach (S5 s in input)
-                result += s.A | 1;
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS5WithSpan(ReadOnlySpan<S5> input)
-        {
-            int result = 0;
-            foreach (S5 s in input)
-                result += s.A | 1;
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS5StrengthReducedWithArray(S5[] input)
-        {
-            int result = 0;
-            uint length = (uint)input.Length;
-            if (length > 0)
-            {
-                ref S5 p = ref input[0];
-                do
-                {
-                    S5 s = p;
-                    result += s.A | 1;
-                    p = ref Unsafe.Add(ref p, 1);
-                    length--;
-                } while (length != 0);
-            }
-
-            return result;
-        }
-
-        [Benchmark(Baseline = true), BenchmarkCategory("S6")]
-        public int SumS6Array()
-        {
-            return SumS6WithArray(_arrayS6);
-        }
-
-        [Benchmark, BenchmarkCategory("S6")]
-        public int SumS6Span()
-        {
-            return SumS6WithSpan(_arrayS6);
-        }
-
-        [Benchmark, BenchmarkCategory("S6")]
-        public int SumS6ArrayStrengthReduced()
-        {
-            return SumS6StrengthReducedWithArray(_arrayS6);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS6WithArray(S6[] input)
-        {
-            int result = 0;
-            foreach (S6 s in input)
-                result += s.A | 1;
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS6WithSpan(ReadOnlySpan<S6> input)
-        {
-            int result = 0;
-            foreach (S6 s in input)
-                result += s.A | 1;
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private int SumS6StrengthReducedWithArray(S6[] input)
-        {
-            int result = 0;
-            uint length = (uint)input.Length;
-            if (length > 0)
-            {
-                ref S6 p = ref input[0];
-                do
-                {
-                    S6 s = p;
                     result += s.A | 1;
                     p = ref Unsafe.Add(ref p, 1);
                     length--;

--- a/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
+++ b/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
@@ -1,4 +1,3 @@
-
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -499,16 +498,6 @@ namespace Loops
         private struct S3
         {
             public byte A, B, C;
-        }
-
-        private struct S5
-        {
-            public byte A, B, C, D, E;
-        }
-
-        private struct S6
-        {
-            public ushort A, B, C;
         }
 
         public struct S8

--- a/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
+++ b/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
@@ -1,0 +1,652 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Loops
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.JIT)]
+    [GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByCategory)]
+    [MemoryRandomization]
+    public class StrengthReduction
+    {
+        private short[] _arrayShorts;
+        private int[] _arrayInts;
+        private long[] _arrayLongs;
+
+        private S3[] _arrayS3;
+        private S5[] _arrayS5;
+        private S6[] _arrayS6;
+        private S8[] _arrayS8;
+        private S12[] _arrayS12;
+        private S16[] _arrayS16;
+        private S29[] _arrayS29;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _arrayShorts = Enumerable.Range(0, 10000).Select(i => (short)i).ToArray();
+            _arrayInts = Enumerable.Range(0, 10000).Select(i => i).ToArray();
+            _arrayLongs = Enumerable.Range(0, 10000).Select(i => (long)i).ToArray();
+
+            _arrayS3 = Enumerable.Range(0, 10000).Select(i => new S3 { A = (byte)i, B = (byte)i, C = (byte)i }).ToArray();
+            _arrayS5 = Enumerable.Range(0, 10000).Select(i => new S5 { A = (byte)i, B = (byte)i, C = (byte)i, D = (byte)i, E = (byte)i }).ToArray();
+            _arrayS6 = Enumerable.Range(0, 10000).Select(i => new S6 { A = (ushort)i, B = (ushort)i, C = (ushort)i, }).ToArray();
+            _arrayS8 = Enumerable.Range(0, 10000).Select(i => new S8 { A = i, B = i, }).ToArray();
+            _arrayS12 = Enumerable.Range(0, 10000).Select(i => new S12 { A = i, B = i, C = i, }).ToArray();
+            _arrayS16 = Enumerable.Range(0, 10000).Select(i => new S16 { A = i, B = i, }).ToArray();
+            _arrayS29 = Enumerable.Range(0, 10000).Select(i => new S29 { A = (byte)i, }).ToArray();
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("short")]
+        public int SumShortsArray()
+        {
+            return SumShortsWithArray(_arrayShorts);
+        }
+
+        [Benchmark, BenchmarkCategory("short")]
+        public int SumShortsSpan()
+        {
+            return SumShortsWithSpan(_arrayShorts);
+        }
+
+        [Benchmark, BenchmarkCategory("short")]
+        public int SumShortsArrayStrengthReduced()
+        {
+            return SumShortsStrengthReducedWithArray(_arrayShorts);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumShortsWithArray(short[] input)
+        {
+            int result = 0;
+            // 'or' by 1 to make loop body slightly larger to work around
+            // https://github.com/dotnet/runtime/issues/104665
+            foreach (short s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumShortsWithSpan(ReadOnlySpan<short> input)
+        {
+            int result = 0;
+            foreach (short s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumShortsStrengthReducedWithArray(short[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref short p = ref input[0];
+                do
+                {
+                    result += p | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("int")]
+        public int SumIntsArray()
+        {
+            return SumIntsWithArray(_arrayInts);
+        }
+
+        [Benchmark, BenchmarkCategory("int")]
+        public int SumIntsSpan()
+        {
+            return SumIntsWithSpan(_arrayInts);
+        }
+
+        [Benchmark, BenchmarkCategory("int")]
+        public int SumIntsArrayStrengthReduced()
+        {
+            return SumIntsStrengthReducedWithArray(_arrayInts);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumIntsWithArray(int[] input)
+        {
+            int result = 0;
+            foreach (short s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumIntsWithSpan(ReadOnlySpan<int> input)
+        {
+            int result = 0;
+            foreach (int s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumIntsStrengthReducedWithArray(int[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref int p = ref input[0];
+                do
+                {
+                    result += p | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("long")]
+        public long SumLongsArray()
+        {
+            return SumLongsWithArray(_arrayLongs);
+        }
+
+        [Benchmark, BenchmarkCategory("long")]
+        public long SumLongsSpan()
+        {
+            return SumLongsWithSpan(_arrayLongs);
+        }
+
+        [Benchmark, BenchmarkCategory("long")]
+        public long SumLongsArrayStrengthReduced()
+        {
+            return SumLongsStrengthReducedWithArray(_arrayLongs);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumLongsWithArray(long[] input)
+        {
+            long result = 0;
+            foreach (long s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumLongsWithSpan(ReadOnlySpan<long> input)
+        {
+            int result = 0;
+            foreach (int s in input)
+                result += s | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumLongsStrengthReducedWithArray(long[] input)
+        {
+            long result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref long p = ref input[0];
+                do
+                {
+                    result += p | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S3")]
+        public int SumS3Array()
+        {
+            return SumS3WithArray(_arrayS3);
+        }
+
+        [Benchmark, BenchmarkCategory("S3")]
+        public int SumS3Span()
+        {
+            return SumS3WithSpan(_arrayS3);
+        }
+
+        [Benchmark, BenchmarkCategory("S3")]
+        public int SumS3ArrayStrengthReduced()
+        {
+            return SumS3StrengthReducedWithArray(_arrayS3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS3WithArray(S3[] input)
+        {
+            int result = 0;
+            foreach (S3 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS3WithSpan(ReadOnlySpan<S3> input)
+        {
+            int result = 0;
+            foreach (S3 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS3StrengthReducedWithArray(S3[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S3 p = ref input[0];
+                do
+                {
+                    S3 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S5")]
+        public int SumS5Array()
+        {
+            return SumS5WithArray(_arrayS5);
+        }
+
+        [Benchmark, BenchmarkCategory("S5")]
+        public int SumS5Span()
+        {
+            return SumS5WithSpan(_arrayS5);
+        }
+
+        [Benchmark, BenchmarkCategory("S5")]
+        public int SumS5ArrayStrengthReduced()
+        {
+            return SumS5StrengthReducedWithArray(_arrayS5);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS5WithArray(S5[] input)
+        {
+            int result = 0;
+            foreach (S5 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS5WithSpan(ReadOnlySpan<S5> input)
+        {
+            int result = 0;
+            foreach (S5 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS5StrengthReducedWithArray(S5[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S5 p = ref input[0];
+                do
+                {
+                    S5 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S6")]
+        public int SumS6Array()
+        {
+            return SumS6WithArray(_arrayS6);
+        }
+
+        [Benchmark, BenchmarkCategory("S6")]
+        public int SumS6Span()
+        {
+            return SumS6WithSpan(_arrayS6);
+        }
+
+        [Benchmark, BenchmarkCategory("S6")]
+        public int SumS6ArrayStrengthReduced()
+        {
+            return SumS6StrengthReducedWithArray(_arrayS6);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS6WithArray(S6[] input)
+        {
+            int result = 0;
+            foreach (S6 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS6WithSpan(ReadOnlySpan<S6> input)
+        {
+            int result = 0;
+            foreach (S6 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS6StrengthReducedWithArray(S6[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S6 p = ref input[0];
+                do
+                {
+                    S6 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S8")]
+        public int SumS8Array()
+        {
+            return SumS8WithArray(_arrayS8);
+        }
+
+        [Benchmark, BenchmarkCategory("S8")]
+        public int SumS8Span()
+        {
+            return SumS8WithSpan(_arrayS8);
+        }
+
+        [Benchmark, BenchmarkCategory("S8")]
+        public int SumS8ArrayStrengthReduced()
+        {
+            return SumS8StrengthReducedWithArray(_arrayS8);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS8WithArray(S8[] input)
+        {
+            int result = 0;
+            foreach (S8 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS8WithSpan(ReadOnlySpan<S8> input)
+        {
+            int result = 0;
+            foreach (S8 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS8StrengthReducedWithArray(S8[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S8 p = ref input[0];
+                do
+                {
+                    S8 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S12")]
+        public int SumS12Array()
+        {
+            return SumS12WithArray(_arrayS12);
+        }
+
+        [Benchmark, BenchmarkCategory("S12")]
+        public int SumS12Span()
+        {
+            return SumS12WithSpan(_arrayS12);
+        }
+
+        [Benchmark, BenchmarkCategory("S12")]
+        public int SumS12ArrayStrengthReduced()
+        {
+            return SumS12StrengthReducedWithArray(_arrayS12);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS12WithArray(S12[] input)
+        {
+            int result = 0;
+            foreach (S12 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS12WithSpan(ReadOnlySpan<S12> input)
+        {
+            int result = 0;
+            foreach (S12 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS12StrengthReducedWithArray(S12[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S12 p = ref input[0];
+                do
+                {
+                    S12 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S16")]
+        public long SumS16Array()
+        {
+            return SumS16WithArray(_arrayS16);
+        }
+
+        [Benchmark, BenchmarkCategory("S16")]
+        public long SumS16Span()
+        {
+            return SumS16WithSpan(_arrayS16);
+        }
+
+        [Benchmark, BenchmarkCategory("S16")]
+        public long SumS16ArrayStrengthReduced()
+        {
+            return SumS16StrengthReducedWithArray(_arrayS16);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumS16WithArray(S16[] input)
+        {
+            long result = 0;
+            foreach (S16 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumS16WithSpan(ReadOnlySpan<S16> input)
+        {
+            long result = 0;
+            foreach (S16 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private long SumS16StrengthReducedWithArray(S16[] input)
+        {
+            long result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S16 p = ref input[0];
+                do
+                {
+                    S16 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true), BenchmarkCategory("S29")]
+        public int SumS29Array()
+        {
+            int sum = 0;
+            //for (int i = 0; i < 100; i++)
+                sum += SumS29WithArray(_arrayS29);
+            return sum;
+        }
+
+        [Benchmark, BenchmarkCategory("S29")]
+        public int SumS29Span()
+        {
+            int sum = 0;
+            //for (int i = 0; i < 100; i++)
+                sum += SumS29WithSpan(_arrayS29);
+            return sum;
+        }
+
+        [Benchmark, BenchmarkCategory("S29")]
+        public int SumS29ArrayStrengthReduced()
+        {
+            int sum = 0;
+            //for (int i = 0; i < 100; i++)
+                sum += SumS29StrengthReducedWithArray(_arrayS29);
+            return sum;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS29WithArray(S29[] input)
+        {
+            int result = 0;
+            foreach (S29 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS29WithSpan(ReadOnlySpan<S29> input)
+        {
+            int result = 0;
+            foreach (S29 s in input)
+                result += s.A | 1;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int SumS29StrengthReducedWithArray(S29[] input)
+        {
+            int result = 0;
+            uint length = (uint)input.Length;
+            if (length > 0)
+            {
+                ref S29 p = ref input[0];
+                do
+                {
+                    S29 s = p;
+                    result += s.A | 1;
+                    p = ref Unsafe.Add(ref p, 1);
+                    length--;
+                } while (length != 0);
+            }
+
+            return result;
+        }
+
+        private struct S3
+        {
+            public byte A, B, C;
+        }
+
+        private struct S5
+        {
+            public byte A, B, C, D, E;
+        }
+
+        private struct S6
+        {
+            public ushort A, B, C;
+        }
+
+        public struct S8
+        {
+            public int A, B;
+        }
+
+        public struct S12
+        {
+            public int A, B, C;
+        }
+
+        public struct S16
+        {
+            public long A, B;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 29)]
+        public struct S29
+        {
+            public byte A;
+        }
+    }
+}

--- a/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
+++ b/src/benchmarks/micro/runtime/Loops/StrengthReduction.cs
@@ -14,7 +14,6 @@ namespace Loops
 {
     [BenchmarkCategory(Categories.Runtime, Categories.JIT)]
     [GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByCategory)]
-    [MemoryRandomization]
     public class StrengthReduction
     {
         private short[] _arrayShorts;


### PR DESCRIPTION
This adds strength reduction benchmarks for arrays of a few different element sizes, motivated by the differences in codegen. The element sizes give different characteristics of how we access each element. For x64, the current instruction codegen looks like:

2: load
3: lea + load
4: load
8: load
12: lea + load
16: shl + load
29: imul + load

Each size has 3 variants of benchmarks: an array version, a span version, and a fully strength reduced manual version. The JIT is expected to be able to transform the array version into the strength reduced version soon. The span version will also be transformed, but not quite all the way (the strength reduction will not be able to fold in the base byref of the span).

There is one current annoyance to work around in the JIT: we do not align the strength-reduced versions of the loops because they end up being "too small", meaning that they still fit within a single cache line. However, it turns out alignment is still beneficial in these cases, and this skews the results compared to the non-strength reduced versions. I have opened https://github.com/dotnet/runtime/issues/104665 about this. To work around the problem in these benchmarks I have added a superfluous bitwise or operation in the body of all the loops.

On my Intel CPU the current results are:
| Method                        | Mean     | Error     | StdDev    | Median   | Min      | Max      | Ratio | RatioSD | Code Size | Allocated | Alloc Ratio |
|------------------------------ |---------:|----------:|----------:|---------:|---------:|---------:|------:|--------:|----------:|----------:|------------:|
| SumS12Array                   | 4.813 us | 0.2538 us | 0.2923 us | 4.722 us | 4.445 us | 5.394 us |  1.00 |    0.08 |      73 B |         - |          NA |
| SumS12Span                    | 4.530 us | 0.1372 us | 0.1580 us | 4.467 us | 4.334 us | 4.844 us |  0.94 |    0.06 |     126 B |         - |          NA |
| SumS12ArrayStrengthReduced    | 3.712 us | 0.0918 us | 0.1058 us | 3.653 us | 3.608 us | 3.913 us |  0.77 |    0.05 |      65 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumS16Array                   | 4.557 us | 0.0569 us | 0.0532 us | 4.544 us | 4.482 us | 4.677 us |  1.00 |    0.02 |      73 B |         - |          NA |
| SumS16Span                    | 4.529 us | 0.0277 us | 0.0259 us | 4.532 us | 4.479 us | 4.572 us |  0.99 |    0.01 |     126 B |         - |          NA |
| SumS16ArrayStrengthReduced    | 3.836 us | 0.0349 us | 0.0326 us | 3.828 us | 3.796 us | 3.920 us |  0.84 |    0.01 |      65 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumS29Array                   | 5.260 us | 0.0623 us | 0.0583 us | 5.243 us | 5.181 us | 5.378 us |  1.00 |    0.02 |      84 B |         - |          NA |
| SumS29Span                    | 5.265 us | 0.0474 us | 0.0444 us | 5.258 us | 5.200 us | 5.349 us |  1.00 |    0.01 |     132 B |         - |          NA |
| SumS29ArrayStrengthReduced    | 4.340 us | 0.0349 us | 0.0326 us | 4.339 us | 4.282 us | 4.384 us |  0.83 |    0.01 |      76 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumS3Array                    | 4.324 us | 0.0318 us | 0.0298 us | 4.321 us | 4.287 us | 4.392 us |  1.00 |    0.01 |      74 B |         - |          NA |
| SumS3Span                     | 4.352 us | 0.0243 us | 0.0228 us | 4.360 us | 4.301 us | 4.382 us |  1.01 |    0.01 |     127 B |         - |          NA |
| SumS3ArrayStrengthReduced     | 3.289 us | 0.0195 us | 0.0183 us | 3.287 us | 3.266 us | 3.339 us |  0.76 |    0.01 |      66 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumS8Array                    | 3.794 us | 0.1145 us | 0.1319 us | 3.744 us | 3.691 us | 4.177 us |  1.00 |    0.05 |      69 B |         - |          NA |
| SumS8Span                     | 3.743 us | 0.0213 us | 0.0199 us | 3.738 us | 3.720 us | 3.805 us |  0.99 |    0.03 |     122 B |         - |          NA |
| SumS8ArrayStrengthReduced     | 3.435 us | 0.0647 us | 0.0719 us | 3.425 us | 3.346 us | 3.713 us |  0.91 |    0.03 |      65 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumIntsArray                  | 3.719 us | 0.1488 us | 0.1713 us | 3.631 us | 3.568 us | 4.032 us |  1.00 |    0.06 |      70 B |         - |          NA |
| SumIntsSpan                   | 3.621 us | 0.0188 us | 0.0176 us | 3.621 us | 3.589 us | 3.646 us |  0.98 |    0.04 |     121 B |         - |          NA |
| SumIntsArrayStrengthReduced   | 3.447 us | 0.2373 us | 0.2733 us | 3.338 us | 3.286 us | 4.516 us |  0.93 |    0.08 |      65 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumLongsArray                 | 3.785 us | 0.1116 us | 0.1285 us | 3.741 us | 3.669 us | 4.180 us |  1.00 |    0.05 |      69 B |         - |          NA |
| SumLongsSpan                  | 3.792 us | 0.1443 us | 0.1662 us | 3.695 us | 3.617 us | 4.123 us |  1.00 |    0.05 |     123 B |         - |          NA |
| SumLongsArrayStrengthReduced  | 3.454 us | 0.0634 us | 0.0593 us | 3.443 us | 3.402 us | 3.656 us |  0.91 |    0.03 |      65 B |         - |          NA |
|                               |          |           |           |          |          |          |       |         |           |           |             |
| SumShortsArray                | 3.626 us | 0.0810 us | 0.0933 us | 3.619 us | 3.507 us | 3.869 us |  1.00 |    0.04 |      70 B |         - |          NA |
| SumShortsSpan                 | 3.586 us | 0.0416 us | 0.0389 us | 3.581 us | 3.526 us | 3.693 us |  0.99 |    0.03 |     122 B |         - |          NA |
| SumShortsArrayStrengthReduced | 3.317 us | 0.0541 us | 0.0506 us | 3.302 us | 3.263 us | 3.442 us |  0.92 |    0.03 |      66 B |         - |          NA |