### PR TITLE
Disable startup scenarios on Ubuntu

### DIFF
--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -75,9 +75,10 @@
     </PreparePayloadWorkItem>
   </ItemGroup>
 
+  <!-- Startup scenarios are temporarily disabled on non-Windows runs as lttng kernel modules are failing to install: https://github.com/dotnet/performance/issues/4149 -->
 
   <!-- UI Startup FDD publish -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <HelixWorkItem Include="@(UIScenario -> 'Startup - %(Identity) - FDD Publish')">
       <PreCommands Condition="'$(TargetsWindows)' == 'true'">xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)_fdd %HELIX_WORKITEM_ROOT%\pub /E /I /Y</PreCommands>
       <PreCommands Condition="'$(TargetsWindows)' != 'true'">cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)_fdd $HELIX_WORKITEM_ROOT/pub</PreCommands>
@@ -86,7 +87,7 @@
   </ItemGroup>
 
   <!-- Startup FDD publish -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <HelixWorkItem Include="@(Scenario -> 'Startup - %(Identity) - FDD Publish')">
       <PreCommands Condition="'$(TargetsWindows)' == 'true'">xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)_fdd %HELIX_WORKITEM_ROOT%\pub /E /I /Y</PreCommands>
       <PreCommands Condition="'$(TargetsWindows)' != 'true'">cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)_fdd $HELIX_WORKITEM_ROOT/pub</PreCommands>


### PR DESCRIPTION
Due to #4149, the LTTNG kernel modules are failing to install on Ubuntu. Pending the investigation and work to resolve the bug, this PR disables these scenarios from running.