### PR TITLE
Remove Rlcse experiment

### DIFF
--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -414,9 +414,7 @@ def main(args: Any):
     if args.r2r_status == 'nor2r':
         r2r_config = variable_format % ('DOTNET_ReadyToRun', '0')
 
-    if args.experiment_name == "rlcse":
-        experiment_config = variable_format % ('DOTNET_JitRLCSEGreedy', '1')
-    elif args.experiment_name == "jitoptrepeat":
+    if args.experiment_name == "jitoptrepeat":
         experiment_config = variable_format % ('DOTNET_JitOptRepeat', '*')
     elif args.experiment_name == "rpolayout":
         experiment_config = variable_format % ('DOTNET_JitDoReversePostOrderLayout', '1')


### PR DESCRIPTION
This reverts commit 06fc49ab3650ff0dd054a043578f27c9645c105d.
Remove Rlcse experiment as we are removing it from runtime runs as it is no longer needed and to help the perfowl queues.

Runtime PR: https://github.com/dotnet/runtime/pull/105731
