### PR TITLE
Update Maui version flows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,273 +57,273 @@ jobs:
 # Public correctness jobs
 ######################################################
 
-# - ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
 
-#   # Scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: scenarios
-#         projectFile: scenarios.proj
-#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-#           - main
-#           - 8.0
+  # Scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios.proj
+        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+          - main
+          - 8.0
 
-#   ## MAUI scenario benchmarks
-#   #- template: /eng/performance/build_machine_matrix.yml
-#   #  parameters:
-#   #    jobTemplate: /eng/performance/scenarios.yml
-#   #    buildMachines:
-#   #      - win-x64
-#   #      - ubuntu-x64
-#   #    isPublic: true
-#   #    jobParameters:
-#   #      kind: maui_scenarios
-#   #      projectFile: maui_scenarios.proj
-#   #      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-#   #        - main
-#   #        - 8.0
+  ## MAUI scenario benchmarks
+  #- template: /eng/performance/build_machine_matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/performance/scenarios.yml
+  #    buildMachines:
+  #      - win-x64
+  #      - ubuntu-x64
+  #    isPublic: true
+  #    jobParameters:
+  #      kind: maui_scenarios
+  #      projectFile: maui_scenarios.proj
+  #      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+  #        - main
+  #        - 8.0
 
-#   # Blazor scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: blazor_scenarios
-#         projectFile: blazor_scenarios.proj
-#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-#           - main
-#           - 8.0
+  # Blazor scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: blazor_scenarios
+        projectFile: blazor_scenarios.proj
+        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+          - main
+          - 8.0
 
-#   # SDK scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - win-x86
-#         - ubuntu-x64-1804
-#       isPublic: true
-#       jobParameters:
-#         kind: sdk_scenarios
-#         projectFile: sdk_scenarios.proj
-#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-#           - main
-#           - 8.0
+  # SDK scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-x86
+        - ubuntu-x64-1804
+      isPublic: true
+      jobParameters:
+        kind: sdk_scenarios
+        projectFile: sdk_scenarios.proj
+        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+          - main
+          - 8.0
   
-#   # micro benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - win-x86
-#       isPublic: true
-#       jobParameters:
-#         kind: micro
-#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-#         runCategories: 'runtime libraries' 
-#         channels:
-#           - main
-#           - 8.0
+  # micro benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - win-x86
+      isPublic: true
+      jobParameters:
+        kind: micro
+        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+        runCategories: 'runtime libraries' 
+        channels:
+          - main
+          - 8.0
 
-#   # Ubuntux64 Default and NativeAOT micro benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: micro
-#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-#         runCategories: 'runtime libraries' 
-#         channels:
-#           - main
-#           - nativeaot9.0
-#           - nativeaot8.0
-#           - 8.0
+  # Ubuntux64 Default and NativeAOT micro benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: micro
+        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+        runCategories: 'runtime libraries' 
+        channels:
+          - main
+          - nativeaot9.0
+          - nativeaot8.0
+          - 8.0
 
-#   # net462 micro benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-rs5-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: micro_net462
-#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-#         runCategories: 'runtime libraries'
-#         channels:
-#           - net462
+  # net462 micro benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-rs5-x64
+      isPublic: true
+      jobParameters:
+        kind: micro_net462
+        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+        runCategories: 'runtime libraries'
+        channels:
+          - net462
 
-#   # ML.NET benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: mlnet
-#         csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-#         runCategories: 'mldotnet' 
-#         channels:
-#           - main
-#           - 8.0
+  # ML.NET benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: mlnet
+        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet' 
+        channels:
+          - main
+          - 8.0
 
-#   # F# benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: fsharp
-#         csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-#         runCategories: 'fsharp'
-#         channels:
-#           - main
-#           - 8.0
+  # F# benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: fsharp
+        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+        runCategories: 'fsharp'
+        channels:
+          - main
+          - 8.0
 
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: fsharpmicro
-#         csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-#         runCategories: 'FSharpMicro'
-#         channels:
-#           - main
-#           - 8.0
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: fsharpmicro
+        csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+        runCategories: 'FSharpMicro'
+        channels:
+          - main
+          - 8.0
 
-#   # bepuphysics benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: bepuphysics
-#         csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-#         runCategories: 'BepuPhysics'
-#         channels:
-#           - main
-#           - 8.0
+  # bepuphysics benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: bepuphysics
+        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+        runCategories: 'BepuPhysics'
+        channels:
+          - main
+          - 8.0
 
-#   # ImageSharp benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: imagesharp
-#         csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-#         runCategories: 'ImageSharp'
-#         channels:
-#           - main
-#           - 8.0
+  # ImageSharp benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: imagesharp
+        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+        runCategories: 'ImageSharp'
+        channels:
+          - main
+          - 8.0
 
-#   # Akade.IndexedSet benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: akadeindexedset
-#         csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-#         runCategories: 'AkadeIndexedSet'
-#         channels:
-#           - main
-#           - 8.0
+  # Akade.IndexedSet benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: akadeindexedset
+        csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+        runCategories: 'AkadeIndexedSet'
+        channels:
+          - main
+          - 8.0
 
-#   # Roslyn benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: roslyn
-#         csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-#         runCategories: 'roslyn'
-#         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-#           - main
-#           - 8.0
+  # Roslyn benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: roslyn
+        csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+        runCategories: 'roslyn'
+        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
+          - 8.0
 
-#   # ILLink benchmarks
-#   # disabled because of: https://github.com/dotnet/performance/issues/3569
-#   # - template: /eng/performance/build_machine_matrix.yml
-#   #   parameters:
-#   #     jobTemplate: /eng/performance/benchmark_jobs.yml
-#   #     buildMachines:
-#   #       - win-x64
-#   #       - ubuntu-x64
-#   #     isPublic: true
-#   #     jobParameters:
-#   #       kind: illink
-#   #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-#   #       runCategories: 'illink'
-#   #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-#   #         - main
+  # ILLink benchmarks
+  # disabled because of: https://github.com/dotnet/performance/issues/3569
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #     isPublic: true
+  #     jobParameters:
+  #       kind: illink
+  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+  #       runCategories: 'illink'
+  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+  #         - main
 
-#   # NativeAOT scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: nativeaot_scenarios
-#         projectFile: nativeaot_scenarios.proj
-#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-#           - main
-#           - 8.0
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+          - main
+          - 8.0
 
-#   # Powershell benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#       isPublic: true
-#       jobParameters:
-#         kind: powershell
-#         csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-#         runCategories: 'Public'
-#         channels:
-#           - main
-#           - 8.0
+  # Powershell benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+      isPublic: true
+      jobParameters:
+        kind: powershell
+        csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+        runCategories: 'Public'
+        channels:
+          - main
+          - 8.0
 
 ###########################################
 # Private Jobs
@@ -331,44 +331,44 @@ jobs:
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
-  # # Scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios.proj
-  #       channels:
-  #         - main
-  #         - 8.0
+  # Scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios.proj
+        channels:
+          - main
+          - 8.0
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -402,21 +402,21 @@ jobs:
           - 8.0
         runtimeFlavor: mono
 
-  # # Maui iOS Native AOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: maui_scenarios_ios
-  #       projectFile: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         9.0: ./eng/Version.Details.xml
-  #       channels:
-  #         - 8.0
-  #       runtimeFlavor: coreclr
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: ./eng/Version.Details.xml
+        channels:
+          - 8.0
+        runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
@@ -435,312 +435,312 @@ jobs:
   #        - main
   #        - 8.0
 
-#   # NativeAOT scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#       isPublic: false
-#       jobParameters:
-#         kind: nativeaot_scenarios
-#         projectFile: nativeaot_scenarios.proj
-#         channels:
-#           - main
-#           - 8.0
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 8.0
 
-# ################################################
-# # Scheduled Private jobs
-# ################################################
+################################################
+# Scheduled Private jobs
+################################################
 
-# # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
-# - ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
+# Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
+- ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
 
-#   # SDK scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#         - win-x86
-#         - ubuntu-x64-1804
-#       isPublic: false
-#       jobParameters:
-#         kind: sdk_scenarios
-#         projectFile: sdk_scenarios.proj
-#         channels:
-#           - main
-#           - 8.0
+  # SDK scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-x86
+        - ubuntu-x64-1804
+      isPublic: false
+      jobParameters:
+        kind: sdk_scenarios
+        projectFile: sdk_scenarios.proj
+        channels:
+          - main
+          - 8.0
 
-#   # Blazor 3.2 scenario benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/scenarios.yml
-#       buildMachines:
-#         - win-x64
-#       isPublic: false
-#       jobParameters:
-#         kind: blazor_scenarios
-#         projectFile: blazor_scenarios.proj
-#         channels:
-#           - main
-#           - 8.0
+  # Blazor 3.2 scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+      isPublic: false
+      jobParameters:
+        kind: blazor_scenarios
+        projectFile: blazor_scenarios.proj
+        channels:
+          - main
+          - 8.0
 
