### PR TITLE
Update binlog path check for build time measurements

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -969,7 +969,7 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.BUILDTIME:
             startup = StartupWrapper()
-            if not (self.binlogpath and os.path.exists(self.binlogpath)):
+            if not (self.binlogpath and os.path.exists(os.path.join(const.TRACEDIR, self.binlogpath))):
                 raise Exception("For build time measurements a valid binlog path must be provided.")
             self.traits.add_traits(overwrite=True, apptorun="app", startupmetric=const.BUILDTIME, tracename=self.binlogpath, scenarioname=self.scenarioname)
             startup.parsetraces(self.traits)

--- a/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
+++ b/src/tools/ScenarioMeasurement/Util/Parsers/BuildTimeParser.cs
@@ -40,39 +40,39 @@ public class BuildTimeParser : IParser
             foreach (var task in build.FindChildrenRecursive<Task>())
             {
                 var name = task.Name;
-                var ms = task.Duration.TotalMilliseconds;
+                var s = task.Duration.TotalMilliseconds / 1000.0;
 
                 if (name.Equals("ILLink", StringComparison.OrdinalIgnoreCase))
                 {
-                    illinkTimes.Add(ms);
+                    illinkTimes.Add(s);
                 }
                 else if (name.Equals("MonoAOTCompiler", StringComparison.OrdinalIgnoreCase))
                 {
-                    monoaotcompilerTimes.Add(ms);
+                    monoaotcompilerTimes.Add(s);
                 }
                 else if (name.Equals("AppleAppBuilderTask", StringComparison.OrdinalIgnoreCase))
                 {
-                    appleappbuilderTimes.Add(ms);
+                    appleappbuilderTimes.Add(s);
                 }
                 else if (name.Equals("AndroidAppBuilderTask", StringComparison.OrdinalIgnoreCase))
                 {
-                    androidappbuilderTimes.Add(ms);
+                    androidappbuilderTimes.Add(s);
                 }
             }
 
-            publishTimes.Add(build.Duration.TotalMilliseconds);
+            publishTimes.Add(build.Duration.TotalMilliseconds / 1000.0);
         }
 
 
         if (illinkTimes.Count > 0)
-            yield return new Counter { Name = "ILLink Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
+            yield return new Counter { Name = "ILLink Time", MetricName = "s", DefaultCounter = false, TopCounter = true, Results = illinkTimes.ToArray() };
         if (monoaotcompilerTimes.Count > 0)
-            yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
+            yield return new Counter { Name = "MonoAOTCompiler Time", MetricName = "s", DefaultCounter = false, TopCounter = true, Results = monoaotcompilerTimes.ToArray() };
         if (appleappbuilderTimes.Count > 0)
-            yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
+            yield return new Counter { Name = "AppleAppBuilderTask Time", MetricName = "s", DefaultCounter = false, TopCounter = true, Results = appleappbuilderTimes.ToArray() };
         if (androidappbuilderTimes.Count > 0)
-            yield return new Counter { Name = "AndroidAppBuilderTask Time", MetricName = "ms", DefaultCounter = false, TopCounter = true, Results = androidappbuilderTimes.ToArray() };
+            yield return new Counter { Name = "AndroidAppBuilderTask Time", MetricName = "s", DefaultCounter = false, TopCounter = true, Results = androidappbuilderTimes.ToArray() };
         if (publishTimes.Count > 0)
-            yield return new Counter { Name = "Publish Time", MetricName = "ms", DefaultCounter = true, TopCounter = true, Results = publishTimes.ToArray() };
+            yield return new Counter { Name = "Publish Time", MetricName = "s", DefaultCounter = true, TopCounter = true, Results = publishTimes.ToArray() };
     }
 }


### PR DESCRIPTION
## Description

This PR updates the condition in shared/runner.py to check the correct path for the binlog. 
```
  File "D:\h\w\B99E09B5\p\shared\runner.py", line 973, in run
    raise Exception("For build time measurements a valid binlog path must be provided.")
```
It also sets seconds as the default level of granularity for build time metrics in BuildTimeParser.cs.

## Validation

Validated using the internal dotnet-runtime-perf pipeline.