### PR TITLE
[maui] track workload versions with Maestro

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,5 +27,42 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>b4e499d1f6e6b3a981feabfed290d99261762382</Sha>
     </Dependency>
+    <!-- Dependencies for .NET MAUI workload -->
+    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24368.8">
+      <Sha>cf76a629023c99557239464a278daec280d1f448</Sha>
+      <Uri>https://github.com/dotnet/maui</Uri>
+    </Dependency>
+    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.7.24360.5" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>9a028e12b90e6a583b09ccb3008fdfaf85761f19</Sha>
+      <Uri>https://github.com/dotnet/sdk</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.7.24357.2" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
+      <Sha>4e278fe17f69ea31fbdcbab74ac47ec6fa84914b</Sha>
+      <Uri>https://github.com/dotnet/runtime</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.7.24319.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Sha>ffe9afdc046cf7a6f82cc7c5796aade54047af64</Sha>
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.7.346" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>06bb1dc6a292ef5618a3bb6ecca3ca869253ff2e</Sha>
+      <Uri>https://github.com/dotnet/android</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="14.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+      <Uri>https://github.com/xamarin/xamarin-macios</Uri>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/blob/main/Documentation/Darc.md

MAUI is currently pushing nightly .NET 9 builds to the `.NET 9.0.1xx SDK` Maestro channel.

To set this up, I created a set of dependencies in the `eng/Version.Details.xml`:

    <Dependency Name="Microsoft.Maui.Controls" Version="1" />
    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />
    <Dependency Name="Microsoft.NETCore.App.Ref" Version="1" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver" />
    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="1" CoherentParentDependency="Microsoft.NETCore.App.Ref" />
    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />
    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />
    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />
    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />
    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="1" CoherentParentDependency="Microsoft.Maui.Controls" />

With `Version="1"` as just a placeholder, I updated to the latest build:

    > darc update-dependencies --id 232243

Found at: https://maestro-prod.westus2.cloudapp.azure.com/3884/https:%2F%2Fgithub.com%2Fdotnet%2Fmaui/latest/graph

Or you can also lookup builds such as using a commit has from the `dotnet/maui/net9.0` branch:

    > darc get-build --repo dotnet/maui --commit cf76a629023c99557239464a278daec280d1f448
    Repository:    https://github.com/dotnet/maui
    Branch:        net9.0
    Commit:        cf76a629023c99557239464a278daec280d1f448
    Build Number:  9.0.0-preview.7.24368.8+azdo.9904060
    Date Produced: 7/18/2024 1:47 PM
    Build Link:    https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=9904060
    AzDO Build Id: 9904060
    BAR Build Id:  232243
    Released:      False
    Channels:
    - .NET 9.0.1xx SDK

Using the numbers now in `Version.Details.xml`, you could install the corresponding .NET SDK and workloads with:

* `VS.Tools.Net.Core.SDK.Resolver` -> version of .NET SDK for  `dotnet-install.sh/ps1`

Remaining versions can be mapped to a "rollback" file for workloads:

    {
        "microsoft.net.sdk.android": "34.99.0-preview.7.346/9.0.0-preview.7",
        "microsoft.net.sdk.ios": "17.2.9714-net9-p6/9.0.0-preview.7",
        "microsoft.net.sdk.maccatalyst": "17.2.9714-net9-p6/9.0.0-preview.7",
        "microsoft.net.sdk.macos": "14.2.9714-net9-p6/9.0.0-preview.7",
        "microsoft.net.sdk.maui": "9.0.0-preview.7.24368.8/9.0.0-preview.7",
        "microsoft.net.sdk.tvos": "17.2.9714-net9-p6/9.0.0-preview.7",
        "microsoft.net.sdk.mono.toolchain.net9.0": "9.0.0-preview.7.24357.2/9.0.0-preview.7",
        "microsoft.net.sdk.mono.toolchain.current": "9.0.0-preview.7.24357.2/9.0.0-preview.7",
        "microsoft.net.sdk.mono.emscripten.net9.0": "9.0.0-preview.7.24319.4/9.0.0-preview.7",
        "microsoft.net.sdk.mono.emscripten.current": "9.0.0-preview.7.24319.4/9.0.0-preview.7"
    }

Saved as `workload.json` you could run:

    > dotnet workload install maui --from-rollback-file workload.json

If we had some script in place to use `Version.Details.xml`, we could then use Maestro to update it with a subscription such as:

    darc add-subscription --channel ".NET 9.0.1xx SDK" --target-branch main --source-repo https://github.com/dotnet/maui --target-repo https://github.com/dotnet/performance

/cc @LoopedBard3 if this is a solution for MAUI-related scenarios.

