### PR TITLE
[android] Partial revert of previous change to Maui Android Blazor startup measurements

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -79,13 +79,13 @@
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; %(HelixWorkItem.StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity) NoAnimation')">
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) == ''">%(Identity)</_ScenarioName>
       <_ScenarioName Condition="%(HelixWorkItem.StartupAdditionalArguments) != ''">%(Identity) [%(HelixWorkItem.StartupAdditionalArguments)]</_ScenarioName>
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
-      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; --disable-animations $(_StartupAdditionalArguments) $(ScenarioArgs)</Command>
+      <Command>$(Python) test.py devicestartup --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(_ScenarioName)&quot; --disable-animations %(HelixWorkItem.StartupAdditionalArguments) $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Memory Consumption - %(Identity)')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('galaxy'))">
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>


### PR DESCRIPTION
My previous change https://github.com/dotnet/performance/pull/4837 incorrectly replaced `HelixWorkItem.StartupAdditionalArguments` with `_StartupAdditionalArguments` in MAUI Blazor Android  which is undefined. This PR reverts this change.

This caused the MAUI Android Blazor startup measurements to miss `--use-fully-drawn-time` in the argument list.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2691010
<img width="836" alt="image" src="https://github.com/user-attachments/assets/086ed83c-c745-41c1-a8fb-4c48bd6954c5" />

