### PR TITLE
Add release/9.0 and matching 10.0 channel maps.

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -7,7 +7,27 @@ class ChannelMap():
             'branch': '9.0',
             'quality': 'daily'
         },
+        '10.0': {
+            'tfm': 'net10.0',
+            'branch': '10.0',
+            'quality': 'daily'
+        },
+        'release/10.0': {
+            'tfm': 'net10.0',
+            'branch': '10.0',
+            'quality': 'daily'
+        },
+        'nativeaot10.0': {
+            'tfm': 'nativeaot10.0',
+            'branch': '10.0',
+            'quality': 'daily'
+        },
         '9.0': {
+            'tfm': 'net9.0',
+            'branch': '9.0',
+            'quality': 'daily'
+        },
+        'release/9.0': {
             'tfm': 'net9.0',
             'branch': '9.0',
             'quality': 'daily'


### PR DESCRIPTION
Not sure if net10.0 is targetable yet, still need to test that, but wanted to get the 10.0 specific mappings added to prepare for it.