### PR TITLE
Update the runtime jobs we are running

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -272,27 +272,7 @@ jobs:
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  # run coreclr perfviper microbenchmarks perf jitoptrepeat jobs
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perfviper'
-        experimentName: 'jitoptrepeat'
-        additionalJobIdentifier: jitoptrepeat
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+          ${{ parameter.key }}: ${{ parameter.value }}ex
 
   # run coreclr crossgen perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -182,7 +182,7 @@ jobs:
   # run mono aot microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
       buildConfig: release
       runtimeFlavor: aot
       platforms:
@@ -201,7 +201,7 @@ jobs:
   # run mono aot microbenchmarks perf job - perfviper
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
       buildConfig: release
       runtimeFlavor: aot
       platforms:
@@ -272,7 +272,7 @@ jobs:
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}ex
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # run coreclr crossgen perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -237,25 +237,6 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perfviper microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perfviper'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
   # run coreclr perfowl microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
@@ -283,6 +264,7 @@ jobs:
       platforms:
       - linux_x64
       - windows_x64
+      - windows_x86
       jobParameters:
         liveLibrariesBuildConfig: Release
         runKind: micro

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -39,20 +39,6 @@ parameters:
       configs:
         - windows_x64
         - linux_x64
-  - name: tigerNoR2R
-    type: object
-    default:
-      enabled: true
-      configs:
-        - windows_x64
-        - linux_x64
-  - name: tigerNoPGO
-    type: object
-    default:
-      enabled: true
-      configs:
-        - windows_x64
-        - linux_x64
   - name: tigerMicro
     type: object
     default:
@@ -137,6 +123,24 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+  # run mono microbenchmarks perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
   # run mono interpreter perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
@@ -156,6 +160,25 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+  # run mono interpreter perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
   # run mono aot microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
@@ -170,6 +193,25 @@ jobs:
         codeGenType: 'AOT'
         runKind: micro_mono
         logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run mono aot microbenchmarks perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:
@@ -195,25 +237,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perftiger'
-        pgoRunType: nodynamicpgo
-        additionalJobIdentifier: nodynamicpgo
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
+  # run coreclr perfviper microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -221,49 +245,12 @@ jobs:
       runtimeFlavor: coreclr
       platforms:
       - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perftiger'
-        pgoRunType: nodynamicpgo
-        additionalJobIdentifier: nodynamicpgo
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  # run coreclr perftiger microbenchmarks no R2R perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
       - windows_x64
+      - windows_x86
       jobParameters:
         liveLibrariesBuildConfig: Release
         runKind: micro
-        logicalMachine: 'perftiger'
-        r2rRunType: nor2r
-        additionalJobIdentifier: nor2r
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perftiger'
-        r2rRunType: nor2r
-        additionalJobIdentifier: nor2r
+        logicalMachine: 'perfviper'
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -59,7 +59,7 @@ jobs:
     # run mono aot microbenchmarks perf job
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
         buildConfig: release
         runtimeFlavor: aot
         platforms:

--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -94,46 +94,6 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    #run coreclr Linux arm64 ampere no dynamic pgo microbenchmarks perf job
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: coreclr
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runKind: micro
-          logicalMachine: 'perfampere'
-          timeoutInMinutes: 780
-          pgoRunType: nodynamicpgo
-          additionalJobIdentifier: nodynamicpgo
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
-    #run coreclr Linux arm64 ampere no R2R microbenchmarks perf job
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: coreclr
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runKind: micro
-          logicalMachine: 'perfampere'
-          timeoutInMinutes: 780
-          r2rRunType: nor2r
-          additionalJobIdentifier: nor2r
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
     # run coreclr Windows arm64 microbenchmarks perf job
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
@@ -164,46 +124,6 @@ jobs:
           runKind: micro
           logicalMachine: 'perfampere'
           timeoutInMinutes: 780
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
-    # run coreclr Windows arm64 ampere no dynamic pgo microbenchmarks perf job
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: coreclr
-        platforms:
-        - windows_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runKind: micro
-          logicalMachine: 'perfampere'
-          pgoRunType: nodynamicpgo
-          timeoutInMinutes: 780
-          additionalJobIdentifier: nodynamicpgo
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
-    # run coreclr Windows arm64 ampere no R2R microbenchmarks perf job
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: coreclr
-        platforms:
-        - windows_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runKind: micro
-          logicalMachine: 'perfampere'
-          r2rRunType: nor2r
-          timeoutInMinutes: 780
-          additionalJobIdentifier: nor2r
           runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
           ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/runtime-wasm-perf-jobs.yml
+++ b/eng/pipelines/runtime-wasm-perf-jobs.yml
@@ -56,6 +56,52 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+
+  ### PerfViper copy of the above jobs ###
+  #run mono wasm microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: Release
+      runtimeFlavor: wasm
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        runKind: micro
+        logicalMachine: 'perfviper'
+        javascriptEngine: 'javascriptcore'
+        additionalJobIdentifier: javascriptcore
+        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: Release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        runkind: micro
+        logicalMachine: 'perfviper'
+        javascriptengine: 'javascriptcore'
+        additionalJobIdentifier: javascriptcore
+        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
 - ${{ if eq(parameters.runProfile, 'v8') }}:
   # run mono wasm interpreter (default) microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -124,6 +170,80 @@ jobs:
         # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
         #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
         logicalMachine: 'perftiger'
+        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  ### PerfViper copy of the above jobs ###
+  # run mono wasm interpreter (default) microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        runKind: micro
+        logicalMachine: 'perfviper'
+        javascriptEngine: 'v8'
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        #additionalSetupParameters: '--dotnet-versions 8.0.0'
+        additionalJobIdentifier: v8
+        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  #run mono wasm aot microbenchmarks perf job
+  # Disabled for runtime-wasm-perf on PRs due to https://github.com/dotnet/runtime/issues/95101
+  - ${{if not(in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+        buildconfig: release
+        runtimeflavor: wasm
+        platforms:
+        - linux_x64
+        jobparameters:
+          livelibrariesbuildconfig: Release
+          runtimetype: wasm
+          codegentype: 'aot'
+          runkind: micro
+          logicalMachine: 'perfviper'
+          javascriptEngine: 'v8'
+          # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+          #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
+          additionalJobIdentifier: v8
+          downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run mono wasm blazor perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
+        runKind: blazor_scenarios
+        isScenario: true
+        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+        #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
+        logicalMachine: 'perfviper'
         downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}


### PR DESCRIPTION
Copied current tiger runs to also run on viper queue so we have some time of overlapping data running as well as removed the nodynamicpgo and nor2r runs as they are not currently being looked at. The viper runs are for preparation to downsize our Viper machine queue, and the nodynamicpgo and nor2r runs are no longer being looked at so this should help our compute (talked with @AndyAyersMS about this offline).

Runtime pipeline test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2642451&view=results
