### PR TITLE
Fix FSharp and inner loop SDK scenarios.

### DIFF
--- a/eng/performance/Scenarios.Common.props
+++ b/eng/performance/Scenarios.Common.props
@@ -12,6 +12,7 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
+    <FrameworkVersion>$([System.Text.RegularExpressions.Regex]::Match($(PERFLAB_Framework), '(\d+\.\d+)$').Groups[1].Value)</FrameworkVersion>
     <HelixResultsDestinationDir>$(CorrelationPayloadDirectory)performance/artifacts/helix-results</HelixResultsDestinationDir>
   </PropertyGroup>
 

--- a/eng/performance/Scenarios.Common.props
+++ b/eng/performance/Scenarios.Common.props
@@ -12,7 +12,6 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <FrameworkVersion>$([System.Text.RegularExpressions.Regex]::Match($(PERFLAB_Framework), '(\d+\.\d+)$').Groups[1].Value)</FrameworkVersion>
     <HelixResultsDestinationDir>$(CorrelationPayloadDirectory)performance/artifacts/helix-results</HelixResultsDestinationDir>
   </PropertyGroup>
 

--- a/eng/performance/Scenarios.Common.props
+++ b/eng/performance/Scenarios.Common.props
@@ -12,7 +12,7 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <FrameworkVersion>$(PERFLAB_Framework.Substring($([MSBuild]::Subtract($(PERFLAB_Framework.Length), 3))))</FrameworkVersion>
+    <FrameworkVersion>$([System.Text.RegularExpressions.Regex]::Match($(PERFLAB_Framework), '(\d+\.\d+)$').Groups[1].Value)</FrameworkVersion>
     <HelixResultsDestinationDir>$(CorrelationPayloadDirectory)performance/artifacts/helix-results</HelixResultsDestinationDir>
   </PropertyGroup>
 

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -2,6 +2,18 @@
 
   <Import Project="Scenarios.Common.props" />
 
+  <!-- <ItemGroup>
+      <Framework Include="netcoreapp2.1" FrameworkName="%(Identity)"/>
+      <Framework Include="netcoreapp3.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '2.1'"/>
+      <Framework Include="netcoreapp3.1" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.0'"/>
+      <Framework Include="netcoreapp5.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.1'"/>
+      <Framework Include="net6.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '5.0'"/>
+      <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
+      <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
+      <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
+      <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
+  </ItemGroup> -->
+
   <ItemDefinitionGroup>
     <SDKWorkItem>
       <PreCommands>$(Python) pre.py default</PreCommands>
@@ -11,6 +23,13 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
+  <!-- This does not appear to be run at all currently, and is covered by the SDK Console Template just below. -->
+    <!-- <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
+      <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
+    </SDKWorkItem> -->
+
     <SDKWorkItem Include="SDK Console Template">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
@@ -70,9 +89,10 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem> -->
 
-    <SDKWorkItem Include="SDK ASP.NET MVC App Template">
+    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <PreCommands>%(PreCommands) -f $(PERFLAB_Framework)</PreCommands>
     </SDKWorkItem>
 
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1
@@ -82,7 +102,7 @@
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem> -->
 
-    <!-- We never run against Framework 3.0 or 3.1. This applies for the following 4 disabled items -->
+    <!-- We never run against Framework 3.0 or 3.1 -->
     <!-- <SDKWorkItem Include="@(Framework -> 'SDK Windows Forms Large %(Identity)')" Exclude="*2.1" Condition="'$(TargetsWindows)' == 'true' and ('$(FrameworkVersion)' == '3.0' or '$(FrameworkVersion)' == '3.1')">
       <ScenarioDirectoryName>windowsformslarge</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -11,6 +11,7 @@
       <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
       <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
       <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
+      <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
   </ItemGroup>
 
   <ItemDefinitionGroup>
@@ -22,7 +23,7 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
-    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0">
+    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
@@ -87,7 +88,7 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem>
 