-#   # F# benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: fsharp
-#         csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-#         runCategories: 'fsharp'
-#         channels:
-#           - main
-#           - 8.0
+  # F# benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: fsharp
+        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+        runCategories: 'fsharp'
+        channels:
+          - main
+          - 8.0
 
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: fsharpmicro
-#         csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-#         runCategories: 'FSharpMicro'
-#         channels:
-#           - main
-#           - 8.0
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: fsharpmicro
+        csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+        runCategories: 'FSharpMicro'
+        channels:
+          - main
+          - 8.0
 
-#   # bepuphysics benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: bepuphysics
-#         csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-#         runCategories: 'BepuPhysics'
-#         channels:
-#           - main
-#           - 8.0
+  # bepuphysics benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: bepuphysics
+        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+        runCategories: 'BepuPhysics'
+        channels:
+          - main
+          - 8.0
 
-#   # ImageSharp benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: imagesharp
-#         csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-#         runCategories: 'ImageSharp'
-#         channels:
-#           - main
-#           - 8.0
+  # ImageSharp benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: imagesharp
+        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+        runCategories: 'ImageSharp'
+        channels:
+          - main
+          - 8.0
 
-#   # Akade.IndexedSet benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: akadeindexedset
-#         csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-#         runCategories: 'AkadeIndexedSet'
-#         channels:
-#           - main
+  # Akade.IndexedSet benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: akadeindexedset
+        csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+        runCategories: 'AkadeIndexedSet'
+        channels:
+          - main
 
-#   # ML.NET benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - win-arm64-ampere
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: mlnet
-#         csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-#         runCategories: 'mldotnet'
-#         channels:
-#           - main
-#           - 8.0
-#         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-#         runEnvVars: 
-#           - DOTNET_GCgen0size=410000 # ~4MB
-#           - DOTNET_GCHeapCount=4
-#           - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # ML.NET benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: mlnet
+        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet'
+        channels:
+          - main
+          - 8.0
+        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-#   # Roslyn benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - win-arm64-ampere
-#         - ubuntu-arm64-ampere
-#       isPublic: false
-#       jobParameters:
-#         kind: roslyn
-#         csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-#         runCategories: 'roslyn'
-#         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-#           - main
-#           - 8.0
-#         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-#         runEnvVars: 
-#           - DOTNET_GCgen0size=410000 # ~4MB
-#           - DOTNET_GCHeapCount=4
-#           - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Roslyn benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: roslyn
+        csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+        runCategories: 'roslyn'
+        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
+          - 8.0
+        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-#   # ILLink benchmarks
-#   # disabled because of: https://github.com/dotnet/performance/issues/3569
-#   # - template: /eng/performance/build_machine_matrix.yml
-#   #   parameters:
-#   #     jobTemplate: /eng/performance/benchmark_jobs.yml
-#   #     buildMachines:
-#   #       - win-x64
-#   #       - ubuntu-x64
-#   #       # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
-#   #     isPublic: false
-#   #     jobParameters:
-#   #       kind: illink
-#   #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-#   #       runCategories: 'illink'
-#   #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-#   #         - main
-#   #         - 8.0
+  # ILLink benchmarks
+  # disabled because of: https://github.com/dotnet/performance/issues/3569
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/benchmark_jobs.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: illink
+  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+  #       runCategories: 'illink'
+  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+  #         - main
+  #         - 8.0
 
-#   # Powershell benchmarks
-#   - template: /eng/performance/build_machine_matrix.yml
-#     parameters:
-#       jobTemplate: /eng/performance/benchmark_jobs.yml
-#       buildMachines:
-#         - win-x64
-#         - ubuntu-x64
-#         - win-arm64
-#         - ubuntu-arm64
-#       isPublic: false
-#       jobParameters:
-#         kind: powershell
-#         csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-#         runCategories: 'Public Internal'
-#         channels:
-#           - main
-#           - 8.0
+  # Powershell benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/benchmark_jobs.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        kind: powershell
+        csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+        runCategories: 'Public Internal'
+        channels:
+          - main
+          - 8.0
 
-#   # Secret Sync
-#   - job: Synchronize
-#     pool:
-#       name: NetCore1ESPool-Internal-NoMSI
-#       demands: ImageOverride -equals 1es-windows-2019
-#     steps:
-#     - task: UseDotNet@2
-#       displayName: Install .NET 6.0 
-#       inputs:
-#         version: 6.x
+  # Secret Sync
+  - job: Synchronize
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    - task: UseDotNet@2
+      displayName: Install .NET 6.0 
+      inputs:
+        version: 6.x
 
-#     - task: DeleteFiles@1
-#       inputs:
-#         Contents: global.json
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
 
-#     - script: dotnet tool restore
+    - script: dotnet tool restore
 
-#     - task: AzureCLI@2
-#       inputs:
-#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-#         scriptType: ps
-#         scriptLocation: inlineScript
-#         inlineScript: |
-#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
-# ################################################
-# # Manually Triggered Job
-# ################################################
+################################################
+# Manually Triggered Job
+################################################
 
 
-# - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual'), not(parameters.runPublicJobs), not(parameters.runScheduledPrivateJobs), not(parameters.runPrivateJobs)) }}:
-#   - job: Synchronize
-#     pool:
-#       name: NetCore1ESPool-Internal-NoMSI
-#       demands: ImageOverride -equals 1es-windows-2019
-#     steps:
-#     - task: UseDotNet@2
-#       displayName: Install .NET 6.0 
-#       inputs:
-#         version: 6.x
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual'), not(parameters.runPublicJobs), not(parameters.runScheduledPrivateJobs), not(parameters.runPrivateJobs)) }}:
+  - job: Synchronize
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    - task: UseDotNet@2
+      displayName: Install .NET 6.0 
+      inputs:
+        version: 6.x
 
-#     - task: DeleteFiles@1
-#       inputs:
-#         Contents: global.json
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
 
-#     - script: dotnet tool restore
+    - script: dotnet tool restore
 
-#     - task: AzureCLI@2
-#       inputs:
-#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-#         scriptType: ps
-#         scriptLocation: inlineScript
-#         inlineScript: |
-#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
-# ################################################
-# # Scheduled Private jobs (Weekly)
-# ################################################
+################################################
+# Scheduled Private jobs (Weekly)
+################################################
 
-# # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
-# - ${{ if and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), contains(variables['Build.QueuedBy'], 'Weekly')) }}:
-#   - job: Synchronize
-#     pool:
-#       name: NetCore1ESPool-Internal-NoMSI
-#       demands: ImageOverride -equals 1es-windows-2019
-#     steps:
-#     - task: UseDotNet@2
-#       displayName: Install .NET 6.0 
-#       inputs:
-#         version: 6.x
+# Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
+- ${{ if and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), contains(variables['Build.QueuedBy'], 'Weekly')) }}:
+  - job: Synchronize
+    pool:
+      name: NetCore1ESPool-Internal-NoMSI
+      demands: ImageOverride -equals 1es-windows-2019
+    steps:
+    - task: UseDotNet@2
+      displayName: Install .NET 6.0 
+      inputs:
+        version: 6.x
 
-#     - task: DeleteFiles@1
-#       inputs:
-#         Contents: global.json
+    - task: DeleteFiles@1
+      inputs:
+        Contents: global.json
 
-#     - script: dotnet tool restore
+    - script: dotnet tool restore
 
-#     - task: AzureCLI@2
-#       inputs:
-#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-#         scriptType: ps
-#         scriptLocation: inlineScript
-#         inlineScript: |
-#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+    - task: AzureCLI@2
+      inputs:
+        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+        scriptType: ps
+        scriptLocation: inlineScript
+        inlineScript: |
+          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,273 +57,273 @@ jobs:
 # Public correctness jobs
 ######################################################
 
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
+# - ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
 
-  # Scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios.proj
-        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-          - main
-          - 8.0
+#   # Scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: scenarios
+#         projectFile: scenarios.proj
+#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+#           - main
+#           - 8.0
 
-  ## MAUI scenario benchmarks
-  #- template: /eng/performance/build_machine_matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/performance/scenarios.yml
-  #    buildMachines:
-  #      - win-x64
-  #      - ubuntu-x64
-  #    isPublic: true
-  #    jobParameters:
-  #      kind: maui_scenarios
-  #      projectFile: maui_scenarios.proj
-  #      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-  #        - main
-  #        - 8.0
+#   ## MAUI scenario benchmarks
+#   #- template: /eng/performance/build_machine_matrix.yml
+#   #  parameters:
+#   #    jobTemplate: /eng/performance/scenarios.yml
+#   #    buildMachines:
+#   #      - win-x64
+#   #      - ubuntu-x64
+#   #    isPublic: true
+#   #    jobParameters:
+#   #      kind: maui_scenarios
+#   #      projectFile: maui_scenarios.proj
+#   #      channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+#   #        - main
+#   #        - 8.0
 
