### PR TITLE
Fix info log format to properly use lazy formatting in run_performance_job.py

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -886,7 +886,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
             os.environ["DOTNET_MULTILEVEL_LOOKUP"] = "0"
             os.environ["UseSharedCompilation"] = "false"
 
-            getLogger().info("Current dotnet directory:", ci_setup_arguments.install_dir)
+            getLogger().info("Current dotnet directory: %s", ci_setup_arguments.install_dir)
             getLogger().info("If more than one version exist in this directory, usually the latest runtime and sdk will be used.")
 
             # PreparePayloadWorkItems is only available for scenarios runs defined inside the performance repo


### PR DESCRIPTION
Fix info log format to properly use lazy formatting to keep run_performance_job from throwing an error in the middle of execution. The error was not impactful, just kept the current dotnet directory from being printed to user and dirtying the run logs.

The specific error from run_performance_job.py execution in any pipeline was:
```
--- Logging error ---
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "D:\a\1\s\scripts\run_performance_job.py", line 1199, in <module>
    main(sys.argv)
  File "D:\a\1\s\scripts\run_performance_job.py", line 1187, in main
    run_performance_job(RunPerformanceJobArgs(**args))
  File "D:\a\1\s\scripts\run_performance_job.py", line 889, in run_performance_job
    getLogger().info("Current dotnet directory:", ci_setup_arguments.install_dir)
Message: 'Current dotnet directory:'
Arguments: ('D:\\a\\1\\s\\CorrelationStaging\\payload\\dotnet',)
--- Logging error ---
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.12.6\x64\Lib\logging\__init__.py", line 703, in format
    record.message = record.getMessage()
```

