### PR TITLE
Fix WASM dotnet pathing bug

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -786,7 +786,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     else:
         runtime_id = "linux" + f"-{args.os_sub_group}" if args.os_sub_group else "" + f"-{args.architecture}"
 
-    dotnet_executable_path = os.path.join(ci_setup_arguments.install_dir, "dotnet")
+    dotnet_executable_path = ci_setup_arguments.dotnet_path if ci_setup_arguments.dotnet_path else os.path.join(ci_setup_arguments.install_dir, "dotnet")
 
     RunCommand([
         dotnet_executable_path, "publish", 

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -786,7 +786,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     else:
         runtime_id = "linux" + f"-{args.os_sub_group}" if args.os_sub_group else "" + f"-{args.architecture}"
 
-    dotnet_executable_path = ci_setup_arguments.dotnet_path if ci_setup_arguments.dotnet_path else os.path.join(ci_setup_arguments.install_dir, "dotnet")
+    dotnet_executable_path = os.path.join(ci_setup_arguments.dotnet_path, "dotnet") if ci_setup_arguments.dotnet_path else os.path.join(ci_setup_arguments.install_dir, "dotnet")
 
     RunCommand([
         dotnet_executable_path, "publish", 

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -784,7 +784,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     elif args.os_group == "osx":
         runtime_id = f"osx-{args.architecture}"
     else:
-        runtime_id = "linux" + f"-{args.os_sub_group}" if args.os_sub_group else "" + f"-{args.architecture}"
+        runtime_id = "linux" + (f"-{args.os_sub_group}" if args.os_sub_group else "") + f"-{args.architecture}"
 
     dotnet_executable_path = os.path.join(ci_setup_arguments.dotnet_path, "dotnet") if ci_setup_arguments.dotnet_path else os.path.join(ci_setup_arguments.install_dir, "dotnet")
 


### PR DESCRIPTION
For WASM, we use a pre-downloaded version of dotnet, and do not install it using `dotnet-install.ps1`. As a result we setup the environment using the `dotnet_path` variable instead of `install_dir`. This change will now set the path to `dotnet` with the same precedence as our setup script does. Preferring `dotnet_path` if it exists, and falling back to `install_dir` if it does not.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