-    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0">
+    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
@@ -190,9 +191,5 @@
     </HelixWorkItem>
   </ItemGroup>
 
-
   <Import Project="PreparePayloadWorkItems.targets" />
-
-
 </Project>
-

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -9,7 +9,7 @@
       <Framework Include="netcoreapp5.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.1'"/>
       <Framework Include="net6.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '5.0'"/>
       <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
-      <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
+      <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0' and '$(PERFLAB_Framework)' != 'net9.0'"/>
       <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
       <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
   </ItemGroup>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -2,18 +2,6 @@
 
   <Import Project="Scenarios.Common.props" />
 
-  <!-- <ItemGroup>
-      <Framework Include="netcoreapp2.1" FrameworkName="%(Identity)"/>
-      <Framework Include="netcoreapp3.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '2.1'"/>
-      <Framework Include="netcoreapp3.1" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.0'"/>
-      <Framework Include="netcoreapp5.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.1'"/>
-      <Framework Include="net6.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '5.0'"/>
-      <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
-      <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
-      <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
-      <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
-  </ItemGroup> -->
-
   <ItemDefinitionGroup>
     <SDKWorkItem>
       <PreCommands>$(Python) pre.py default</PreCommands>
@@ -23,13 +11,6 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
-  <!-- This does not appear to be run at all currently, and is covered by the SDK Console Template just below. -->
-    <!-- <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
-      <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
-      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
-    </SDKWorkItem> -->
-
     <SDKWorkItem Include="SDK Console Template">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
@@ -89,10 +70,9 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem> -->
 
-    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
+    <SDKWorkItem Include="SDK ASP.NET MVC App Template">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>%(PreCommands) -f $(PERFLAB_Framework)</PreCommands>
     </SDKWorkItem>
 
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1
@@ -102,7 +82,7 @@
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem> -->
 
-    <!-- We never run against Framework 3.0 or 3.1 -->
+    <!-- We never run against Framework 3.0 or 3.1. This applies for the following 4 disabled items -->
     <!-- <SDKWorkItem Include="@(Framework -> 'SDK Windows Forms Large %(Identity)')" Exclude="*2.1" Condition="'$(TargetsWindows)' == 'true' and ('$(FrameworkVersion)' == '3.0' or '$(FrameworkVersion)' == '3.1')">
       <ScenarioDirectoryName>windowsformslarge</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -2,7 +2,7 @@
 
   <Import Project="Scenarios.Common.props" />
 
-  <!-- <ItemGroup>
+  <ItemGroup>
       <Framework Include="netcoreapp2.1" FrameworkName="%(Identity)"/>
       <Framework Include="netcoreapp3.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '2.1'"/>
       <Framework Include="netcoreapp3.1" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.0'"/>
@@ -12,7 +12,7 @@
       <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
       <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
       <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
-  </ItemGroup> -->
+  </ItemGroup>
 
   <ItemDefinitionGroup>
     <SDKWorkItem>
@@ -24,11 +24,11 @@
   
   <ItemGroup>
   <!-- This does not appear to be run at all currently, and is covered by the SDK Console Template just below. -->
-    <!-- <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
+    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
-    </SDKWorkItem> -->
+    </SDKWorkItem>
 
     <SDKWorkItem Include="SDK Console Template">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
@@ -89,7 +89,7 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem> -->
 
-    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
+    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f $(PERFLAB_Framework)</PreCommands>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -88,11 +88,12 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </SDKWorkItem> -->
 
-    <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
+    <!-- Failing when targeting net8.0 when running net10.0 -->
+    <!-- <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
-    </SDKWorkItem>
+    </SDKWorkItem> -->
 
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1
     <SDKWorkItem Include="@(Framework -> 'SDK Web Large 3.0 %(Identity)')" Exclude="*2.1;*5.0">

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -23,7 +23,6 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
-  <!-- This does not appear to be run at all currently, and is covered by the SDK Console Template just below. -->
     <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
