### PR TITLE
[release/6.0] Disable Startup and SDK scenarios on Ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -538,21 +538,22 @@ jobs:
       channels:
         - release/6.0
 
+  # reenable under new machine on new ubuntu once lttng/events are available
   # Ubuntu 2204 x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: ubuntu
-      osVersion: 2204
-      architecture: x64
-      pool: 
-        vmImage: ubuntu-latest
-      kind: sdk_scenarios
-      machinePool: Tiger
-      queue: Ubuntu.2204.Amd64.Tiger.Perf
-      container: ubuntu_x64_build_container
-      projectFile: sdk_scenarios.proj
-      channels:
-        - release/6.0
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: ubuntu
+  #     osVersion: 2204
+  #     architecture: x64
+  #     pool: 
+  #       vmImage: ubuntu-latest
+  #     kind: sdk_scenarios
+  #     machinePool: Tiger
+  #     queue: Ubuntu.2204.Amd64.Tiger.Perf
+  #     container: ubuntu_x64_build_container
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - release/6.0
 
   # Windows x64 Blazor 3.2 scenario benchmarks
   - template: /eng/performance/scenarios.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,22 +103,22 @@ jobs:
       projectFile: sdk_scenarios.proj
       channels:
         - release/6.0
-  
-  # Ubuntu 2204 x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: ubuntu
-      osVersion: 2204
-      kind: sdk_scenarios
-      architecture: x64
-      pool: 
-        vmImage: ubuntu-latest
-      machinePool: Open
-      queue: Ubuntu.2204.Amd64.Open
-      container: ubuntu_x64_build_container
-      projectFile: sdk_scenarios.proj
-      channels:
-        - release/6.0
+
+  # reenable under new machine on new ubuntu once lttng/events are available
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: ubuntu
+  #     osVersion: 2204
+  #     kind: sdk_scenarios
+  #     architecture: x64
+  #     pool: 
+  #       vmImage: ubuntu-latest
+  #     machinePool: Open
+  #     queue: Ubuntu.2204.Amd64.Open
+  #     container: ubuntu_x64_build_container
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - release/6.0
 
   # Windows x86 SDK scenario benchmarks
   - template: /eng/performance/scenarios.yml
@@ -607,18 +607,19 @@ jobs:
       channels:
         - $(channel) # for manual runs we can specify channel variable 
 
+  # reenable under new machine on new ubuntu once lttng/events are available
   # Ubuntu 2204 x64 SDK scenario benchmarks
-  - template: /eng/performance/scenarios.yml
-    parameters:
-      osName: ubuntu
-      osVersion: 2204
-      architecture: x64
-      pool:
-        vmImage: ubuntu-latest
-      kind: sdk_scenarios
-      machinePool: Tiger
-      queue: Ubuntu.2204.Amd64.Tiger.Perf
-      container: ubuntu_x64_build_container
-      projectFile: sdk_scenarios.proj
-      channels:
-        - $(channel)
+  # - template: /eng/performance/scenarios.yml
+  #   parameters:
+  #     osName: ubuntu
+  #     osVersion: 2204
+  #     architecture: x64
+  #     pool:
+  #       vmImage: ubuntu-latest
+  #     kind: sdk_scenarios
+  #     machinePool: Tiger
+  #     queue: Ubuntu.2204.Amd64.Tiger.Perf
+  #     container: ubuntu_x64_build_container
+  #     projectFile: sdk_scenarios.proj
+  #     channels:
+  #       - $(channel)

--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -86,9 +86,10 @@
     </PreparePayloadWorkItem>
   </ItemGroup>
 
+  <!-- Startup scenarios are temporarily disabled on non-Windows runs as lttng kernel modules are failing to install: https://github.com/dotnet/performance/issues/4149 -->
 
   <!-- Startup FDD publish -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <HelixWorkItem Include="@(Scenario -> 'Startup - %(Identity) - FDD Publish')">
       <PreCommands Condition="'$(TargetsWindows)' == 'true'">xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)_fdd %HELIX_WORKITEM_ROOT%\pub /E /I /Y</PreCommands>
       <PreCommands Condition="'$(TargetsWindows)' != 'true'">cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)_fdd $HELIX_WORKITEM_ROOT/pub</PreCommands>


### PR DESCRIPTION
This is backporting two changes as startup and SDK scenarios are currently broken due to LTTNG installation issues. This should make the release/6.0 scheduled runs show as green.