### PR TITLE
Update the iOS scenarios build flow to match android

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -12,9 +12,6 @@
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
     
     <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
-    <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise didn't add anything.
-    This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
-    <RunConfigsString>$(RuntimeFlavor)</RunConfigsString>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -29,19 +26,19 @@
   </ItemDefinitionGroup>
 
   <ItemGroup>
-    <MAUIiOSScenario Include=".NET iOS Default $(RunConfigsString)">
+    <MAUIiOSScenario Include=".NET iOS Default Template">
       <ScenarioDirectoryName>netios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>NetiOSDefault</IPAName>
       <PackageName>com.companyname.NetiOSDefault</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui iOS Default $(RunConfigsString)">
+    <MAUIiOSScenario Include="Maui iOS Default Template">
       <ScenarioDirectoryName>mauiios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiiOSDefault</IPAName>
       <PackageName>net.dot.mauitesting</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui Blazor iOS Default $(RunConfigsString)">
+    <MAUIiOSScenario Include="Maui Blazor iOS Default Template (TTFD)">
       <ScenarioDirectoryName>mauiblazorios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiBlazoriOSDefault</IPAName>
@@ -61,11 +58,11 @@
       <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
-    <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) Unzipped')">
+    <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) Extracted Size')">
       <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; mv $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; unzip -d $HELIX_WORKITEM_ROOT/pub $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; rm $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS .NET Default $(RunConfigsString)">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS .NET Default Template">
       <AppBundlePath>$(ScenariosDir)netios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -93,7 +90,7 @@
           ]]>
         </CustomCommands>
     </XHarnessAppBundleToTest>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default $(RunConfigsString)">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default Template">
       <AppBundlePath>$(ScenariosDir)mauiios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -122,7 +119,7 @@
         </CustomCommands>
     </XHarnessAppBundleToTest>
     <!-- Now also disabled for normal mono runs. (Reenable for mono and native aot once fixed). Tracking issue: https://github.com/dotnet/performance/issues/3148 -->
-    <!-- <XHarnessAppBundleToTest Condition="'$(RuntimeFlavor)' == 'mono'" Include="Device Startup - iOS Maui Blazor Default $(RunConfigsString)">
+    <!-- <XHarnessAppBundleToTest Condition="'$(RuntimeFlavor)' == 'mono'" Include="Device Startup - iOS Maui Blazor Default Template">
       <AppBundlePath>$(ScenariosDir)mauiblazorios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -38,7 +38,7 @@
       <IPAName>MauiiOSDefault</IPAName>
       <PackageName>net.dot.mauitesting</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui Blazor iOS Default Template (TTFD)">
+    <MAUIiOSScenario Include="Maui Blazor iOS Default Template">
       <ScenarioDirectoryName>mauiblazorios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiBlazoriOSDefault</IPAName>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_16.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_16.3.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -436,10 +436,8 @@ jobs:
       jobParameters:
         runKind: maui_scenarios_ios
         projectFileName: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
         channels:
-          - 8.0
+          - main
         runtimeFlavor: mono
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:
@@ -455,10 +453,8 @@ jobs:
       jobParameters:
         runKind: maui_scenarios_ios
         projectFileName: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
         channels:
-          - 8.0
+          - main
         runtimeFlavor: coreclr
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -431,7 +431,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - osx-arm64-ios-arm64
+        - osx-x64-ios-arm64
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_ios
@@ -448,7 +448,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - osx-arm64-ios-arm64
+        - osx-x64-ios-arm64
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_ios

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -439,6 +439,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: mono
+        codeGenType: FullAOT
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
@@ -456,6 +457,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: coreclr
+        codeGenType: NativeAOT
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -431,7 +431,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - osx-x64-ios-arm64
+        - osx-arm64-ios-arm64
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_ios
@@ -448,7 +448,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - osx-x64-ios-arm64
+        - osx-arm64-ios-arm64
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_ios

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -129,11 +129,11 @@ jobs:
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if and(containsValue(parameters.buildMachines, 'osx-arm64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 12mini only used in private builds currently
+- ${{ if and(containsValue(parameters.buildMachines, 'osx-x64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 12mini only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osGroup: osx
-      archType: arm64
+      archType: x64
       osVersion: 15
       pool:
         vmImage: 'macos-15'

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -129,14 +129,14 @@ jobs:
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if and(containsValue(parameters.buildMachines, 'osx-x64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 12mini only used in private builds currently
+- ${{ if and(containsValue(parameters.buildMachines, 'osx-arm64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 12mini only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osGroup: osx
-      archType: x64
-      osVersion: 14
+      archType: arm64
+      osVersion: 15
       pool:
-        vmImage: 'macos-14'
+        vmImage: 'macos-15'
       queue: OSX.13.Amd64.Iphone.Perf
       machinePool: iPhoneMini12
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -548,6 +548,13 @@ def run_performance_job(args: RunPerformanceJobArgs):
         configurations["CodegenType"] = str(args.codegen_type)
         configurations["RuntimeType"] = str(args.runtime_flavor)
 
+    # .NET iOS and .NET MAUI iOS sample app scenarios
+    if args.run_kind == "maui_scenarios_ios":
+        if not args.runtime_flavor in ("mono", "coreclr"):
+            raise Exception("Runtime flavor must be specified for maui_scenarios_ios")
+        configurations["CodegenType"] = str(args.codegen_type)
+        configurations["RuntimeType"] = str(args.runtime_flavor)
+
     if ios_mono:
         runtime_type = "Mono"
         configurations["iOSLlvmBuild"] = str(args.ios_llvm_build)

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -5,14 +5,15 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui
 from shared.precommands import PreCommands
-from shared.versionmanager import versions_write_json, get_version_from_dll_powershell_ios
+from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
 
 setup_loggers(True)
 precommands = PreCommands()
-install_versioned_maui(precommands)
+install_latest_maui(precommands)
+precommands.print_dotnet_info()
 
 # Setup the Maui folder
 precommands.new(template='maui-blazor',
@@ -39,7 +40,6 @@ with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
 
 # Build the IPA
 # NuGet.config file cannot be in the build directory due same cause as to https://github.com/dotnet/aspnetcore/issues/41397
-shutil.copy('./MauiNuGet.config', './Nuget.config')
 precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
 
 output_dir = const.PUBDIR
@@ -47,9 +47,8 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Copy the MauiVersion to a file so we have it on the machine
-maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
-version_dict = { "mauiVersion": maui_version }
+# Extract the versions of used SDKs from the linked folder DLLs
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")
 

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -6,15 +6,16 @@ import sys
 import subprocess
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_versioned_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui
 from shared.precommands import PreCommands
-from shared.versionmanager import versions_write_json, get_version_from_dll_powershell_ios
+from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
 
 setup_loggers(True)
 
 precommands = PreCommands()
-install_versioned_maui(precommands)
+install_latest_maui(precommands)
+precommands.print_dotnet_info()
 
 # Setup the Maui folder
 precommands.new(template='maui',
@@ -25,7 +26,6 @@ precommands.new(template='maui',
                 no_restore=False)
 
 # Build the APK
-shutil.copy('./MauiNuGet.config', './app/Nuget.config')
 precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
 
 # Remove the aab files as we don't need them, this saves space
@@ -34,8 +34,7 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Copy the MauiVersion to a file so we have it on the machine
-maui_version = get_version_from_dll_powershell_ios(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
-version_dict = { "mauiVersion": maui_version }
+# Extract the versions of used SDKs from the linked folder DLLs
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked/Microsoft.Maui.dll")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -74,7 +74,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
 
     mobile_sdks = {
         "net_android": "Mono.Android.dll",
-        "net_ios": "Mono.iOS.dll",
+        "net_ios": "Microsoft.iOS.dll",
         "net_maui": "Microsoft.Maui.dll",
         "runtime": "System.Runtime.dll"
     }


### PR DESCRIPTION
Update the iOS scenarios to use the same flow as android, bringing them up to running net10. This copies the build flow update from https://github.com/dotnet/performance/pull/4770 to the iOS scenarios.

Successful test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2689882&view=results


