### PR TITLE
Use .NET 8.0 for scenarios libraries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
         "**/logs/": true,
         "**/obj/": true,
         "**/packages/": true,
-        "tools/": true,
+        "/tools/": true,
     },
     "python.analysis.typeCheckingMode": "strict",
     "python.analysis.diagnosticSeverityOverrides": {

--- a/src/tools/ScenarioMeasurement/Directory.Build.props
+++ b/src/tools/ScenarioMeasurement/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
     <PropertyGroup>
         <FallbackTargetFramework>net8.0</FallbackTargetFramework>
-        <LibrariesTargetFramework>net6.0</LibrariesTargetFramework>
+        <LibrariesTargetFramework>net8.0</LibrariesTargetFramework>
         <NoWarn>$(NoWarn);CS8002</NoWarn>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
This change makes it so that Utils.csproj will get compiled with .NET 8 instead of .NET 6. The version of this library isn't too important, however there is a bug where .NET 6 projects are failing to build on the latest version of the .NET 8 SDK (https://github.com/dotnet/sdk/issues/42379), so this is good workaround to get our scenarios that run on .NET 8 working again. I also fixed an incorrect exclusion rule in the vscode settings that was causing the /src/tools directory to not be shown in VS and VS Code.