### PR TITLE
Enable iteration for microbenchmarks

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Server.yaml
@@ -23,6 +23,7 @@ microbenchmark_configurations:
   bdn_arguments: --warmupCount 1 --iterationCount 20 --allStats --outliers DontRemove --keepFiles
 environment:
   default_max_seconds: 3000
+  iteration: 1
 output:
   cpu_columns: 
   additional_report_metrics: 

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Microbenchmark/Microbenchmarks_Workstation.yaml
@@ -23,6 +23,7 @@ microbenchmark_configurations:
   bdn_arguments: --warmupCount 1 --iterationCount 20 --allStats --outliers DontRemove --keepFiles
 environment:
   default_max_seconds: 3000
+  iteration: 1
 output:
   cpu_columns: 
   additional_report_metrics: 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Microbenchmarks.Configuration.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Configurations/Microbenchmarks.Configuration.cs
@@ -24,6 +24,7 @@ namespace GC.Infrastructure.Core.Configurations.Microbenchmarks
     public class Environment
     {
         public uint default_max_seconds { get; set; } = 300;
+        public uint iteration { get; set; } = 1;
     }
 
     public sealed class MicrobenchmarkConfigurations

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/Microbenchmarks.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/Microbenchmarks.yaml
@@ -6,6 +6,7 @@ microbenchmark_configurations:
 
 environment:
     default_max_seconds: 3000
+    iteration: 1
 
 # Configurations that involve capturing a trace.
 trace_configurations:


### PR DESCRIPTION
Enable iteration for microbenchmarks. Now we can repeat bdnProcess several times based on `Environment.iteration` and each iteration has its own result folder and trace files.