### PR TITLE
Revert "Update dependencies from https://github.com/dotnet/maui build9.0.0-preview.7.24381.14+azdo.9974970 (#4361)"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -38,9 +38,9 @@
       Mapping_Microsoft.iOS.Sdk:9.0.100-preview.6
       Mapping_Microsoft.tvOS.Sdk:9.0.100-preview.6
     -->
-    <!-- Dependencies for .NET MAUI workload -->
-    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24381.14">
-      <Sha>a52e5fae4a2ac414e0f402b1f384815be909d3e5</Sha>
+     <!-- Dependencies for .NET MAUI workload -->
+    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24368.8">
+      <Sha>cf76a629023c99557239464a278daec280d1f448</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
     <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.7.24360.5" CoherentParentDependency="Microsoft.Maui.Controls">


### PR DESCRIPTION
This reverts commit 284d9c9443c7bde861480e26f3e3dc2d9fa7cc44.

This update caused Maui 9.0 runs to start erroring during publishing due to: `error CS0246: The type or namespace name 'MauiUIApplicationDelegate' could not be found (are you missing a using directive or an assembly reference?)`. Reverting to get working runs again. Will watch for the next update to the Maui Versions to check and see if they hit the same issue.

Test run showing the error is no longer hit: https://dev.azure.com/dnceng/internal/_build/results?buildId=2507571&view=logs&j=e26215b6-af1c-525e-f2f7-b6bf79206f84&t=2e69d411-e41e-5b24-03f7-bc7d42e9385d

Run with the error: https://dev.azure.com/dnceng/internal/_build/results?buildId=2507422&view=logs&j=10398454-ccb2-5fdf-bc8b-112f474350c3&t=ccc37d5a-e0c2-59e7-0eac-90be9c4d97c0