### PR TITLE
Change BytesAllocatedPerOperation to long?

### DIFF
--- a/src/tools/ResultsComparer/DataTransferContracts.cs
+++ b/src/tools/ResultsComparer/DataTransferContracts.cs
@@ -88,7 +88,7 @@ namespace DataTransferContracts // generated with http://json2csharp.com/#
         public int Gen1Collections { get; set; }
         public int Gen2Collections { get; set; }
         public long TotalOperations { get; set; }
-        public long BytesAllocatedPerOperation { get; set; }
+        public long? BytesAllocatedPerOperation { get; set; }
     }
 
     public class Measurement

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -103,10 +103,10 @@ namespace ResultsComparer
 
         private static string GetAllocatedDiff(Benchmark diffResult, Benchmark baseResult)
         {
-            long baseline = baseResult.Memory.BytesAllocatedPerOperation;
+            long baseline = baseResult.Memory.BytesAllocatedPerOperation ?? 0;
             if (baseline == 0)
                 baseline = GetMetricValue(baseResult);
-            long diff = diffResult.Memory.BytesAllocatedPerOperation;
+            long diff = diffResult.Memory.BytesAllocatedPerOperation ?? 0;
             if (diff == 0)
                 diff = GetMetricValue(diffResult);
 


### PR DESCRIPTION
Fixes #4552 

`BytesAllocatedPerOperation` can be null valued so change it from `long` to `long?`