### PR TITLE
Add more F# microbenchmarks

### DIFF
--- a/src/benchmarks/micro-fsharp/Equality/Arrays.fs
+++ b/src/benchmarks/micro-fsharp/Equality/Arrays.fs
@@ -1,0 +1,26 @@
+module MicroBenchmarks.FSharp.Equality.Arrays
+
+open BenchmarkDotNet.Attributes
+open MicroBenchmarks.FSharp
+
+[<MemoryDiagnoser>]
+[<BenchmarkCategory(Categories.FSharpMicroCategory)>]
+type Arrays() =
+
+    let numbers = Array.init 1000 id
+
+    [<Benchmark>]
+    member _.Int32() =
+        numbers |> Array.countBy  (fun n -> [| n % 7 |])
+
+    [<Benchmark>]
+    member _.Int64() =
+        numbers |> Array.countBy  (fun n -> [| int64 (n % 7) |])
+
+    [<Benchmark>]
+    member _.Byte() =
+        numbers |> Array.countBy  (fun n -> [| byte (n % 7) |])
+
+    [<Benchmark>]
+    member _.Obj() =
+        numbers |> Array.countBy  (fun n -> [| box (n % 7) |])

--- a/src/benchmarks/micro-fsharp/Equality/BasicTypes.fs
+++ b/src/benchmarks/micro-fsharp/Equality/BasicTypes.fs
@@ -1,0 +1,65 @@
+module MicroBenchmarks.FSharp.Equality.BasicTypes
+
+open BenchmarkDotNet.Attributes
+open MicroBenchmarks.FSharp
+
+[<MemoryDiagnoser>]
+[<BenchmarkCategory(Categories.FSharpMicroCategory)>]
+type BasicTypes() =
+
+    let bools = Array.init 1000 (fun n -> n % 2 = 0)
+    let sbytes = Array.init 1000 sbyte
+    let bytes = Array.init 1000 byte
+    let int16s = Array.init 1000 int16
+    let uint16s = Array.init 1000 uint16
+    let int32s = Array.init 1000 id
+    let uint32s = Array.init 1000 uint32
+    let int64s = Array.init 1000 int64
+    let uint64s = Array.init 1000 uint64
+    let intptrs = Array.init 1000 nativeint
+    let uintptrs = Array.init 1000 unativeint
+    let chars = Array.init 1000 char
+    let strings = Array.init 1000 string
+    let decimals = Array.init 1000 decimal
+
+    [<Benchmark>]
+    member _.Bool() = bools |> Array.distinct
+
+    [<Benchmark>]
+    member _.SByte() = sbytes |> Array.distinct
+
+    [<Benchmark>]
+    member _.Byte() = bytes |> Array.distinct
+
+    [<Benchmark>]
+    member _.Int16() = int16s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt16() = uint16s |> Array.distinct
+    
+    [<Benchmark>]
+    member _.Int32() = int32s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt32() = uint32s |> Array.distinct
+
+    [<Benchmark>]
+    member _.Int64() = int64s |> Array.distinct
+
+    [<Benchmark>]
+    member _.UInt64() = uint64s |> Array.distinct
+
+    [<Benchmark>]
+    member _.IntPtr() = intptrs |> Array.distinct
+
+    [<Benchmark>]
+    member _.UIntPtr() = uintptrs |> Array.distinct
+
+    [<Benchmark>]
+    member _.Char() = chars |> Array.distinct
+
+    [<Benchmark>]
+    member _.String() = strings |> Array.distinct
+
+    [<Benchmark>]
+    member _.Decimal() = decimals |> Array.distinct

--- a/src/benchmarks/micro-fsharp/Equality/FSharpCoreFunctions.fs
+++ b/src/benchmarks/micro-fsharp/Equality/FSharpCoreFunctions.fs
@@ -1,0 +1,105 @@
+module MicroBenchmarks.FSharp.Equality.FSharpCoreFunctions
+
+open BenchmarkDotNet.Attributes
+open MicroBenchmarks.FSharp
+
+[<Struct>]
+type SomeStruct =
+    val A : int
+    new a = { A = a }
+
+[<MemoryDiagnoser>]
+[<BenchmarkCategory(Categories.FSharpMicroCategory)>]
+type FSharpCoreFunctions() =
+
+    let array = Array.init 1000 id
+    let list = List.init 1000 id
+    let seq = Seq.init 1000 id
+
+    [<Benchmark>]
+    member _.ArrayCountBy() =
+        array
+        |> Array.countBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayGroupBy() =
+        array
+        |> Array.groupBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayDistinct() =
+        array
+        |> Array.map (fun n -> SomeStruct(n % 7))
+        |> Array.distinct
+
+    [<Benchmark>]
+    member _.ArrayDistinctBy() =
+        array
+        |> Array.distinctBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ArrayExcept() =
+        array
+        |> Array.map SomeStruct
+        |> Array.except ([| SomeStruct 42 |])
+
+    [<Benchmark>]
+    member _.ListCountBy() =
+        list
+        |> List.countBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListGroupBy() =
+        list
+        |> List.groupBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListDistinct() =
+        list
+        |> List.map (fun n -> SomeStruct(n % 7))
+        |> List.distinct
+
+    [<Benchmark>]
+    member _.ListDistinctBy() =
+        list
+        |> List.distinctBy (fun n -> SomeStruct(n % 7))
+
+    [<Benchmark>]
+    member _.ListExcept() =
+        List.init 1000 id
+        |> List.map SomeStruct
+        |> List.except ([| SomeStruct 42 |])
+
+    [<Benchmark>]
+    member _.SeqCountBy() =
+        seq
+        |> Seq.countBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqGroupBy() =
+        seq
+        |> Seq.groupBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqDistinct() =
+        seq
+        |> Seq.map (fun n -> SomeStruct(n % 7))
+        |> Seq.distinct
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqDistinctBy() =
+        seq
+        |> Seq.distinctBy (fun n -> SomeStruct(n % 7))
+        |> Seq.last
+
+    [<Benchmark>]
+    member _.SeqExcept() =
+        seq
+        |> Seq.map SomeStruct
+        |> Seq.except ([| SomeStruct 42 |])
+        |> Seq.last
+
+

