### PR TITLE
Update Roslyn Microsoft.CodeAnalysis.CSharp package version to 4.5.0

### DIFF
--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update the Roslyn Microsoft.CodeAnalysis.CSharp package version to 45.0 to match the BDN versions. This fixes the error that performance-ci runs of roslyn are hitting due to:
```
C:\h\w\ABF908CC\w\B79409EA\e\performance\src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.CodeAnalysis.CSharp from 4.5.0 to 4.3.0. Reference the package directly from the project to select a different version.
C:\h\w\ABF908CC\w\B79409EA\e\performance\src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj : error NU1605:  CompilerBenchmarks -> BenchmarkDotNet.Extensions -> BenchmarkDotNet 0.14.1-nightly.20240924.187 -> Microsoft.CodeAnalysis.CSharp (>= 4.5.0)
C:\h\w\ABF908CC\w\B79409EA\e\performance\src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj : error NU1605:  CompilerBenchmarks -> Microsoft.CodeAnalysis.CSharp (>= 4.3.0)
```

