### PR TITLE
Add build time measurement to Startup tool

### DIFF
--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -180,6 +180,27 @@ jobs:
             
             displayName: 'Android Sample App'
 
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download binlog files'
+          inputs:
+            buildType: current
+            downloadType: single
+            downloadPath: '$(builtAppDir)/androidHelloWorldBinlog'
+            # AndroidMono
+            ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
+              ${{ if eq(parameters.codeGenType, 'JIT') }}:
+                artifactName: 'AndroidMonoArm64BuildLog'
+              ${{ if eq(parameters.codeGenType, 'AOT') }}:
+                artifactName: 'AndroidMonoAOTArm64BuildLog'
+
+            # AndroidCoreCLR
+            ${{ if eq(parameters.runtimeType, 'AndroidCoreCLR')}}:
+              ${{ if eq(parameters.codeGenType, 'JIT') }}:
+                artifactName: 'AndroidCoreCLRArm64BuildLog'
+              ${{ if eq(parameters.codeGenType, 'R2R') }}:
+                artifactName: 'AndroidCoreCLRR2RArm64BuildLog'
+            checkDownloadedFiles: true
+
         # Disabled due to not working and needing consistent normal android results. https://github.com/dotnet/performance/issues/4729
         # - template: /eng/pipelines/templates/download-artifact-step.yml 
         #   parameters:
@@ -232,6 +253,25 @@ jobs:
               artifactName: 'iOSSampleAppSymbolsHybridGlobalization${{parameters.hybridGlobalization}}'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppNoSymbolsHybridGlobalization${{parameters.hybridGlobalization}}'
+            checkDownloadedFiles: true
+        - task: DownloadBuildArtifacts@0
+          displayName: 'Download binlog files'
+          inputs:
+            buildType: current
+            downloadType: single
+            downloadPath: '$(builtAppDir)/iosHelloWorldBinlog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'False')) }}:
+              artifactName: 'iOSMonoArm64NoLLVMNoStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSMonoArm64NoLLVMStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'False')) }}:
+              artifactName: 'iOSMonoArm64LLVMNoStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSMonoArm64LLVMStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
+              artifactName: 'iOSNativeAOTArm64NoStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSNativeAOTArm64StripSymbolsBuildLog'
             checkDownloadedFiles: true
 
       - ${{ if notIn(parameters.runtimeType, 'wasm', 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSNativeAOT') }}:

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -742,11 +742,11 @@ def run_performance_job(args: RunPerformanceJobArgs):
         android_binlog_dir = os.path.join(root_payload_dir, "androidHelloWorldBinlog")
         shutil.copytree(os.path.join(args.built_app_dir, "androidHelloWorldBinlog"), android_binlog_dir)
 
-        for file in glob(os.path.join(android_binlog_dir, "**", "*.binlog"), recursive=True):
+        binlog_files = glob(os.path.join(android_binlog_dir, "**", "*.binlog"))
+        if binlog_files:
             dest = os.path.join(android_binlog_dir, "msbuild.binlog")
-            getLogger().info(f"Moving {file} to {dest}")
-            shutil.move(file, dest)
-            break
+            getLogger().info(f"Moving {binlog_files[0]} to {dest}")
+            shutil.move(binlog_files[0], dest)
         # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
         # if android_mono:
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))
@@ -765,20 +765,20 @@ def run_performance_job(args: RunPerformanceJobArgs):
         shutil.copytree(os.path.join(args.built_app_dir, "iosHelloWorldZip"), ios_hello_world_zip_dir)
 
         # Find the zip file in the directory and move it to iOSSampleApp.zip
-        for file in glob(os.path.join(ios_hello_world_zip_dir, "**", "*.zip")):
+        zip_files = glob(os.path.join(ios_hello_world_zip_dir, "**", "*.zip"))
+        if zip_files:
             dest = os.path.join(ios_hello_world_zip_dir, "iOSSampleApp.zip")
-            getLogger().info(f"Moving {file} to {dest}")
-            shutil.move(file, dest)
-            break
+            getLogger().info(f"Moving {zip_files[0]} to {dest}")
+            shutil.move(zip_files[0], dest)
 
         ios_hello_world_binlog_dir = os.path.join(payload_dir, "iosHelloWorldBinlog")
         shutil.copytree(os.path.join(args.built_app_dir, "iosHelloWorldBinlog"), ios_hello_world_binlog_dir)
 
-        for file in glob(os.path.join(ios_hello_world_binlog_dir, "**", "*.binlog")):
+        binlog_files = glob(os.path.join(ios_hello_world_binlog_dir, "**", "*.binlog"))
+        if binlog_files:
             dest = os.path.join(ios_hello_world_binlog_dir, "msbuild.binlog")
-            getLogger().info(f"Moving {file} to {dest}")
-            shutil.move(file, dest)
-            break
+            getLogger().info(f"Moving {binlog_files[0]} to {dest}")
+            shutil.move(binlog_files[0], dest)
 
     # ensure work item directory is not empty
     getLogger().info("Copying docs to work item directory so it isn't empty")

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -738,6 +738,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
             raise Exception("Built apps directory must be present for Android benchmarks")
         getLogger().info("Copying Android apps to payload directory")
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
+        shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorldBinlog", "msbuild.binlog"), os.path.join(root_payload_dir, "msbuild.binlog"))
         # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
         # if android_mono:
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))
@@ -758,6 +759,15 @@ def run_performance_job(args: RunPerformanceJobArgs):
         # Find the zip file in the directory and move it to iOSSampleApp.zip
         for file in glob(os.path.join(ios_hello_world_zip_dir, "**", "*.zip")):
             dest = os.path.join(ios_hello_world_zip_dir, "iOSSampleApp.zip")
