### PR TITLE
Update maui versions manually from maui net9.0 repo.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -59,36 +59,36 @@
       <Sha>31e9a55d18214973b791c058658e763068e578e3</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.102-servicing.24605.31" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>92d3e8bae1b2c04b64cb333fb78b5294fa32731a</Sha>
+    <Dependency Name="Microsoft.NET.Sdk" Version="9.0.103-servicing.25065.25" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>049799c39d766c58ef6388865d5f5ed273b6a75e</Sha>
       <Uri>https://github.com/dotnet/sdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0" CoherentParentDependency="Microsoft.NET.Sdk">
-      <Sha>9d5a6a9aa463d6d10b0b0ba6d5982cc82f363dc3</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.1" CoherentParentDependency="Microsoft.NET.Sdk">
+      <Sha>c8acea22626efab11c13778c028975acdc34678f</Sha>
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-rtm.24528.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
-      <Sha>763d10a1a251be35337ee736832bfde3f9200672</Sha>
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100" Version="9.0.1" CoherentParentDependency="Microsoft.NETCore.App.Ref">
+      <Sha>4c9d1b112c16716c2479e054e9ad4db8b5b8c70c</Sha>
       <Uri>https://github.com/dotnet/emsdk</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.37" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>f6936a77dac699b6a361d5acb93c6b894de8941c</Sha>
+    <Dependency Name="Microsoft.Android.Sdk.Windows" Version="35.0.47" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>51763388d99cd24a6041348112d7b94b10aafabf</Sha>
       <Uri>https://github.com/dotnet/android</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.0" Version="18.0.9617" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>797d30720e5e629d23eb146935da94cb1b61047e</Sha>
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.2" Version="18.2.9180" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.0" Version="15.0.9617" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>797d30720e5e629d23eb146935da94cb1b61047e</Sha>
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.2" Version="15.2.9180" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.0" Version="18.0.9617" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>797d30720e5e629d23eb146935da94cb1b61047e</Sha>
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.2" Version="18.2.9180" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.0" Version="18.0.9617" CoherentParentDependency="Microsoft.Maui.Controls">
-      <Sha>797d30720e5e629d23eb146935da94cb1b61047e</Sha>
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.2" Version="18.2.9180" CoherentParentDependency="Microsoft.Maui.Controls">
+      <Sha>63d5ccc690e8c35e0ea0f608b5d05a664f9b7775</Sha>
       <Uri>https://github.com/xamarin/xamarin-macios</Uri>
     </Dependency>
   </ToolsetDependencies>


### PR DESCRIPTION
Update maui versions manually from maui net9.0 repo to get the dotnet-performance android testing mostly working again. This does not fix the 8.0 test failures.

Test run:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2639712&view=logs&j=b581e2ff-26bd-5c71-0721-7ac8f4d86f29&t=da44c22a-7f92-58a5-3228-797a46f4a0fb
