### PR TITLE
Fix for Mac Certs

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -38,6 +38,9 @@ def get_machine_architecture():
 def iswin():
     return sys.platform == 'win32'
 
+def ismac():
+    return sys.platform == 'darwin'
+
 def extension():
     'gets platform specific extension'
     return '.exe' if iswin() else ''
@@ -205,6 +208,29 @@ def retry_on_exception(
             getLogger().info('Retrying in %d seconds...', retry_delay)
             time.sleep(retry_delay)
             retry_delay *= retry_delay_multiplier
+
+def get_certificates() -> List[str]:
+    '''
+    Gets the certificates from the certhelper tool and on Mac uses find-certificate.
+    '''
+    if ismac():
+        certs: List[str] = []
+        with open("/Users/helix-runner/certs/LabCert1.pfx", "rb") as f:
+            certs.append(base64.b64encode(f.read()).decode())
+        with open("/Users/helix-runner/certs/LabCert2.pfx", "rb") as f:
+            certs.append(base64.b64encode(f.read()).decode())
+        return certs
+    else:
+        cmd_line = [(os.path.join(str(helixpayload()), 'certhelper', "CertHelper%s" % extension()))]
+        cert_helper = RunCommand(cmd_line, None, True, False, 0)
+        try:
+            cert_helper.run()
+            return cert_helper.stdout.splitlines()
+        except Exception as ex:
+            getLogger().error("Failed to get certificates")
+            getLogger().error('{0}: {1}'.format(type(ex), str(ex)))
+            return []
+
 
 def __write_pipeline_variable(name: str, value: str):
     # Create a variable in the build pipeline

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -44,8 +44,6 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
                     try:
                         credential.get_token("https://storage.azure.com/.default")
                     except ClientAuthenticationError as ex:
-                        getLogger().error(ex.message)
-                        getLogger().error(ex.exc_traceback)
                         credential = None
                         continue
             except Exception as ex:

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -40,18 +40,15 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
             try:
                 certs = get_certificates()
                 for cert in certs:
-                    print(cert)
                     credential = CertificateCredential(TENANT_ID, CERT_CLIENT_ID, certificate_data=base64_to_bytes(cert))
                     try:
                         credential.get_token("https://storage.azure.com/.default")
                     except ClientAuthenticationError as ex:
-                        print(cert)
                         getLogger().error(ex.message)
                         getLogger().error(ex.exc_traceback)
                         credential = None
                         continue
             except Exception as ex:
-                print("Get certs failed")
                 credential = None
         if credential is None:
             getLogger().error("Unable to authenticate with managed identity or certificates.")

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -32,7 +32,7 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
         credential = None
         try:
             dac = DefaultAzureCredential()
-            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token)
+            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token, send_certificate_chain=True)
             credential.get_token("https://storage.azure.com/.default")
         except ClientAuthenticationError as ex:
             credential = None

--- a/src/tools/CertHelper/KeyVaultCert.cs
+++ b/src/tools/CertHelper/KeyVaultCert.cs
@@ -84,9 +84,9 @@ public class KeyVaultCert
         }
         var certBytes = Convert.FromBase64String(secret.Value.Value);
 #if NET9_0_OR_GREATER        
