### PR TITLE
[maui, android] explicitly set R2R properties

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -17,8 +17,10 @@
 
     <!-- Mono AOT -->
     <_MSBuildArgs Condition="'$(CodegenType)' == 'AOT'">$(_MSBuildArgs);/p:RunAOTCompilation=true;/p:AndroidEnableProfiledAot=false</_MSBuildArgs>
+    <!-- CoreCLR JIT -->
+    <_MSBuildArgs Condition="'$(CodegenType)' == 'JIT'">$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
     <!-- CoreCLR R2R -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'R2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(CodegenType)' == 'R2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
     <!-- CoreCLR R2R composite -->
     <_MSBuildArgs Condition="'$(CodegenType)' == 'R2RComposite'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=true</_MSBuildArgs>
     <!-- CoreCLR NativeAOT -->


### PR DESCRIPTION
We are shortly going to change the defaults for CoreCLR, where `Release` mode will use by default:

    -p:PublishReadyToRun=true -p:PublishReadyToRunComposite=true

...when `$(PublishReadyToRun)` or `$(PublishReadyToRunComposite)` are not set.

Let's explicitly set the MSBuild properties, so the existing graphs will not change in behavior.

