### PR TITLE
[Android] Add MAUI Android Sample Content template app + refactor TTFD naming

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -76,16 +76,16 @@
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity)')">
-      <_StartupAdditionalArguments>%(HelixWorkItem.StartupAdditionalArguments)</_StartupAdditionalArguments>
-      <_StartupTTFD Condition="$(_StartupAdditionalArguments.Contains('--use-fully-drawn-time'))"> (TTFD)</_StartupTTFD>
+      <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
+      <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)%(_StartupTTFD)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;$(_ScenarioName)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity) NoAnimation')">
-      <_StartupAdditionalArguments>%(HelixWorkItem.StartupAdditionalArguments)</_StartupAdditionalArguments>
-      <_StartupTTFD Condition="$(_StartupAdditionalArguments.Contains('--use-fully-drawn-time'))"> (TTFD)</_StartupTTFD>
+      <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
+      <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)%(_StartupTTFD)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;$(_ScenarioName)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Memory Consumption - %(Identity)')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('galaxy'))">
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -41,7 +41,13 @@
       <ApkName>com.companyname.mauiandroiddefault-Signed</ApkName>
       <PackageName>com.companyname.mauiandroiddefault</PackageName>
     </MAUIAndroidScenario>
-    <MAUIAndroidScenario Include="MAUI Blazor Android Default Template (TTFD)">
+    <MAUIAndroidScenario Include="MAUI Android Sample Content Template">
+      <ScenarioDirectoryName>mauisamplecontentandroid</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <ApkName>com.companyname.mauisamplecontentandroid-Signed</ApkName>
+      <PackageName>com.companyname.mauisamplecontentandroid</PackageName>
+    </MAUIAndroidScenario>
+    <MAUIAndroidScenario Include="MAUI Blazor Android Default Template">
       <ScenarioDirectoryName>mauiblazorandroid</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <ApkName>com.companyname.mauiblazorandroiddefault-Signed</ApkName>
@@ -53,7 +59,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog %(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog  -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog %(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -70,12 +76,16 @@
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity)')">
+      <_StartupAdditionalArguments>%(HelixWorkItem.StartupAdditionalArguments)</_StartupAdditionalArguments>
+      <_StartupTTFD Condition="$(_StartupAdditionalArguments.Contains('--use-fully-drawn-time'))"> (TTFD)</_StartupTTFD>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot; %(HelixWorkItem.StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)%(_StartupTTFD)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity) NoAnimation')">
+      <_StartupAdditionalArguments>%(HelixWorkItem.StartupAdditionalArguments)</_StartupAdditionalArguments>
+      <_StartupTTFD Condition="$(_StartupAdditionalArguments.Contains('--use-fully-drawn-time'))"> (TTFD)</_StartupTTFD>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot; --disable-animations %(HelixWorkItem.StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)%(_StartupTTFD)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Memory Consumption - %(Identity)')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('galaxy'))">
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -79,13 +79,13 @@
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;$(_ScenarioName)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity) NoAnimation')">
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;$(_ScenarioName)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Memory Consumption - %(Identity)')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('galaxy'))">
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,49 +344,49 @@ jobs:
 - ${{ if parameters.runPrivateJobs }}:
 
   # Scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios_affinitized.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui Android scenario benchmarks (Mono)
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -427,82 +427,82 @@ jobs:
           ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_ios
-        projectFileName: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
-        runtimeFlavor: mono
-        additionalJobIdentifier: Mono
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_ios
+  #       projectFileName: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         9.0: ./eng/Version.Details.xml
+  #       channels:
+  #         - 8.0
+  #       runtimeFlavor: mono
+  #       additionalJobIdentifier: Mono
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_ios
-        projectFileName: maui_scenarios_ios.proj
-        dotnetVersionsLinks:
-          9.0: ./eng/Version.Details.xml
-        channels:
-          - 8.0
-        runtimeFlavor: coreclr
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui iOS Native AOT scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_ios
+  #       projectFileName: maui_scenarios_ios.proj
+  #       dotnetVersionsLinks:
+  #         9.0: ./eng/Version.Details.xml
+  #       channels:
+  #         - 8.0
+  #       runtimeFlavor: coreclr
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui scenario benchmarks
-  - ${{ if false }}:
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-        buildMachines:
-          - win-x64
-          - ubuntu-x64
-          - win-arm64
-          - ubuntu-arm64-ampere
-        isPublic: false
-        jobParameters:
-          runKind: maui_scenarios
-          projectFileName: maui_scenarios.proj
-          channels:
-            - main
-            - 9.0
-            - 8.0
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui scenario benchmarks
+  # - ${{ if false }}:
+  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #     parameters:
+  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #       buildMachines:
+  #         - win-x64
+  #         - ubuntu-x64
+  #         - win-arm64
+  #         - ubuntu-arm64-ampere
+  #       isPublic: false
+  #       jobParameters:
+  #         runKind: maui_scenarios
+  #         projectFileName: maui_scenarios.proj
+  #         channels:
+  #           - main
+  #           - 9.0
+  #           - 8.0
+  #         ${{ each parameter in parameters.jobParameters }}:
+  #           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        runKind: nativeaot_scenarios
-        projectFileName: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: nativeaot_scenarios
+  #       projectFileName: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,49 +344,49 @@ jobs:
 - ${{ if parameters.runPrivateJobs }}:
 
   # Scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios_affinitized.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui Android scenario benchmarks (Mono)
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -427,82 +427,82 @@ jobs:
           ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_ios
