### PR TITLE
Update BDN version to support more net10.0 testing.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>10.0.0-alpha.1.24617.3</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>10.0.0-alpha.1.24617.3</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>10.0.0-alpha.1.24617.3</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.14.1-nightly.20240924.187</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>9.0.1</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
   </PropertyGroup>
   <!--Package names-->

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -275,7 +275,7 @@ def __get_benchmarkdotnet_arguments(framework: str, args: Any) -> List[str]:
         elif framework == "net9.0":
             run_args += ['--runtimes', 'wasmnet90']
         elif framework == "net10.0":
-            run_args += ['--runtimes', 'wasmnet100']
+            run_args += ['--runtimes', 'wasmnet10_0']
         else:
             raise ArgumentTypeError('Framework {} is not supported for wasm'.format(framework))
 

--- a/src/benchmarks/real-world/ILLink/ILLinkBenchmarks.csproj
+++ b/src/benchmarks/real-world/ILLink/ILLinkBenchmarks.csproj
@@ -16,7 +16,6 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Net.ILLink" Version="$(MicrosoftNetILLinkPackageVersion)" />
 		<PackageReference Include="Microsoft.Net.ILLink.Tasks" Version="$(MicrosoftNetILLinkTasksVersion)" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Build" Version="17.3.1" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.3.1" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/Helpers.cs
+++ b/src/benchmarks/real-world/Roslyn/Helpers.cs
@@ -60,6 +60,7 @@ namespace CompilerBenchmarks
                 new List<DiagnosticInfo>(),
                 MessageProvider.Instance,
                 new DefaultAnalyzerAssemblyLoader(),
+                cmdLineArgs.CompilationOptions,
                 skipAnalyzers: false,
                 out var analyzers,
                 out var generators);

--- a/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
+++ b/src/benchmarks/real-world/Roslyn/StageBenchmarks.cs
@@ -102,8 +102,6 @@ namespace CompilerBenchmarks
             success = _comp.CompileMethods(
                 _moduleBeingBuilt,
                 emittingPdb: embedPdb,
-                emitMetadataOnly: _options.EmitMetadataOnly,
-                emitTestCoverageData: _options.EmitTestCoverageData,
                 diagnostics: diagnostics,
                 filterOpt: null,
                 cancellationToken: default);


### PR DESCRIPTION
Update BDN version to support more net10.0 testing. This should fix WASM runs.