-  # Blazor scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: blazor_scenarios
-        projectFile: blazor_scenarios.proj
-        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-          - main
-          - 8.0
+#   # Blazor scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: blazor_scenarios
+#         projectFile: blazor_scenarios.proj
+#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+#           - main
+#           - 8.0
 
-  # SDK scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-x86
-        - ubuntu-x64-1804
-      isPublic: true
-      jobParameters:
-        kind: sdk_scenarios
-        projectFile: sdk_scenarios.proj
-        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-          - main
-          - 8.0
+#   # SDK scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - win-x86
+#         - ubuntu-x64-1804
+#       isPublic: true
+#       jobParameters:
+#         kind: sdk_scenarios
+#         projectFile: sdk_scenarios.proj
+#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+#           - main
+#           - 8.0
   
-  # micro benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - win-x86
-      isPublic: true
-      jobParameters:
-        kind: micro
-        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-        runCategories: 'runtime libraries' 
-        channels:
-          - main
-          - 8.0
+#   # micro benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - win-x86
+#       isPublic: true
+#       jobParameters:
+#         kind: micro
+#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+#         runCategories: 'runtime libraries' 
+#         channels:
+#           - main
+#           - 8.0
 
-  # Ubuntux64 Default and NativeAOT micro benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: micro
-        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-        runCategories: 'runtime libraries' 
-        channels:
-          - main
-          - nativeaot9.0
-          - nativeaot8.0
-          - 8.0
+#   # Ubuntux64 Default and NativeAOT micro benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: micro
+#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+#         runCategories: 'runtime libraries' 
+#         channels:
+#           - main
+#           - nativeaot9.0
+#           - nativeaot8.0
+#           - 8.0
 
-  # net462 micro benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-rs5-x64
-      isPublic: true
-      jobParameters:
-        kind: micro_net462
-        csproj: src\benchmarks\micro\MicroBenchmarks.csproj
-        runCategories: 'runtime libraries'
-        channels:
-          - net462
+#   # net462 micro benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-rs5-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: micro_net462
+#         csproj: src\benchmarks\micro\MicroBenchmarks.csproj
+#         runCategories: 'runtime libraries'
+#         channels:
+#           - net462
 
-  # ML.NET benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: mlnet
-        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-        runCategories: 'mldotnet' 
-        channels:
-          - main
-          - 8.0
+#   # ML.NET benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: mlnet
+#         csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+#         runCategories: 'mldotnet' 
+#         channels:
+#           - main
+#           - 8.0
 
-  # F# benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: fsharp
-        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-        runCategories: 'fsharp'
-        channels:
-          - main
-          - 8.0
+#   # F# benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: fsharp
+#         csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+#         runCategories: 'fsharp'
+#         channels:
+#           - main
+#           - 8.0
 
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: fsharpmicro
-        csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-        runCategories: 'FSharpMicro'
-        channels:
-          - main
-          - 8.0
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: fsharpmicro
+#         csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+#         runCategories: 'FSharpMicro'
+#         channels:
+#           - main
+#           - 8.0
 
-  # bepuphysics benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: bepuphysics
-        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-        runCategories: 'BepuPhysics'
-        channels:
-          - main
-          - 8.0
+#   # bepuphysics benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: bepuphysics
+#         csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+#         runCategories: 'BepuPhysics'
+#         channels:
+#           - main
+#           - 8.0
 
-  # ImageSharp benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: imagesharp
-        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-        runCategories: 'ImageSharp'
-        channels:
-          - main
-          - 8.0
+#   # ImageSharp benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: imagesharp
+#         csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+#         runCategories: 'ImageSharp'
+#         channels:
+#           - main
+#           - 8.0
 
-  # Akade.IndexedSet benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: akadeindexedset
-        csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-        runCategories: 'AkadeIndexedSet'
-        channels:
-          - main
-          - 8.0
+#   # Akade.IndexedSet benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: akadeindexedset
+#         csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+#         runCategories: 'AkadeIndexedSet'
+#         channels:
+#           - main
+#           - 8.0
 
-  # Roslyn benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: roslyn
-        csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-        runCategories: 'roslyn'
-        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
-          - 8.0
+#   # Roslyn benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: roslyn
+#         csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+#         runCategories: 'roslyn'
+#         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+#           - main
+#           - 8.0
 
-  # ILLink benchmarks
-  # disabled because of: https://github.com/dotnet/performance/issues/3569
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #     isPublic: true
-  #     jobParameters:
-  #       kind: illink
-  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-  #       runCategories: 'illink'
-  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-  #         - main
+#   # ILLink benchmarks
+#   # disabled because of: https://github.com/dotnet/performance/issues/3569
+#   # - template: /eng/performance/build_machine_matrix.yml
+#   #   parameters:
+#   #     jobTemplate: /eng/performance/benchmark_jobs.yml
+#   #     buildMachines:
+#   #       - win-x64
+#   #       - ubuntu-x64
+#   #     isPublic: true
+#   #     jobParameters:
+#   #       kind: illink
+#   #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+#   #       runCategories: 'illink'
+#   #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+#   #         - main
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
-          - main
-          - 8.0
+#   # NativeAOT scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: nativeaot_scenarios
+#         projectFile: nativeaot_scenarios.proj
+#         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
+#           - main
+#           - 8.0
 
-  # Powershell benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-      isPublic: true
-      jobParameters:
-        kind: powershell
-        csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-        runCategories: 'Public'
-        channels:
-          - main
-          - 8.0
+#   # Powershell benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#       isPublic: true
+#       jobParameters:
+#         kind: powershell
+#         csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+#         runCategories: 'Public'
+#         channels:
+#           - main
+#           - 8.0
 
 ###########################################
 # Private Jobs
@@ -331,44 +331,44 @@ jobs:
 
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
-  # Scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios.proj
-        channels:
-          - main
-          - 8.0
+  # # Scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios.proj
+  #       channels:
+  #         - main
+  #         - 8.0
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -402,21 +402,21 @@ jobs:
           - 8.0
         runtimeFlavor: mono
 
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
-        runtimeFlavor: coreclr
+  # # Maui iOS Native AOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: maui_scenarios_ios
+  #       projectFile: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         9.0: ./eng/Version.Details.xml
+  #       channels:
+  #         - 8.0
+  #       runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
   #- template: /eng/performance/build_machine_matrix.yml
@@ -435,312 +435,312 @@ jobs:
   #        - main
   #        - 8.0
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 8.0
+#   # NativeAOT scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#       isPublic: false
+#       jobParameters:
+#         kind: nativeaot_scenarios
+#         projectFile: nativeaot_scenarios.proj
+#         channels:
+#           - main
+#           - 8.0
 
-################################################
-# Scheduled Private jobs
-################################################
+# ################################################
+# # Scheduled Private jobs
+# ################################################
 
-# Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
-- ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
+# # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
+# - ${{ if or(and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), not(contains(variables['Build.QueuedBy'], 'Weekly'))), parameters.runScheduledPrivateJobs) }}:
 
-  # SDK scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-x86
-        - ubuntu-x64-1804
-      isPublic: false
-      jobParameters:
-        kind: sdk_scenarios
-        projectFile: sdk_scenarios.proj
-        channels:
-          - main
-          - 8.0
+#   # SDK scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#         - win-x86
+#         - ubuntu-x64-1804
+#       isPublic: false
+#       jobParameters:
+#         kind: sdk_scenarios
+#         projectFile: sdk_scenarios.proj
+#         channels:
+#           - main
+#           - 8.0
 
-  # Blazor 3.2 scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-      isPublic: false
-      jobParameters:
-        kind: blazor_scenarios
-        projectFile: blazor_scenarios.proj
-        channels:
-          - main
-          - 8.0
+#   # Blazor 3.2 scenario benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/scenarios.yml
+#       buildMachines:
+#         - win-x64
+#       isPublic: false
+#       jobParameters:
+#         kind: blazor_scenarios
+#         projectFile: blazor_scenarios.proj
+#         channels:
+#           - main
+#           - 8.0
 
-  # F# benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: fsharp
-        csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-        runCategories: 'fsharp'
-        channels:
-          - main
-          - 8.0
+#   # F# benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: fsharp
+#         csproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+#         runCategories: 'fsharp'
+#         channels:
+#           - main
+#           - 8.0
 
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: fsharpmicro
-        csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-        runCategories: 'FSharpMicro'
-        channels:
-          - main
-          - 8.0
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: fsharpmicro
+#         csproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+#         runCategories: 'FSharpMicro'
+#         channels:
+#           - main
+#           - 8.0
 
-  # bepuphysics benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: bepuphysics
-        csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-        runCategories: 'BepuPhysics'
-        channels:
-          - main
-          - 8.0
+#   # bepuphysics benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: bepuphysics
+#         csproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+#         runCategories: 'BepuPhysics'
+#         channels:
+#           - main
+#           - 8.0
 
