### PR TITLE
[Android] Setup infrastructure around Android sample app for AOT/R2R testings

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -86,7 +86,7 @@ jobs:
       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
       jobParameters: ${{ parameters.jobParameters }}
 
-  # run android scenarios - Mono
+  # run android scenarios - Mono JIT
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -96,6 +96,7 @@ jobs:
         - windows_x64
       jobParameters:
         runtimeType: AndroidMono
+        codeGenType: JIT
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
         runKind: android_scenarios
         isScenario: true
@@ -105,7 +106,27 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run android scenarios - CoreCLR
+  # run android scenarios - Mono AOT
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - windows_x64
+      jobParameters:
+        runtimeType: AndroidMono
+        codeGenType: AOT
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+        runKind: android_scenarios
+        isScenario: true
+        logicalMachine: 'perfpixel4a'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run android scenarios - CoreCLR JIT
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -115,6 +136,27 @@ jobs:
         - windows_x64
       jobParameters:
         runtimeType: AndroidCoreCLR
+        codeGenType: JIT
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+        runKind: android_scenarios
+        isScenario: true
+        logicalMachine: 'perfpixel4a'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run android scenarios - CoreCLR R2R
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+        - windows_x64
+      jobParameters:
+        runtimeType: AndroidCoreCLR
+        codeGenType: R2R
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
         runKind: android_scenarios
         isScenario: true

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -42,7 +42,7 @@ jobs:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}
         - ${{ if eq(parameters.runtimeType, 'wasm')}}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}_{5}', 'browser', '', 'wasm', 'linux', parameters.buildConfig, parameters.runtimeType) }}
-        - ${{ if and(eq(parameters.codeGenType, 'AOT'), ne(parameters.runtimeType, 'wasm'))}}:
+        - ${{ if and(eq(parameters.codeGenType, 'AOT'), not(in(parameters.runtimeType, 'wasm', 'AndroidMono'))) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.codeGenType) }}
         - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
           - ${{ 'build_android_arm64_release_AndroidMono' }}
@@ -128,7 +128,7 @@ jobs:
             find $(librariesDownloadDir)/bin/wasm -type d &&
             find $(librariesDownloadDir)/bin/wasm -type f -exec chmod 664 {} \;
           displayName: "Create wasm directory (Linux)"
-      - ${{ elseif eq(parameters.codeGenType, 'AOT') }}:
+      - ${{ elseif and(eq(parameters.codeGenType, 'AOT'), not(eq(parameters.runtimeType, 'AndroidMono'))) }}:
         # Download mono AOT
         - template: /eng/pipelines/templates/download-artifact-step.yml
           parameters:
@@ -153,15 +153,33 @@ jobs:
             artifactFileName: 'BuildArtifacts_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_$(buildConfigUpper)_${{ parameters.runtimeType }}$(archiveExtension)'
             artifactName: 'BuildArtifacts_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_$(buildConfigUpper)_${{ parameters.runtimeType }}'
             displayName: 'Runtime artifacts'
-      - ${{ elseif eq(parameters.runtimeType, 'AndroidMono')}}:
+      - ${{ elseif or(eq(parameters.runtimeType, 'AndroidMono'), eq(parameters.runtimeType, 'AndroidCoreCLR'))}}:
         # Download artifacts for Android Testing
         - template: /eng/pipelines/templates/download-artifact-step.yml
           parameters:
             unpackFolder: $(builtAppDir)/androidHelloWorld
             cleanUnpackFolder: false
-            artifactFileName: 'AndroidHelloWorldArm64Mono.tar.gz'
-            artifactName: 'AndroidHelloWorldArm64Mono'
-            displayName: 'Mono Android HelloWorld'
+
+            # AndroidMono
+            ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
+              ${{ if eq(parameters.codeGenType, 'JIT') }}:
+                artifactFileName: 'AndroidHelloWorldArm64Mono.tar.gz'
+                artifactName: 'AndroidHelloWorldArm64Mono'
+              ${{ if eq(parameters.codeGenType, 'AOT') }}:
+                artifactFileName: 'AndroidHelloWorldArm64MonoAOT.tar.gz'
+                artifactName: 'AndroidHelloWorldArm64MonoAOT'
+
+            # AndroidCoreCLR
+            ${{ if eq(parameters.runtimeType, 'AndroidCoreCLR')}}:
+              ${{ if eq(parameters.codeGenType, 'JIT') }}:
+                artifactFileName: 'AndroidHelloWorldArm64CoreCLR.tar.gz'
+                artifactName: 'AndroidHelloWorldArm64CoreCLR'
+              ${{ if eq(parameters.codeGenType, 'R2R') }}:
+                artifactFileName: 'AndroidHelloWorldArm64CoreCLRR2R.tar.gz'
+                artifactName: 'AndroidHelloWorldArm64CoreCLRR2R'
+            
+            displayName: 'Android Sample App'
+
         # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
         # - template: /eng/pipelines/templates/download-artifact-step.yml 
         #   parameters:
