### PR TITLE
Remove send_certificate_chain arg from ClientAssertionCredential initialization

### DIFF
--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -32,7 +32,7 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
         credential = None
         try:
             dac = DefaultAzureCredential()
-            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token, send_certificate_chain=True)
+            credential = ClientAssertionCredential(TENANT_ID, ARC_CLIENT_ID, lambda: dac.get_token("api://AzureADTokenExchange/.default").token)
             credential.get_token("https://storage.azure.com/.default")
         except ClientAuthenticationError as ex:
             credential = None


### PR DESCRIPTION
Remove the non-existant argument send_certificate_chain from ClientAssertionCredential.

Alternative to https://github.com/dotnet/performance/pull/4687 if a quick test run succeeds. Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2636167&view=results. The primary thing to look for is the upload to succeed. Not sure if this will keep the Macs from working, but it should work as a stop gap to keep from missing out the rest of the data.

