### PR TITLE
Removed no longer necessary Maui 8 package feeds and rollback mappings

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -28,17 +28,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
-    <!-- Package Sources for Maui -->
-    <!-- Added manually for dotnet/runtime 8.0.10 -->
-    <add key="darc-pub-dotnet-emsdk-d667257" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-d6672570/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-b5f5349" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b5f53494/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 8.0.9 -->
-    <add key="darc-pub-dotnet-emsdk-2674f58" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-emsdk-2674f580/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-ed13b35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-ed13b351/nuget/v3/index.json" />
-    <!-- Added manually for .NET 8 Android -->
-    <add key="darc-pub-dotnet-android-45bb7f3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-45bb7f36/nuget/v3/index.json" />
-    <!-- Added manually for .NET 8 iOS -->
-    <add key="darc-pub-xamarin-xamarin-macios-a8d7eab" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-a8d7eab2/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -333,43 +333,43 @@ jobs:
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
   # Scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios.proj
-  #       channels:
-  #         - main
-  #         - 8.0
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios.proj
+        channels:
+          - main
+          - 8.0
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: scenarios
-  #       projectFile: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        kind: scenarios
+        projectFile: scenarios_affinitized.proj
+        channels:
+          - main
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -377,15 +377,15 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        # - win-x64-android-arm64-galaxy
+        - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        # channels:
-        #   - 8.0
+        channels:
+          - 8.0
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -399,8 +399,8 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        # channels:
-        #   - 8.0
+        channels:
+          - 8.0
         runtimeFlavor: mono
 
   # Maui iOS Native AOT scenario benchmarks
@@ -415,8 +415,8 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        # channels:
-        #   - 8.0
+        channels:
+          - 8.0
         runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
@@ -436,21 +436,21 @@ jobs:
   #        - main
   #        - 8.0
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/performance/build_machine_matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/performance/scenarios.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       kind: nativeaot_scenarios
-  #       projectFile: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 8.0
+  # NativeAOT scenario benchmarks
+  - template: /eng/performance/build_machine_matrix.yml
+    parameters:
+      jobTemplate: /eng/performance/scenarios.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        kind: nativeaot_scenarios
+        projectFile: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 8.0
 
 ################################################
 # Scheduled Private jobs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -333,43 +333,43 @@ jobs:
 - ${{ if or(and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest', 'Manual')), parameters.runPrivateJobs) }}:
 
   # Scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios.proj
-        channels:
-          - main
-          - 8.0
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios.proj
+  #       channels:
+  #         - main
+  #         - 8.0
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        kind: scenarios
-        projectFile: scenarios_affinitized.proj
-        channels:
-          - main
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: scenarios
+  #       projectFile: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
 
   # Maui Android scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -377,15 +377,15 @@ jobs:
       jobTemplate: /eng/performance/scenarios.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
+        # - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         kind: maui_scenarios_android
         projectFile: maui_scenarios_android.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
+        # channels:
+        #   - 8.0
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/performance/build_machine_matrix.yml
@@ -399,8 +399,8 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
+        # channels:
+        #   - 8.0
         runtimeFlavor: mono
 
   # Maui iOS Native AOT scenario benchmarks
@@ -415,8 +415,8 @@ jobs:
         projectFile: maui_scenarios_ios.proj
         dotnetVersionsLinks:
           9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
+        # channels:
+        #   - 8.0
         runtimeFlavor: coreclr
 
   ## Maui scenario benchmarks
@@ -436,21 +436,21 @@ jobs:
   #        - main
   #        - 8.0
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/performance/build_machine_matrix.yml
-    parameters:
-      jobTemplate: /eng/performance/scenarios.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        kind: nativeaot_scenarios
-        projectFile: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 8.0
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/performance/build_machine_matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/performance/scenarios.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       kind: nativeaot_scenarios
+  #       projectFile: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 8.0
 
 ################################################
 # Scheduled Private jobs

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,10 +41,10 @@
       Mapping_Microsoft.NETCore.App.Ref:default
       Mapping_Microsoft.NET.Workload.Emscripten.Current:default
       Mapping_Microsoft.Android.Sdk:default
-      Mapping_Microsoft.MacCatalyst.Sdk:9.0.100-rc.2
-      Mapping_Microsoft.macOS.Sdk:9.0.100-rc.2
-      Mapping_Microsoft.iOS.Sdk:9.0.100-rc.2
-      Mapping_Microsoft.tvOS.Sdk:9.0.100-rc.2
+      Mapping_Microsoft.MacCatalyst.Sdk:default
+      Mapping_Microsoft.macOS.Sdk:default
+      Mapping_Microsoft.iOS.Sdk:default
+      Mapping_Microsoft.tvOS.Sdk:default
     -->
     <!-- Dependencies for .NET MAUI workload -->
     <Dependency Name="Microsoft.Maui.Controls" Version="9.0.0-rtm.24519.2">

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -42,7 +42,7 @@ def generate_maui_rollback_dict():
         full_band_version_holder = general_version_obj.get("Version")
         if full_band_version_holder is None:
             raise ValueError("Unable to find Microsoft.NET.Sdk with proper version in Version.Details.xml")
-        match = re.search(r'^\d+\.\d+\.\d+\-(preview|rc|alpha).\d+', full_band_version_holder)
+        match = re.search(r'^\d+\.\d+\.\d+(\-(preview|rc|alpha).\d+)?', full_band_version_holder)
         if match:
             default_band_version = match.group(0)
         else:

--- a/src/tools/ScenarioMeasurement/Directory.Build.props
+++ b/src/tools/ScenarioMeasurement/Directory.Build.props
@@ -3,7 +3,7 @@
     <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
     <PropertyGroup>
         <FallbackTargetFramework>net8.0</FallbackTargetFramework>
-        <NoWarn>$(NoWarn);CS8002</NoWarn>
+        <NoWarn>$(NoWarn);CS8002;NU1507</NoWarn> <!-- NU1507: Darc does not seem to support auto updating of packageSourceMapping causing tool publishes to fail without manual updating of the NuGet.config with package mappings, disable this check so we don't have to manually update the source mappings. -->
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removed no longer necessary Maui 8 package feeds and updated the iOS related rollback mappings back to default. This matches the current setup in the maui repo for the associated data: https://github.com/dotnet/maui/blob/c72387d31b6b5579be6bcefbec98f5f27c422d2c/NuGet.config and https://github.com/dotnet/maui/blob/c72387d31b6b5579be6bcefbec98f5f27c422d2c/eng/Version.Details.xml 

Internal test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2565937&view=results