@@ -170,15 +188,6 @@ jobs:
         #     artifactFileName: 'AndroidBDNApk.tar.gz'
         #     artifactName: 'AndroidBDNApk'
         #     displayName: 'Mono Android BDN Apk'
-      - ${{ elseif eq(parameters.runtimeType, 'AndroidCoreCLR')}}:
-        # Download artifacts for Android Testing
-        - template: /eng/pipelines/templates/download-artifact-step.yml
-          parameters:
-            unpackFolder: $(builtAppDir)/androidHelloWorld
-            cleanUnpackFolder: false
-            artifactFileName: 'AndroidHelloWorldArm64CoreCLR.tar.gz'
-            artifactName: 'AndroidHelloWorldArm64CoreCLR'
-            displayName: 'CoreCLR Android HelloWorld'
       - ${{ elseif or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:
         # Download iOSMono and Native AOT tests
         - template: /eng/pipelines/templates/download-artifact-step.yml

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -391,9 +391,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if args.libraries_download_dir is None and not args.performance_repo_ci and args.runtime_repo_dir is not None:
         args.libraries_download_dir = os.path.join(args.runtime_repo_dir, "artifacts")
 
-    llvm = args.codegen_type.lower() == "aot" and args.runtime_type != "wasm"
-    android_mono = args.runtime_type == "AndroidMono"
-    android_coreclr = args.runtime_type == "AndroidCoreCLR"
+    llvm = args.codegen_type.lower() == "aot" and args.runtime_type != "wasm" and not args.run_kind == "android_scenarios"
     ios_mono = args.runtime_type == "iOSMono"
     ios_nativeaot = args.runtime_type == "iOSNativeAOT"
     mono_aot = False
@@ -531,15 +529,16 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     runtime_type = ""
 
-    if android_mono:
-        runtime_type = "Mono"
-        configurations["CompilationMode"] = "JIT"
-        configurations["RuntimeType"] = str(runtime_type)
-
-    if android_coreclr:
-        runtime_type = "CoreCLR"
-        configurations["CompilationMode"] = "JIT"
-        configurations["RuntimeType"] = str(runtime_type)
+    if args.run_kind == "android_scenarios":
+        # Mapping runtime_type to runtime_flavor before sending to helix
+        if args.runtime_type == "AndroidMono":
+            args.runtime_flavor = "mono"
+        elif args.runtime_type == "AndroidCoreCLR":
+            args.runtime_flavor = "coreclr"
+        else:
+            raise Exception("Android scenarios only support Mono and CoreCLR runtimes")
+        configurations["CodegenType"] = str(args.codegen_type)
+        configurations["RuntimeType"] = str(args.runtime_flavor)
 
     if ios_mono:
         runtime_type = "Mono"
@@ -719,7 +718,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         if args.runtime_repo_dir is not None:
             args.built_app_dir = args.runtime_repo_dir
     
-    if android_mono or android_coreclr:
+    if args.run_kind == "android_scenarios":
         if args.built_app_dir is None:
             raise Exception("Built apps directory must be present for Android benchmarks")
         getLogger().info("Copying Android apps to payload directory")
@@ -1090,6 +1089,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         helix_build=args.build_number,
         partition_count=args.partition_count,
         runtime_flavor=args.runtime_flavor or "",
+        codegen_type=args.codegen_type,
         hybrid_globalization=args.hybrid_globalization,
         target_csproj=args.target_csproj,
         work_item_command=work_item_command or None,

--- a/scripts/send_to_helix.py
+++ b/scripts/send_to_helix.py
@@ -67,6 +67,7 @@ class PerfSendToHelixArgs:
 
     # Used by scenarios projects
     runtime_flavor: Optional[str] = None
+    codegen_type: Optional[str] = None
     hybrid_globalization: Optional[bool] = None
     python: Optional[str] = None
     affinity: Optional[str] = None
@@ -108,6 +109,7 @@ class PerfSendToHelixArgs:
         set_env_var("Creator", self.creator)
         set_env_var("PartitionCount", self.partition_count)
         set_env_var("RuntimeFlavor", self.runtime_flavor)
+        set_env_var("CodegenType", self.codegen_type)
         set_env_var("HybridGlobalization", self.hybrid_globalization)
         set_env_var("iOSStripSymbols", self.ios_strip_symbols)
         set_env_var("iOSLlvmBuild", self.ios_llvm_build)


### PR DESCRIPTION
- Added Mono AOT and CoreCLR R2R scenario for dotnet/runtime Android sample app.
- Added `codeGenType` parameter to android scenarios with JIT/AOT/R2R values.
- Ensured that `RuntimeFlavor` and `CodegenType` is passed over to helix.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2676838
Associated dotnet/runtime PR: https://github.com/dotnet/runtime/pull/114117

