### PR TITLE
Update perf pipelines to use 1ES templates for pipelines.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,11 @@ resources:
   containers:
     - container: ubuntu_x64_build_container
       image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
 trigger:
   branches:
@@ -54,42 +59,47 @@ schedules:
     - main
   always: true
 
-jobs:
-  - template: /eng/pipelines/sdk-perf-jobs.yml
-    parameters:
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
-        runPublicJobs: true
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        ${{ if or(notin(variables['Build.Reason'], 'PullRequest', 'Manual'), parameters.runPrivateJobs) }}:
-          runPrivateJobs: true
-        ${{ if or(eq(variables['Build.CronSchedule.DisplayName'], 'Every 12 hours build'), parameters.runScheduledPrivateJobs) }}:
-          runScheduledPrivateJobs: true
-      jobParameters:
-        ${{ if parameters.onlySanityCheck }}:
-          onlySanityCheck: true
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    stages:
+    - stage: Run
+      jobs:
+        - template: /eng/pipelines/sdk-perf-jobs.yml
+          parameters:
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), parameters.runPublicJobs) }}:
+              runPublicJobs: true
+            ${{ if ne(variables['System.TeamProject'], 'public') }}:
+              ${{ if or(notin(variables['Build.Reason'], 'PullRequest', 'Manual'), parameters.runPrivateJobs) }}:
+                runPrivateJobs: true
+              ${{ if or(eq(variables['Build.CronSchedule.DisplayName'], 'Every 12 hours build'), parameters.runScheduledPrivateJobs) }}:
+                runScheduledPrivateJobs: true
+            jobParameters:
+              ${{ if parameters.onlySanityCheck }}:
+                onlySanityCheck: true
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule', 'Manual')) }}:
-    # Secret Sync
-    - job: Synchronize
-      pool:
-        name: NetCore1ESPool-Internal-NoMSI
-        demands: ImageOverride -equals 1es-windows-2019
-      steps:
-      - task: UseDotNet@2
-        displayName: Install .NET 6.0 
-        inputs:
-          version: 6.x
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule', 'Manual')) }}:
+          # Secret Sync
+          - job: Synchronize
+            pool:
+              name: NetCore1ESPool-Internal-NoMSI
+              demands: ImageOverride -equals 1es-windows-2019
+            steps:
+            - task: UseDotNet@2
+              displayName: Install .NET 6.0 
+              inputs:
+                version: 6.x
 
-      - task: DeleteFiles@1
-        inputs:
-          Contents: global.json
+            - task: DeleteFiles@1
+              inputs:
+                Contents: global.json
 
-      - script: dotnet tool restore
+            - script: dotnet tool restore
 