+            getLogger().info(f"Moving {file} to {dest}")
+            shutil.move(file, dest)
+            break
+
+        ios_hello_world_binlog_dir = os.path.join(payload_dir, "iosHelloWorldBinlog")
+        shutil.copytree(os.path.join(args.built_app_dir, "iosHelloWorldBinlog"), ios_hello_world_binlog_dir)
+
+        for file in glob(os.path.join(ios_hello_world_binlog_dir, "**", "*.binlog")):
+            dest = os.path.join(ios_hello_world_binlog_dir, "msbuild.binlog")
             getLogger().info(f"Moving {file} to {dest}")
             shutil.move(file, dest)
             break

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -739,8 +739,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         getLogger().info("Copying Android apps to payload directory")
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
         matches = glob(os.path.join(args.built_app_dir, "androidHelloWorldBinlog", "**", "msbuild.binlog"), recursive=True)
-        if matches:
-            shutil.copy(matches[0], os.path.join(root_payload_dir, "msbuild.binlog"))
+        shutil.copy(matches[0], os.path.join(root_payload_dir, "msbuild.binlog"))
         # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
         # if android_mono:
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -738,7 +738,9 @@ def run_performance_job(args: RunPerformanceJobArgs):
             raise Exception("Built apps directory must be present for Android benchmarks")
         getLogger().info("Copying Android apps to payload directory")
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
-        shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorldBinlog", "msbuild.binlog"), os.path.join(root_payload_dir, "msbuild.binlog"))
+        matches = glob(os.path.join(args.built_app_dir, "androidHelloWorldBinlog", "**", "msbuild.binlog"), recursive=True)
+        if matches:
+            shutil.copy(matches[0], os.path.join(root_payload_dir, "msbuild.binlog"))
         # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
         # if android_mono:
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -740,7 +740,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
 
         android_binlog_dir = os.path.join(root_payload_dir, "androidHelloWorldBinlog")
