### PR TITLE
Add performance internal runs for Viper machine queues.

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -351,6 +351,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -370,6 +372,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64
+        - win-x64-viper
         - win-arm64
         - win-arm64-ampere
       isPublic: false
@@ -547,6 +550,8 @@ jobs:
         buildMachines:
           - win-x64
           - ubuntu-x64
+          - win-x64-viper
+          - ubuntu-x64-viper
           - win-arm64
           - ubuntu-arm64-ampere
         isPublic: false
@@ -567,6 +572,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
       isPublic: false
       jobParameters:
@@ -592,7 +599,9 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64
+        - win-x64-viper
         - win-x86
+        - win-x86-viper
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: false
       jobParameters:
@@ -611,6 +620,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64
+        - win-x64-viper
       isPublic: false
       jobParameters:
         runKind: blazor_scenarios
@@ -630,6 +640,8 @@ jobs:
         buildMachines:
           - win-x64
           - ubuntu-x64
+          - win-x64-viper
+          - ubuntu-x64-viper
           - win-arm64
           - ubuntu-arm64-ampere
         isPublic: false
@@ -650,6 +662,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -671,6 +685,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -692,6 +708,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -713,6 +731,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64-ampere
       isPublic: false
@@ -733,6 +753,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - win-arm64-ampere
         - ubuntu-arm64-ampere
@@ -760,6 +782,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - win-arm64-ampere
         - ubuntu-arm64-ampere
@@ -789,6 +813,8 @@ jobs:
         buildMachines:
           - win-x64
           - ubuntu-x64
+          - win-x64-viper
+          - ubuntu-x64-viper
           # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
         isPublic: false
         jobParameters:
@@ -807,6 +833,8 @@ jobs:
       buildMachines:
         - win-x64
         - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
         - win-arm64
         - ubuntu-arm64
       isPublic: false

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -66,7 +66,7 @@ jobs:
         queue: Ubuntu.2204.Amd64.Open
       ${{ else }}:
         machinePool: Tiger
-        queue: Ubuntu.2204.Amd64.Tiger.Perf # using a dedicated private Helix queue (perftigers)
+        queue: Ubuntu.2204.Amd64.Tiger.Perf
 
 - ${{ if and(containsValue(parameters.buildMachines, 'win-arm64'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
@@ -139,4 +139,41 @@ jobs:
         vmImage: 'macos-15'
       queue: OSX.13.Amd64.Iphone.Perf
       machinePool: iPhoneMini12
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if and(containsValue(parameters.buildMachines, 'win-x64-viper'), not(eq(parameters.isPublic, true))) }}: # Windows x64 Viper only used in private builds
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: windows
+      osVersion: Win11
+      archType: x64
+      pool:
+        vmImage: windows-2019
+      machinePool: Viper
+      queue: windows.11.amd64.viper.perf
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if and(containsValue(parameters.buildMachines, 'win-x86-viper'), not(eq(parameters.isPublic, true))) }}: # Windows x86 Viper only used in private builds
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: windows
+      osVersion: Win11
+      archType: x86
+      pool:
+        vmImage: windows-2019
+      machinePool: Viper
+      queue: windows.11.amd64.viper.perf
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if and(containsValue(parameters.buildMachines, 'ubuntu-x64-viper'), not(eq(parameters.isPublic, true))) }}: # Ubuntu x64 Viper only used in private builds
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: ubuntu
+      osVersion: 2204
+      archType: x64
+      pool: 
+        vmImage: ubuntu-latest
+      container: ubuntu_x64_build_container
+      machinePool: Viper
+      queue: ubuntu.2204.amd64.viper.perf
       ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Add performance internal runs for Viper machine queues. This ensures we will have some data overlap between the two queue types. This only sets up the Viper queues to be able to run internally. 

Successful internal test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2737540&view=results
