### PR TITLE
Disable Performance Crossgen tests

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -336,21 +336,22 @@ jobs:
           ${{ parameter.key }}: ${{ parameter.value }}
 
   # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
-        runKind: crossgen_scenarios
-        isScenario: true
-        logicalMachine: 'perftiger_crossgen'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  - ${{ if false }}: # Disabling as all crossgen jobs are failing at the moment - https://github.com/dotnet/performance/issues/4819
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+        - windows_x64
+        - windows_x86
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
+          runKind: crossgen_scenarios
+          isScenario: true
+          logicalMachine: 'perftiger_crossgen'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}


### PR DESCRIPTION
Crossgen tests are currently failing per https://github.com/dotnet/performance/issues/4819. They have been this way for a while, and we haven't had a chance to look into them. Disabling them will allow us to more quickly act on other issues that pop up in our testing.