### PR TITLE
Remove release/7.0 tiggers from main branch yml.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,6 @@ trigger:
   branches:
     include:
     - main
-    - release/7.0
   paths:
     exclude: # don't trigger if only docs and similar files changed
     - docs/*
@@ -28,7 +27,6 @@ pr:
   branches:
     include:
     - main
-    - release/7.0
   paths:
     exclude: # don't trigger if only docs and similar files changed
     - docs/*
@@ -42,7 +40,6 @@ schedules:
   branches:
     include:
     - main
-    - release/7.0
   always: true
 - cron: "0 21 * * THU"
   displayName: Weekly Build


### PR DESCRIPTION
Disable release/7.0 runs as net7.0 is no longer supported. This covers the yml in the main branch.