-  # ImageSharp benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: imagesharp
-        csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-        runCategories: 'ImageSharp'
-        channels:
-          - main
-          - 8.0
+#   # ImageSharp benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: imagesharp
+#         csproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+#         runCategories: 'ImageSharp'
+#         channels:
+#           - main
+#           - 8.0
 
-  # Akade.IndexedSet benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: akadeindexedset
-        csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-        runCategories: 'AkadeIndexedSet'
-        channels:
-          - main
+#   # Akade.IndexedSet benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: akadeindexedset
+#         csproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+#         runCategories: 'AkadeIndexedSet'
+#         channels:
+#           - main
 
-  # ML.NET benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - win-arm64-ampere
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: mlnet
-        csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-        runCategories: 'mldotnet'
-        channels:
-          - main
-          - 8.0
-        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+#   # ML.NET benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - win-arm64-ampere
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: mlnet
+#         csproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+#         runCategories: 'mldotnet'
+#         channels:
+#           - main
+#           - 8.0
+#         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+#         runEnvVars: 
+#           - DOTNET_GCgen0size=410000 # ~4MB
+#           - DOTNET_GCHeapCount=4
+#           - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-  # Roslyn benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - win-arm64-ampere
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: roslyn
-        csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-        runCategories: 'roslyn'
-        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
-          - 8.0
-        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+#   # Roslyn benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - win-arm64-ampere
+#         - ubuntu-arm64-ampere
+#       isPublic: false
+#       jobParameters:
+#         kind: roslyn
+#         csproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+#         runCategories: 'roslyn'
+#         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+#           - main
+#           - 8.0
+#         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+#         runEnvVars: 
+#           - DOTNET_GCgen0size=410000 # ~4MB
+#           - DOTNET_GCHeapCount=4
+#           - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
-  # ILLink benchmarks
-  # disabled because of: https://github.com/dotnet/performance/issues/3569
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/benchmark_jobs.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: illink
-  #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-  #       runCategories: 'illink'
-  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-  #         - main
-  #         - 8.0
+#   # ILLink benchmarks
+#   # disabled because of: https://github.com/dotnet/performance/issues/3569
+#   # - template: /eng/performance/build_machine_matrix.yml
+#   #   parameters:
+#   #     jobTemplate: /eng/performance/benchmark_jobs.yml
+#   #     buildMachines:
+#   #       - win-x64
+#   #       - ubuntu-x64
+#   #       # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
+#   #     isPublic: false
+#   #     jobParameters:
+#   #       kind: illink
+#   #       csproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+#   #       runCategories: 'illink'
+#   #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+#   #         - main
+#   #         - 8.0
 
-  # Powershell benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/benchmark_jobs.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        kind: powershell
-        csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-        runCategories: 'Public Internal'
-        channels:
-          - main
-          - 8.0
+#   # Powershell benchmarks
+#   - template: /eng/performance/build_machine_matrix.yml
+#     parameters:
+#       jobTemplate: /eng/performance/benchmark_jobs.yml
+#       buildMachines:
+#         - win-x64
+#         - ubuntu-x64
+#         - win-arm64
+#         - ubuntu-arm64
+#       isPublic: false
+#       jobParameters:
+#         kind: powershell
+#         csproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+#         runCategories: 'Public Internal'
+#         channels:
+#           - main
+#           - 8.0
 
-  # Secret Sync
-  - job: Synchronize
-    pool:
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
-    steps:
-    - task: UseDotNet@2
-      displayName: Install .NET 6.0 
-      inputs:
-        version: 6.x
+#   # Secret Sync
+#   - job: Synchronize
+#     pool:
+#       name: NetCore1ESPool-Internal-NoMSI
+#       demands: ImageOverride -equals 1es-windows-2019
+#     steps:
+#     - task: UseDotNet@2
+#       displayName: Install .NET 6.0 
+#       inputs:
+#         version: 6.x
 
-    - task: DeleteFiles@1
-      inputs:
-        Contents: global.json
+#     - task: DeleteFiles@1
+#       inputs:
+#         Contents: global.json
 
-    - script: dotnet tool restore
+#     - script: dotnet tool restore
 
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+#     - task: AzureCLI@2
+#       inputs:
+#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+#         scriptType: ps
+#         scriptLocation: inlineScript
+#         inlineScript: |
+#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
-################################################
-# Manually Triggered Job
-################################################
+# ################################################
+# # Manually Triggered Job
+# ################################################
 
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual'), not(parameters.runPublicJobs), not(parameters.runScheduledPrivateJobs), not(parameters.runPrivateJobs)) }}:
-  - job: Synchronize
-    pool:
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
-    steps:
-    - task: UseDotNet@2
-      displayName: Install .NET 6.0 
-      inputs:
-        version: 6.x
+# - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Manual'), not(parameters.runPublicJobs), not(parameters.runScheduledPrivateJobs), not(parameters.runPrivateJobs)) }}:
+#   - job: Synchronize
+#     pool:
+#       name: NetCore1ESPool-Internal-NoMSI
+#       demands: ImageOverride -equals 1es-windows-2019
+#     steps:
+#     - task: UseDotNet@2
+#       displayName: Install .NET 6.0 
+#       inputs:
+#         version: 6.x
 
-    - task: DeleteFiles@1
-      inputs:
-        Contents: global.json
+#     - task: DeleteFiles@1
+#       inputs:
+#         Contents: global.json
 
-    - script: dotnet tool restore
+#     - script: dotnet tool restore
 
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+#     - task: AzureCLI@2
+#       inputs:
+#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+#         scriptType: ps
+#         scriptLocation: inlineScript
+#         inlineScript: |
+#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
 
-################################################
-# Scheduled Private jobs (Weekly)
-################################################
+# ################################################
+# # Scheduled Private jobs (Weekly)
+# ################################################
 
-# Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
-- ${{ if and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), contains(variables['Build.QueuedBy'], 'Weekly')) }}:
-  - job: Synchronize
-    pool:
-      name: NetCore1ESPool-Internal-NoMSI
-      demands: ImageOverride -equals 1es-windows-2019
-    steps:
-    - task: UseDotNet@2
-      displayName: Install .NET 6.0 
-      inputs:
-        version: 6.x
+# # Scheduled runs will run all of the jobs on the PerfTigers, as well as the Arm64 job
+# - ${{ if and(and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')), contains(variables['Build.QueuedBy'], 'Weekly')) }}:
+#   - job: Synchronize
+#     pool:
+#       name: NetCore1ESPool-Internal-NoMSI
+#       demands: ImageOverride -equals 1es-windows-2019
+#     steps:
+#     - task: UseDotNet@2
+#       displayName: Install .NET 6.0 
+#       inputs:
+#         version: 6.x
 
-    - task: DeleteFiles@1
-      inputs:
-        Contents: global.json
+#     - task: DeleteFiles@1
+#       inputs:
+#         Contents: global.json
 
-    - script: dotnet tool restore
+#     - script: dotnet tool restore
 
-    - task: AzureCLI@2
-      inputs:
-        azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-        scriptType: ps
-        scriptLocation: inlineScript
-        inlineScript: |
-          Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+#     - task: AzureCLI@2
+#       inputs:
+#         azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+#         scriptType: ps
+#         scriptLocation: inlineScript
+#         inlineScript: |
+#           Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,8 +382,7 @@ jobs:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
-          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          9.0: ./eng/Version.Details.xml
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -396,8 +395,7 @@ jobs:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
-          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          9.0: ./eng/Version.Details.xml
         runtimeFlavor: mono
 
   # Maui iOS Native AOT scenario benchmarks
@@ -411,8 +409,49 @@ jobs:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
-          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
-          8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
+          9.0: ./eng/Version.Details.xml
+        runtimeFlavor: coreclr
+
+  # Maui Android scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_android
+        projectFile: maui_scenarios_android.proj
+        channels:
+          - 8.0
+
+  # Maui iOS Mono scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        channels:
+          - 8.0
+        runtimeFlavor: mono
+
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        kind: maui_scenarios_ios
+        projectFile: maui_scenarios_ios.proj
+        channels:
+          - 8.0
         runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -383,46 +383,6 @@ jobs:
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-
-  # Maui iOS Mono scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
-        runtimeFlavor: mono
-
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_ios
-        projectFile: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
-        runtimeFlavor: coreclr
-
-  # Maui Android scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        kind: maui_scenarios_android
-        projectFile: maui_scenarios_android.proj
         channels:
           - 8.0
 
@@ -436,6 +396,8 @@ jobs:
       jobParameters:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: ./eng/Version.Details.xml
         channels:
           - 8.0
         runtimeFlavor: mono
@@ -450,6 +412,8 @@ jobs:
       jobParameters:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: ./eng/Version.Details.xml
         channels:
           - 8.0
         runtimeFlavor: coreclr

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -382,7 +382,7 @@ jobs:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
-          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
           8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
 
   # Maui iOS Mono scenario benchmarks
