### PR TITLE
[android] Accept both `ActivityManager` and `ActivityTaskManager` for reporting TTID and TTFD

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -533,12 +533,12 @@ ex: C:\repos\performance;C:\repos\runtime
                 # Create the fullydrawn command
                 fullyDrawnRetrieveCmd = xharness_adb() + [ 
                     'shell',
-                    f"logcat -d | grep 'ActivityTaskManager: Fully drawn {self.packagename}'"
+                    f"logcat -d | grep -E 'ActivityManager|ActivityTaskManager: Fully drawn {self.packagename}'"
                 ]
 
                 basicStartupRetrieveCmd = xharness_adb() + [ 
                     'shell',
-                    f"logcat -d | grep 'ActivityTaskManager: Displayed {androidHelper.activityname}'"
+                    f"logcat -d | grep -E 'ActivityManager|ActivityTaskManager: Displayed {androidHelper.activityname}'"
                 ]
 
                 clearLogsCmd = xharness_adb() + [


### PR DESCRIPTION
## Description

As the title says, this PR changes how we parse logcat for TTID and TTFD events, accepting both `ActivityManager` and `ActivityTaskManager` as sources.

Fixes: https://github.com/dotnet/performance/issues/4779

