### PR TITLE
[Release/7.0] Disable release/7.0 runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,34 +17,11 @@ resources:
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
 
 # Disable this pipeline as release/7.0 is no longer supported
-# # CI Trigger on release/7.0 branch
-# trigger:
-#   branches:
-#     include:
-#     - release/7.0
-#   paths:
-#     include:
-#     - eng/Version.Details.xml
+# CI Trigger on release/7.0 branch
+trigger: none
 
-# # Trigger builds for PR's targeting release/7.0
-# pr:
-#   branches:
-#     include:
-#     - release/7.0
-#   paths:
-#     exclude: # don't trigger the CI if only a doc file was changed
-#     - docs/
-#     - '**/*.md'
-#     - scripts/benchmarks_monthly.py
-
-# schedules:
-#   - cron: "0 */12 * * *"
-#     displayName: Every 12 hours build
-#     branches:
-#       include:
-#       - release/7.0
-#     always: true
-
+# Trigger builds for PR's targeting release/7.0
+pr: none
 jobs:
 
 ######################################################

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,33 +16,34 @@ resources:
     - container: centos_x64_build_container
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7
 
-# CI Trigger on release/7.0 branch
-trigger:
-  branches:
-    include:
-    - release/7.0
-  paths:
-    include:
-    - eng/Version.Details.xml
+# Disable this pipeline as release/7.0 is no longer supported
+# # CI Trigger on release/7.0 branch
+# trigger:
+#   branches:
+#     include:
+#     - release/7.0
+#   paths:
+#     include:
+#     - eng/Version.Details.xml
 
-# Trigger builds for PR's targeting release/7.0
-pr:
-  branches:
-    include:
-    - release/7.0
-  paths:
-    exclude: # don't trigger the CI if only a doc file was changed
-    - docs/
-    - '**/*.md'
-    - scripts/benchmarks_monthly.py
+# # Trigger builds for PR's targeting release/7.0
+# pr:
+#   branches:
+#     include:
+#     - release/7.0
+#   paths:
+#     exclude: # don't trigger the CI if only a doc file was changed
+#     - docs/
+#     - '**/*.md'
+#     - scripts/benchmarks_monthly.py
 
-schedules:
-  - cron: "0 */12 * * *"
-    displayName: Every 12 hours build
-    branches:
-      include:
-      - release/7.0
-    always: true
+# schedules:
+#   - cron: "0 */12 * * *"
+#     displayName: Every 12 hours build
+#     branches:
+#       include:
+#       - release/7.0
+#     always: true
 
 jobs:
 


### PR DESCRIPTION
Disable release/7.0 runs as net7.0 is no longer supported. This covers the yml in the release/7.0 branch.

