### PR TITLE
Update iOS test building mac image to use MacOS 14

### DIFF
--- a/eng/performance/build_machine_matrix.yml
+++ b/eng/performance/build_machine_matrix.yml
@@ -152,9 +152,9 @@ jobs:
     parameters:
       osName: osx
       architecture: x64
-      osVersion: 13
+      osVersion: 14
       pool:
-        vmImage: 'macos-13'
+        vmImage: 'macos-14'
       queue: OSX.13.Amd64.Iphone.Perf
       machinePool: iPhoneMini12
       ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Update iOS test building mac image to use MacOS 14 instead of 13 for the newer version of XCode. Fixes: https://github.com/dotnet/performance/issues/4367

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2509127&view=results, (as of PR creation, the run hasn't done the actual tests, but the coreclr app for 8.0 was successfully built)