### PR TITLE
Combine iOS and Android XHarnessCLI versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,6 +39,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>02e2a71bd9c33ea333c9e3acc2404d6c061532bb</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.24610.1">
+      <Uri>https://github.com/dotnet/xharness</Uri>
+      <Sha>3119edb6d70fb252e6128b0c7e45d3fc2f49f249</Sha>
+    </Dependency>
     <!--
       Maui Rollback Version mappings, default means generated from sdk version. Allows for manual override of version similar to https://github.com/dotnet/maui/blob/df8cfcf635a590955a8cc3d6cf7ae6280449dd3f/eng/Versions.props#L138-L146, where the logic comes from:
       Mapping_Microsoft.Maui.Controls:default

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,7 @@
     <MicrosoftExtensionsLoggingPackageVersion>9.0.2</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>9.0.2</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
+    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.24610.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.24524.9</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <MicrosoftDotNetXHarnessCLIVersion>9.0.0-prerelease.23606.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Remove the separate version of XHarness CLI for iOS and Android runs and instead use a shared version in Versions.props and Version.Details.xml. The next step will be to automate the updating of the xharness version using darc/maestro.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2630248&view=results. 

This test run does include the iOS xcode version update here https://github.com/dotnet/performance/pull/4667 while the PR does not. Android run has the same memory consumption failure as main which was missed with the general xharness version update due to a different break, so I have the investigation of this new failure on my task list and it should not keep this PR from merging. The iOS test succeeded so we should be good there.