-      - task: AzureCLI@2
-        inputs:
-          azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
-          scriptType: ps
-          scriptLocation: inlineScript
-          inlineScript: |
-            Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}
+            - task: AzureCLI@2
+              inputs:
+                azureSubscription: .NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)
+                scriptType: ps
+                scriptLocation: inlineScript
+                inlineScript: |
+                  Get-ChildItem .vault-config/*.yaml |% { dotnet secret-manager synchronize $_}

--- a/eng/pipelines/register-build-jobs.yml
+++ b/eng/pipelines/register-build-jobs.yml
@@ -4,9 +4,14 @@ parameters:
   buildType: []
   mauiFramework: ''
 
-jobs:
-- ${{ each type in parameters.buildType }}:
-  - template: /eng/pipelines/templates/register-build-job.yml@${{ parameters.performanceRepoAlias }}
-    parameters:
-      buildType: ${{ type }}
-      buildId: $(Build.BuildId)
+extends:
+  template: /eng/pipelines/common/templates/pipeline-with-resources.yml@${{ parameters.runtimeRepoAlias }}
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+      - ${{ each type in parameters.buildType }}:
+        - template: /eng/pipelines/templates/register-build-job.yml@${{ parameters.performanceRepoAlias }}
+          parameters:
+            buildType: ${{ type }}
+            buildId: $(Build.BuildId)

--- a/eng/pipelines/runtime-wasm-perf-jobs.yml
+++ b/eng/pipelines/runtime-wasm-perf-jobs.yml
@@ -6,246 +6,252 @@ parameters:
   performanceRepoAlias: self
   jobParameters: {}
 
-jobs:
-- ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
-  # build mono on wasm - if not using an existing build
-  - template: /eng/pipelines/performance/templates/perf-wasm-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
 
-- ${{ if eq(parameters.runProfile, 'non-v8') }}:
-  #run mono wasm microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: Release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        runKind: micro
-        logicalMachine: 'perftiger'
-        javascriptEngine: 'javascriptcore'
-        additionalJobIdentifier: javascriptcore
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+extends:
+  template: /eng/pipelines/common/templates/pipeline-with-resources.yml@${{ parameters.runtimeRepoAlias }}
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+      - ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
+        # build mono on wasm - if not using an existing build
+        - template: /eng/pipelines/performance/templates/perf-wasm-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: Release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        runkind: micro
-        logicalMachine: 'perftiger'
-        javascriptengine: 'javascriptcore'
-        additionalJobIdentifier: javascriptcore
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+      - ${{ if eq(parameters.runProfile, 'non-v8') }}:
+        #run mono wasm microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+            buildConfig: Release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              codeGenType: 'wasm'
+              runKind: micro
+              logicalMachine: 'perftiger'
+              javascriptEngine: 'javascriptcore'
+              additionalJobIdentifier: javascriptcore
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
+
+        #run mono wasm aot microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+            buildconfig: Release
+            runtimeflavor: wasm
+            platforms:
+            - linux_x64
+            jobparameters:
+              livelibrariesbuildconfig: Release
+              runtimetype: wasm
+              codegentype: 'aot'
+              runkind: micro
+              logicalMachine: 'perftiger'
+              javascriptengine: 'javascriptcore'
+              additionalJobIdentifier: javascriptcore
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
 
-  ### PerfViper copy of the above jobs ###
-  #run mono wasm microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: Release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        runKind: micro
-        logicalMachine: 'perfviper'
-        javascriptEngine: 'javascriptcore'
-        additionalJobIdentifier: javascriptcore
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        ### PerfViper copy of the above jobs ###
+        #run mono wasm microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+            buildConfig: Release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              codeGenType: 'wasm'
+              runKind: micro
+              logicalMachine: 'perfviper'
+              javascriptEngine: 'javascriptcore'
+              additionalJobIdentifier: javascriptcore
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: Release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        runkind: micro
-        logicalMachine: 'perfviper'
-        javascriptengine: 'javascriptcore'
-        additionalJobIdentifier: javascriptcore
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        #run mono wasm aot microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+            buildconfig: Release
+            runtimeflavor: wasm
+            platforms:
+            - linux_x64
+            jobparameters:
+              livelibrariesbuildconfig: Release
+              runtimetype: wasm
+              codegentype: 'aot'
+              runkind: micro
+              logicalMachine: 'perfviper'
+              javascriptengine: 'javascriptcore'
+              additionalJobIdentifier: javascriptcore
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-- ${{ if eq(parameters.runProfile, 'v8') }}:
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        runKind: micro
-        logicalMachine: 'perftiger'
-        javascriptEngine: 'v8'
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnet-versions 8.0.0'
-        additionalJobIdentifier: v8
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+      - ${{ if eq(parameters.runProfile, 'v8') }}:
+        # run mono wasm interpreter (default) microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              codeGenType: 'wasm'
+              runKind: micro
+              logicalMachine: 'perftiger'
+              javascriptEngine: 'v8'
+              # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+              #additionalSetupParameters: '--dotnet-versions 8.0.0'
+              additionalJobIdentifier: v8
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-  #run mono wasm aot microbenchmarks perf job
-  # Disabled for runtime-wasm-perf on PRs due to https://github.com/dotnet/runtime/issues/95101
-  - ${{if not(in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-        buildconfig: release
-        runtimeflavor: wasm
-        platforms:
-        - linux_x64
-        jobparameters:
-          livelibrariesbuildconfig: Release
-          runtimetype: wasm
-          codegentype: 'aot'
-          runkind: micro
-          logicalMachine: 'perftiger'
-          javascriptEngine: 'v8'
-          # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-          #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
-          additionalJobIdentifier: v8
-          downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+        #run mono wasm aot microbenchmarks perf job
+        # Disabled for runtime-wasm-perf on PRs due to https://github.com/dotnet/runtime/issues/95101
+        - ${{if not(in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
+          - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+            parameters:
+              jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+              buildconfig: release
+              runtimeflavor: wasm
+              platforms:
+              - linux_x64
+              jobparameters:
+                livelibrariesbuildconfig: Release
+                runtimetype: wasm
+                codegentype: 'aot'
+                runkind: micro
+                logicalMachine: 'perftiger'
+                javascriptEngine: 'v8'
+                # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+                #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
+                additionalJobIdentifier: v8
+                downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+                runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+                performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+                ${{ each parameter in parameters.jobParameters }}:
+                  ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
-        runKind: blazor_scenarios
-        isScenario: true
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
-        logicalMachine: 'perftiger'
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        # run mono wasm blazor perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
+              runKind: blazor_scenarios
+              isScenario: true
+              # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+              #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
+              logicalMachine: 'perftiger'
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-  ### PerfViper copy of the above jobs ###
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        runKind: micro
-        logicalMachine: 'perfviper'
-        javascriptEngine: 'v8'
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnet-versions 8.0.0'
-        additionalJobIdentifier: v8
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        ### PerfViper copy of the above jobs ###
+        # run mono wasm interpreter (default) microbenchmarks perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              codeGenType: 'wasm'
+              runKind: micro
+              logicalMachine: 'perfviper'
+              javascriptEngine: 'v8'
+              # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+              #additionalSetupParameters: '--dotnet-versions 8.0.0'
+              additionalJobIdentifier: v8
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-  #run mono wasm aot microbenchmarks perf job
-  # Disabled for runtime-wasm-perf on PRs due to https://github.com/dotnet/runtime/issues/95101
-  - ${{if not(in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-        buildconfig: release
-        runtimeflavor: wasm
-        platforms:
-        - linux_x64
-        jobparameters:
-          livelibrariesbuildconfig: Release
-          runtimetype: wasm
-          codegentype: 'aot'
-          runkind: micro
-          logicalMachine: 'perfviper'
-          javascriptEngine: 'v8'
-          # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-          #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
-          additionalJobIdentifier: v8
-          downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+        #run mono wasm aot microbenchmarks perf job
+        # Disabled for runtime-wasm-perf on PRs due to https://github.com/dotnet/runtime/issues/95101
+        - ${{if not(in(variables['Build.DefinitionName'], 'runtime-wasm-perf')) }}:
+          - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+            parameters:
+              jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }} # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+              buildconfig: release
+              runtimeflavor: wasm
+              platforms:
+              - linux_x64
+              jobparameters:
+                livelibrariesbuildconfig: Release
+                runtimetype: wasm
+                codegentype: 'aot'
+                runkind: micro
+                logicalMachine: 'perfviper'
+                javascriptEngine: 'v8'
+                # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+                #additionalSetupParameters: '--dotnet-versions 8.0.0' # passed to ci_setup.py
+                additionalJobIdentifier: v8
+                downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+                runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+                performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+                ${{ each parameter in parameters.jobParameters }}:
+                  ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
-        runKind: blazor_scenarios
-        isScenario: true
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
-        logicalMachine: 'perfviper'
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        # run mono wasm blazor perf job
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: wasm
+            platforms:
+            - linux_x64
+            jobParameters:
+              liveLibrariesBuildConfig: Release
+              runtimeType: wasm
+              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
+              runKind: blazor_scenarios
+              isScenario: true
+              # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+              #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
+              logicalMachine: 'perfviper'
+              downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -4,20 +4,27 @@ parameters:
   jobTemplate: ''
   jobParameters: {}
 
+variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
+
 jobs:
 - ${{ if containsValue(parameters.buildMachines, 'win-x64') }}:
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osGroup: windows
       archType: x64
-      pool:
-        vmImage: windows-2019
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
+        pool: # Pool information set based off xplat-setup.yml in runtime repo
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         osVersion: 22H2
         machinePool: Open
         queue: Windows.10.Amd64.Client.Open
       ${{ else }}:
+        pool:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64
         osVersion: Win11
         machinePool: Tiger
         queue: Windows.11.Amd64.Tiger.Perf
@@ -29,7 +36,8 @@ jobs:
       osVersion: RS5
       archType: x64
       pool:
-        vmImage: windows-2019
+        name: $(DncEngPublicBuildPool)
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       machinePool: Open
       queue: Windows.10.Amd64.ClientRS5.Open
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -39,14 +47,18 @@ jobs:
     parameters:
       osGroup: windows
       archType: x86
-      pool:
-        vmImage: windows-2019
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
+        pool:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64.open
         osVersion: 22H2
         machinePool: Open
         queue: Windows.10.Amd64.Client.Open
       ${{ else }}:
+        pool:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals windows.vs2022.amd64
         osVersion: Win11
         machinePool: Tiger
         queue: Windows.11.Amd64.Tiger.Perf
@@ -57,14 +69,18 @@ jobs:
       osGroup: ubuntu
       osVersion: 2204
       archType: x64
-      pool: 
-        vmImage: ubuntu-latest
       container: ubuntu_x64_build_container
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
+        pool:
+          name: $(DncEngPublicBuildPool)
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
         machinePool: Open
         queue: Ubuntu.2204.Amd64.Open
       ${{ else }}:
+        pool:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals 1es-ubuntu-2204
         machinePool: Tiger
         queue: Ubuntu.2204.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
 
@@ -75,7 +91,8 @@ jobs:
       osVersion: 20H1
       archType: arm64
       pool:
-        vmImage: windows-2019
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals windows.vs2022.amd64
       machinePool: Tiger
       queue: Windows.11.Arm64.Surf.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -87,7 +104,8 @@ jobs:
       osVersion: 22H2
       archType: arm64
       pool:
-        vmImage: windows-2019
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals windows.vs2022.amd64
       machinePool: Ampere
       queue: Windows.Server.Arm64.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -99,7 +117,8 @@ jobs:
       osVersion: 2204
       archType: arm64
       pool:
-        vmImage: ubuntu-latest
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals 1es-ubuntu-2204
       container: ubuntu_x64_build_container
       machinePool: Ampere
       queue: Ubuntu.2204.Arm64.Perf
@@ -112,7 +131,8 @@ jobs:
       archType: x64
       osVersion: 22H2
       pool:
-        vmImage: 'windows-2022'
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       queue: Windows.11.Amd64.Pixel.Perf
       machinePool: Pixel
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -124,7 +144,8 @@ jobs:
       archType: x64
       osVersion: 22H2
       pool:
-        vmImage: 'windows-2022'
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       queue: Windows.11.Amd64.Galaxy.Perf
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -136,6 +157,7 @@ jobs:
       archType: x64
       osVersion: 15
       pool:
+        name: Azure Pipelines
         vmImage: 'macos-15'
       queue: OSX.13.Amd64.Iphone.Perf
       machinePool: iPhoneMini12


### PR DESCRIPTION
Updated pipelines for dotnet-runtime-perf-build, runtime-wasm-perf, and dotnet-performance/performance-ci pipelines to use 1ES templates based on the tool auto-converted yaml and runtime repo setup.


