### PR TITLE
run WasmRunWasmOpt

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.props
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.props
@@ -4,6 +4,6 @@
     <WasmMainJSPath>$(WasmDataDir)\test-main.js</WasmMainJSPath>
     <TrimMode>partial</TrimMode>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
-    <WasmNativeStrip>false</WasmNativeStrip>
+    <WasmBuildNative>true</WasmBuildNative>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- don't disable `WasmRunWasmOpt` via `WasmNativeStrip`
    - I don't think we need native symbols in the perf repo
    - related https://github.com/dotnet/performance/pull/3288
- make sure that re-link is triggered via `WasmBuildNative`

Fixes https://github.com/dotnet/perf-autofiling-issues/issues/55886