@@ -92,7 +91,7 @@
     <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>%(PreCommands) -f $(PERFLAB_Framework)</PreCommands>
+      <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem>
 
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -2,7 +2,7 @@
 
   <Import Project="Scenarios.Common.props" />
 
-  <ItemGroup>
+  <!-- <ItemGroup>
       <Framework Include="netcoreapp2.1" FrameworkName="%(Identity)"/>
       <Framework Include="netcoreapp3.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '2.1'"/>
       <Framework Include="netcoreapp3.1" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '3.0'"/>
@@ -12,7 +12,7 @@
       <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0'"/>
       <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
       <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
-  </ItemGroup>
+  </ItemGroup> -->
 
   <ItemDefinitionGroup>
     <SDKWorkItem>
@@ -23,11 +23,12 @@
   </ItemDefinitionGroup>
   
   <ItemGroup>
-    <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
+  <!-- This does not appear to be run at all currently, and is covered by the SDK Console Template just below. -->
+    <!-- <SDKWorkItem Include="@(Framework -> 'SDK Console Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
-    </SDKWorkItem>
+    </SDKWorkItem> -->
 
     <SDKWorkItem Include="SDK Console Template">
       <ScenarioDirectoryName>emptyconsoletemplate</ScenarioDirectoryName>
@@ -83,15 +84,15 @@
     </SDKWorkItem>
 
     <!-- For netstandard library we test only netstandard2.0 framework -->
-    <SDKWorkItem Include="SDK .NET 2.0 Library Template">
+    <!-- <SDKWorkItem Include="SDK .NET 2.0 Library Template">
       <ScenarioDirectoryName>netstandard2.0</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-    </SDKWorkItem>
+    </SDKWorkItem> -->
 
     <SDKWorkItem Include="@(Framework -> 'SDK ASP.NET MVC App Template %(Identity)')" Exclude="*2.1;*3.0;*3.1;*5.0;*6.0;*7.0;*8.0;*9.0">
       <ScenarioDirectoryName>mvcapptemplate</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
+      <PreCommands>%(PreCommands) -f $(PERFLAB_Framework)</PreCommands>
     </SDKWorkItem>
 
     <!-- WebLarge3.0 asset is specific to netcoreapp3.0 and netcoreapp3.1
@@ -101,7 +102,8 @@
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
     </SDKWorkItem> -->
 
-    <SDKWorkItem Include="@(Framework -> 'SDK Windows Forms Large %(Identity)')" Exclude="*2.1" Condition="'$(TargetsWindows)' == 'true' and ('$(FrameworkVersion)' == '3.0' or '$(FrameworkVersion)' == '3.1')">
+    <!-- We never run against Framework 3.0 or 3.1 -->
+    <!-- <SDKWorkItem Include="@(Framework -> 'SDK Windows Forms Large %(Identity)')" Exclude="*2.1" Condition="'$(TargetsWindows)' == 'true' and ('$(FrameworkVersion)' == '3.0' or '$(FrameworkVersion)' == '3.1')">
       <ScenarioDirectoryName>windowsformslarge</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
@@ -123,7 +125,7 @@
       <ScenarioDirectoryName>wpf</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <PreCommands>%(PreCommands) -f %(FrameworkName)</PreCommands>
-    </SDKWorkItem>
+    </SDKWorkItem> -->
   </ItemGroup>
 
   <ItemGroup>
@@ -148,28 +150,28 @@
     <HelixWorkItem Include="Inner Loop Console">
       <ScenarioDirectoryName>emptyconsoletemplateinnerloop</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(PERFLAB_Framework)</PreCommands>
       <Command>$(Python) test.py innerloop --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="Inner Loop MVC">
       <ScenarioDirectoryName>mvcinnerloop</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(PERFLAB_Framework)</PreCommands>
       <Command>$(Python) test.py innerloop --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="Inner Loop MsBuild Console">
       <ScenarioDirectoryName>emptyconsoletemplateinnerloopmsbuild</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(PERFLAB_Framework)</PreCommands>
       <Command>$(Python) test.py innerloopmsbuild --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="Inner Loop Blazor Client">
       <ScenarioDirectoryName>blazorwasminnerloop</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py default -f net$(FrameworkVersion)</PreCommands>
