### PR TITLE
Fix sanity check arg

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -1111,7 +1111,7 @@ def main(argv: List[str]):
                 "--hybrid-globalization": "hybrid_globalization",
                 "--send-to-helix": "send_to_helix",
                 "--performance-repo-ci": "performance_repo_ci",
-                "--only-sanity-check": "only_sanity_check",
+                "--only-sanity": "only_sanity_check",
                 "--use-local-commit-time": "use_local_commit_time",
             }
 


### PR DESCRIPTION
I had set the sanity check arg to `--only-sanity-check`, but it seems that we were already using `--only-sanity`. This is causing the public wasm runs to fail ([link](https://dev.azure.com/dnceng-public/public/_build/results?buildId=810615&view=logs&j=0f08c62b-ed4c-50b2-1260-59a23cc961c9)). This fixes the argument to the correct one.