-  #       projectFileName: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         9.0: ./eng/Version.Details.xml
-  #       channels:
-  #         - 8.0
-  #       runtimeFlavor: mono
-  #       additionalJobIdentifier: Mono
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: ./eng/Version.Details.xml
+        channels:
+          - 8.0
+        runtimeFlavor: mono
+        additionalJobIdentifier: Mono
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui iOS Native AOT scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_ios
-  #       projectFileName: maui_scenarios_ios.proj
-  #       dotnetVersionsLinks:
-  #         9.0: ./eng/Version.Details.xml
-  #       channels:
-  #         - 8.0
-  #       runtimeFlavor: coreclr
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        dotnetVersionsLinks:
+          9.0: ./eng/Version.Details.xml
+        channels:
+          - 8.0
+        runtimeFlavor: coreclr
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui scenario benchmarks
-  # - ${{ if false }}:
-  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #     parameters:
-  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #       buildMachines:
-  #         - win-x64
-  #         - ubuntu-x64
-  #         - win-arm64
-  #         - ubuntu-arm64-ampere
-  #       isPublic: false
-  #       jobParameters:
-  #         runKind: maui_scenarios
-  #         projectFileName: maui_scenarios.proj
-  #         channels:
-  #           - main
-  #           - 9.0
-  #           - 8.0
-  #         ${{ each parameter in parameters.jobParameters }}:
-  #           ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui scenario benchmarks
+  - ${{ if false }}:
+    - template: /eng/pipelines/templates/build-machine-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+        buildMachines:
+          - win-x64
+          - ubuntu-x64
+          - win-arm64
+          - ubuntu-arm64-ampere
+        isPublic: false
+        jobParameters:
+          runKind: maui_scenarios
+          projectFileName: maui_scenarios.proj
+          channels:
+            - main
+            - 9.0
+            - 8.0
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: nativeaot_scenarios
-  #       projectFileName: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # NativeAOT scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        runKind: nativeaot_scenarios
+        projectFileName: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -405,7 +405,8 @@ class CSharpProject:
             exename: Optional[str] = None,
             language: Optional[str] = None,
             no_https: bool = False,
-            no_restore: bool = True
+            no_restore: bool = True,
+            extra_args: Optional[List[str]] = None
             ):
         '''
         Creates a new project with the specified template
@@ -429,6 +430,9 @@ class CSharpProject:
 
         if no_https:
             cmdline += ['--no-https']
+
+        if extra_args:
+            cmdline += extra_args
 
         RunCommand(cmdline, verbose=verbose).run(
             working_directory

--- a/src/scenarios/mauisamplecontentandroid/post.py
+++ b/src/scenarios/mauisamplecontentandroid/post.py
@@ -1,0 +1,7 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+
+clean_directories()

--- a/src/scenarios/mauisamplecontentandroid/pre.py
+++ b/src/scenarios/mauisamplecontentandroid/pre.py
@@ -1,0 +1,43 @@
+'''
+pre-command
+'''
+import shutil
+import sys
+from performance.logger import setup_loggers, getLogger
+from shared import const
+from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.precommands import PreCommands
+from shared.versionmanager import versions_write_json, get_sdk_versions
+from test import EXENAME
+
+setup_loggers(True)
+logger = getLogger(__name__)
+logger.info(f"Starting pre-command for MAUI Sample Content template app (dotnet new maui --sample-content)")
+
+precommands = PreCommands()
+
+install_latest_maui(precommands)
+precommands.print_dotnet_info()
+
+# Setup the Maui folder
+precommands.new(template='maui',
+                output_dir=const.APPDIR,
+                bin_dir=const.BINDIR,
+                exename=EXENAME,
+                working_directory=sys.path[0],
+                no_restore=False,
+                extra_args=['--sample-content'])
+
+# Build the APK
+precommands.execute([])
+
+# Remove the aab files as we don't need them, this saves space
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+remove_aab_files(output_dir)
+
+# Extract the versions of used SDKs from the linked folder DLLs
+version_dict = get_sdk_versions(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
+versions_write_json(version_dict, rf"{output_dir}\versions.json")
+print(f"Versions: {version_dict} from location " + rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")

--- a/src/scenarios/mauisamplecontentandroid/test.py
+++ b/src/scenarios/mauisamplecontentandroid/test.py
@@ -1,0 +1,16 @@
+'''
+Mobile Maui App
+'''
+from shared.const import PUBDIR
+from shared.runner import TestTraits, Runner
+from shared.versionmanager import versions_read_json_file_save_env
+
+EXENAME = 'MauiSampleContentAndroid'
+
+if __name__ == "__main__":    
+    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+
+    traits = TestTraits(exename=EXENAME, 
+                        guiapp='false',
+                        )
+    Runner(traits).run()

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -122,7 +122,8 @@ class PreCommands:
             working_directory: str,
             language: Optional[str] = None,
             no_https: bool = False,
-            no_restore: bool = True):
+            no_restore: bool = True,
+            extra_args: Optional[List[str]] = None):
         'makes a new app with the given template'
         self.project = CSharpProject.new(template=template,
                                  output_dir=output_dir,
@@ -133,7 +134,8 @@ class PreCommands:
                                  verbose=True,
                                  language=language,
                                  no_https=no_https,
-                                 no_restore=no_restore)
+                                 no_restore=no_restore,
+                                 extra_args=extra_args)
         self._updateframework(self.project.csproj_file)
         self._addstaticmsbuildproperty(self.project.csproj_file)
 


### PR DESCRIPTION
- Add support for maui sample content android scenario by passing an extra argument to the dotnet new command
- Refactor MAUI Blazor Android naming so that TTFD tag is only included in startup measurements.

Internal run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2688185&view=results


---

https://github.com/dotnet/performance/issues/4794
