### PR TITLE
Add arm64 support for scenarios scripts

### DIFF
--- a/src/scenarios/init.sh
+++ b/src/scenarios/init.sh
@@ -27,6 +27,21 @@ download_dotnet() {
     python3 $dotnetScript install --channels $1 -v
 }
 
+# Function to determine CPU architecture
+get_cpu_architecture() {
+    local arch
+    arch=$(uname -m)
+    
+    if [ "$arch" = "x86_64" ]; then
+        echo "x64"
+    elif [ "$arch" = "aarch64" ]; then
+        echo "arm64"
+    else
+        echo "Unsupported architecture: $arch"
+        exit 1
+    fi
+}
+
 # Add scripts and current directory to PYTHONPATH
 absolutePath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 scriptPath="$absolutePath/../../scripts"
@@ -48,7 +63,7 @@ elif [ "$1" = "-channel" ] && [ "$2" != "" ]
 then
     channel="$2"
     download_dotnet $channel
-    dotnetDirectory="$absolutePath/../../tools/dotnet/x64"
+    dotnetDirectory="$absolutePath/../../tools/dotnet/$(get_cpu_architecture)"
     setup_env $dotnetDirectory
 elif [ "$#" -gt 0 ]
 then 

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -54,7 +54,7 @@ def getruntimeidentifier():
     else:
         raise Exception('Platform %s not supported.' % sys.platform)
 
-    if 'aarch64' in platform.machine() or os.environ.get('PERFLAB_BUILDARCH') == 'arm64':
+    if 'aarch64' in platform.machine() or platform.machine() == 'arm64' or os.environ.get('PERFLAB_BUILDARCH') == 'arm64':
         rid += 'arm64'
     elif platform.machine() == 's390x':
         rid += 's390x'


### PR DESCRIPTION
There was a missing support for arm64 in `init.sh` and `getruntimeidentifier` in `utils.py` were incorrectly handling a case where `platform.machine() == 'arm64'`.


