### PR TITLE
Revert "[main] Update dependencies to ensure coherency (#4719)"

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,12 +10,16 @@
     <add key="darc-pub-dotnet-android-5176338" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-51763388/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-runtime -->
-    <add key="darc-pub-dotnet-runtime-468bfc4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-468bfc4d/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-689f4e9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-689f4e9a/nuget/v3/index.json" />
+    <add key="darc-int-dotnet-runtime-c8acea2" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-c8acea22/nuget/v3/index.json" />
+    <add key="darc-int-dotnet-runtime-c8acea2-8" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-c8acea22-8/nuget/v3/index.json" />
+    <add key="darc-int-dotnet-runtime-c8acea2-3" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-runtime-c8acea22-3/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
     <add key="darc-pub-dotnet-windowsdesktop-192ae85" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-192ae85f/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-windowsdesktop -->
     <!--  Begin: Package sources from xamarin-xamarin-macios -->
+    <add key="darc-pub-xamarin-xamarin-macios-63d5ccc" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-xamarin-xamarin-macios-63d5ccc6/nuget/v3/index.json" />
     <!--  End: Package sources from xamarin-xamarin-macios -->
     <!--  Begin: Package sources from dotnet-aspnetcore -->
     <add key="darc-pub-dotnet-aspnetcore-eeb8b14" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-eeb8b145/nuget/v3/index.json" />
@@ -55,6 +59,9 @@
     <!--  Begin: Package sources from dotnet-maui -->
     <!--  End: Package sources from dotnet-maui -->
     <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-int-dotnet-runtime-c8acea2-3" value="true" />
+    <add key="darc-int-dotnet-runtime-c8acea2-8" value="true" />
+    <add key="darc-int-dotnet-runtime-c8acea2" value="true" />
     <!--  End: Package sources from dotnet-runtime -->
     <!--  Begin: Package sources from dotnet-windowsdesktop -->
     <!--  End: Package sources from dotnet-windowsdesktop -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,13 +31,13 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25120.6">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.25112.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ecdb2f499cb5f5c99b58fba1a14fdf977c56e1ac</Sha>
+      <Sha>c7b4cf2b26fdef0e503ba8d2f67d67cf5a1594c8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25120.6">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="10.0.0-beta.25112.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>ecdb2f499cb5f5c99b58fba1a14fdf977c56e1ac</Sha>
+      <Sha>c7b4cf2b26fdef0e503ba8d2f67d67cf5a1594c8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25103.1">
       <Uri>https://github.com/dotnet/xharness</Uri>

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -76,11 +76,12 @@ jobs:
       fetchDepth: 3
       clean: true
       
-    - task: DownloadPipelineArtifact@2
-      displayName: Download Asset Manifests
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifact
       inputs:
         artifactName: AssetManifests
-        targetPath: '$(Build.StagingDirectory)/AssetManifests'
+        downloadPath: '$(Build.StagingDirectory)/Download'
+        checkDownloadedFiles: true
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     
@@ -94,7 +95,7 @@ jobs:
         scriptLocation: scriptPath
         scriptPath: $(Build.SourcesDirectory)/eng/common/sdk-task.ps1
         arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
-          /p:ManifestsPath='$(Build.StagingDirectory)/AssetManifests'
+          /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:PublishUsingPipelines=${{ parameters.publishUsingPipelines }}
           /p:OfficialBuildId=$(Build.BuildNumber)

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.13.0" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.12.0" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -383,8 +383,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.13.0
-  $defaultXCopyMSBuildVersion = '17.13.0'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.12.0
+  $defaultXCopyMSBuildVersion = '17.12.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/global.json
+++ b/global.json
@@ -1,15 +1,15 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.2.25118.3",
+    "version": "10.0.100-alpha.1.25077.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.2.25118.3"
+    "dotnet": "10.0.100-alpha.1.25077.2"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25120.6",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25120.6"
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25112.2",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25112.2"
   },
   "native-tools": {
     "python3": "3.7.1"


### PR DESCRIPTION
This reverts commit 2557b14289de1c0e194960281c3e835abad82cdd.

This commit is causing wasm to error as runtime has not updated its default to a version newer than the one in the global.json yet. The PR to runtime that we can merge this in after: https://github.com/dotnet/runtime/pull/112730.


