### PR TITLE
Remove Upload SAS token references and code flow.

### DIFF
--- a/eng/pipelines/templates/run-performance-job-script-step.yml
+++ b/eng/pipelines/templates/run-performance-job-script-step.yml
@@ -6,6 +6,4 @@ steps:
   - script: $(Python) ${{ parameters.performanceRepoDir }}/scripts/run_performance_job.py ${{ join(' ', parameters.runPerformanceJobArgs) }}
     displayName: Run performance job script
     env:
-      PerfCommandUploadToken: '$(PerfCommandUploadToken)'
-      PerfCommandUploadTokenLinux: '$(PerfCommandUploadTokenLinux)'
       HelixAccessToken: '$(HelixApiAccessToken)'

--- a/helix.yml
+++ b/helix.yml
@@ -33,7 +33,7 @@ jobs:
     dockerImageName: helix_sender
     dockerCommand: python ./performance/scripts/run_performance_job.py --queue {{ queue }} --framework {{ framework }} --run-kind {{ kind }} --core-root-dir /performance/coreRoot --performance-repo-dir /performance/performance --architecture {{ architecture }} --os-group {{ osGroup }} --os-sub-group {{ osSubGroup }} {% if internal %}--internal{% endif %} --run-categories "{{ runCategories }}" {% if bdnArgs != blank and bdnArgs != empty %} --extra-bdn-args "{{ bdnArgs }}" {% endif %} --partition-count {{ partitionCount }} --project-file {{ projectFile }} {% if isScenario %} --is-scenario {% endif %} {% if isLocalBuild %} --local-build {% endif %}
     dockerContextDirectory: .
-    arguments: '--env HelixAccessToken --env SYSTEM_ACCESSTOKEN --env PerfCommandUploadToken --env PerfCommandUploadTokenLinux'
+    arguments: '--env HelixAccessToken --env SYSTEM_ACCESSTOKEN'
     environmentVariables:
       BUILD_BUILDNUMBER: '{{ buildNumber }}'
       BUILD_SOURCEVERSION: '{{ buildSourceVersion }}'

--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -33,7 +33,7 @@ from typing import Any, List, Optional
 from performance.common import get_repo_root_path, validate_supported_runtime, get_artifacts_directory, helixuploadroot
 from performance.logger import setup_loggers
 from performance.tracer import setup_tracing, enable_trace_console_exporter, get_tracer
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from channel_map import ChannelMap
 from subprocess import CalledProcessError
 from glob import glob
@@ -382,7 +382,7 @@ def main(argv: List[str]):
         if args.upload_to_perflab_container:
             reports_globpath = os.path.join(artifacts_dir, '**', '*perf-lab-report.json')
             import upload
