### PR TITLE
Update Viper machines to use windows-2025 vm image

### DIFF
--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -136,7 +136,7 @@ jobs:
       osVersion: Win11
       archType: x64
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       machinePool: Viper
       queue: windows.11.amd64.viper.perf
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -148,7 +148,7 @@ jobs:
       osVersion: Win11
       archType: x86
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2025
       machinePool: Viper
       queue: windows.11.amd64.viper.perf
       ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Update viper machines to use windows-2025 vm image for pre-test steps rather than the depreciating windows 2019. This matches what the other windows machines have been using, the viper PR and windows update pr just missed each other slightly.

Internal test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2747539&view=results

