### PR TITLE
Update Maui Versions and name for runtime version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,15 +39,15 @@
       Mapping_Microsoft.tvOS.Sdk:9.0.100-preview.6
     -->
     <!-- Dependencies for .NET MAUI workload -->
-    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-preview.7.24381.14">
-      <Sha>a52e5fae4a2ac414e0f402b1f384815be909d3e5</Sha>
+    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-rc.1.24409.7">
+      <Sha>31086013facdabcb577b2bb2f1aa41fc2aedf573</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.7.24360.5" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.100-preview.7.24360.5">
       <Sha>9a028e12b90e6a583b09ccb3008fdfaf85761f19</Sha>
       <Uri>https://github.com/dotnet/sdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.7.24357.2" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.7.24357.2" CoherentParentDependency="Microsoft.NET.Sdk">
       <Sha>4e278fe17f69ea31fbdcbab74ac47ec6fa84914b</Sha>
       <Uri>https://github.com/dotnet/runtime</Uri>
     </Dependency>
@@ -55,23 +55,23 @@
       <Sha>ffe9afdc046cf7a6f82cc7c5796aade54047af64</Sha>
       <Uri>https://github.com/dotnet/emsdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.7.346" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.7.346">
       <Sha>06bb1dc6a292ef5618a3bb6ecca3ca869253ff2e</Sha>
       <Uri>https://github.com/dotnet/android</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
       <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="14.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="14.2.9714-net9-p6">
       <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
       <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6" CoherentParentDependency="Microsoft.Maui.Controls">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
       <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,40 +39,40 @@
       Mapping_Microsoft.tvOS.Sdk:9.0.100-preview.6
     -->
     <!-- Dependencies for .NET MAUI workload -->
-    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-rc.1.24409.7">
-      <Sha>31086013facdabcb577b2bb2f1aa41fc2aedf573</Sha>
+    <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-rc.1.24413.7">
+      <Sha>b7872228ac6059a2a6cfa8af34c9952a3b40170f</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.100-preview.7.24360.5">
-      <Sha>9a028e12b90e6a583b09ccb3008fdfaf85761f19</Sha>
+    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.100-rc.1.24409.1" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>43360291a50c9c7c471551f8f8363919d38014ea</Sha>
       <Uri>https://github.com/dotnet/sdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.7.24357.2" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Sha>4e278fe17f69ea31fbdcbab74ac47ec6fa84914b</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-rc.1.24408.12" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Sha>68511fd27fe4055ce5203742998ba12019dfcbd4</Sha>
       <Uri>https://github.com/dotnet/runtime</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.7.24319.4" CoherentParentDependency="Microsoft.NETCore.App.Ref">
-      <Sha>ffe9afdc046cf7a6f82cc7c5796aade54047af64</Sha>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-rc.1.24402.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Sha>edf3e90fa25b1fc4f7f63ceb45ef70f49c6b121a</Sha>
       <Uri>https://github.com/dotnet/emsdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="34.99.0-preview.7.346">
-      <Sha>06bb1dc6a292ef5618a3bb6ecca3ca869253ff2e</Sha>
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.0-rc.1.46" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>99ba8135fc47358702a5918757651d53d7b6fabd</Sha>
       <Uri>https://github.com/dotnet/android</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
-      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_17.5" Version="17.5.9237-net9-rc1" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>49f9973a2f95c9bd1fd3de9dfa97de3a704552f6</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.2" Version="14.2.9714-net9-p6">
-      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_14.5" Version="14.5.9237-net9-rc1" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>49f9973a2f95c9bd1fd3de9dfa97de3a704552f6</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
-      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_17.5" Version="17.5.9237-net9-rc1" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>49f9973a2f95c9bd1fd3de9dfa97de3a704552f6</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.2" Version="17.2.9714-net9-p6">
-      <Sha>4741d540eee2390fa075d0bdb49083cb58e43048</Sha>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_17.5" Version="17.5.9237-net9-rc1" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>49f9973a2f95c9bd1fd3de9dfa97de3a704552f6</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
   </ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,10 +33,10 @@
       Mapping_Microsoft.NETCore.App.Ref:default
       Mapping_Microsoft.NET.Workload.Emscripten.Current:default
       Mapping_Microsoft.Android.Sdk:default
-      Mapping_Microsoft.MacCatalyst.Sdk:9.0.100-preview.6
-      Mapping_Microsoft.macOS.Sdk:9.0.100-preview.6
-      Mapping_Microsoft.iOS.Sdk:9.0.100-preview.6
-      Mapping_Microsoft.tvOS.Sdk:9.0.100-preview.6
+      Mapping_Microsoft.MacCatalyst.Sdk:default
+      Mapping_Microsoft.macOS.Sdk:default
+      Mapping_Microsoft.iOS.Sdk:default
+      Mapping_Microsoft.tvOS.Sdk:default
     -->
     <!-- Dependencies for .NET MAUI workload -->
     <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-rc.1.24413.7">

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -558,7 +558,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         elif os.path.exists(os.path.join(args.performance_repo_dir, args.dotnet_version_link)) and args.dotnet_version_link.endswith("Version.Details.xml"): # version_link is a file in the perf repo
             with open(os.path.join(args.performance_repo_dir, args.dotnet_version_link), encoding="utf-8") as f:
                 root = ET.fromstring(f.read())
-            dependency = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']") # For net9.0
+            dependency = root.find(".//Dependency[@Name='Microsoft.NET.Sdk']") # For net9.0
             if dependency is None: # For older than net9.0
                 dependency = root.find(".//Dependency[@Name='Microsoft.Dotnet.Sdk.Internal']")
             if dependency is not None and "Version" in dependency.attrib: # Get the actual version

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -17,7 +17,7 @@ def generate_maui_rollback_dict():
     # Generate and use rollback based on Version.Details.xml
     # Generate the list of versions starts to get and the names to save them as in the rollback.
     # These mapping values were taken from the previously generated rollback files for the maui workload. There should be at least one entry for each
-    # of the Maui Workload dependencies in the /eng/Version.Details.xml file, aside from VS.Tools.Net.Core.SDK.Resolver.
+    # of the Maui Workload dependencies in the /eng/Version.Details.xml file, aside from Microsoft.NET.Sdk.
     # If there are errors in the future, reach out to the maui team.
     rollback_name_to_xml_name_mappings: dict[str, str] = {
         "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
@@ -37,11 +37,11 @@ def generate_maui_rollback_dict():
         root = ET.fromstring(version_details_xml)
 
     # Get the General Band version from the Version.Details.xml file sdk version
-    general_version_obj = root.find(".//Dependency[@Name='VS.Tools.Net.Core.SDK.Resolver']")
+    general_version_obj = root.find(".//Dependency[@Name='Microsoft.NET.Sdk']")
     if general_version_obj is not None:
         full_band_version_holder = general_version_obj.get("Version")
         if full_band_version_holder is None:
-            raise ValueError("Unable to find VS.Tools.Net.Core.SDK.Resolver with proper version in Version.Details.xml")
+            raise ValueError("Unable to find Microsoft.NET.Sdk with proper version in Version.Details.xml")
         match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
         if match:
             default_band_version = match.group(0)


### PR DESCRIPTION
Update Maui Versions and name for runtime version to use. The rename of the runtime version should be very rare and the Maui version updates going forward should mostly be done via maestro.


