### PR TITLE
Update iOS builds to disable code signing again

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,167 +344,167 @@ jobs:
 
 - ${{ if parameters.runPrivateJobs }}:
 
-  # # Scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-x64-viper
-  #       - ubuntu-x64-viper
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-x64-viper
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - win-x64-viper
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios_affinitized.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (Mono ProfiledAOT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: mono
-  #       codeGenType: ProfiledAOT
-  #       additionalJobIdentifier: Mono
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (Mono ProfiledAOT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: mono
+        codeGenType: ProfiledAOT
+        additionalJobIdentifier: Mono
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (Mono AOT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: mono
-  #       codeGenType: AOT
-  #       additionalJobIdentifier: Mono
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (Mono AOT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: mono
+        codeGenType: AOT
+        additionalJobIdentifier: Mono
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR JIT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: JIT
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR JIT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: JIT
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR R2R)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: R2R
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR R2R)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: R2R
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR R2R Composite)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: R2RComposite
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR R2R Composite)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: R2RComposite
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR NativeAOT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: NativeAOT
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR NativeAOT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: NativeAOT
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -542,49 +542,49 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui scenario benchmarks
-  # - ${{ if false }}:
-  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #     parameters:
-  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #       buildMachines:
-  #         - win-x64
-  #         - ubuntu-x64
-  #         - win-x64-viper
-  #         - ubuntu-x64-viper
-  #         - win-arm64
-  #         - ubuntu-arm64-ampere
-  #       isPublic: false
-  #       jobParameters:
-  #         runKind: maui_scenarios
-  #         projectFileName: maui_scenarios.proj
-  #         channels:
-  #           - main
-  #           - 9.0
-  #           - 8.0
-  #         ${{ each parameter in parameters.jobParameters }}:
-  #           ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui scenario benchmarks
+  - ${{ if false }}:
+    - template: /eng/pipelines/templates/build-machine-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+        buildMachines:
+          - win-x64
+          - ubuntu-x64
+          - win-x64-viper
+          - ubuntu-x64-viper
+          - win-arm64
+          - ubuntu-arm64-ampere
+        isPublic: false
+        jobParameters:
+          runKind: maui_scenarios
+          projectFileName: maui_scenarios.proj
+          channels:
+            - main
+            - 9.0
+            - 8.0
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-x64-viper
-  #       - ubuntu-x64-viper
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: nativeaot_scenarios
-  #       projectFileName: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # NativeAOT scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        runKind: nativeaot_scenarios
+        projectFileName: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,167 +344,167 @@ jobs:
 
 - ${{ if parameters.runPrivateJobs }}:
 
-  # Scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-x64-viper
-        - ubuntu-x64-viper
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-x64-viper
+  #       - ubuntu-x64-viper
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - win-x64-viper
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios_affinitized.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-x64-viper
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono ProfiledAOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: mono
-        codeGenType: ProfiledAOT
-        additionalJobIdentifier: Mono
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (Mono ProfiledAOT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: mono
+  #       codeGenType: ProfiledAOT
+  #       additionalJobIdentifier: Mono
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono AOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: mono
-        codeGenType: AOT
-        additionalJobIdentifier: Mono
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (Mono AOT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: mono
+  #       codeGenType: AOT
+  #       additionalJobIdentifier: Mono
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR JIT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: JIT
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR JIT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: JIT
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2R
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR R2R)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: R2R
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R Composite)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2RComposite
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR R2R Composite)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: R2RComposite
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR NativeAOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: NativeAOT
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR NativeAOT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: NativeAOT
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -542,49 +542,49 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui scenario benchmarks
-  - ${{ if false }}:
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-        buildMachines:
-          - win-x64
-          - ubuntu-x64
-          - win-x64-viper
-          - ubuntu-x64-viper
-          - win-arm64
-          - ubuntu-arm64-ampere
-        isPublic: false
-        jobParameters:
-          runKind: maui_scenarios
-          projectFileName: maui_scenarios.proj
-          channels:
-            - main
-            - 9.0
-            - 8.0
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui scenario benchmarks
+  # - ${{ if false }}:
+  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #     parameters:
+  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #       buildMachines:
+  #         - win-x64
+  #         - ubuntu-x64
+  #         - win-x64-viper
+  #         - ubuntu-x64-viper
+  #         - win-arm64
+  #         - ubuntu-arm64-ampere
+  #       isPublic: false
+  #       jobParameters:
+  #         runKind: maui_scenarios
+  #         projectFileName: maui_scenarios.proj
+  #         channels:
+  #           - main
+  #           - 9.0
+  #           - 8.0
+  #         ${{ each parameter in parameters.jobParameters }}:
+  #           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-x64-viper
-        - ubuntu-x64-viper
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        runKind: nativeaot_scenarios
-        projectFileName: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-x64-viper
+  #       - ubuntu-x64-viper
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: nativeaot_scenarios
+  #       projectFileName: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -40,7 +40,7 @@ with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
 
 # Build the IPA
 # NuGet.config file cannot be in the build directory due same cause as to https://github.com/dotnet/aspnetcore/issues/41397
-precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
 
 output_dir = const.PUBDIR
 if precommands.output:

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -26,7 +26,7 @@ precommands.new(template='maui',
                 no_restore=False)
 
 # Build the APK
-precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/netios/pre.py
+++ b/src/scenarios/netios/pre.py
@@ -25,7 +25,7 @@ precommands.new(template='ios',
                 no_restore=False)
 
 # Build the APK
-precommands.execute(['/p:_RequireCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting'])
+precommands.execute(['/p:_RequireCodeSigning=false', '/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting'])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR


### PR DESCRIPTION
Update iOS builds to disable code signing again.

After updating the maui packages recently in __, we started hitting an error around the signing certificates not being able to be found. Looking at the updates we took, it seems likely that this update https://github.com/dotnet/macios/pull/20824 caused the _RequireCodeSigning parameter we were setting to false to no longer block the same code path. This PR adds the setting of the parameter EnableCodeSigning to false to re-disable that flow.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2767936&view=results