### PR TITLE
Enable Android CoreCLR and device startup testing

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -78,13 +78,13 @@ jobs:
     parameters:
       perfBranch: ${{ parameters.perfBranch }}
 
-  # Build and run iOS Mono and NativeAOT scenarios
-  - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
-    parameters:
-      hybridGlobalization: True
-      runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-      performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-      jobParameters: ${{ parameters.jobParameters }}
+  # # Build and run iOS Mono and NativeAOT scenarios
+  # - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+  #   parameters:
+  #     hybridGlobalization: True
+  #     runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #     performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #     jobParameters: ${{ parameters.jobParameters }}
 
   # run android scenarios - Mono
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -124,191 +124,191 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        runKind: micro_mono
-        logicalMachine: 'perftiger'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       runKind: micro_mono
+  #       logicalMachine: 'perftiger'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono microbenchmarks perf job - perfviper
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        runKind: micro_mono
-        logicalMachine: 'perfviper'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono microbenchmarks perf job - perfviper
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       runKind: micro_mono
+  #       logicalMachine: 'perfviper'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        runKind: micro_mono
-        logicalMachine: 'perftiger'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono interpreter perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'Interpreter'
+  #       runKind: micro_mono
+  #       logicalMachine: 'perftiger'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono interpreter perf job - perfviper
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        runKind: micro_mono
-        logicalMachine: 'perfviper'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono interpreter perf job - perfviper
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'Interpreter'
+  #       runKind: micro_mono
+  #       logicalMachine: 'perfviper'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        runKind: micro_mono
-        logicalMachine: 'perftiger'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono aot microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       runKind: micro_mono
+  #       logicalMachine: 'perftiger'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono aot microbenchmarks perf job - perfviper
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        runKind: micro_mono
-        logicalMachine: 'perfviper'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run mono aot microbenchmarks perf job - perfviper
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       runKind: micro_mono
+  #       logicalMachine: 'perfviper'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perftiger'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run coreclr perftiger microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runKind: micro
+  #       logicalMachine: 'perftiger'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perfowl'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run coreclr perfowl microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runKind: micro
+  #       logicalMachine: 'perfowl'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perfviper microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perfviper'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run coreclr perfviper microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       runKind: micro
+  #       logicalMachine: 'perfviper'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
-        runKind: crossgen_scenarios
-        isScenario: true
-        logicalMachine: 'perftiger_crossgen'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # run coreclr crossgen perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
+  #       runKind: crossgen_scenarios
+  #       isScenario: true
+  #       logicalMachine: 'perftiger_crossgen'
+  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -86,7 +86,7 @@ jobs:
       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
       jobParameters: ${{ parameters.jobParameters }}
 
-  # run android scenarios
+  # run android scenarios - Mono
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -96,6 +96,25 @@ jobs:
         - windows_x64
       jobParameters:
         runtimeType: AndroidMono
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+        runKind: android_scenarios
+        isScenario: true
+        logicalMachine: 'perfpixel4a'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run android scenarios - CoreCLR
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - windows_x64
+      jobParameters:
+        runtimeType: AndroidCoreCLR
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
         runKind: android_scenarios
         isScenario: true

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -78,13 +78,13 @@ jobs:
     parameters:
       perfBranch: ${{ parameters.perfBranch }}
 
-  # # Build and run iOS Mono and NativeAOT scenarios
-  # - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
-  #   parameters:
-  #     hybridGlobalization: True
-  #     runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #     performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #     jobParameters: ${{ parameters.jobParameters }}
+  # Build and run iOS Mono and NativeAOT scenarios
+  - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+    parameters:
+      hybridGlobalization: True
+      runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+      performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+      jobParameters: ${{ parameters.jobParameters }}
 
   # run android scenarios - Mono
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -124,191 +124,191 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       runKind: micro_mono
-  #       logicalMachine: 'perftiger'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        runKind: micro_mono
+        logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono microbenchmarks perf job - perfviper
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono microbenchmarks perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono interpreter perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perftiger'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        runKind: micro_mono
+        logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono interpreter perf job - perfviper
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono interpreter perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono aot microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perftiger'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        runKind: micro_mono
+        logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono aot microbenchmarks perf job - perfviper
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono aot microbenchmarks perf job - perfviper
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run coreclr perftiger microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runKind: micro
-  #       logicalMachine: 'perftiger'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runKind: micro
+        logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run coreclr perfowl microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runKind: micro
-  #       logicalMachine: 'perfowl'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runKind: micro
+        logicalMachine: 'perfowl'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run coreclr perfviper microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runKind: micro
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run coreclr perfviper microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runKind: micro
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run coreclr crossgen perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     - windows_x86
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
-  #       runKind: crossgen_scenarios
-  #       isScenario: true
-  #       logicalMachine: 'perftiger_crossgen'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
+        runKind: crossgen_scenarios
+        isScenario: true
+        logicalMachine: 'perftiger_crossgen'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -110,7 +110,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
       buildConfig: release
-      runtimeFlavor: mono
+      runtimeFlavor: coreclr
       platforms:
         - windows_x64
       jobParameters:

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -36,7 +36,7 @@ jobs:
     # Test job depends on the corresponding build job
     ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
       dependsOn:
-        - ${{ if not(or(in(parameters.runtimeType, 'AndroidMono', 'iOSMono', 'iOSNativeAOT', 'wasm'), and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')))) }}:
+        - ${{ if not(or(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR' 'iOSMono', 'iOSNativeAOT', 'wasm'), and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')))) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'coreclr') }}
         - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}