-        shutil.copytree(os.path.join(args.built_app_dir, "androidHelloWorldBinlog"),android_binlog_dir)
+        shutil.copytree(os.path.join(args.built_app_dir, "androidHelloWorldBinlog"), android_binlog_dir)
 
         for file in glob(os.path.join(android_binlog_dir, "**", "*.binlog"), recursive=True):
             dest = os.path.join(android_binlog_dir, "msbuild.binlog")

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -738,8 +738,15 @@ def run_performance_job(args: RunPerformanceJobArgs):
             raise Exception("Built apps directory must be present for Android benchmarks")
         getLogger().info("Copying Android apps to payload directory")
         shutil.copy(os.path.join(args.built_app_dir, "androidHelloWorld", "HelloAndroid.apk"), os.path.join(root_payload_dir, "HelloAndroid.apk"))
-        matches = glob(os.path.join(args.built_app_dir, "androidHelloWorldBinlog", "**", "msbuild.binlog"), recursive=True)
-        shutil.copy(matches[0], os.path.join(root_payload_dir, "msbuild.binlog"))
+
+        android_binlog_dir = os.path.join(root_payload_dir, "androidHelloWorldBinlog")
+        shutil.copytree(os.path.join(args.built_app_dir, "androidHelloWorldBinlog"),android_binlog_dir)
+
+        for file in glob(os.path.join(android_binlog_dir, "**", "*.binlog"), recursive=True):
+            dest = os.path.join(android_binlog_dir, "msbuild.binlog")
+            getLogger().info(f"Moving {file} to {dest}")
+            shutil.move(file, dest)
+            break
         # Disabled due to not successfully building at the moment. https://github.com/dotnet/performance/issues/4729
         # if android_mono:
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))

--- a/src/scenarios/shared/const.py
+++ b/src/scenarios/shared/const.py
@@ -18,6 +18,7 @@ DEVICESTARTUP = "devicestartup"
 DEVICEMEMORYCONSUMPTION = "devicememoryconsumption"
 ANDROIDINSTRUMENTATION = "androidinstrumentation"
 DEVICEPOWERCONSUMPTION = "devicepowerconsumption"
+DEVICEBUILD = "devicebuild"
 
 SCENARIO_NAMES = {STARTUP: 'Startup',
                   SDK: 'SDK',
@@ -25,7 +26,8 @@ SCENARIO_NAMES = {STARTUP: 'Startup',
                   CROSSGEN2: 'Crossgen2',
                   INNERLOOP: 'Innerloop',
                   INNERLOOPMSBUILD: 'InnerLoopMsBuild',
-                  DOTNETWATCH: 'DotnetWatch'}
+                  DOTNETWATCH: 'DotnetWatch',
+                  DEVICEBUILD: 'DeviceBuild'}
 
 BINDIR = 'bin'
 PUBDIR = 'pub'
