### PR TITLE
Use hash of the test name to determine what partition it is run in

### DIFF
--- a/scripts/benchmarks_ci.py
+++ b/scripts/benchmarks_ci.py
@@ -360,7 +360,10 @@ def main(argv: List[str]):
                     all_reports: List[Any] = []
                     for file in glob(reports_globpath, recursive=True):
                         with open(file, 'r', encoding="utf8") as report_file:
-                            all_reports.append(json.load(report_file))
+                            try:
+                                all_reports.append(json.load(report_file))
+                            except Exception as e:
+                                getLogger().warning(f"Failed to load report file '{file}': {e}")
                     json.dump(all_reports, all_reports_file)
 
                 # ensure binlogs directory exists

--- a/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PartitionFilter.cs
@@ -1,16 +1,21 @@
+using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Running;
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
 
 public class PartitionFilter : IFilter
 {
     private readonly int? _partitionsCount;
     private readonly int? _partitionIndex; // indexed from 0
-    private int _counter = 0;
+    private readonly SHA256 _sha256;
  
     public PartitionFilter(int? partitionCount, int? partitionIndex)
     {
         _partitionsCount = partitionCount;
         _partitionIndex = partitionIndex;
+        _sha256 = SHA256.Create();
     }
  
     public bool Predicate(BenchmarkCase benchmarkCase)
@@ -18,6 +23,12 @@ public class PartitionFilter : IFilter
         if (!_partitionsCount.HasValue || !_partitionIndex.HasValue)
             return true; // the filter is not enabled so it does not filter anything out and can be added to RecommendedConfig
 
-        return _counter++ % _partitionsCount.Value == _partitionIndex.Value; // will return true only for benchmarks that belong to it’s partition
+        // Hash the test name to ensure a balanced partitioning strategy that is not dependent on the order of benchmarks
+        var testName = FullNameProvider.GetBenchmarkName(benchmarkCase);
+        var hash = _sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(testName));
+
+        // Use the first 4 bytes of the hash to determine the partition
+        var hashAsNum = BinaryPrimitives.ReadUInt32LittleEndian(hash.AsSpan(0, 4));
+        return hashAsNum % _partitionsCount.Value == _partitionIndex.Value;
     }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -59,7 +59,9 @@ public class Reporter
     {
         if (Tests.Any(t => t.Name.Equals(test.Name)))
         {
-            throw new Exception($"Duplicate test name, {test.Name}");
+            // TODO: Make this surface as a failure so it gets fixed, this is just temporary to fix the pipeline
+            Console.Error.WriteLine($"Duplicate test name: {test.Name}, skipping from results");
+            return;
         }
 
         Tests.Add(test);


### PR DESCRIPTION
Due to one of the changes in the following commit range, some Mono tests started getting skipped as they were not being run as part of any partitions: https://github.com/dotnet/runtime/compare/33ce341cd9e83fb8da17e5a71104c23593cef209...b146d7512ce67051e127ab48dc2d4f65d30e818f

This change makes it so that partitioning is done in a way that guarantees each test is run in exactly one partition. For configurations that run a small number of tests, this may make them slightly unbalanced, but we can investigate ways to balance them better in the future while this resolves the immediate bug.