### PR TITLE
Fix minor global.json typo in global.net9.json

### DIFF
--- a/global.net9.json
+++ b/global.net9.json
@@ -9,7 +9,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24572.2",
-    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24572.2",
+    "Microsoft.DotNet.Helix.Sdk": "9.0.0-beta.24572.2"
   },
   "native-tools": {
     "python3": "3.7.1"


### PR DESCRIPTION
Fix minor global.json typo in global.net9.json causing runs that use global.net9.json to fail.

Test run here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2605187&view=logs&j=efa3ffcd-91e9-5b69-9db7-650958b3131c to that tests the global.net9.json file (Working was getting past run performance_job.py and actually sending jobs).