@@ -51,6 +53,7 @@ ITERATION_SETUP_FILE = os.path.join(os.path.dirname(shared.__file__), 'sdk_itera
 STARTUP_PROCESSTIME = "ProcessTime"
 STARTUP_CROSSGEN2 = "Crossgen2"
 STARTUP_DEVICETIMETOMAIN = "DeviceTimeToMain"
+BUILD_TIME = "BuildTime"
 
 MEMORYCONSUMPTION_ANDROID = "AndroidMemoryConsumption"
 

--- a/src/scenarios/shared/const.py
+++ b/src/scenarios/shared/const.py
@@ -18,7 +18,7 @@ DEVICESTARTUP = "devicestartup"
 DEVICEMEMORYCONSUMPTION = "devicememoryconsumption"
 ANDROIDINSTRUMENTATION = "androidinstrumentation"
 DEVICEPOWERCONSUMPTION = "devicepowerconsumption"
-DEVICEBUILD = "devicebuild"
+BUILDTIME = "buildtime"
 
 SCENARIO_NAMES = {STARTUP: 'Startup',
                   SDK: 'SDK',
@@ -27,7 +27,7 @@ SCENARIO_NAMES = {STARTUP: 'Startup',
                   INNERLOOP: 'Innerloop',
                   INNERLOOPMSBUILD: 'InnerLoopMsBuild',
                   DOTNETWATCH: 'DotnetWatch',
-                  DEVICEBUILD: 'DeviceBuild'}
+                  BUILDTIME: 'BuildTime'}
 
 BINDIR = 'bin'
 PUBDIR = 'pub'
@@ -53,7 +53,6 @@ ITERATION_SETUP_FILE = os.path.join(os.path.dirname(shared.__file__), 'sdk_itera
 STARTUP_PROCESSTIME = "ProcessTime"
 STARTUP_CROSSGEN2 = "Crossgen2"
 STARTUP_DEVICETIMETOMAIN = "DeviceTimeToMain"
-BUILD_TIME = "BuildTime"
 
 MEMORYCONSUMPTION_ANDROID = "AndroidMemoryConsumption"
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -169,7 +169,7 @@ ex: C:\repos\performance;C:\repos\runtime
 '''                            )
         self.add_common_arguments(sodparser)
 
-        buildtimeparser = subparsers.add_parser(const.DEVICEBUILD,
+        buildtimeparser = subparsers.add_parser(const.BUILDTIME,
                                               description='measure build time from a binlog')
         buildtimeparser.add_argument('--binlog-path', help='Location of binlog', dest='binlogpath')
         self.add_common_arguments(buildtimeparser)
@@ -194,7 +194,7 @@ ex: C:\repos\performance;C:\repos\runtime
         if self.testtype == const.SOD:
             self.dirs = args.dirs
 
-        if self.testtype == const.DEVICEBUILD:
+        if self.testtype == const.BUILDTIME:
             self.binlogpath = args.binlogpath
         
         if self.testtype == const.DEVICESTARTUP:
@@ -967,9 +967,9 @@ ex: C:\repos\performance;C:\repos\runtime
                 raise Exception("Dirs was not passed in and neither %s nor %s exist" % (const.PUBDIR, const.BINDIR))
             sod.runtests(scenarioname=self.scenarioname, dirs=self.dirs or builtdir, upload_to_perflab_container=self.upload_to_perflab_container, artifact=self.traits.artifact)
 
-        elif self.testtype == const.DEVICEBUILD:
+        elif self.testtype == const.BUILDTIME:
             startup = StartupWrapper()
             if not (self.binlogpath):
                 raise Exception("Binlog path was not passed provided.")
-            self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.BUILD_TIME, tracename=self.binlogpath, scenarioname=self.scenarioname)
+            self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.BUILDTIME, tracename=self.binlogpath, scenarioname=self.scenarioname)
             startup.parsetraces(self.traits)

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -969,7 +969,7 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.BUILDTIME:
             startup = StartupWrapper()
-            if not (self.binlogpath):
-                raise Exception("Binlog path was not passed provided.")
+            if not (self.binlogpath and os.path.exists(self.binlogpath)):
+                raise Exception("For build time measurements a valid binlog path must be provided.")
             self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.BUILDTIME, tracename=self.binlogpath, scenarioname=self.scenarioname)
             startup.parsetraces(self.traits)

--- a/src/scenarios/shared/testtraits.py
+++ b/src/scenarios/shared/testtraits.py
@@ -8,7 +8,8 @@ testtypes = [const.STARTUP,
              const.CROSSGEN2,
              const.SOD,
              const.INNERLOOP,
-             const.DEVICESTARTUP]
+             const.DEVICESTARTUP,
+             const.DEVICEBUILD]
 
 class TestTraits:
 

--- a/src/scenarios/shared/testtraits.py
+++ b/src/scenarios/shared/testtraits.py
@@ -9,7 +9,7 @@ testtypes = [const.STARTUP,
              const.SOD,
              const.INNERLOOP,
              const.DEVICESTARTUP,
-             const.DEVICEBUILD]
+             const.BUILDTIME]
 
 class TestTraits:
 

--- a/src/tools/ScenarioMeasurement/Directory.Packages.props
+++ b/src/tools/ScenarioMeasurement/Directory.Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="coverlet.collector" Version="1.0.1" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.7" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="4.7.0" />
+    <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.386" />
   </ItemGroup>
 </Project>

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -25,6 +25,7 @@ enum MetricType
     WinUI,
     WinUIBlazor,
     TimeToMain2,
+    BuildTime,
 }
 
 public class InnerLoopMarkerEventSource : EventSource
@@ -288,6 +289,7 @@ public class Startup
             MetricType.WinUI => new WinUIParser(),
             MetricType.WinUIBlazor => new WinUIBlazorParser(),
             MetricType.TimeToMain2 => new TimeToMain2Parser(AddTestProcessEnvironmentVariable),
+            MetricType.BuildTime => new BuildTimeParser(),
             _ => throw new ArgumentOutOfRangeException(),
         };
 

--- a/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Logging.StructuredLogger;  // BinaryLog, FindChildrenRecursive<T>
+using StructuredLogViewer;                         // BuildAnalyzer
+using Microsoft.Diagnostics.Tracing;
+using Reporting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ScenarioMeasurement;
+
+/// <summary>
+///
+/// </summary>
+public class BuildTimeParser : IParser
+{
+    public void EnableKernelProvider(ITraceSession kernel)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void EnableUserProviders(ITraceSession user)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerable<Counter> Parse(string binlogFile, string processName, IList<int> pids, string commandLine)
+    {
+        var illinkTimes = new List<double>();
+        var monoaotcompilerTimes = new List<double>();
+        var appleappbuilderTimes = new List<double>();
+        var publishTimes = new List<double>();
+
+        if (File.Exists(binlogFile))
+        {
+            var build = BinaryLog.ReadBuild(binlogFile);
+            BuildAnalyzer.AnalyzeBuild(build);
+
+            foreach (var task in build.FindChildrenRecursive<Task>())
+            {
+                var name = task.Name;
+                var ms   = task.Duration.TotalMilliseconds;
+
+                if (name.Equals("ILLink", StringComparison.OrdinalIgnoreCase))
+                {
+                    illinkTimes.Add(ms);
+                }
+                else if (name.Equals("MonoAOTCompiler", StringComparison.OrdinalIgnoreCase))
+                {
+                    monoaotcompilerTimes.Add(ms);
+                }
+                else if (name.Equals("AppleAppBuilderTask", StringComparison.OrdinalIgnoreCase))
+                {
+                    appleappbuilderTimes.Add(ms);
+                }
+            }
+        }
+
+        yield return new Counter { Name = "ILLink Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
+        yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
+        yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
+    }
+}

--- a/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
@@ -2,20 +2,15 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Logging.StructuredLogger;  // BinaryLog, FindChildrenRecursive<T>
-using StructuredLogViewer;                         // BuildAnalyzer
+using Microsoft.Build.Logging.StructuredLogger;
+using StructuredLogViewer;
 using Microsoft.Diagnostics.Tracing;
 using Reporting;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace ScenarioMeasurement;
 
 /// <summary>
-///
+/// Parses the build time from a binary log file.
 /// </summary>
 public class BuildTimeParser : IParser
 {
@@ -44,7 +39,7 @@ public class BuildTimeParser : IParser
             foreach (var task in build.FindChildrenRecursive<Task>())
             {
                 var name = task.Name;
-                var ms   = task.Duration.TotalMilliseconds;
+                var ms = task.Duration.TotalMilliseconds;
 
                 if (name.Equals("ILLink", StringComparison.OrdinalIgnoreCase))
                 {
@@ -59,10 +54,18 @@ public class BuildTimeParser : IParser
                     appleappbuilderTimes.Add(ms);
                 }
             }
+
+            publishTimes.Add(build.Duration.TotalMilliseconds);
         }
 
-        yield return new Counter { Name = "ILLink Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
-        yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
-        yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
+
+        if (illinkTimes.Count > 0)
+            yield return new Counter { Name = "ILLink Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
+        if (monoaotcompilerTimes.Count > 0)
+            yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
+        if (appleappbuilderTimes.Count > 0)
+            yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
+        if (publishTimes.Count > 0)
+            yield return new Counter { Name = "Publish Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = publishTimes.ToArray() };
     }
 }

--- a/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
@@ -62,10 +62,10 @@ public class BuildTimeParser : IParser
         if (illinkTimes.Count > 0)
             yield return new Counter { Name = "ILLink Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
         if (monoaotcompilerTimes.Count > 0)
-            yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
+            yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
         if (appleappbuilderTimes.Count > 0)
             yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
         if (publishTimes.Count > 0)
-            yield return new Counter { Name = "Publish Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = publishTimes.ToArray() };
+            yield return new Counter { Name = "Publish Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = publishTimes.ToArray() };
     }
 }

--- a/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
@@ -29,6 +29,7 @@ public class BuildTimeParser : IParser
         var illinkTimes = new List<double>();
         var monoaotcompilerTimes = new List<double>();
         var appleappbuilderTimes = new List<double>();
+        var androidappbuilderTimes = new List<double>();
         var publishTimes = new List<double>();
 
         if (File.Exists(binlogFile))
@@ -53,6 +54,10 @@ public class BuildTimeParser : IParser
                 {
                     appleappbuilderTimes.Add(ms);
                 }
+                else if (name.Equals("AndroidAppBuilderTask", StringComparison.OrdinalIgnoreCase))
+                {
+                    androidappbuilderTimes.Add(ms);
+                }
             }
 
             publishTimes.Add(build.Duration.TotalMilliseconds);
@@ -65,6 +70,8 @@ public class BuildTimeParser : IParser
             yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
         if (appleappbuilderTimes.Count > 0)
             yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
+        if (androidappbuilderTimes.Count > 0)
+            yield return new Counter { Name = "AndroidAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = androidappbuilderTimes.ToArray() };
         if (publishTimes.Count > 0)
             yield return new Counter { Name = "Publish Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = publishTimes.ToArray() };
     }

--- a/src/tools/ScenarioMeasurement/Util/Util.csproj
+++ b/src/tools/ScenarioMeasurement/Util/Util.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
     <PackageReference Include="System.Security.Principal.Windows" />
+    <PackageReference Include="MSBuild.StructuredLogger" VersionOverride="2.2.386" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/ScenarioMeasurement/Util/Util.csproj
+++ b/src/tools/ScenarioMeasurement/Util/Util.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
     <PackageReference Include="System.Security.Principal.Windows" />
-    <PackageReference Include="MSBuild.StructuredLogger" VersionOverride="2.2.386" />
+    <PackageReference Include="MSBuild.StructuredLogger" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

This PR adds support for measuring total build time in the `Startup` tool using binlog files.

## Changes

 - Add `DownloadBuildArtifacts` task to retrieve binlog files from the build machines
 - Update `run_performance_job.py` to copy binlog files into the helix payload directory
 - Update `Startup` tool to invoke `BuildTimeParser`
 - Implement BuildTimeParser to retrieve overall publish duration, plus `ILLink` and Mono-specific task times

## Validation

Run the internal dotnet-runtime-perf tool to verify that `BuildTimeParser` collects build times.

## Out-of-scope

These measurements are collected from the build machines. With lack of any build time measurements atm, we want to standup these now and iterate later if needed. As suggested in https://github.com/dotnet/runtime/issues/113073, apps build may be moved to Helix in the future.

Contributes to https://github.com/dotnet/runtime/issues/113073