@@ -396,7 +396,7 @@ jobs:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
-          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
           8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: mono
 
@@ -411,7 +411,7 @@ jobs:
         kind: maui_scenarios_ios
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
-          9.0: https://maui.blob.core.windows.net/metadata/sdks/net9.0.json
+          9.0: https://raw.githubusercontent.com/dotnet/maui/net9.0/eng/Version.Details.xml
           8.0: https://aka.ms/dotnet/sdk/maui/net8.0.json
         runtimeFlavor: coreclr
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,5 +27,42 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>731d793be2d0a66bafc96b1a79dc96b4d1f0301b</Sha>
     </Dependency>
+     <!-- Dependencies for .NET MAUI workload -->
+    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24368.8">
+      <Sha>cf76a629023c99557239464a278daec280d1f448</Sha>
+      <Uri>https://github.com/dotnet/maui</Uri>
+    </Dependency>
+    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.7.24360.5" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>9a028e12b90e6a583b09ccb3008fdfaf85761f19</Sha>
+      <Uri>https://github.com/dotnet/sdk</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.7.24357.2" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
+      <Sha>4e278fe17f69ea31fbdcbab74ac47ec6fa84914b</Sha>
+      <Uri>https://github.com/dotnet/runtime</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.7.24319.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Sha>ffe9afdc046cf7a6f82cc7c5796aade54047af64</Sha>
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.7.346" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>06bb1dc6a292ef5618a3bb6ecca3ca869253ff2e</Sha>
+      <Uri>https://github.com/dotnet/android</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="14.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,6 +27,17 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>731d793be2d0a66bafc96b1a79dc96b4d1f0301b</Sha>
     </Dependency>
+    <!--
+      Maui Rollback Version mappings, default means generated from sdk version. Allows for manual override of version similar to https://github.com/dotnet/maui/blob/df8cfcf635a590955a8cc3d6cf7ae6280449dd3f/eng/Versions.props#L138-L146, where the logic comes from:
+      Mapping_Microsoft.Maui.Controls:default
+      Mapping_Microsoft.NETCore.App.Ref:default
+      Mapping_Microsoft.NET.Workload.Emscripten.Current:default
+      Mapping_Microsoft.Android.Sdk:default
+      Mapping_Microsoft.MacCatalyst.Sdk:9.0.100-preview.6
+      Mapping_Microsoft.macOS.Sdk:9.0.100-preview.6
+      Mapping_Microsoft.iOS.Sdk:9.0.100-preview.6
+      Mapping_Microsoft.tvOS.Sdk:9.0.100-preview.6
+    -->
      <!-- Dependencies for .NET MAUI workload -->
     <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24368.8">
       <Sha>cf76a629023c99557239464a278daec280d1f448</Sha>

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -555,6 +555,8 @@ def run_performance_job(args: RunPerformanceJobArgs):
                         ci_setup_arguments.dotnet_versions = [values["dotnet_version"]]
                     else:
                         ci_setup_arguments.dotnet_versions = [values["version"]]
+            else:
+                raise ValueError("Invalid dotnet_version_link provided. Must be a json file if a url.")
         elif os.path.exists(os.path.join(args.performance_repo_dir, args.dotnet_version_link)) and args.dotnet_version_link.endswith("Version.Details.xml"): # version_link is a file in the perf repo
             with open(os.path.join(args.performance_repo_dir, args.dotnet_version_link), encoding="utf-8") as f:
                 root = ET.fromstring(f.read())

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -2,7 +2,7 @@ import json
 import os
 import xml.etree.ElementTree as ET
 import re
-import requests
+import urllib.request
 from logging import getLogger
 from performance.common import get_repo_root_path
 from shared.precommands import PreCommands
@@ -82,7 +82,8 @@ def install_versioned_maui(precommands: PreCommands):
 
     # Download what we need
     with open("MauiNuGet.config", "wb") as f:
-        f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True, timeout=10).content)
+        with urllib.request.urlopen(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config') as response:
+            f.write(response.read())
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 7

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -21,7 +21,7 @@ def install_versioned_maui(precommands: PreCommands):
         f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True, timeout=10).content)
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
-    if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
+    if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 7
         # Generate and use rollback based on Version.Details.xml
         # Generate the list of versions starts to get and the names to save them as in the rollback.
         rollback_dict: dict[str, str] = {}

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -1,7 +1,11 @@
+import json
 import subprocess
 import os
 import requests
+import urllib.request
+import xml.etree.ElementTree as ET
 from shared.precommands import PreCommands
+from collections import namedtuple
 
 # Remove the aab files as we don't need them, this saves space in the correlation payload
 def remove_aab_files(output_dir="."):
@@ -19,6 +23,34 @@ def install_versioned_maui(precommands: PreCommands):
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
-        workload_install_args += ['--from-rollback-file', f'https://maui.blob.core.windows.net/metadata/rollbacks/{target_framework_wo_platform}.json']
+        # Generate and use rollback based on Version.Details.xml
+        # Generate the list of versions starts to get and the names to save them as in the rollback.
+        rollback_name_to_xml_name_mappings: dict[str, str] = {}
+        rollback_dict: dict[str, str] = {}
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.android"] = "Microsoft.Android.Sdk"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.ios"] = "Microsoft.iOS.Sdk"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maccatalyst"] = "Microsoft.MacCatalyst.Sdk"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.macos"] = "Microsoft.macOS.Sdk"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maui"] = "Microsoft.Android.Sdk" # TODO
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.tvos"] = "Microsoft.tvOS.Sdk"
+        rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "Microsoft.NETCore.App.Ref"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.toolchain.current"] = "Microsoft.NETCore.App.Ref"
+        rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "Microsoft.NET.Workload.Emscripten.Current"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.emscripten.current"] = "Microsoft.NET.Workload.Emscripten.Current"
+
+        root = ET.fromstring(urllib.request.urlopen(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Version.Details.xml").read())
+        dependencies = root.findall(".//Dependency[@Name]")
+        for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
+            for dependency in dependencies:
+                if dependency.get("Name").startswith(xml_name): # type: ignore, we know Name is present
+                    rollback_dict[rollback_name] = dependency.get("Version", "ERROR: Failed to get version")
+                    break
+            if rollback_dict[rollback_name] == "ERROR: Failed to get version":
+                raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
+
+        json_output = json.dumps(rollback_dict, indent=4)
+        with open(f"rollback_{target_framework_wo_platform}.json", "w", encoding="utf-8") as f:
+            f.write(json_output)
+        workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']
 
     precommands.install_workload('maui', workload_install_args) 

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -3,6 +3,7 @@ import os
 import xml.etree.ElementTree as ET
 import re
 import requests
+from performance.common import get_repo_root_path
 from shared.precommands import PreCommands
 
 # Remove the aab files as we don't need them, this saves space in the correlation payload
@@ -10,71 +11,48 @@ def remove_aab_files(output_dir="."):
     file_list = os.listdir(output_dir)
     for file in file_list:
         if file.endswith(".aab"):
-            os.remove(os.path.join(output_dir, file))
+            os.remove(os.path.join(output_dir, file))  
 
 def install_versioned_maui(precommands: PreCommands):
     target_framework_wo_platform = precommands.framework.split('-')[0]
 
     # Download what we need
     with open ("MauiNuGet.config", "wb") as f:
-        f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True).content)
+        f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True, timeout=10).content)
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
         # Generate and use rollback based on Version.Details.xml
         # Generate the list of versions starts to get and the names to save them as in the rollback.
         rollback_name_to_xml_name_mappings: dict[str, str] = {}
-        rollback_name_to_verion_property_mappings: dict[str, str] = {}
+        rollback_name_to_version_property_mappings: dict[str, str] = {}
         rollback_dict: dict[str, str] = {}
 
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.android"] = "Microsoft.Android.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.ios"] = "Microsoft.iOS.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.maccatalyst"] = "Microsoft.MacCatalyst.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.macos"] = "Microsoft.macOS.Sdk"
+        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maui"] = "Microsoft.Maui.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.tvos"] = "Microsoft.tvOS.Sdk"
         rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "Microsoft.NETCore.App.Ref"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.toolchain.current"] = "Microsoft.NETCore.App.Ref"
         rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "Microsoft.NET.Workload.Emscripten.Current"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.emscripten.current"] = "Microsoft.NET.Workload.Emscripten.Current"
-        
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.android"] = "DotNetAndroidManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.ios"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.maccatalyst"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.maui"] = "DotNetMauiManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.macos"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.tvos"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_verion_property_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "DotNetMonoManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.mono.toolchain.current"] = "DotNetMonoManifestVersionBand"
-        rollback_name_to_verion_property_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "DotNetEmscriptenManifestVersionBand"
-        rollback_name_to_verion_property_mappings["microsoft.net.sdk.mono.emscripten.current"] = "DotNetEmscriptenManifestVersionBand"
 
