### PR TITLE
Fix Alpine builds and add try except

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -784,7 +784,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     elif args.os_group == "osx":
         runtime_id = f"osx-{args.architecture}"
     else:
-        runtime_id = f"linux-{args.architecture}"
+        runtime_id = "linux" + f"-{args.os_sub_group}" if args.os_sub_group else "" + f"-{args.architecture}"
 
     dotnet_executable_path = os.path.join(ci_setup_arguments.install_dir, "dotnet")
 

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -39,14 +39,17 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
             getLogger().info("Unable to use managed identity. Falling back to certificate.")
             cmd_line = [(os.path.join(str(helixpayload()), 'certhelper', "CertHelper%s" % extension()))]
             cert_helper = RunCommand(cmd_line, None, True, False, 0)
-            cert_helper.run()
-            for cert in cert_helper.stdout.splitlines():
-                credential = CertificateCredential(TENANT_ID, CERT_CLIENT_ID, certificate_data=base64_to_bytes(cert))
-                try:
-                    credential.get_token("https://storage.azure.com/.default")
-                except ClientAuthenticationError as ex:
-                    credential = None
-                    continue
+            try:
+                cert_helper.run()
+                for cert in cert_helper.stdout.splitlines():
+                    credential = CertificateCredential(TENANT_ID, CERT_CLIENT_ID, certificate_data=base64_to_bytes(cert))
+                    try:
+                        credential.get_token("https://storage.azure.com/.default")
+                    except ClientAuthenticationError as ex:
+                        credential = None
+                        continue
+            except Exception as ex:
+                credential = None
         if credential is None:
             getLogger().error("Unable to authenticate with managed identity or certificates.")
             getLogger().info("Falling back to environment variable.")


### PR DESCRIPTION
For Alpine builds we were not respecting the osSubGroup variable and as such were not using the correct rid when building. I also added a try block around our call to run, as that can throw, and we still want to fall back to the sas token for now if the cert fails.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


