### PR TITLE
System.Reflection.Metadata.TypeName benchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -100,6 +100,8 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '8.0'">
     <!-- we want both net8.0 and net9.0 targets to use the 9.0.0 version of the NuGet package (since this is where the generic math APIs were first added) -->
     <PackageReference Include="System.Numerics.Tensors" Version="$(SystemThreadingChannelsPackageVersion)" />
+    <!-- The TypeName API was introduced in System.ReflectioMetadata 9.0, so we include it only for 9.0 and above -->
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -229,6 +231,10 @@
     <Compile Remove="libraries\System.Buffers\SearchValuesCharTests.cs" />
     <Compile Remove="libraries\System.Text.Encoding\Perf.Ascii.cs" />
     <Compile Remove="libraries\System.Numerics.Tensors\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '9.0')">
+    <Compile Remove="libraries\System.Reflection.Metadata\*.cs" />
   </ItemGroup>
 
   <!-- This is not removing things from older Net versions, it is removing from newer Net versions -->

--- a/src/benchmarks/micro/libraries/System.Reflection.Metadata/Perf.TypeName.cs
+++ b/src/benchmarks/micro/libraries/System.Reflection.Metadata/Perf.TypeName.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+using System.Collections.Generic;
+
+namespace System.Reflection.Metadata
+{
+    [BenchmarkCategory(Categories.Libraries)]
+    public class Perf_TypeName
+    {
+        public IEnumerable<object> TypeArguments()
+        {
+            // We don't return strings here, as they change over the time when assembly versions get increased.
+            // This would change benchmark ID and loose historical data tracking.
+            yield return typeof(int); // elemental type
+            yield return typeof(int).MakePointerType(); // a pointer to an elemental type
+            yield return typeof(int).MakeByRefType(); // a reference to an elemental type
+            yield return typeof(int[]); // SZArray
+            yield return typeof(int).MakeArrayType(1); // single-dimensional array, but not indexed from 0
+            yield return typeof(int).MakeArrayType(2); // multi-dimensional array
+            yield return typeof(Dictionary<string, bool>); // generic type
+            yield return typeof(Dictionary<string, bool>[]); // an array of generic types
+            yield return typeof(Nested); // nested type
+            yield return typeof(Nested.NestedGeneric<string, bool>); // nested generic type
+            yield return typeof(Dictionary<List<int[]>[,], List<int?[][][,]>>[]); // complex generic type (node count = 16)
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TypeArguments))]
+        public TypeName Parse_FullNames(Type input) => TypeName.Parse(input.FullName);
+
+        // The FullName property is lazy and cached, so we need to parse a new TypName instance
+        // in order to get the FullName property calculated.
+        [Benchmark]
+        [ArgumentsSource(nameof(TypeArguments))]
+        public string ParseAndGetFullName(Type input) => TypeName.Parse(input.FullName).FullName;
+
+        [Benchmark]
+        [ArgumentsSource(nameof(TypeArguments))]
+        public TypeName Parse_AssemblyQualifiedName(Type input) => TypeName.Parse(input.AssemblyQualifiedName);
+
+        public IEnumerable<string> InvalidArguments()
+        {
+            yield return "Wrong.Syntax[[]]";
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(InvalidArguments))]
+        public bool TryParse_Invalid(string input) => TypeName.TryParse(input, out _);
+
+        public class Nested
+        {
+            public class NestedGeneric<T1, T2> { }
+        }
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Reflection.Metadata/Perf.TypeName.cs
+++ b/src/benchmarks/micro/libraries/System.Reflection.Metadata/Perf.TypeName.cs
@@ -32,15 +32,19 @@ namespace System.Reflection.Metadata
         [ArgumentsSource(nameof(TypeArguments))]
         public TypeName Parse_FullNames(Type input) => TypeName.Parse(input.FullName);
 
-        // The FullName property is lazy and cached, so we need to parse a new TypName instance
-        // in order to get the FullName property calculated.
+        [Benchmark]
+        [ArgumentsSource(nameof(TypeArguments))]
+        public TypeName Parse_AssemblyQualifiedName(Type input) => TypeName.Parse(input.AssemblyQualifiedName);
+
+        // The Name, FullName and AssemblyQualifiedName properties are lazy and cached,
+        // so we need to parse a new TypName instance in order to get these properties calculated.
         [Benchmark]
         [ArgumentsSource(nameof(TypeArguments))]
         public string ParseAndGetFullName(Type input) => TypeName.Parse(input.FullName).FullName;
 
         [Benchmark]
         [ArgumentsSource(nameof(TypeArguments))]
-        public TypeName Parse_AssemblyQualifiedName(Type input) => TypeName.Parse(input.AssemblyQualifiedName);
+        public string ParseAndGetAssemblyQualifiedName(Type input) => TypeName.Parse(input.AssemblyQualifiedName).AssemblyQualifiedName;
 
         public IEnumerable<string> InvalidArguments()
         {


### PR DESCRIPTION
So far, we were benchmarking the `TypeName.Parse` implementation only in an indirect way, when benchmarking `Type.GetType` (which internally uses the same parser). We are now considering changing some parts of the implementation (https://github.com/dotnet/runtime/pull/112242), so it would be good to understand the perf and make sure we don't introduce any regressions.