### PR TITLE
Add datetime of SDK install to the PERFLAB_DATA

### DIFF
--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -95,7 +95,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
         results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
 
     # Add datetime of the SDK installation to the results
-    now = datetime.now()
-    results["PERFLAB_DATA_sdk_install_datetime"] = now.strftime("%Y-%m-%d %H:%M:%S")
+    now = datetime.utcnow()
+    results["PERFLAB_DATA_sdk_install_datetime"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     return results

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 from performance.logger import getLogger
 from typing import Dict
+from datetime import datetime
 
 def versions_write_json(versiondict: Dict[str, str], outputfile: str = 'versions.json'):
     with open(outputfile, 'w', encoding='utf-8') as file:
@@ -92,5 +93,9 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
         version, commit = parse_version_output(result)
         results[f"{sdk}_version"] = version
         results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
-            
+
+    # Add datetime of the SDK installation to the results
+    now = datetime.now()
+    results["PERFLAB_DATA_sdk_install_datetime"] = now.strftime("%Y-%m-%d %H:%M:%S")
+
     return results


### PR DESCRIPTION
Currently, for SDK scenarios, we don't have reliable way of determining when the job was run other than cross-cluster join as described in https://github.com/dotnet/performance/issues/4832 which brings requirements to users to have access to another cluster, etc.

This PR tries to work around it by saving datetime of SDK version extraction to `PERFLAB_DATA_`. This should roughly correspond to the time when the SDK + workloads got installed for the individual scenarios.

Internal run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2689560&view=results