@@ -47,6 +47,8 @@ jobs:
         - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
           - ${{ 'build_android_arm64_release_AndroidMono' }}
           # - ${{ 'Build_ios_arm64_release_PerfBDNApp' }} # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
+        - ${{ if eq(parameters.runtimeType, 'AndroidCoreCLR')}}:
+          - ${{ 'build_android_arm64_release_AndroidCoreCLR' }}
         - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
           - ${{ 'build_ios_arm64_release_iOSMono' }}
         - ${{ if eq(parameters.runtimeType, 'iOSNativeAOT')}}:
@@ -157,8 +159,8 @@ jobs:
           parameters:
             unpackFolder: $(builtAppDir)/androidHelloWorld
             cleanUnpackFolder: false
-            artifactFileName: 'AndroidMonoarm64.tar.gz'
-            artifactName: 'AndroidMonoarm64'
+            artifactFileName: 'AndroidHelloWorldArm64Mono.tar.gz'
+            artifactName: 'AndroidHelloWorldArm64Mono'
             displayName: 'Mono Android HelloWorld'
         # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
         # - template: /eng/pipelines/templates/download-artifact-step.yml 
@@ -168,6 +170,15 @@ jobs:
         #     artifactFileName: 'AndroidBDNApk.tar.gz'
         #     artifactName: 'AndroidBDNApk'
         #     displayName: 'Mono Android BDN Apk'
+      - ${{ elseif eq(parameters.runtimeType, 'AndroidCoreCLR')}}:
+        # Download artifacts for Android Testing
+        - template: /eng/pipelines/templates/download-artifact-step.yml
+          parameters:
+            unpackFolder: $(builtAppDir)/androidHelloWorld
+            cleanUnpackFolder: false
+            artifactFileName: 'AndroidHelloWorldArm64CoreCLR.tar.gz'
+            artifactName: 'AndroidHelloWorldArm64CoreCLR'
+            displayName: 'CoreCLR Android HelloWorld'
       - ${{ elseif or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:
         # Download iOSMono and Native AOT tests
         - template: /eng/pipelines/templates/download-artifact-step.yml
@@ -214,7 +225,7 @@ jobs:
               artifactName: 'iOSSampleAppNoSymbolsHybridGlobalization${{parameters.hybridGlobalization}}'
             checkDownloadedFiles: true
 
-      - ${{ if notIn(parameters.runtimeType, 'wasm', 'AndroidMono', 'iOSMono', 'iOSNativeAOT') }}:
+      - ${{ if notIn(parameters.runtimeType, 'wasm', 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSNativeAOT') }}:
         - ${{ if ne(parameters.runtimeFlavor, 'Mono') }}:
           # Create Core_Root
           - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) ${{ parameters.buildConfig }} ${{ parameters.archType }} generatelayoutonly $(librariesOverrideArg) $(_crossBuildPropertyArg)

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -36,7 +36,7 @@ jobs:
     # Test job depends on the corresponding build job
     ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
       dependsOn:
-        - ${{ if not(or(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR' 'iOSMono', 'iOSNativeAOT', 'wasm'), and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')))) }}:
+        - ${{ if not(or(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSNativeAOT', 'wasm'), and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')))) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'coreclr') }}
         - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -393,6 +393,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     llvm = args.codegen_type.lower() == "aot" and args.runtime_type != "wasm"
     android_mono = args.runtime_type == "AndroidMono"
+    android_coreclr = args.runtime_type == "AndroidCoreCLR"
     ios_mono = args.runtime_type == "iOSMono"
     ios_nativeaot = args.runtime_type == "iOSNativeAOT"
     mono_aot = False
@@ -529,6 +530,14 @@ def run_performance_job(args: RunPerformanceJobArgs):
             extra_bdn_arguments += ["--memoryRandomization", "true"]
 
     runtime_type = ""
+
+    if android_mono:
+        runtime_type = "Mono"
+        configurations["RuntimeType"] = str(runtime_type)
+
+    if android_coreclr:
+        runtime_type = "CoreCLR"
+        configurations["RuntimeType"] = str(runtime_type)
 
     if ios_mono:
         runtime_type = "Mono"
@@ -708,13 +717,14 @@ def run_performance_job(args: RunPerformanceJobArgs):
         if args.runtime_repo_dir is not None:
             args.built_app_dir = args.runtime_repo_dir
     
-    if android_mono:
+    if android_mono or android_coreclr:
         if args.built_app_dir is None:
-            raise Exception("Built apps directory must be present for Android Mono benchmarks")
+            raise Exception("Built apps directory must be present for Android benchmarks")
         getLogger().info("Copying Android apps to payload directory")
-        # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
-        #shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
+        # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
+        # if android_mono:
+            # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))
         ci_setup_arguments.architecture = "arm64"
 
     if ios_mono or ios_nativeaot:

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -533,10 +533,12 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     if android_mono:
         runtime_type = "Mono"
+        configurations["CompilationMode"] = "JIT"
         configurations["RuntimeType"] = str(runtime_type)
 
     if android_coreclr:
         runtime_type = "CoreCLR"
+        configurations["CompilationMode"] = "JIT"
         configurations["RuntimeType"] = str(runtime_type)
 
     if ios_mono:


### PR DESCRIPTION
Added the CoreCLR android run step, updated AndroidMono checks to have mirrors for AndroidCoreCLR, and setup RuntimeType to be a configuration for the android runs going forward. This should bring support for Android CoreCLR runs and data uploading.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2650816&view=results
Associated runtime PR: https://github.com/dotnet/runtime/pull/112939
