### PR TITLE
Revert "Fix for Mac Certs (#4680)"

### DIFF
--- a/scripts/performance/common.py
+++ b/scripts/performance/common.py
@@ -38,9 +38,6 @@ def get_machine_architecture():
 def iswin():
     return sys.platform == 'win32'
 
-def ismac():
-    return sys.platform == 'darwin'
-
 def extension():
     'gets platform specific extension'
     return '.exe' if iswin() else ''
@@ -208,29 +205,6 @@ def retry_on_exception(
             getLogger().info('Retrying in %d seconds...', retry_delay)
             time.sleep(retry_delay)
             retry_delay *= retry_delay_multiplier
-
-def get_certificates() -> List[str]:
-    '''
-    Gets the certificates from the certhelper tool and on Mac uses find-certificate.
-    '''
-    if ismac():
-        certs: List[str] = []
-        with open("/Users/helix-runner/certs/LabCert1.pfx", "rb") as f:
-            certs.append(base64.b64encode(f.read()).decode())
-        with open("/Users/helix-runner/certs/LabCert2.pfx", "rb") as f:
-            certs.append(base64.b64encode(f.read()).decode())
-        return certs
-    else:
-        cmd_line = [(os.path.join(str(helixpayload()), 'certhelper', "CertHelper%s" % extension()))]
-        cert_helper = RunCommand(cmd_line, None, True, False, 0)
-        try:
-            cert_helper.run()
-            return cert_helper.stdout.splitlines()
-        except Exception as ex:
-            getLogger().error("Failed to get certificates")
-            getLogger().error('{0}: {1}'.format(type(ex), str(ex)))
-            return []
-
 
 def __write_pipeline_variable(name: str, value: str):
     # Create a variable in the build pipeline

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -6,7 +6,7 @@ from azure.core.exceptions import ResourceExistsError, ClientAuthenticationError
 from azure.identity import DefaultAzureCredential, ClientAssertionCredential, CertificateCredential
 from traceback import format_exc
 from glob import glob
-from performance.common import retry_on_exception, RunCommand, helixpayload, base64_to_bytes, extension, get_certificates
+from performance.common import retry_on_exception, RunCommand, helixpayload, base64_to_bytes, extension
 from performance.constants import TENANT_ID, ARC_CLIENT_ID, CERT_CLIENT_ID
 import os
 import json
@@ -32,14 +32,16 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
         credential = None
         try:
             dac = DefaultAzureCredential()
-            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token, send_certificate_chain=True)
+            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token)
             credential.get_token("https://storage.azure.com/.default")
         except ClientAuthenticationError as ex:
             credential = None
             getLogger().info("Unable to use managed identity. Falling back to certificate.")
+            cmd_line = [(os.path.join(str(helixpayload()), 'certhelper', "CertHelper%s" % extension()))]
+            cert_helper = RunCommand(cmd_line, None, True, False, 0)
             try:
-                certs = get_certificates()
-                for cert in certs:
+                cert_helper.run()
+                for cert in cert_helper.stdout.splitlines():
                     credential = CertificateCredential(TENANT_ID, CERT_CLIENT_ID, certificate_data=base64_to_bytes(cert))
                     try:
                         credential.get_token("https://storage.azure.com/.default")

--- a/src/tools/CertHelper/KeyVaultCert.cs
+++ b/src/tools/CertHelper/KeyVaultCert.cs
@@ -84,9 +84,9 @@ public class KeyVaultCert
         }
         var certBytes = Convert.FromBase64String(secret.Value.Value);
 #if NET9_0_OR_GREATER        
-        var cert = X509CertificateLoader.LoadPkcs12(certBytes, "", X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        var cert = X509CertificateLoader.LoadPkcs12(certBytes, "", X509KeyStorageFlags.Exportable);
 #else
-        var cert = new X509Certificate2(certBytes, "", X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        var cert = new X509Certificate2(certBytes, "", X509KeyStorageFlags.Exportable);
 #endif
         return cert;
     }

--- a/src/tools/CertHelper/Program.cs
+++ b/src/tools/CertHelper/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
@@ -9,10 +8,8 @@ namespace CertHelper;
 
 internal class Program
 {
-
     static readonly string TENANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47";
     static readonly string CERT_CLIENT_ID = "8c4b65ef-5a73-4d5a-a298-962d4a4ef7bc";
-
     static async Task<int> Main(string[] args)
     {
         try
@@ -31,7 +28,7 @@ internal class Program
             var bcc = new BlobContainerClient(new Uri("https://pvscmdupload.blob.core.windows.net/certstatus"),
                 new ClientCertificateCredential(TENANT_ID, CERT_CLIENT_ID, kvc.KeyVaultCertificates.First()));
             var currentKeyValutCertThumbprints = "";
-            foreach (var cert in kvc.KeyVaultCertificates)
+            foreach(var cert in kvc.KeyVaultCertificates)
             {
                 currentKeyValutCertThumbprints += $"[{DateTimeOffset.UtcNow}] {cert.Thumbprint}{Environment.NewLine}";
             }
@@ -47,6 +44,7 @@ internal class Program
             {
                 blob.Upload(new MemoryStream(Encoding.UTF8.GetBytes(currentKeyValutCertThumbprints)), overwrite: false);
             }
+            
         }
         catch (Exception ex)
         {
@@ -54,6 +52,8 @@ internal class Program
             Console.WriteLine(ex.Message);
             Console.WriteLine(ex.StackTrace);
         }
+
+
 
         using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite))
         {


### PR DESCRIPTION
This reverts commit 0f47692677265e23a837c94696a3de340a4165e9.

This commit introduced the following error which seems to be due to send_certificate_chain not existing as an option for ClientAssertionCredential. 

```
[2025/02/05 13:12:09][ERROR] <class 'TypeError'>: object.__init__() takes exactly one argument (the instance to initialize)
[2025/02/05 13:12:09][ERROR] Traceback (most recent call last):
  File "/home/helixbot/work/A1F5095C/w/A18508F5/e/performance/scripts/upload.py", line 35, in upload
    credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token, send_certificate_chain=True)
  File "/home/helixbot/work/A1F5095C/w/A18508F5/e/.venv/lib/python3.10/site-packages/azure/identity/_credentials/client_assertion.py", line 56, in __init__
    super(ClientAssertionCredential, self).__init__(**kwargs)
  File "/home/helixbot/work/A1F5095C/w/A18508F5/e/.venv/lib/python3.10/site-packages/azure/identity/_internal/get_token_mixin.py", line 22, in __init__
    super(GetTokenMixin, self).__init__(*args, **kwargs)  # type: ignore
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```

This option does exist on CertificateCredential https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.certificatecredential?view=azure-python.