+      <PreCommands>$(Python) pre.py default -f $(PERFLAB_Framework)</PreCommands>
       <Command>$(Python) test.py innerloop --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
@@ -177,7 +179,7 @@
     <HelixWorkItem Include="Hot Reload Blazor Client" Condition="'$(FrameworkVersion)' == '6.0'">
       <ScenarioDirectoryName>blazorwasmdotnetwatch</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py build -f net$(FrameworkVersion) -c Release</PreCommands>
+      <PreCommands>$(Python) pre.py build -f $(PERFLAB_Framework) -c Release</PreCommands>
       <Command>$(Python) test.py dotnetwatch -(-fixme when uncommenting!!)scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
@@ -185,7 +187,7 @@
     <HelixWorkItem Include="Hot Reload MVC" Condition="'$(FrameworkVersion)' == '6.0'">
       <ScenarioDirectoryName>mvcdotnetwatch</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
-      <PreCommands>$(Python) pre.py build -f net$(FrameworkVersion) -c Release</PreCommands>
+      <PreCommands>$(Python) pre.py build -f $(PERFLAB_Framework) -c Release</PreCommands>
       <Command>$(Python) test.py dotnetwatch --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -510,218 +510,218 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Blazor 3.2 scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: blazor_scenarios
-  #       projectFileName: blazor_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Blazor 3.2 scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+      isPublic: false
+      jobParameters:
+        runKind: blazor_scenarios
+        projectFileName: blazor_scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # F# benchmarks
-  # - ${{ if false }}: # skipping, no useful benchmarks there currently
-  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #     parameters:
-  #       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #       buildMachines:
-  #         - win-x64
-  #         - ubuntu-x64
-  #         - win-arm64
-  #         - ubuntu-arm64-ampere
-  #       isPublic: false
-  #       jobParameters:
-  #         runKind: fsharp
-  #         targetCsproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-  #         runCategories: 'fsharp'
-  #         channels:
-  #           - main
-  #           - 9.0
-  #           - 8.0
-  #         ${{ each parameter in parameters.jobParameters }}:
-  #           ${{ parameter.key }}: ${{ parameter.value }}
+  # F# benchmarks
+  - ${{ if false }}: # skipping, no useful benchmarks there currently
+    - template: /eng/pipelines/templates/build-machine-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+        buildMachines:
+          - win-x64
+          - ubuntu-x64
+          - win-arm64
+          - ubuntu-arm64-ampere
+        isPublic: false
+        jobParameters:
+          runKind: fsharp
+          targetCsproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+          runCategories: 'fsharp'
+          channels:
+            - main
+            - 9.0
+            - 8.0
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: fsharpmicro
-  #       targetCsproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-  #       runCategories: 'FSharpMicro'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: fsharpmicro
+        targetCsproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+        runCategories: 'FSharpMicro'
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # bepuphysics benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: bepuphysics
-  #       targetCsproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-  #       runCategories: 'BepuPhysics'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # bepuphysics benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: bepuphysics
+        targetCsproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+        runCategories: 'BepuPhysics'
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # ImageSharp benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: imagesharp
-  #       targetCsproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-  #       runCategories: 'ImageSharp'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # ImageSharp benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: imagesharp
+        targetCsproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+        runCategories: 'ImageSharp'
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Akade.IndexedSet benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: akadeindexedset
-  #       targetCsproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-  #       runCategories: 'AkadeIndexedSet'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Akade.IndexedSet benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: akadeindexedset
+        targetCsproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+        runCategories: 'AkadeIndexedSet'
+        channels:
+          - main
+          - 9.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # ML.NET benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: mlnet
-  #       targetCsproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-  #       runCategories: 'mldotnet'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # ML.NET benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: mlnet
+        targetCsproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+        runCategories: 'mldotnet'
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Roslyn benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: roslyn
-  #       targetCsproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-  #       runCategories: 'roslyn'
-  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Roslyn benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: roslyn
+        targetCsproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+        runCategories: 'roslyn'
+        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+          - main
+          - 9.0
+          - 8.0
+        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # ILLink benchmarks
-  # # disabled because of: https://github.com/dotnet/performance/issues/3569
-  # - ${{ if false }}:
-  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #     parameters:
-  #       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #       buildMachines:
-  #         - win-x64
-  #         - ubuntu-x64
-  #         # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
-  #       isPublic: false
-  #       jobParameters:
-  #         runKind: illink
-  #         targetCsproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-  #         runCategories: 'illink'
-  #         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-  #           - main
-  #           - 9.0
-  #           - 8.0
+  # ILLink benchmarks
+  # disabled because of: https://github.com/dotnet/performance/issues/3569
+  - ${{ if false }}:
+    - template: /eng/pipelines/templates/build-machine-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+        buildMachines:
+          - win-x64
+          - ubuntu-x64
+          # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
+        isPublic: false
+        jobParameters:
+          runKind: illink
+          targetCsproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+          runCategories: 'illink'
+          channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+            - main
+            - 9.0
+            - 8.0
 