-        # Get the available versions from the Version.Details.xml file (Everything in rollback_name_to_xml_name_mappings)
-        root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Version.Details.xml", timeout=10).content)
-        dependencies = root.findall(".//Dependency[@Name]")
-        for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
-            for dependency in dependencies:
-                if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
-                    rollback_dict[rollback_name] = dependency.get("Version", "ERROR: Failed to get version")
-                    break
-            if rollback_dict[rollback_name] == "ERROR: Failed to get version":
-                raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.android"] = "DotNetAndroidManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.ios"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.maccatalyst"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.maui"] = "DotNetMauiManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.macos"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.tvos"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_version_property_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "DotNetMonoManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.mono.toolchain.current"] = "DotNetMonoManifestVersionBand"
+        rollback_name_to_version_property_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "DotNetEmscriptenManifestVersionBand"
+        rollback_name_to_version_property_mappings["microsoft.net.sdk.mono.emscripten.current"] = "DotNetEmscriptenManifestVersionBand"
 
-        # Separately handle the maui workload version as it is not on the Version.Details.xml page
-        status_json = requests.get(f"https://api.github.com/repos/dotnet/maui/commits/{target_framework_wo_platform}/status", timeout=10).json()
-        maui_version = "ERROR: Failed to get version"
-        for status in status_json.get("statuses", []):
-            if status.get("context") == "MAUI-Release":
-                description = status.get("description", "")
-                # Find the version substring before "+azdo"
-                maui_version = description.split("+azdo")[0].strip("# ")
-
-        if maui_version == "ERROR: Failed to get version":
-            raise ValueError("Unable to find MAUI version in the provided status json")
-        rollback_dict["microsoft.net.sdk.maui"] = maui_version
-
-        # Get the band version from the Version.props xml file (Everything in rollback_name_to_verion_property_mappings)
-        root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Versions.props", timeout=10).content)
-        general_version_obj = root.find(".//PropertyGroup/VSToolsNetCoreSDKResolverPackageVersion")
+        # Get the General Band version from the Version.props xml file from the Maui repo
+        band_version_root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Versions.props", timeout=10).content)
+        general_version_obj = band_version_root.find(".//PropertyGroup/VSToolsNetCoreSDKResolverPackageVersion")
         if general_version_obj is not None and general_version_obj.text is not None:
             general_version = general_version_obj.text
             match = re.match(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', general_version)
@@ -84,20 +62,33 @@ def install_versioned_maui(precommands: PreCommands):
                 raise ValueError("Unable to find general version in the provided xml file")
         else:
             raise ValueError("Unable to find general version in the provided xml file")
-        
-        # Get the band version for each of the workloads and append it to the rollback_dict entries
-        for rollback_name, version_property in rollback_name_to_verion_property_mappings.items():
-            for props_version_property in root.findall(".//PropertyGroup/*"):
-                if props_version_property.tag == version_property:
-                    if props_version_property.text is None or props_version_property.text == "":
-                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/ERROR: Failed to get band version"
-                    elif props_version_property.text != "$(DotNetVersionBand)":
-                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/" + props_version_property.text
-                    else:
-                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/" + general_version
+
+        # Get the available versions from the Version.Details.xml file
+        with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
+            root = ET.fromstring(f.read())
+        dependencies = root.findall(".//Dependency[@Name]")
+        for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
+            for dependency in dependencies:
+                if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
+                    workload_version = dependency.get("Version", "ERROR: Failed to get version")
+                    if workload_version == "ERROR: Failed to get version":
+                        raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
+                                        
+                    # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
+                    band_version = None
+                    for rollback_name, version_property in rollback_name_to_version_property_mappings.items():
+                        for props_version_property in band_version_root.findall(".//PropertyGroup/*"):
+                            if props_version_property.tag == version_property:
+                                if props_version_property.text is None or props_version_property.text == "":
+                                    band_version = "ERROR: Failed to get band version"
+                                elif props_version_property.text != "$(DotNetVersionBand)":
+                                    band_version = props_version_property.text
+                                else:
+                                    band_version = general_version
+                                break
+                    rollback_dict[rollback_name] = f"{workload_version}/{band_version}"
                     break
-            print(rollback_dict)
-            if rollback_dict[rollback_name].split("/")[1] == "ERROR: Failed to get band version":
+            if rollback_name not in rollback_dict:
                 raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
             
         json_output = json.dumps(rollback_dict, indent=4)

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -3,7 +3,6 @@ import os
 import xml.etree.ElementTree as ET
 import re
 import urllib.request
-from logging import getLogger
 from performance.common import get_repo_root_path
 from shared.precommands import PreCommands
 
@@ -40,8 +39,8 @@ def generate_maui_rollback_dict():
     # Get the General Band version from the Version.Details.xml file sdk version
     general_version_obj = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']")
     if general_version_obj is not None:
-        full_band_version_holder = general_version_obj.get("Version", "ERROR: Failed to get version")
-        if full_band_version_holder == "ERROR: Failed to get version":
+        full_band_version_holder = general_version_obj.get("Version")
+        if full_band_version_holder is None:
             raise ValueError("Unable to find VS.Tools.Net.Core.SDK.Resolver with proper version in Version.Details.xml")
         match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
         if match:
@@ -56,8 +55,8 @@ def generate_maui_rollback_dict():
     for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
         for dependency in dependencies:
             if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
-                workload_version = dependency.get("Version", "ERROR: Failed to get version")
-                if workload_version == "ERROR: Failed to get version":
+                workload_version = dependency.get("Version")
+                if workload_version is None:
                     raise ValueError(f"Unable to find {xml_name} with proper version in the provided xml file")
 
                 # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
@@ -95,4 +94,3 @@ def install_versioned_maui(precommands: PreCommands):
         workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']
 
     precommands.install_workload('maui', workload_install_args) 
-

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -3,6 +3,7 @@ import os
 import xml.etree.ElementTree as ET
 import re
 import requests
+from logging import getLogger
 from performance.common import get_repo_root_path
 from shared.precommands import PreCommands
 
@@ -32,9 +33,7 @@ def install_versioned_maui(precommands: PreCommands):
             "microsoft.net.sdk.macos" : "Microsoft.macOS.Sdk",
             "microsoft.net.sdk.maui" : "Microsoft.Maui.Controls",
             "microsoft.net.sdk.tvos" : "Microsoft.tvOS.Sdk",
-            f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}" : "Microsoft.NETCore.App.Ref",
             "microsoft.net.sdk.mono.toolchain.current" : "Microsoft.NETCore.App.Ref",
-            f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}" : "Microsoft.NET.Workload.Emscripten.Current",
             "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
         }
 
@@ -81,6 +80,7 @@ def install_versioned_maui(precommands: PreCommands):
                 raise ValueError(f"Unable to find {rollback_name} with proper version in Version.Details.xml")
 
         json_output = json.dumps(rollback_dict, indent=4)
+        getLogger().info(f"Rollback file: \n{json_output}")
         with open(f"rollback_{target_framework_wo_platform}.json", "w", encoding="utf-8") as f:
             f.write(json_output)
         workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -1,11 +1,9 @@
 import json
-import subprocess
 import os
-import requests
-import urllib.request
 import xml.etree.ElementTree as ET
+import re
+import requests
 from shared.precommands import PreCommands
-from collections import namedtuple
 
 # Remove the aab files as we don't need them, this saves space in the correlation payload
 def remove_aab_files(output_dir="."):
@@ -26,28 +24,82 @@ def install_versioned_maui(precommands: PreCommands):
         # Generate and use rollback based on Version.Details.xml
         # Generate the list of versions starts to get and the names to save them as in the rollback.
         rollback_name_to_xml_name_mappings: dict[str, str] = {}
+        rollback_name_to_verion_property_mappings: dict[str, str] = {}
         rollback_dict: dict[str, str] = {}
+
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.android"] = "Microsoft.Android.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.ios"] = "Microsoft.iOS.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.maccatalyst"] = "Microsoft.MacCatalyst.Sdk"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.macos"] = "Microsoft.macOS.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maui"] = "Microsoft.Android.Sdk" # TODO
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.tvos"] = "Microsoft.tvOS.Sdk"
         rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "Microsoft.NETCore.App.Ref"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.toolchain.current"] = "Microsoft.NETCore.App.Ref"
         rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "Microsoft.NET.Workload.Emscripten.Current"
         rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.emscripten.current"] = "Microsoft.NET.Workload.Emscripten.Current"
+        
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.android"] = "DotNetAndroidManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.ios"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.maccatalyst"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.maui"] = "DotNetMauiManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.macos"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.tvos"] = "DotNetMaciOSManifestVersionBand"
+        rollback_name_to_verion_property_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "DotNetMonoManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.mono.toolchain.current"] = "DotNetMonoManifestVersionBand"
+        rollback_name_to_verion_property_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "DotNetEmscriptenManifestVersionBand"
+        rollback_name_to_verion_property_mappings["microsoft.net.sdk.mono.emscripten.current"] = "DotNetEmscriptenManifestVersionBand"
 
