### PR TITLE
Make TraceCollector work on Linux

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultsAnalyzer.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultsAnalyzer.cs
@@ -48,23 +48,10 @@ namespace GC.Infrastructure.Core.Analysis.Microbenchmarks
 
                     foreach (var analyzer in analyzers)
                     {
-                        List<GCProcessData> allPertinentProcesses = analyzer.Value.GetProcessGCData("dotnet");
-                        List<GCProcessData> corerunProcesses = analyzer.Value.GetProcessGCData("corerun");
-                        allPertinentProcesses.AddRange(corerunProcesses);
                         foreach (var benchmark in runsToResults[run.Value])
                         {
-                            GCProcessData? benchmarkGCData = null;
-                            foreach (var process in allPertinentProcesses)
-                            {
-                                string commandLine = process.CommandLine.Replace("\"", "").Replace("\\", "");
-                                string runCleaned = benchmark.Key.Replace("\"", "").Replace("\\", "");
-                                if (commandLine.Contains(runCleaned) && commandLine.Contains("--benchmarkName"))
-                                {
-                                    benchmarkGCData = process;
-                                    break;
-                                }
-                            }
-
+                            GCProcessData? benchmarkGCData = analyzer.Value.GetProcessGCData("MicroBenchmarks").FirstOrDefault();
+                            
                             if (benchmarkGCData != null)
                             {
                                 int processID = benchmarkGCData.ProcessID;

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/Microbenchmark.CommandBuilder.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/CommandBuilders/Microbenchmark.CommandBuilder.cs
@@ -11,7 +11,7 @@ namespace GC.Infrastructure.Core.CommandBuilders
             string filter = benchmark ?? configuration.MicrobenchmarkConfigurations.Filter;
 
             // Base command: Add mandatory commands.
-            string command = $"run -f {frameworkVersion} --filter \"{filter}\" -c Release --noOverwrite --no-build";
+            string command = $"run -f {frameworkVersion} --filter \"{filter}\" -c Release --inProcess --noOverwrite --no-build";
 
             // [Optional] Add corerun.
             if (!string.IsNullOrEmpty(run.Value.corerun))

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj
@@ -5,7 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute> 
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+	<IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+	<DefineConstants>Windows</DefineConstants>
   </PropertyGroup>
 
   <Import Project="../Versions.props" />

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
@@ -205,7 +205,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
                         if (configuration.TraceConfigurations?.Type != "none")
                         {
                             // Not checking Linux here since the local run only allows for Windows.
-                            if (!File.Exists(Path.Combine(outputPath, traceName + ".etl.zip")))
+                            if (!File.Exists(Path.Combine(outputPath, traceName + ".etl.zip")) && !File.Exists(Path.Combine(outputPath, traceName + ".nettrace")))
                             {
                                 AnsiConsole.MarkupLine($"[yellow bold] ({DateTime.Now}) The trace for the run wasn't successfully captured. Please check the log file for more details: {Markup.Escape(output)} Full run details: {Path.GetFileNameWithoutExtension(configuration.Name)}: {runInfo.CorerunDetails.Key} for {runInfo.RunDetails.Key} [/]");
                             }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -189,8 +189,19 @@ namespace GC.Infrastructure.Commands.Microbenchmark
                             }
                             else
                             {
+                                Process microBenchmarksProcess = new();
                                 bdnProcess.Start();
-                                using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, bdnProcess.Id))
+                                // wait for Microbenchmark to start
+                                while (true)
+                                {
+                                    Process[] microBenchmarksProcessList = Process.GetProcessesByName("MicroBenchmarks");
+                                    if (microBenchmarksProcessList.Count() != 0)
+                                    {
+                                        microBenchmarksProcess = microBenchmarksProcessList.First();
+                                        break;
+                                    }
+                                }
+                                using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, microBenchmarksProcess.Id))
                                 {
                                     bdnProcess.BeginOutputReadLine();
                                     bdnProcess.BeginErrorReadLine();

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -177,12 +177,25 @@ namespace GC.Infrastructure.Commands.Microbenchmark
                             };
 
                             string traceName = $"{benchmarkCleanedName}_{index}";
-                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath))
+                            if (OperatingSystem.IsWindows())
+                            {
+                                using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath))
+                                {
+                                    bdnProcess.Start();
+                                    bdnProcess.BeginOutputReadLine();
+                                    bdnProcess.BeginErrorReadLine();
+                                    bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);
+                                }
+                            }
+                            else
                             {
                                 bdnProcess.Start();
-                                bdnProcess.BeginOutputReadLine();
-                                bdnProcess.BeginErrorReadLine();
-                                bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);
+                                using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, bdnProcess.Id))
+                                {
+                                    bdnProcess.BeginOutputReadLine();
+                                    bdnProcess.BeginErrorReadLine();
+                                    bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);
+                                }
                             }
 
                             string processDetailsKey = $"{run.Key}_{benchmark}_{index}";

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Program.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Program.cs
@@ -20,6 +20,7 @@ namespace GC.Infrastructure
 
             if (OperatingSystem.IsWindows())
             {
+                bool IsAdministrator = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
                 if (!IsAdministrator)
                 {
                     AnsiConsole.WriteLine("Not running in admin mode - please elevate privileges to run this process.");
@@ -79,9 +80,5 @@ namespace GC.Infrastructure
                 }
             }
         }
-
-        [SupportedOSPlatform("windows")]
-        internal static bool IsAdministrator =>
-            new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
     }
 }


### PR DESCRIPTION
Since PerfView only works on Windows, we use dotnet-trace as trace collector on Linux. 