--- a/src/benchmarks/micro-fsharp/MicrobenchmarksFSharp.fsproj
+++ b/src/benchmarks/micro-fsharp/MicrobenchmarksFSharp.fsproj
@@ -9,6 +9,9 @@
 
   <ItemGroup>
     <Compile Include="Categories.fs" />
+    <Compile Include="equality\BasicTypes.fs" />
+    <Compile Include="Equality\FSharpCoreFunctions.fs" />
+    <Compile Include="Equality\Arrays.fs" />
     <Compile Include="Collections.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -16,5 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
+
+  <ItemGroup />
 
 </Project>

--- a/src/benchmarks/micro-fsharp/MicrobenchmarksFSharp.fsproj
+++ b/src/benchmarks/micro-fsharp/MicrobenchmarksFSharp.fsproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Categories.fs" />
-    <Compile Include="equality\BasicTypes.fs" />
+    <Compile Include="Equality\BasicTypes.fs" />
     <Compile Include="Equality\FSharpCoreFunctions.fs" />
     <Compile Include="Equality\Arrays.fs" />
     <Compile Include="Collections.fs" />
@@ -19,7 +19,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
-
-  <ItemGroup />
 
 </Project>


### PR DESCRIPTION
F# microbenchmarks added [here](https://github.com/dotnet/performance/pull/4051) proved to be helpful, providing what looks like a reliable picture:
![image](https://github.com/user-attachments/assets/cc8d60bc-3344-49dc-bf54-f66f0f36bfce)

Hence I am adding more F# benchmarks on the topic of equality test performance - which we have been addressing earlier this year. Let's see how these perform, we might add even more in the future.

For reference, here are current local results:

```
// * Summary *

BenchmarkDotNet v0.13.13-nightly.20240311.145, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
11th Gen Intel Core i9-11950H 2.60GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.100-preview.6.24328.19
  [Host]     : .NET 9.0.0 (9.0.24.32707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI DEBUG
  Job-YRJNUM : .NET 9.0.0 (9.0.24.32707), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250ms  MaxIterationCount=20
MinIterationCount=15  WarmupCount=1
```

**Basic Types**

| Method  | Mean      | Error     | StdDev    | Median    | Min       | Max       | Gen0    | Gen1   | Allocated |
|-------- |----------:|----------:|----------:|----------:|----------:|----------:|--------:|-------:|----------:|
| Bool    |  5.981 us | 0.3187 us | 0.3273 us |  5.943 us |  5.583 us |  6.752 us |  0.0895 |      - |    1.2 KB |
| SByte   | 11.155 us | 0.9669 us | 1.1135 us | 10.877 us |  9.742 us | 13.234 us |  1.0993 | 0.0407 |  13.92 KB |
| Byte    |  9.854 us | 0.5168 us | 0.5745 us |  9.842 us |  8.839 us | 10.751 us |  1.1222 | 0.0432 |  13.92 KB |
| Int16   | 23.766 us | 2.0514 us | 2.1950 us | 23.149 us | 21.312 us | 30.203 us |  4.9114 | 0.4815 |  61.24 KB |
| UInt16  | 25.258 us | 1.1121 us | 1.1420 us | 25.176 us | 23.561 us | 27.438 us |  4.9705 | 0.5523 |  61.24 KB |
| Int32   | 19.856 us | 1.4690 us | 1.6917 us | 19.592 us | 17.789 us | 23.764 us |  5.2830 | 0.7163 |  65.15 KB |
| UInt32  | 20.843 us | 2.9725 us | 3.3039 us | 20.999 us | 16.088 us | 27.461 us |  5.2817 | 0.6771 |  65.15 KB |
| Int64   | 21.476 us | 0.6588 us | 0.7049 us | 21.440 us | 19.997 us | 23.196 us |  7.0266 | 1.0170 |  87.11 KB |
| UInt64  | 20.524 us | 1.1351 us | 1.2616 us | 20.229 us | 19.027 us | 23.628 us |  7.0592 | 1.0331 |  87.11 KB |
| IntPtr  | 25.442 us | 2.3798 us | 2.6452 us | 25.599 us | 20.560 us | 31.005 us |  7.0631 | 0.9855 |  87.11 KB |
| UIntPtr | 23.415 us | 1.2541 us | 1.4442 us | 23.214 us | 21.381 us | 26.289 us |  7.0423 | 0.9903 |  87.11 KB |
| Char    | 19.449 us | 1.5564 us | 1.7924 us | 19.210 us | 17.388 us | 24.325 us |  4.9683 | 0.5760 |  61.24 KB |
| String  | 27.332 us | 0.9775 us | 1.0038 us | 27.157 us | 25.802 us | 28.865 us |  7.0489 | 1.0573 |  87.11 KB |
| Decimal | 25.703 us | 0.9960 us | 1.1071 us | 25.316 us | 24.255 us | 27.803 us | 10.5838 | 2.2282 |  131.1 KB |

**FSharpCoreFunctions**

| Method          | Mean      | Error     | StdDev    | Median    | Min       | Max       | Gen0    | Gen1   | Allocated |
|---------------- |----------:|----------:|----------:|----------:|----------:|----------:|--------:|-------:|----------:|
| ArrayCountBy    |  57.19 us |  1.078 us |  0.900 us |  57.43 us |  54.92 us |  58.00 us | 11.3122 |      - | 140.56 KB |
| ArrayGroupBy    |  38.95 us |  4.904 us |  5.647 us |  38.69 us |  31.68 us |  52.59 us |  7.2556 | 0.2546 |  90.23 KB |
| ArrayDistinct   |  33.54 us |  1.658 us |  1.774 us |  33.22 us |  30.87 us |  38.22 us |  6.3406 | 0.1510 |  78.23 KB |
| ArrayDistinctBy |  31.08 us |  1.583 us |  1.694 us |  30.81 us |  27.75 us |  35.13 us |  6.0227 |      - |   74.3 KB |
| ArrayExcept     |  36.49 us |  7.429 us |  8.556 us |  33.48 us |  28.25 us |  57.32 us |  7.2021 | 1.0986 |  88.89 KB |
| ListCountBy     |  76.78 us |  6.494 us |  7.219 us |  76.95 us |  64.51 us |  90.61 us | 11.3669 |      - |  140.7 KB |
| ListGroupBy     |  42.88 us |  2.692 us |  2.764 us |  43.65 us |  38.23 us |  47.26 us |  8.3349 | 0.7409 | 102.54 KB |
| ListDistinct    |  43.11 us |  3.309 us |  3.678 us |  42.70 us |  38.33 us |  52.64 us |  8.2547 | 0.5896 | 101.78 KB |
| ListDistinctBy  |  38.12 us |  4.878 us |  5.618 us |  36.45 us |  31.77 us |  53.07 us |  5.6342 |      - |  70.53 KB |
| ListExcept      |  91.69 us | 12.298 us | 14.163 us |  91.23 us |  70.81 us | 127.14 us | 14.2096 | 2.6643 |  174.6 KB |
| SeqCountBy      | 194.66 us | 18.658 us | 21.487 us | 189.20 us | 168.12 us | 237.79 us | 26.2172 |      - | 328.38 KB |
| SeqGroupBy      | 143.99 us | 12.568 us | 14.473 us | 140.34 us | 123.79 us | 172.28 us | 22.5722 | 0.5249 | 278.44 KB |
| SeqDistinct     | 148.25 us | 18.364 us | 21.149 us | 147.05 us | 124.19 us | 198.42 us | 20.9790 |      - | 258.18 KB |
| SeqDistinctBy   | 151.33 us | 19.782 us | 22.781 us | 149.06 us | 113.62 us | 198.82 us | 20.6136 |      - | 258.07 KB |
| SeqExcept       | 138.28 us | 11.030 us | 12.702 us | 134.30 us | 120.92 us | 160.62 us | 21.6017 | 2.6344 | 268.74 KB |

**Arrays**

| Method | Mean      | Error     | StdDev    | Median    | Min       | Max       | Gen0   | Allocated |
|------- |----------:|----------:|----------:|----------:|----------:|----------:|-------:|----------:|
| Int32  |  56.59 us |  1.983 us |  2.121 us |  56.55 us |  51.77 us |  61.09 us | 2.5568 |  32.02 KB |
| Int64  |  52.27 us |  3.265 us |  3.493 us |  50.71 us |  47.47 us |  58.57 us | 2.5168 |  32.02 KB |
| Byte   |  54.81 us |  2.720 us |  3.133 us |  53.96 us |  50.64 us |  61.87 us | 2.4588 |  32.02 KB |
| Obj    | 201.78 us | 23.270 us | 26.798 us | 190.38 us | 172.54 us | 262.75 us | 3.5971 |  55.46 KB |
