### PR TITLE
Add flaky on VM to some SSL tests

### DIFF
--- a/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.Protocols.cs
+++ b/src/benchmarks/micro/libraries/System.Net.Security/SslStreamTests.Protocols.cs
@@ -32,22 +32,23 @@ namespace System.Net.Security.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(TlsProtocols))]
-        [BenchmarkCategory(Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoAOT, Categories.FlakyOnVM)]
         public Task HandshakeECDSA256CertAsync(SslProtocols protocol) => SslStreamTests.HandshakeAsync(SslStreamTests._ec256Cert, protocol);
 
         [Benchmark]
         [ArgumentsSource(nameof(TlsProtocols))]
-        [BenchmarkCategory(Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoAOT, Categories.FlakyOnVM)]
         [OperatingSystemsFilter(allowed: true, platforms: OS.Linux)]    // Not supported on Windows at the moment.
         public Task HandshakeECDSA512CertAsync(SslProtocols protocol) => SslStreamTests.HandshakeAsync(SslStreamTests._ec512Cert, protocol);
 
         [Benchmark]
         [ArgumentsSource(nameof(TlsProtocols))]
-        [BenchmarkCategory(Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoAOT, Categories.FlakyOnVM)]
         public Task HandshakeRSA2048CertAsync(SslProtocols protocol) => SslStreamTests.HandshakeAsync(SslStreamTests._rsa2048Cert, protocol);
 
         [Benchmark]
         [ArgumentsSource(nameof(TlsProtocols))]
+        [BenchmarkCategory(Categories.NoAOT, Categories.FlakyOnVM)]
         public Task HandshakeRSA4096CertAsync(SslProtocols protocol) => SslStreamTests.HandshakeAsync(SslStreamTests._rsa4096Cert, protocol);
 
         private static bool GetTls13Support()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