-        var cert = X509CertificateLoader.LoadPkcs12(certBytes, "", X509KeyStorageFlags.Exportable);
+        var cert = X509CertificateLoader.LoadPkcs12(certBytes, "", X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 #else
-        var cert = new X509Certificate2(certBytes, "", X509KeyStorageFlags.Exportable);
+        var cert = new X509Certificate2(certBytes, "", X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
 #endif
         return cert;
     }

--- a/src/tools/CertHelper/Program.cs
+++ b/src/tools/CertHelper/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
@@ -8,52 +9,55 @@ namespace CertHelper;
 
 internal class Program
 {
+
     static readonly string TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
     static readonly string CERT_CLIENT_ID = "8c4b65ef-5a73-4d5a-a298-962d4a4ef7bc";
+
     static async Task<int> Main(string[] args)
     {
-        try
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            var kvc = new KeyVaultCert();
-            await kvc.LoadKeyVaultCertsAsync();
-            if (kvc.ShouldRotateCerts())
+            Console.WriteLine("Not Here");
+            try
             {
-                using (var localMachineCerts = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                var kvc = new KeyVaultCert();
+                await kvc.LoadKeyVaultCertsAsync();
+                if (kvc.ShouldRotateCerts())
                 {
-                    localMachineCerts.Open(OpenFlags.ReadWrite);
-                    localMachineCerts.RemoveRange(kvc.LocalCerts.Certificates);
-                    localMachineCerts.AddRange(kvc.KeyVaultCertificates);
+                    using (var localMachineCerts = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                    {
+                        localMachineCerts.Open(OpenFlags.ReadWrite);
+                        localMachineCerts.RemoveRange(kvc.LocalCerts.Certificates);
+                        localMachineCerts.AddRange(kvc.KeyVaultCertificates);
+                    }
+                }
+                var bcc = new BlobContainerClient(new Uri("https://pvscmdupload.blob.core.windows.net/certstatus"),
+                    new ClientCertificateCredential(TENANT_ID, CERT_CLIENT_ID, kvc.KeyVaultCertificates.First()));
+                var currentKeyValutCertThumbprints = "";
+                foreach (var cert in kvc.KeyVaultCertificates)
+                {
+                    currentKeyValutCertThumbprints += $"[{DateTimeOffset.UtcNow}] {cert.Thumbprint}{Environment.NewLine}";
+                }
+                var blob = bcc.GetBlobClient(System.Environment.MachineName);
+                if (blob.Exists())
+                {
+                    var result = blob.DownloadContent();
+                    var currentBlob = result.Value.Content.ToString();
+                    currentBlob = currentBlob + currentKeyValutCertThumbprints;
+                    blob.Upload(new MemoryStream(Encoding.UTF8.GetBytes(currentBlob)), overwrite: true);
+                }
+                else
+                {
+                    blob.Upload(new MemoryStream(Encoding.UTF8.GetBytes(currentKeyValutCertThumbprints)), overwrite: false);
                 }
             }
-            var bcc = new BlobContainerClient(new Uri("https://pvscmdupload.blob.core.windows.net/certstatus"),
-                new ClientCertificateCredential(TENANT_ID, CERT_CLIENT_ID, kvc.KeyVaultCertificates.First()));
-            var currentKeyValutCertThumbprints = "";
-            foreach(var cert in kvc.KeyVaultCertificates)
+            catch (Exception ex)
             {
-                currentKeyValutCertThumbprints += $"[{DateTimeOffset.UtcNow}] {cert.Thumbprint}{Environment.NewLine}";
+                Console.WriteLine("Failed to rotate certificates");
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
             }
-            var blob = bcc.GetBlobClient(System.Environment.MachineName);
-            if (blob.Exists())
-            {
-                var result = blob.DownloadContent();
-                var currentBlob = result.Value.Content.ToString();
-                currentBlob = currentBlob + currentKeyValutCertThumbprints;
-                blob.Upload(new MemoryStream(Encoding.UTF8.GetBytes(currentBlob)), overwrite: true);
-            }
-            else
-            {
-                blob.Upload(new MemoryStream(Encoding.UTF8.GetBytes(currentKeyValutCertThumbprints)), overwrite: false);
-            }
-            
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failed to rotate certificates");
-            Console.WriteLine(ex.Message);
-            Console.WriteLine(ex.StackTrace);
-        }
-
-
 
         using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite))
         {


### PR DESCRIPTION
From my work it does not appear that there is any programmatic way to recover the public/private key pair in a Key Chain without having to enter a password. As a result, we are going to grab the certificates directly off the disk, like we do on Linux machines.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


