### PR TITLE
Supress SYSLIB0057

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
@@ -26,9 +26,9 @@ namespace System.Net.Test.Common
             private static X509Certificate2 GetCertificate(string certificateFileName)
             {
                 try
-				{
+                {
 #pragma warning disable SYSLIB0057 // Type or member is obsolete
-					return new X509Certificate2(
+                    return new X509Certificate2(
                          File.ReadAllBytes(
                              Path.Combine(
                                  AppContext.BaseDirectory,
@@ -37,9 +37,9 @@ namespace System.Net.Test.Common
                                  certificateFileName)),
                          CertificatePassword,
                          X509KeyStorageFlags.DefaultKeySet);
-				}
+                }
 #pragma warning restore SYSLIB0057
-				catch (Exception)
+                catch (Exception)
                 {
                     return null;
                 }

--- a/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Http/Configuration.Certificates.cs
@@ -26,8 +26,9 @@ namespace System.Net.Test.Common
             private static X509Certificate2 GetCertificate(string certificateFileName)
             {
                 try
-                {
-                    return new X509Certificate2(
+				{
+#pragma warning disable SYSLIB0057 // Type or member is obsolete
+					return new X509Certificate2(
                          File.ReadAllBytes(
                              Path.Combine(
                                  AppContext.BaseDirectory,
@@ -36,8 +37,9 @@ namespace System.Net.Test.Common
                                  certificateFileName)),
                          CertificatePassword,
                          X509KeyStorageFlags.DefaultKeySet);
-                }
-                catch (Exception)
+				}
+#pragma warning restore SYSLIB0057
+				catch (Exception)
                 {
                     return null;
                 }


### PR DESCRIPTION
I had trouble compiling since `X509Certificate2` ctor is marked as obsolete as of .NET 9.