### PR TITLE
Fix configs for wasm aot and mono aot

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -227,7 +227,7 @@ def get_pre_commands(args: RunPerformanceJobArgs, v8_version: str):
             ]
 
     # Set MONO_ENV_OPTIONS with for Mono Interpreter runs
-    if args.codegen_type == "Interpreter" and args.runtime_type == "mono":
+    if args.codegen_type.lower() == "interpreter" and args.runtime_type == "mono":
         if args.os_group == "windows":
             helix_pre_commands += ['set MONO_ENV_OPTIONS="--interpreter"']
         else:
@@ -338,7 +338,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     helix_type_suffix = ""
     if args.runtime_type == "wasm":
-        if args.codegen_type == "AOT":
+        if args.codegen_type.lower() == "aot":
             helix_type_suffix = "/wasm/aot"
         else:
             helix_type_suffix = "/wasm"
@@ -377,7 +377,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     
     args.performance_repo_dir = os.path.abspath(args.performance_repo_dir)
 
-    mono_interpreter = args.codegen_type == "Interpreter" and args.runtime_type == "mono"
+    mono_interpreter = args.codegen_type.lower() == "interpreter" and args.runtime_type == "mono"
 
     if args.target_csproj is None:
         if args.os_group == "windows":
@@ -390,7 +390,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if args.libraries_download_dir is None and not args.performance_repo_ci and args.runtime_repo_dir is not None:
         args.libraries_download_dir = os.path.join(args.runtime_repo_dir, "artifacts")
 
-    llvm = args.codegen_type == "AOT" and args.runtime_type != "wasm"
+    llvm = args.codegen_type.lower() == "aot" and args.runtime_type != "wasm"
     android_mono = args.runtime_type == "AndroidMono"
     ios_mono = args.runtime_type == "iOSMono"
     ios_nativeaot = args.runtime_type == "iOSNativeAOT"
@@ -400,7 +400,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     wasm_bundle_dir = None
     wasm_aot = False
     if args.runtime_type == "mono":
-        if args.codegen_type == "AOT":
+        if args.codegen_type.lower() == "aot":
             if args.libraries_download_dir is None:
                 raise Exception("Libraries not downloaded for MonoAOT")
             

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -417,7 +417,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 raise Exception("Libraries not downloaded for WASM")
         
         wasm_bundle_dir = os.path.join(args.libraries_download_dir, "bin", "wasm")
-        if args.codegen_type == "AOT":
+        if args.codegen_type.lower() == "aot":
             wasm_aot = True
 
     working_dir = os.path.join(args.performance_repo_dir, "CorrelationStaging") # folder in which the payload and workitem directories will be made
@@ -474,7 +474,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     configurations = { "CompilationMode": "Tiered", "RunKind": args.run_kind }
 
     using_mono = False
-    if mono_dotnet is not None:
+    if mono_dotnet is not None or mono_aot:
         using_mono = True
         configurations["LLVM"] = str(llvm)
         configurations["MonoInterpreter"] = str(mono_interpreter)
@@ -568,7 +568,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if not args.internal and not args.performance_repo_ci:
         ci_setup_arguments.not_in_lab = True
 
-    if mono_dotnet is not None:
+    if mono_dotnet is not None and not mono_aot:
         mono_dotnet_path = os.path.join(payload_dir, "dotnet-mono")
         getLogger().info("Copying mono dotnet directory to payload directory")
         shutil.copytree(mono_dotnet, mono_dotnet_path)

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -473,9 +473,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     configurations = { "CompilationMode": "Tiered", "RunKind": args.run_kind }
 
-    using_mono = False
     if mono_dotnet is not None or mono_aot:
-        using_mono = True
         configurations["LLVM"] = str(llvm)
         configurations["MonoInterpreter"] = str(mono_interpreter)
         configurations["MonoAOT"] = str(mono_aot)
@@ -945,7 +943,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if using_wasm:
         cli_arguments += ["--run-isolated", "--wasm", "--dotnet-path", "$HELIX_CORRELATION_PAYLOAD/dotnet/"]
 
-    if using_mono:
+    if mono_dotnet is not None:
         if args.versions_props_path is None:
             if args.runtime_repo_dir is None:
                 raise Exception("Version.props must be present for mono runs")

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -482,13 +482,15 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
         # TODO: Validate if this exclusion filter is still needed
         extra_bdn_arguments += ["--exclusion-filter", "*Perf_Image*", "*Perf_NamedPipeStream*"]
-        category_exclusions += ["NoMono"]
+
+        # TODO: Identify why Mono AOT does not exclude NoMono, but instead excludes NoWASM
+        if mono_aot:
+            category_exclusions += ["NoAOT", "NoWASM"]
+        else:
+            category_exclusions += ["NoMono"]
 
         if mono_interpreter:
             category_exclusions += ["NoInterpreter"]
-
-        if mono_aot:
-            category_exclusions += ["NoAOT"]
 
     using_wasm = False
     if wasm_bundle_dir is not None:


### PR DESCRIPTION
This bit of the performance-setup.sh was not ported properly in the move to python pipelines. This will have caused missing data, but should not have caused any bad data