### PR TITLE
Ensure ubuntu arm64 pipeline runs use the ubuntu dotnet prereqs container

### DIFF
--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -117,7 +117,7 @@ jobs:
       osVersion: 2204
       architecture: arm64
       pool:
-        vmImage: ubuntu-22.04
+        vmImage: ubuntu-latest
       machinePool: Ampere
       queue: Ubuntu.2204.Arm64.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -118,6 +118,7 @@ jobs:
       architecture: arm64
       pool:
         vmImage: ubuntu-latest
+      container: ubuntu_x64_build_container
       machinePool: Ampere
       queue: Ubuntu.2204.Arm64.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Runs on ubuntu arm64 were failing as lttng was not installed on the agent machine. This PR ensures that the prereqs container is used so these runs should start passing again.