### PR TITLE
Remove Explicit System.Reflection.Metadata reference

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -102,8 +102,6 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '8.0'">
     <!-- we want both net8.0 and net9.0 targets to use the 9.0.0 version of the NuGet package (since this is where the generic math APIs were first added) -->
     <PackageReference Include="System.Numerics.Tensors" Version="$(SystemThreadingChannelsPackageVersion)" />
-    <!-- The TypeName API was introduced in System.ReflectioMetadata 9.0, so we include it only for 9.0 and above -->
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove System.Reflection.Metadata explicit reference as it is triggering a NU1510 warning which we treat as an error. It is not necessary to explicitly reference it as it seems to be an in-band package. I tested this locally and it fixed the error on net10, net9 doesn't seem to hit the error either way, and it doesn't seem to break net8. 

Fixes an issue caused by: https://github.com/dotnet/performance/pull/4699, although for whatever reason the CI did not fail, likely due to a coinciding update that made this an actual warning as it was recently added: https://github.com/NuGet/docs.microsoft.com-nuget/blob/main/docs/reference/errors-and-warnings/NU1510.md.