-  # # Powershell benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: powershell
-  #       targetCsproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-  #       runCategories: 'Public Internal'
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Powershell benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64
+      isPublic: false
+      jobParameters:
+        runKind: powershell
+        targetCsproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+        runCategories: 'Public Internal'
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -510,218 +510,218 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Blazor 3.2 scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-      isPublic: false
-      jobParameters:
-        runKind: blazor_scenarios
-        projectFileName: blazor_scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Blazor 3.2 scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: blazor_scenarios
+  #       projectFileName: blazor_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # F# benchmarks
-  - ${{ if false }}: # skipping, no useful benchmarks there currently
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-        buildMachines:
-          - win-x64
-          - ubuntu-x64
-          - win-arm64
-          - ubuntu-arm64-ampere
-        isPublic: false
-        jobParameters:
-          runKind: fsharp
-          targetCsproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
-          runCategories: 'fsharp'
-          channels:
-            - main
-            - 9.0
-            - 8.0
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+  # # F# benchmarks
+  # - ${{ if false }}: # skipping, no useful benchmarks there currently
+  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #     parameters:
+  #       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #       buildMachines:
+  #         - win-x64
+  #         - ubuntu-x64
+  #         - win-arm64
+  #         - ubuntu-arm64-ampere
+  #       isPublic: false
+  #       jobParameters:
+  #         runKind: fsharp
+  #         targetCsproj: src\benchmarks\real-world\FSharp\FSharp.fsproj
+  #         runCategories: 'fsharp'
+  #         channels:
+  #           - main
+  #           - 9.0
+  #           - 8.0
+  #         ${{ each parameter in parameters.jobParameters }}:
+  #           ${{ parameter.key }}: ${{ parameter.value }}
 
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: fsharpmicro
-        targetCsproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
-        runCategories: 'FSharpMicro'
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: fsharpmicro
+  #       targetCsproj: src\benchmarks\micro-fsharp\MicrobenchmarksFSharp.fsproj
+  #       runCategories: 'FSharpMicro'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # bepuphysics benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: bepuphysics
-        targetCsproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
-        runCategories: 'BepuPhysics'
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # bepuphysics benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: bepuphysics
+  #       targetCsproj: src\benchmarks\real-world\bepuphysics2\DemoBenchmarks.csproj
+  #       runCategories: 'BepuPhysics'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # ImageSharp benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: imagesharp
-        targetCsproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
-        runCategories: 'ImageSharp'
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # ImageSharp benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: imagesharp
+  #       targetCsproj: src\benchmarks\real-world\ImageSharp\ImageSharp.Benchmarks.csproj
+  #       runCategories: 'ImageSharp'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Akade.IndexedSet benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: akadeindexedset
-        targetCsproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
-        runCategories: 'AkadeIndexedSet'
-        channels:
-          - main
-          - 9.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Akade.IndexedSet benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: akadeindexedset
+  #       targetCsproj: src\benchmarks\real-world\Akade.IndexedSet.Benchmarks\Akade.IndexedSet.Benchmarks.csproj
+  #       runCategories: 'AkadeIndexedSet'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # ML.NET benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - win-arm64-ampere
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: mlnet
-        targetCsproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
-        runCategories: 'mldotnet'
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # ML.NET benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: mlnet
+  #       targetCsproj: src\benchmarks\real-world\Microsoft.ML.Benchmarks\Microsoft.ML.Benchmarks.csproj
+  #       runCategories: 'mldotnet'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Roslyn benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - win-arm64-ampere
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: roslyn
-        targetCsproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
-        runCategories: 'roslyn'
-        channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-          - main
-          - 9.0
-          - 8.0
-        affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Roslyn benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: roslyn
+  #       targetCsproj: src\benchmarks\real-world\Roslyn\CompilerBenchmarks.csproj
+  #       runCategories: 'roslyn'
+  #       channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # ILLink benchmarks
-  # disabled because of: https://github.com/dotnet/performance/issues/3569
-  - ${{ if false }}:
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-        buildMachines:
-          - win-x64
-          - ubuntu-x64
-          # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
-        isPublic: false
-        jobParameters:
-          runKind: illink
-          targetCsproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
-          runCategories: 'illink'
-          channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
-            - main
-            - 9.0
-            - 8.0
+  # # ILLink benchmarks
+  # # disabled because of: https://github.com/dotnet/performance/issues/3569
+  # - ${{ if false }}:
+  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #     parameters:
+  #       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #       buildMachines:
+  #         - win-x64
+  #         - ubuntu-x64
+  #         # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
+  #       isPublic: false
+  #       jobParameters:
+  #         runKind: illink
+  #         targetCsproj: src\benchmarks\real-world\ILLink\ILLinkBenchmarks.csproj
+  #         runCategories: 'illink'
+  #         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
+  #           - main
+  #           - 9.0
+  #           - 8.0
 
