### PR TITLE
Revert global.json to match dotnet/runtime

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,15 +1,15 @@
 {
   "sdk": {
-    "version": "10.0.100-alpha.1.25064.3",
+    "version": "10.0.100-alpha.1.24610.7",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.100-alpha.1.25064.3"
+    "dotnet": "10.0.100-alpha.1.24610.7"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25071.3",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25071.3"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25058.4",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25058.4"
   },
   "native-tools": {
     "python3": "3.7.1"


### PR DESCRIPTION
Revert global.json to match what dotnet/runtime has as wasm runs are failing due to using the runtimes installed dotnet and not the latest daily dotnet like our other runs, making it fail due to too new of a minimum in global.json.

There is currently a blocking issue to merge the latest dotnet/arcade update and we will have to wait for it to go in before we can update it to the same in our repo.