-            upload_code = upload.upload(reports_globpath, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+            upload_code = upload.upload(reports_globpath, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
             getLogger().info("Benchmarks Upload Code: " + str(upload_code))
             if upload_code != 0:
                 sys.exit(upload_code)

--- a/scripts/performance/constants.py
+++ b/scripts/performance/constants.py
@@ -1,7 +1,6 @@
 'Constant strings for scripts in the repo'
 
 UPLOAD_CONTAINER = 'results'
-UPLOAD_TOKEN_VAR = 'PERFLAB_UPLOAD_TOKEN'
 UPLOAD_STORAGE_URI = 'https://pvscmdupload.{}.core.windows.net'
 UPLOAD_QUEUE = 'resultsqueue'
 TENANT_ID = '72f988bf-86f1-41af-91ab-2d7cd011db47'

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -27,7 +27,7 @@ def get_unique_name(filename: str, unique_id: str) -> str:
         newname = "{0}-perf-lab-report.json".format(randint(1000, 9999))
     return newname
 
-def upload(globpath: str, container: str, queue: str, sas_token_env: str, storage_account_uri: str):
+def upload(globpath: str, container: str, queue: str, storage_account_uri: str):
     try:
         credential = None
         try:
@@ -50,9 +50,7 @@ def upload(globpath: str, container: str, queue: str, sas_token_env: str, storag
             except Exception as ex:
                 credential = None
         if credential is None:
-            getLogger().error("Unable to authenticate with managed identity or certificates.")
-            getLogger().info("Falling back to environment variable.")
-            credential = os.getenv(sas_token_env)
+            raise RuntimeError("Authentication failed with managed identity and certificates. No valid authentication method available.")
 
         files = glob(globpath, recursive=True)
         any_upload_or_queue_failed = False

--- a/src/scenarios/shared/androidinstrumentation.py
+++ b/src/scenarios/shared/androidinstrumentation.py
@@ -7,7 +7,7 @@ import json
 from logging import getLogger
 from shutil import copytree
 from performance.common import runninginlab, RunCommand
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from shared.util import helixuploaddir, xharnesscommand, xharness_adb
 from shared.const import *
 from subprocess import CalledProcessError
@@ -139,7 +139,7 @@ class AndroidInstrumentationHelper(object):
                     TRACEDIR,
                     '**',
                     '*perf-lab-report.json')
-                upload_code = upload.upload(globpath, UPLOAD_CONTAINER, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(globpath, UPLOAD_CONTAINER, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
                 getLogger().info("Device Benchmarks Upload Code: " + str(upload_code))
                 if upload_code != 0:
                     sys.exit(upload_code)

--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -10,7 +10,7 @@ from logging import getLogger
 from shutil import copytree
 import time
 from performance.common import extension, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
 from shared import const
 from shared.androidhelper import AndroidHelper
@@ -93,7 +93,7 @@ class DevicePowerConsumptionHelper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
 
     def runtestsandroid(self, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
         getLogger().info("Clearing potential previous run nettraces")

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -6,7 +6,7 @@ import os
 from logging import getLogger
 from shutil import copytree
 from performance.common import extension, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
 from shared.util import helixworkitempayload, helixuploaddir, getruntimeidentifier
 from shared.const import *
@@ -86,7 +86,7 @@ class MemoryConsumptionWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
 
     def runtests(self, traits: TestTraits):
         '''
@@ -159,7 +159,7 @@ class MemoryConsumptionWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
                 getLogger().info("memoryconsumption Upload Code: " + str(upload_code))
                 if upload_code != 0:
                     sys.exit(upload_code)

--- a/src/scenarios/shared/sod.py
+++ b/src/scenarios/shared/sod.py
@@ -8,7 +8,7 @@ import json
 from shutil import copytree, copy
 from typing import Optional
 from performance.common import helixpayload, extension, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
 from shared.util import helixworkitempayload, helixuploaddir, getruntimeidentifier
 from shared.const import *
@@ -97,7 +97,7 @@ class SODWrapper(object):
                 
             if upload_to_perflab_container:
                 import upload
-                upload_code = upload.upload(reportjson, UPLOAD_CONTAINER, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(reportjson, UPLOAD_CONTAINER, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
                 getLogger().info("SoD Upload Code: " + str(upload_code))
                 if upload_code != 0:
                     sys.exit(upload_code)

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -6,7 +6,7 @@ import os
 from logging import getLogger
 from shutil import copytree
 from performance.common import extension, helixpayload, runninginlab, get_artifacts_directory, get_packages_directory, RunCommand
-from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_TOKEN_VAR, UPLOAD_QUEUE
+from performance.constants import UPLOAD_CONTAINER, UPLOAD_STORAGE_URI, UPLOAD_QUEUE
 from dotnet import CSharpProject, CSharpProjFile
 from shared.util import helixworkitempayload, helixuploaddir, getruntimeidentifier
 from shared.const import *
@@ -88,7 +88,7 @@ class StartupWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
 
     def runtests(self, traits: TestTraits):
         '''
@@ -163,7 +163,7 @@ class StartupWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_TOKEN_VAR, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
                 getLogger().info("Startup Upload Code: " + str(upload_code))
                 if upload_code != 0:
                     sys.exit(upload_code)

--- a/src/scenarios/shared/util.py
+++ b/src/scenarios/shared/util.py
@@ -7,7 +7,6 @@ import platform
 from os import environ, path
 from shared import const
 from performance.common import iswin, extension
-from performance.constants import UPLOAD_TOKEN_VAR
 
 def helixworkitempayload():
     '''


### PR DESCRIPTION
Remove all references to the perflab upload token, including secret names and const references for it. This does not include updates for secret munger/sychronization runs as they will be covered in a follow-up PR removing multiple secret references. Also made some minor code flow updates to match with this token being removed.

Internal run to test upload (only one failure that was unrelated/noise): https://dev.azure.com/dnceng/internal/_build/results?buildId=2731528&view=results

