### PR TITLE
Update the libgdiplus repo for Alpine runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -133,7 +133,7 @@ def get_pre_commands(args: RunPerformanceJobArgs, v8_version: str):
     if args.os_sub_group == "_musl":    
         install_prerequisites += [
             "sudo apk add icu-libs krb5-libs libgcc libintl libssl1.1 libstdc++ zlib cargo",
-            "sudo apk add libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+            "sudo apk add libgdiplus --repository http://dl-cdn.alpinelinux.org/alpine/v3.18/community"
         ]
 
     if args.internal:


### PR DESCRIPTION
Update the libgdiplus to point to the community for the current Alpine version we have (3.18) as libgdiplus is now part of the community and not testing. This had been causing issues with PerfTiger158 as it wasn't able to find the package, while all other machines had it already installed so it didn't error. Not sure the underlying reason that it started missing on perftiger158, but this will make sure any new machines work off the bat. 

Link to the package which shows the current repo: https://alpine.pkgs.org/3.18/alpine-community-x86_64/libgdiplus-6.1-r2.apk.html