### PR TITLE
[release/7.0] Use managed identity to download PDN

### DIFF
--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -111,6 +111,7 @@ jobs:
                 scriptType: 'pscore'
                 scriptLocation: 'inlineScript'
                 inlineScript: |
+                  mkdir $(CorrelationStaging)PDN\
                   az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name PDN.zip --file $(CorrelationStaging)PDN\PDN.zip
           - powershell: |
               $(Python) -m pip install --upgrade pip

--- a/eng/performance/scenarios.yml
+++ b/eng/performance/scenarios.yml
@@ -104,10 +104,14 @@ jobs:
               PERFLAB_TARGET_FRAMEWORKS: $(PERFLAB_Framework)
           # Current version of PaintDotNet zip file is PDN10 built on 2023-01-09
           - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            - powershell: |
-                mkdir $(CorrelationStaging)PDN
-                curl "https://pvscmdupload.blob.core.windows.net/assets/PDN.zip$(PerfCommandUploadTokenNonEscaped)" -OutFile $(CorrelationStaging)PDN\PDN.zip
-              displayName: Download PDN
+            - task: AzureCLI@2
+              displayName: 'Download PDN'
+              inputs:
+                azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+                scriptType: 'pscore'
+                scriptLocation: 'inlineScript'
+                inlineScript: |
+                  az storage blob download --auth-mode login --account-name pvscmdupload --container-name assets --name PDN.zip --file $(CorrelationStaging)PDN\PDN.zip
           - powershell: |
               $(Python) -m pip install --upgrade pip
               $(Python) -m pip install urllib3==1.26.15


### PR DESCRIPTION
Backport of https://github.com/dotnet/performance/pull/4287 for release/7.0.
Downloads PDN.zip instead though as this branch does not use the new PDN filename format.