### PR TITLE
Ensure Repeatable Results by Preserving Insert Order in Unique Array Generation Methods

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -54,11 +54,9 @@ namespace BenchmarkDotNet.Extensions
             {
                 T value = GenerateValue<T>(random);
 
-                if (!uniqueValues.Contains(value))
-                    uniqueValues.Add(value);
+                if (uniqueValues.Add(value))
+                    result[uniqueValues.Count - 1] = value;
             }
-
-            uniqueValues.CopyTo(result);
 
             return result;
         }
@@ -178,9 +176,10 @@ namespace BenchmarkDotNet.Extensions
             
             while (unique.Count != count)
             {
-                unique.Add(GenerateRandomString(random, minLength, maxLength));
+                string randomString = GenerateRandomString(random, minLength, maxLength);
+                if (unique.Add(randomString))
+                    strings[unique.Count - 1] = randomString;
             }
-            unique.CopyTo(strings);
             return strings;
         }
 


### PR DESCRIPTION
### Context:
The methods `ArrayOfUniqueValues` and `ArrayOfUniqueStrings` aim to generate repeatable sequences of unique values or strings. The repeatability is achieved using a fixed `Seed` (as noted in the comment on line 16). However, the current implementation relies on the traversal order of `HashSet`, which does not guarantee a consistent order.

### Issue:
The assumption that a fixed insertion sequence into a `HashSet` ensures a repeatable traversal order is flawed:
1. `HashSet` does not provide any guarantees about order semantics in its documentation.
2. Some standard libraries in other programming languages, or even future implementations of `.NET`, may introduce variations in `Set` behavior where traversal order is inconsistent even with a fixed insertion sequence.

This discrepancy could lead to non-repeatable results, breaking the method's intended behavior.

### Solution:
- Instead of relying on `HashSet.CopyTo` for transferring elements to the result array, we now directly assign values to the array in the order they are added to the `HashSet`. This ensures the output matches the insertion order and remains repeatable with a fixed seed.
- Updated both `ArrayOfUniqueValues` and `ArrayOfUniqueStrings` methods to reflect this approach.

### Changes:
1. Modified `ArrayOfUniqueValues`:
   - Removed reliance on `HashSet.CopyTo`.
   - Assigned values to the result array during insertion to preserve order.
2. Modified `ArrayOfUniqueStrings`:
   - Similarly, ensured the assignment to the array occurs during insertion into the `HashSet`.

### Benefits:
- Guarantees repeatable results consistent with the fixed seed.
- Eliminates reliance on undocumented behavior of `HashSet` traversal.