### PR TITLE
Update windows open queue to windows11 and VMimage to windows 2025

### DIFF
--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -11,7 +11,7 @@ jobs:
       osGroup: windows
       archType: x64
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
         osVersion: 24H2
@@ -29,7 +29,7 @@ jobs:
       osVersion: RS5
       archType: x64
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       machinePool: Open
       queue: Windows.10.Amd64.ClientRS5.Open
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -40,7 +40,7 @@ jobs:
       osGroup: windows
       archType: x86
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
         osVersion: 24H2
@@ -75,7 +75,7 @@ jobs:
       osVersion: 20H1
       archType: arm64
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       machinePool: Tiger
       queue: Windows.11.Arm64.Surf.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -87,7 +87,7 @@ jobs:
       osVersion: 22H2
       archType: arm64
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       machinePool: Ampere
       queue: Windows.Server.Arm64.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -14,9 +14,9 @@ jobs:
         vmImage: windows-2019
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
-        osVersion: 22H2
+        osVersion: 24H2
         machinePool: Open
-        queue: Windows.10.Amd64.Client.Open
+        queue: Windows.11.Amd64.Client.Open
       ${{ else }}:
         osVersion: Win11
         machinePool: Tiger
@@ -43,9 +43,9 @@ jobs:
         vmImage: windows-2019
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
-        osVersion: 22H2
+        osVersion: 24H2
         machinePool: Open
-        queue: Windows.10.Amd64.Client.Open
+        queue: Windows.11.Amd64.Client.Open
       ${{ else }}:
         osVersion: Win11
         machinePool: Tiger


### PR DESCRIPTION
Update windows open queue to windows11 and VMimage to windows 2025.

Internal (successful) test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2731529&view=results