-        root = ET.fromstring(urllib.request.urlopen(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Version.Details.xml").read())
+        # Get the available versions from the Version.Details.xml file (Everything in rollback_name_to_xml_name_mappings)
+        root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Version.Details.xml", timeout=10).content)
         dependencies = root.findall(".//Dependency[@Name]")
         for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
             for dependency in dependencies:
-                if dependency.get("Name").startswith(xml_name): # type: ignore, we know Name is present
+                if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
                     rollback_dict[rollback_name] = dependency.get("Version", "ERROR: Failed to get version")
                     break
             if rollback_dict[rollback_name] == "ERROR: Failed to get version":
                 raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
 
+        # Separately handle the maui workload version as it is not on the Version.Details.xml page
+        status_json = requests.get(f"https://api.github.com/repos/dotnet/maui/commits/{target_framework_wo_platform}/status", timeout=10).json()
+        maui_version = "ERROR: Failed to get version"
+        for status in status_json.get("statuses", []):
+            if status.get("context") == "MAUI-Release":
+                description = status.get("description", "")
+                # Find the version substring before "+azdo"
+                maui_version = description.split("+azdo")[0].strip("# ")
+
+        if maui_version == "ERROR: Failed to get version":
+            raise ValueError("Unable to find MAUI version in the provided status json")
+        rollback_dict["microsoft.net.sdk.maui"] = maui_version
+
+        # Get the band version from the Version.props xml file (Everything in rollback_name_to_verion_property_mappings)
+        root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Versions.props", timeout=10).content)
+        general_version_obj = root.find(".//PropertyGroup/VSToolsNetCoreSDKResolverPackageVersion")
+        if general_version_obj is not None and general_version_obj.text is not None:
+            general_version = general_version_obj.text
+            match = re.match(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', general_version)
+            if match:
+                general_version = match.group(0)
+            else:
+                raise ValueError("Unable to find general version in the provided xml file")
+        else:
+            raise ValueError("Unable to find general version in the provided xml file")
+        
+        # Get the band version for each of the workloads and append it to the rollback_dict entries
+        for rollback_name, version_property in rollback_name_to_verion_property_mappings.items():
+            for props_version_property in root.findall(".//PropertyGroup/*"):
+                if props_version_property.tag == version_property:
+                    if props_version_property.text is None or props_version_property.text == "":
+                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/ERROR: Failed to get band version"
+                    elif props_version_property.text != "$(DotNetVersionBand)":
+                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/" + props_version_property.text
+                    else:
+                        rollback_dict[rollback_name] = rollback_dict[rollback_name] + "/" + general_version
+                    break
+            print(rollback_dict)
+            if rollback_dict[rollback_name].split("/")[1] == "ERROR: Failed to get band version":
+                raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
+            
         json_output = json.dumps(rollback_dict, indent=4)
         with open(f"rollback_{target_framework_wo_platform}.json", "w", encoding="utf-8") as f:
             f.write(json_output)

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -17,7 +17,9 @@ def remove_aab_files(output_dir="."):
 def generate_maui_rollback_dict():
     # Generate and use rollback based on Version.Details.xml
     # Generate the list of versions starts to get and the names to save them as in the rollback.
-    rollback_dict: dict[str, str] = {}
+    # These mapping values were taken from the previously generated rollback files for the maui workload. There should be at least one entry for each
+    # of the Maui Workload dependencies in the /eng/Version.Details.xml file, aside from VS.Tools.Net.Core.SDK.Resolver.
+    # If there are errors in the future, reach out to the maui team.
     rollback_name_to_xml_name_mappings: dict[str, str] = {
         "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
         "microsoft.net.sdk.ios" : "Microsoft.iOS.Sdk",
@@ -28,6 +30,7 @@ def generate_maui_rollback_dict():
         "microsoft.net.sdk.mono.toolchain.current" : "Microsoft.NETCore.App.Ref",
         "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
     }
+    rollback_dict: dict[str, str] = {}
 
     # Load in the Version.Details.xml file
     with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
@@ -86,7 +89,7 @@ def install_versioned_maui(precommands: PreCommands):
             f.write(response.read())
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
-    if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 7
+    if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 8 (should be set to only run for versions where we also use a specific dotnet version from the yml)
         rollback_dict = generate_maui_rollback_dict()
         dump_dict_to_json_file(rollback_dict, f"rollback_{target_framework_wo_platform}.json")
         workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -17,80 +17,69 @@ def install_versioned_maui(precommands: PreCommands):
     target_framework_wo_platform = precommands.framework.split('-')[0]
 
     # Download what we need
-    with open ("MauiNuGet.config", "wb") as f:
+    with open("MauiNuGet.config", "wb") as f:
         f.write(requests.get(f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config', allow_redirects=True, timeout=10).content)
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 7: # Use the rollback file for versions greater than 7
         # Generate and use rollback based on Version.Details.xml
         # Generate the list of versions starts to get and the names to save them as in the rollback.
-        rollback_name_to_xml_name_mappings: dict[str, str] = {}
-        rollback_name_to_version_property_mappings: dict[str, str] = {}
         rollback_dict: dict[str, str] = {}
+        rollback_name_to_xml_name_mappings: dict[str, str] = {
+            "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
+            "microsoft.net.sdk.ios" : "Microsoft.iOS.Sdk",
+            "microsoft.net.sdk.maccatalyst" : "Microsoft.MacCatalyst.Sdk",
+            "microsoft.net.sdk.macos" : "Microsoft.macOS.Sdk",
+            "microsoft.net.sdk.maui" : "Microsoft.Maui.Controls",
+            "microsoft.net.sdk.tvos" : "Microsoft.tvOS.Sdk",
+            f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}" : "Microsoft.NETCore.App.Ref",
+            "microsoft.net.sdk.mono.toolchain.current" : "Microsoft.NETCore.App.Ref",
+            f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}" : "Microsoft.NET.Workload.Emscripten.Current",
+            "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
+        }
 
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.android"] = "Microsoft.Android.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.ios"] = "Microsoft.iOS.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maccatalyst"] = "Microsoft.MacCatalyst.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.macos"] = "Microsoft.macOS.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.maui"] = "Microsoft.Maui.Sdk"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.tvos"] = "Microsoft.tvOS.Sdk"
-        rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "Microsoft.NETCore.App.Ref"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.toolchain.current"] = "Microsoft.NETCore.App.Ref"
-        rollback_name_to_xml_name_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "Microsoft.NET.Workload.Emscripten.Current"
-        rollback_name_to_xml_name_mappings["microsoft.net.sdk.mono.emscripten.current"] = "Microsoft.NET.Workload.Emscripten.Current"
+        # Load in the Version.Details.xml file
+        with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
+            version_details_xml = f.read()
+            root = ET.fromstring(version_details_xml)
 
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.android"] = "DotNetAndroidManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.ios"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.maccatalyst"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.maui"] = "DotNetMauiManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.macos"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.tvos"] = "DotNetMaciOSManifestVersionBand"
-        rollback_name_to_version_property_mappings[f"microsoft.net.sdk.mono.toolchain.{target_framework_wo_platform}"] = "DotNetMonoManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.mono.toolchain.current"] = "DotNetMonoManifestVersionBand"
-        rollback_name_to_version_property_mappings[f"microsoft.net.sdk.mono.emscripten.{target_framework_wo_platform}"] = "DotNetEmscriptenManifestVersionBand"
-        rollback_name_to_version_property_mappings["microsoft.net.sdk.mono.emscripten.current"] = "DotNetEmscriptenManifestVersionBand"
-
-        # Get the General Band version from the Version.props xml file from the Maui repo
-        band_version_root = ET.fromstring(requests.get(f"https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Versions.props", timeout=10).content)
-        general_version_obj = band_version_root.find(".//PropertyGroup/VSToolsNetCoreSDKResolverPackageVersion")
-        if general_version_obj is not None and general_version_obj.text is not None:
-            general_version = general_version_obj.text
-            match = re.match(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', general_version)
+        # Get the General Band version from the Version.Details.xml file sdk version
+        general_version_obj = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']")
+        if general_version_obj is not None:
+            full_band_version_holder = general_version_obj.get("Version", "ERROR: Failed to get version")
+            if full_band_version_holder == "ERROR: Failed to get version":
+                raise ValueError("Unable to find VS.Tools.Net.Core.SDK.Resolver with proper version in Version.Details.xml")
+            match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
             if match:
-                general_version = match.group(0)
+                default_band_version = match.group(0)
             else:
-                raise ValueError("Unable to find general version in the provided xml file")
+                raise ValueError("Unable to find general version in Version.Details.xml")
         else:
-            raise ValueError("Unable to find general version in the provided xml file")
+            raise ValueError("Unable to find general version in Version.Details.xml")
 
         # Get the available versions from the Version.Details.xml file
-        with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
-            root = ET.fromstring(f.read())
         dependencies = root.findall(".//Dependency[@Name]")
         for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
             for dependency in dependencies:
                 if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
                     workload_version = dependency.get("Version", "ERROR: Failed to get version")
                     if workload_version == "ERROR: Failed to get version":
-                        raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
-                                        
+                        raise ValueError(f"Unable to find {xml_name} with proper version in the provided xml file")
+
                     # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
-                    band_version = None
-                    for rollback_name, version_property in rollback_name_to_version_property_mappings.items():
-                        for props_version_property in band_version_root.findall(".//PropertyGroup/*"):
-                            if props_version_property.tag == version_property:
-                                if props_version_property.text is None or props_version_property.text == "":
-                                    band_version = "ERROR: Failed to get band version"
-                                elif props_version_property.text != "$(DotNetVersionBand)":
-                                    band_version = props_version_property.text
-                                else:
-                                    band_version = general_version
-                                break
+                    band_name_match_string = rf"^\s*Mapping_{xml_name}:(\S*)"
+                    band_version_mapping = re.search(band_name_match_string, version_details_xml, flags=re.MULTILINE)
+                    if band_version_mapping is None:
+                        raise ValueError(f"Unable to find band version mapping for match {band_name_match_string} in Version.Details.xml")
+                    if band_version_mapping.group(1) == "default":
+                        band_version = default_band_version
+                    else:
+                        band_version = band_version_mapping.group(1)
                     rollback_dict[rollback_name] = f"{workload_version}/{band_version}"
                     break
             if rollback_name not in rollback_dict:
-                raise ValueError(f"Unable to find {rollback_name} with proper version in the provided xml file")
-            
+                raise ValueError(f"Unable to find {rollback_name} with proper version in Version.Details.xml")
+
         json_output = json.dumps(rollback_dict, indent=4)
         with open(f"rollback_{target_framework_wo_platform}.json", "w", encoding="utf-8") as f:
             f.write(json_output)

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -14,6 +14,69 @@ def remove_aab_files(output_dir="."):
         if file.endswith(".aab"):
             os.remove(os.path.join(output_dir, file))  
 
+def generate_maui_rollback_dict():
+    # Generate and use rollback based on Version.Details.xml
+    # Generate the list of versions starts to get and the names to save them as in the rollback.
+    rollback_dict: dict[str, str] = {}
+    rollback_name_to_xml_name_mappings: dict[str, str] = {
+        "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
+        "microsoft.net.sdk.ios" : "Microsoft.iOS.Sdk",
+        "microsoft.net.sdk.maccatalyst" : "Microsoft.MacCatalyst.Sdk",
+        "microsoft.net.sdk.macos" : "Microsoft.macOS.Sdk",
+        "microsoft.net.sdk.maui" : "Microsoft.Maui.Controls",
+        "microsoft.net.sdk.tvos" : "Microsoft.tvOS.Sdk",
+        "microsoft.net.sdk.mono.toolchain.current" : "Microsoft.NETCore.App.Ref",
+        "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
+    }
+
+    # Load in the Version.Details.xml file
+    with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
+        version_details_xml = f.read()
+        root = ET.fromstring(version_details_xml)
+
+    # Get the General Band version from the Version.Details.xml file sdk version
+    general_version_obj = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']")
+    if general_version_obj is not None:
+        full_band_version_holder = general_version_obj.get("Version", "ERROR: Failed to get version")
+        if full_band_version_holder == "ERROR: Failed to get version":
+            raise ValueError("Unable to find VS.Tools.Net.Core.SDK.Resolver with proper version in Version.Details.xml")
+        match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
+        if match:
+            default_band_version = match.group(0)
+        else:
+            raise ValueError("Unable to find general version in Version.Details.xml")
+    else:
+        raise ValueError("Unable to find general version in Version.Details.xml")
+
+    # Get the available versions from the Version.Details.xml file
+    dependencies = root.findall(".//Dependency[@Name]")
+    for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
+        for dependency in dependencies:
+            if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
+                workload_version = dependency.get("Version", "ERROR: Failed to get version")
+                if workload_version == "ERROR: Failed to get version":
+                    raise ValueError(f"Unable to find {xml_name} with proper version in the provided xml file")
+
+                # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
+                band_name_match_string = rf"^\s*Mapping_{xml_name}:(\S*)"
+                band_version_mapping = re.search(band_name_match_string, version_details_xml, flags=re.MULTILINE)
+                if band_version_mapping is None:
+                    raise ValueError(f"Unable to find band version mapping for match {band_name_match_string} in Version.Details.xml")
+                if band_version_mapping.group(1) == "default":
+                    band_version = default_band_version
+                else:
+                    band_version = band_version_mapping.group(1)
+                rollback_dict[rollback_name] = f"{workload_version}/{band_version}"
+                break
+        if rollback_name not in rollback_dict:
+            raise ValueError(f"Unable to find {rollback_name} with proper version in Version.Details.xml")
+    return rollback_dict
+
+def dump_dict_to_json_file(dump_dict: dict[str, str], file_name: str):
+    json_output = json.dumps(dump_dict, indent=4)
+    with open(file_name, "w", encoding="utf-8") as f:
+        f.write(json_output)
+
 def install_versioned_maui(precommands: PreCommands):
     target_framework_wo_platform = precommands.framework.split('-')[0]
 
@@ -23,66 +86,9 @@ def install_versioned_maui(precommands: PreCommands):
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 7
-        # Generate and use rollback based on Version.Details.xml
-        # Generate the list of versions starts to get and the names to save them as in the rollback.
-        rollback_dict: dict[str, str] = {}
-        rollback_name_to_xml_name_mappings: dict[str, str] = {
-            "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
-            "microsoft.net.sdk.ios" : "Microsoft.iOS.Sdk",
-            "microsoft.net.sdk.maccatalyst" : "Microsoft.MacCatalyst.Sdk",
-            "microsoft.net.sdk.macos" : "Microsoft.macOS.Sdk",
-            "microsoft.net.sdk.maui" : "Microsoft.Maui.Controls",
-            "microsoft.net.sdk.tvos" : "Microsoft.tvOS.Sdk",
-            "microsoft.net.sdk.mono.toolchain.current" : "Microsoft.NETCore.App.Ref",
-            "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
-        }
-
-        # Load in the Version.Details.xml file
-        with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
-            version_details_xml = f.read()
-            root = ET.fromstring(version_details_xml)
-
-        # Get the General Band version from the Version.Details.xml file sdk version
-        general_version_obj = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']")
-        if general_version_obj is not None:
-            full_band_version_holder = general_version_obj.get("Version", "ERROR: Failed to get version")
-            if full_band_version_holder == "ERROR: Failed to get version":
-                raise ValueError("Unable to find VS.Tools.Net.Core.SDK.Resolver with proper version in Version.Details.xml")
-            match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
-            if match:
-                default_band_version = match.group(0)
-            else:
-                raise ValueError("Unable to find general version in Version.Details.xml")
-        else:
-            raise ValueError("Unable to find general version in Version.Details.xml")
-
-        # Get the available versions from the Version.Details.xml file
-        dependencies = root.findall(".//Dependency[@Name]")
-        for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
-            for dependency in dependencies:
-                if dependency.get("Name").startswith(xml_name): # type: ignore we know Name is present
-                    workload_version = dependency.get("Version", "ERROR: Failed to get version")
-                    if workload_version == "ERROR: Failed to get version":
-                        raise ValueError(f"Unable to find {xml_name} with proper version in the provided xml file")
-
-                    # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
-                    band_name_match_string = rf"^\s*Mapping_{xml_name}:(\S*)"
-                    band_version_mapping = re.search(band_name_match_string, version_details_xml, flags=re.MULTILINE)
-                    if band_version_mapping is None:
-                        raise ValueError(f"Unable to find band version mapping for match {band_name_match_string} in Version.Details.xml")
-                    if band_version_mapping.group(1) == "default":
-                        band_version = default_band_version
-                    else:
-                        band_version = band_version_mapping.group(1)
-                    rollback_dict[rollback_name] = f"{workload_version}/{band_version}"
-                    break
-            if rollback_name not in rollback_dict:
-                raise ValueError(f"Unable to find {rollback_name} with proper version in Version.Details.xml")
-
-        json_output = json.dumps(rollback_dict, indent=4)
-        getLogger().info(f"Rollback file: \n{json_output}")
-        with open(f"rollback_{target_framework_wo_platform}.json", "w", encoding="utf-8") as f:
-            f.write(json_output)
+        rollback_dict = generate_maui_rollback_dict()
+        dump_dict_to_json_file(rollback_dict, f"rollback_{target_framework_wo_platform}.json")
         workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']
 
     precommands.install_workload('maui', workload_install_args) 
+


### PR DESCRIPTION
Update how we determine dotnet version to use and rollback versions for Performance Maui.

Version.Details.XML update from: https://github.com/dotnet/performance/pull/4327. 
Darc subscription still needs to be setup.

Full test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2506223&view=results