### PR TITLE
Fix quoting issue between python 3.12 and older versions

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -784,7 +784,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     elif args.os_group == "osx":
         runtime_id = f"osx-{args.architecture}"
     else:
-        runtime_id = "linux" + (f"{args.os_sub_group.replace("_", "-")}" if args.os_sub_group else "") + f"-{args.architecture}"
+        runtime_id = "linux" + (f"{args.os_sub_group.replace('_', '-')}" if args.os_sub_group else "") + f"-{args.architecture}"
 
     dotnet_executable_path = os.path.join(ci_setup_arguments.dotnet_path, "dotnet") if ci_setup_arguments.dotnet_path else os.path.join(ci_setup_arguments.install_dir, "dotnet")
 


### PR DESCRIPTION
This was caused because of a difference between Python 3.12 and earlier versions of Python. In 3.12 the double quote inside another double quote is allowed, but older versions it is not. This change was tested on this newer version, and so this was missed.
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


