### PR TITLE
Keep Rfc2898DeriveBytes test from compiling on net10 or greater.

### DIFF
--- a/src/benchmarks/micro/libraries/System.Security.Cryptography/Perf.Rfc2898DeriveBytes.cs
+++ b/src/benchmarks/micro/libraries/System.Security.Cryptography/Perf.Rfc2898DeriveBytes.cs
@@ -7,6 +7,7 @@ using MicroBenchmarks;
 
 namespace System.Security.Cryptography.Tests
 {
+#if !NET10_0_OR_GREATER
     [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public class Perf_Rfc2898DeriveBytes
     {
@@ -15,4 +16,5 @@ namespace System.Security.Cryptography.Tests
         [Benchmark]
         public byte[] DeriveBytes() => s_db.GetBytes(32);
     }
+#endif
 }


### PR DESCRIPTION
Block Rfc2898DeriveBytes test from compiling on net10 or greater as the constructor has been made obsolete. Exact error: 'error SYSLIB0060: 'Rfc2898DeriveBytes.Rfc2898DeriveBytes(string, int, int, HashAlgorithmName)' is obsolete: 'The constructors on Rfc2898DeriveBytes are obsolete. Use the static Pbkdf2 method instead.' (https://aka.ms/dotnet-warnings/SYSLIB0060)'. This is currently keeping the pipelines from running.