-  # Powershell benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64
-      isPublic: false
-      jobParameters:
-        runKind: powershell
-        targetCsproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
-        runCategories: 'Public Internal'
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Powershell benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-performance-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: powershell
+  #       targetCsproj: src\benchmarks\real-world\PowerShell.Benchmarks\PowerShell.Benchmarks.csproj
+  #       runCategories: 'Public Internal'
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}

--- a/src/scenarios/fsharpcompilerservice/src/Service/FSharpSource.fsi
+++ b/src/scenarios/fsharpcompilerservice/src/Service/FSharpSource.fsi
@@ -26,7 +26,7 @@ type internal FSharpSource =
     abstract TimeStamp: DateTime
 
     /// Gets the internal text container. Text may be on-disk, in a stream, or a source text.
-    abstract internal GetTextContainer: unit -> TextContainer
+    abstract GetTextContainer: unit -> TextContainer
 
     /// Creates a FSharpSource from disk. Only used internally.
     static member internal CreateFromFile: filePath: string -> FSharpSource


### PR DESCRIPTION
Fix FSharp and inner loop SDK scenarios. This consists of updating an accessibility reference in the FSharp test's source and updating the tests that explicitly take in a framework to use the PERFLAB_Framework as we no longer need to support netcoreapp and don't know if the framework has 3 or 4 characters for the version number. This also does stop running older targets using newer SDKs as the old packages are not available on with this setup.