### PR TITLE
New gcperfsim output structure

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/AnalyzeTrace.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/AnalyzeTrace.cs
@@ -49,7 +49,8 @@ namespace GC.Infrastructure.Core.Analysis
                 foreach (var analyzer in analyzers)
                 {
                     // Format: runName.corerunName.iterationIdx
-                    string[] splitName = analyzer.Key.Split(".", StringSplitOptions.RemoveEmptyEntries);
+                    string[] splitName = Path.GetFileNameWithoutExtension(analyzer.Key)
+                        .Split(".", StringSplitOptions.RemoveEmptyEntries);
                     string runName = splitName[0];
                     string corerunName = splitName[1];
                     string idx = splitName[2];

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/AnalyzeTrace.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/AnalyzeTrace.cs
@@ -41,15 +41,16 @@ namespace GC.Infrastructure.Core.Analysis
             List<ComparisonResult> allComparisonResults = new();
 
             // Concurrently get all the traces.
-            Parallel.ForEach(configuration.Runs, run =>
+            Parallel.ForEach(configuration.coreruns, corerunDetail =>
             {
-                Dictionary<string, Analyzer> analyzers = AnalyzerManager.GetAllAnalyzers(Path.Combine(configuration.Output.Path, run.Key));
+                // List analyzers in baseline or run
+                Dictionary<string, Analyzer> analyzers = AnalyzerManager.GetAllAnalyzers(Path.Combine(configuration.Output.Path, corerunDetail.Key));
 
                 foreach (var analyzer in analyzers)
                 {
                     // Format: runName.corerunName.iterationIdx
-                    string runName = run.Key;
                     string[] splitName = analyzer.Key.Split(".", StringSplitOptions.RemoveEmptyEntries);
+                    string runName = splitName[0];
                     string corerunName = splitName[1];
                     string idx = splitName[2];
 
@@ -69,12 +70,12 @@ namespace GC.Infrastructure.Core.Analysis
                             // If the process isn't found in the trace, substitute a null ResultItem.
                             if (p == null)
                             {
-                                d[corerunName] = processData = ResultItem.GetNullItem(run.Key, corerun);
+                                d[corerunName] = processData = ResultItem.GetNullItem(runName, corerun);
                             }
 
                             else
                             {
-                                d[corerunName] = processData = new ResultItem(p, run.Key, corerun);
+                                d[corerunName] = processData = new ResultItem(p, runName, corerun);
                             }
                         }
                     }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
@@ -108,8 +108,8 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             {
                 (string, string) processAndParameters = GCPerfSimCommandBuilder.BuildForLocal(configuration, runInfo.RunDetails, runInfo.CorerunDetails.Value);
 
-                // Create the run path directory.
-                string outputPath = Path.Combine(configuration.Output!.Path, runInfo.RunDetails.Key);
+                // Create the baseline and run directory.
+                string outputPath = Path.Combine(configuration.Output!.Path, runInfo.CorerunDetails.Key);
                 Core.Utilities.TryCreateDirectory(outputPath);
 
                 for (int iterationIdx = 0; iterationIdx < configuration.Environment.Iterations; iterationIdx++)
@@ -223,7 +223,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
             foreach (var run in runInfos)
             {
                 // Create the run path directory.
-                string outputPath = Path.Combine(configuration.Output!.Path, run.RunDetails.Key);
+                string outputPath = Path.Combine(configuration.Output!.Path, run.CorerunDetails.Key);
                 Core.Utilities.TryCreateDirectory(outputPath);
 
                 for (int iterationIdx = 0; iterationIdx < configuration.Environment.Iterations; iterationIdx++)


### PR DESCRIPTION
The output structure of gcperfsim is:
- runName1
    - runName1.baseline.iterationIdx.xxx
    - runName1.run.iterationIdx.xxx
- runName2
    - runName2.baseline.iterationIdx.xxx
    - runName2.run.iterationIdx.xxx

This pr aims at matching the output structure of aspnetbenchmarks and microbenchmarks:
- baseline
    - runName1.baseline.iterationIdx.xxx
    - runName2.baseline.iterationIdx.xxx
- run
    - runName1.run.iterationIdx.xxx
    - runName2.run.iterationIdx.xxx
- Result.md
- Result.json