### PR TITLE
Make GCPerfSim NativeAOT friendly

### DIFF
--- a/src/benchmarks/gc/GCPerfSim/GCPerfSim.cs
+++ b/src/benchmarks/gc/GCPerfSim/GCPerfSim.cs
@@ -2713,7 +2713,7 @@ class MemoryAlloc
         return testResult;
     }
 
-    public static int Main(string[] argsStrs)
+    public static int Test(string[] argsStrs)
     {
         try
         {
@@ -2804,7 +2804,13 @@ class MemoryAlloc
         Console.WriteLine($"num_finalized: {ReferenceItemWithSize.NumFinalized}");
         Console.WriteLine($"final_total_memory_bytes: {GC.GetTotalMemory(forceFullCollection: false)}");
 
-        // Use reflection to detect GC.GetGCMemoryInfo because it doesn't exist in dotnet core 2.0 or in .NET framework.
+#if NET5_0_OR_GREATER
+        GCMemoryInfo info = GC.GetGCMemoryInfo();
+        long heapSizeBytes = info.HeapSizeBytes;
+        long fragmentedBytes = info.FragmentedBytes;
+        Console.WriteLine($"final_heap_size_bytes: {heapSizeBytes}");
+        Console.WriteLine($"final_fragmentation_bytes: {fragmentedBytes}");
+#else
         var getGCMemoryInfo = typeof(GC).GetMethod("GetGCMemoryInfo", new Type[] { });
         if (getGCMemoryInfo != null)
         {
@@ -2814,11 +2820,14 @@ class MemoryAlloc
             Console.WriteLine($"final_heap_size_bytes: {heapSizeBytes}");
             Console.WriteLine($"final_fragmentation_bytes: {fragmentedBytes}");
         }
+#endif
     }
 
+#if !NET5_0_OR_GREATER
     private static T GetProperty<T>(object instance, string name)
     {
         PropertyInfo property = Util.NonNull(instance.GetType().GetProperty(name));
         return (T)Util.NonNull(Util.NonNull(property.GetGetMethod()).Invoke(instance, parameters: null));
     }
+#endif
 }

--- a/src/benchmarks/gc/GCPerfSim/Harness.cs
+++ b/src/benchmarks/gc/GCPerfSim/Harness.cs
@@ -1,0 +1,7 @@
+public static class Harness
+{
+    public static void Main(string[] args)
+    {
+        MemoryAlloc.Test(args);
+    }
+}


### PR DESCRIPTION
This change fixes these warnings when published using NativeAOT by simply avoiding reflection:

```
GCPerfSim.cs: warning IL2075: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.

GCPerfSim.cs: Trim analysis warning IL2075: MemoryAlloc.GetProperty<T>(Object,String): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String)'. The return value of method 'System.Object.GetType()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

WIth this change, the publish completed without any more warnings. The reflection is necessary only for .NET Core 3.0/3.1. Earlier versions just simply don't have that method and we will simply skip printing the numbers. I kept the old code just for this case. If we don't think we will ever want this for 3.0/3.1 (out of support anyway), we can simply delete them.

This change also make it easier to embed GCPerfSim as part of some other benchmarks:

We often want GCPerfSim to be a part of something else like request processing or background processing, this change make it easy so that we can simply drop in `GCPerfSim.cs` and call `MemoryAlloc.Test` instead of having to change the code.