### PR TITLE
Add standard parameter for binlog save location to PrepareWorkloadItemItems call

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -27,10 +27,6 @@
     <_MSBuildArgs Condition="'$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
 
     <RunConfigsString>$(RuntimeFlavor)_$(CodegenType)</RunConfigsString>
-    
-    <!-- Use ArtifactsLogDir if provided, otherwise use payload directory for binlogs -->
-    <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
-    <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -75,7 +71,9 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
+      <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog %(PreparePayloadWorkItem.BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -27,6 +27,10 @@
     <_MSBuildArgs Condition="'$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
 
     <RunConfigsString>$(RuntimeFlavor)_$(CodegenType)</RunConfigsString>
+    
+    <!-- Use ArtifactsLogDir if provided, otherwise use payload directory for binlogs -->
+    <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
+    <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</BinlogPath>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -71,8 +75,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command Condition="'$(ArtifactsLogDir)' != ''">$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
-      <Command Condition="'$(ArtifactsLogDir)' == ''">$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -71,7 +71,8 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command Condition="'$(ArtifactsLogDir)' != ''">$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command Condition="'$(ArtifactsLogDir)' == ''">$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -104,7 +105,7 @@
       <Command>$(Python) test.py devicememoryconsumption --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot; --runtime 30 --test-iteration 2 $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Build Time - %(Identity)')">
-      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y &amp;&amp; mkdir %HELIX_WORKITEM_ROOT%\traces &amp;&amp; copy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog %HELIX_WORKITEM_ROOT%\traces\</PreCommands>
+      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
       <Command>$(Python) test.py buildtime --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs) --binlog-path .\%(HelixWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</Command>
     </HelixWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -12,6 +12,10 @@
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
     
     <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
+    
+    <!-- Use ArtifactsLogDir if provided, otherwise use payload directory for binlogs -->
+    <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
+    <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -48,8 +52,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command Condition="'$(ArtifactsLogDir)' != ''">sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
-      <Command Condition="'$(ArtifactsLogDir)' == ''">sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -48,7 +48,8 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command Condition="'$(ArtifactsLogDir)' != ''">sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command Condition="'$(ArtifactsLogDir)' == ''">sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -63,7 +64,7 @@
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIiOSScenario -> 'Build Time - %(Identity)')">
-      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/versions.json $HELIX_WORKITEM_ROOT/pub/versions.json; mkdir -p $HELIX_WORKITEM_ROOT/traces; cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName).binlog $HELIX_WORKITEM_ROOT/traces</PreCommands>
+      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/versions.json $HELIX_WORKITEM_ROOT/pub/versions.json</PreCommands>
       <Command>$(Python) test.py buildtime --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs) --binlog-path ./%(HelixWorkItem.ScenarioDirectoryName).binlog</Command>
     </HelixWorkItem>
     <XHarnessAppBundleToTest Include="Device Startup - iOS .NET Default Template">

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -12,10 +12,6 @@
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
     
     <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
-    
-    <!-- Use ArtifactsLogDir if provided, otherwise use payload directory for binlogs -->
-    <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
-    <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -52,7 +48,9 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <BinlogPath Condition="'$(ArtifactsLogDir)' != ''">$(ArtifactsLogDir)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
+      <BinlogPath Condition="'$(ArtifactsLogDir)' == ''">$(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog</BinlogPath>
+      <Command>sudo xcode-select -s /Applications/Xcode_16.4.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog %(PreparePayloadWorkItem.BinlogPath) -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,53 +344,53 @@ jobs:
 
 - ${{ if parameters.runPrivateJobs }}:
 
-  # Scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-x64-viper
-        - ubuntu-x64-viper
-        - win-arm64
-        - ubuntu-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-x64-viper
+  #       - ubuntu-x64-viper
+  #       - win-arm64
+  #       - ubuntu-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Affinitized Scenario benchmarks (Initially just PDN)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - win-x64-viper
-        - win-arm64
-        - win-arm64-ampere
-      isPublic: false
-      jobParameters:
-        runKind: scenarios
-        projectFileName: scenarios_affinitized.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        additionalJobIdentifier: 'Affinity_85'
-        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-        runEnvVars: 
-          - DOTNET_GCgen0size=410000 # ~4MB
-          - DOTNET_GCHeapCount=4
-          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Affinitized Scenario benchmarks (Initially just PDN)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - win-x64-viper
+  #       - win-arm64
+  #       - win-arm64-ampere
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: scenarios
+  #       projectFileName: scenarios_affinitized.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       additionalJobIdentifier: 'Affinity_85'
+  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+  #       runEnvVars: 
+  #         - DOTNET_GCgen0size=410000 # ~4MB
+  #         - DOTNET_GCHeapCount=4
+  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui Android scenario benchmarks (Mono ProfiledAOT)
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -398,7 +398,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
+        # - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_android
@@ -411,100 +411,100 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono AOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: mono
-        codeGenType: AOT
-        additionalJobIdentifier: Mono
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (Mono AOT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: mono
+  #       codeGenType: AOT
+  #       additionalJobIdentifier: Mono
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR JIT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: JIT
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR JIT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: JIT
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2R
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR R2R)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: R2R
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R Composite)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2RComposite
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR R2R Composite)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: R2RComposite
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR NativeAOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: NativeAOT
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui Android scenario benchmarks (CoreCLR NativeAOT)
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64-android-arm64-pixel
+  #       - win-x64-android-arm64-galaxy
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_android
+  #       projectFileName: maui_scenarios_android.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: NativeAOT
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -524,67 +524,67 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS Native AOT scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - osx-x64-ios-arm64
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_ios
-        projectFileName: maui_scenarios_ios.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: NativeAOT
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui iOS Native AOT scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - osx-x64-ios-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: maui_scenarios_ios
+  #       projectFileName: maui_scenarios_ios.proj
+  #       channels:
+  #         - main
+  #       runtimeFlavor: coreclr
+  #       codeGenType: NativeAOT
+  #       additionalJobIdentifier: CoreCLR
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui scenario benchmarks
-  - ${{ if false }}:
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-        buildMachines:
-          - win-x64
-          - ubuntu-x64
-          - win-x64-viper
-          - ubuntu-x64-viper
-          - win-arm64
-          - ubuntu-arm64-ampere
-        isPublic: false
-        jobParameters:
-          runKind: maui_scenarios
-          projectFileName: maui_scenarios.proj
-          channels:
-            - main
-            - 9.0
-            - 8.0
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
+  # # Maui scenario benchmarks
+  # - ${{ if false }}:
+  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #     parameters:
+  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #       buildMachines:
+  #         - win-x64
+  #         - ubuntu-x64
+  #         - win-x64-viper
+  #         - ubuntu-x64-viper
+  #         - win-arm64
+  #         - ubuntu-arm64-ampere
+  #       isPublic: false
+  #       jobParameters:
+  #         runKind: maui_scenarios
+  #         projectFileName: maui_scenarios.proj
+  #         channels:
+  #           - main
+  #           - 9.0
+  #           - 8.0
+  #         ${{ each parameter in parameters.jobParameters }}:
+  #           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # NativeAOT scenario benchmarks
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64
-        - ubuntu-x64
-        - win-x64-viper
-        - ubuntu-x64-viper
-        - win-arm64
-      isPublic: false
-      jobParameters:
-        runKind: nativeaot_scenarios
-        projectFileName: nativeaot_scenarios.proj
-        channels:
-          - main
-          - 9.0
-          - 8.0
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  # # NativeAOT scenario benchmarks
+  # - template: /eng/pipelines/templates/build-machine-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+  #     buildMachines:
+  #       - win-x64
+  #       - ubuntu-x64
+  #       - win-x64-viper
+  #       - ubuntu-x64-viper
+  #       - win-arm64
+  #     isPublic: false
+  #     jobParameters:
+  #       runKind: nativeaot_scenarios
+  #       projectFileName: nativeaot_scenarios.proj
+  #       channels:
+  #         - main
+  #         - 9.0
+  #         - 8.0
+  #       ${{ each parameter in parameters.jobParameters }}:
+  #         ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -344,53 +344,53 @@ jobs:
 
 - ${{ if parameters.runPrivateJobs }}:
 
-  # # Scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-x64-viper
-  #       - ubuntu-x64-viper
-  #       - win-arm64
-  #       - ubuntu-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
+        - win-arm64
+        - ubuntu-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Affinitized Scenario benchmarks (Initially just PDN)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - win-x64-viper
-  #       - win-arm64
-  #       - win-arm64-ampere
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: scenarios
-  #       projectFileName: scenarios_affinitized.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       additionalJobIdentifier: 'Affinity_85'
-  #       affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
-  #       runEnvVars: 
-  #         - DOTNET_GCgen0size=410000 # ~4MB
-  #         - DOTNET_GCHeapCount=4
-  #         - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Affinitized Scenario benchmarks (Initially just PDN)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - win-x64-viper
+        - win-arm64
+        - win-arm64-ampere
+      isPublic: false
+      jobParameters:
+        runKind: scenarios
+        projectFileName: scenarios_affinitized.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        additionalJobIdentifier: 'Affinity_85'
+        affinity: '85'  # (01010101) Enables alternating process threads to take hyperthreading into account
+        runEnvVars: 
+          - DOTNET_GCgen0size=410000 # ~4MB
+          - DOTNET_GCHeapCount=4
+          - DOTNET_GCTotalPhysicalMemory=400000000 # 16GB
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui Android scenario benchmarks (Mono ProfiledAOT)
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -398,7 +398,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
-        # - win-x64-android-arm64-galaxy
+        - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
         runKind: maui_scenarios_android
@@ -411,100 +411,100 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (Mono AOT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: mono
-  #       codeGenType: AOT
-  #       additionalJobIdentifier: Mono
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (Mono AOT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: mono
+        codeGenType: AOT
+        additionalJobIdentifier: Mono
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR JIT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: JIT
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR JIT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: JIT
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR R2R)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: R2R
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR R2R)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: R2R
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR R2R Composite)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: R2RComposite
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR R2R Composite)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: R2RComposite
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui Android scenario benchmarks (CoreCLR NativeAOT)
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64-android-arm64-pixel
-  #       - win-x64-android-arm64-galaxy
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_android
-  #       projectFileName: maui_scenarios_android.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: NativeAOT
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui Android scenario benchmarks (CoreCLR NativeAOT)
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: NativeAOT
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # Maui iOS Mono scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
@@ -524,67 +524,67 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui iOS Native AOT scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - osx-x64-ios-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: maui_scenarios_ios
-  #       projectFileName: maui_scenarios_ios.proj
-  #       channels:
-  #         - main
-  #       runtimeFlavor: coreclr
-  #       codeGenType: NativeAOT
-  #       additionalJobIdentifier: CoreCLR
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui iOS Native AOT scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: NativeAOT
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # Maui scenario benchmarks
-  # - ${{ if false }}:
-  #   - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #     parameters:
-  #       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #       buildMachines:
-  #         - win-x64
-  #         - ubuntu-x64
-  #         - win-x64-viper
-  #         - ubuntu-x64-viper
-  #         - win-arm64
-  #         - ubuntu-arm64-ampere
-  #       isPublic: false
-  #       jobParameters:
-  #         runKind: maui_scenarios
-  #         projectFileName: maui_scenarios.proj
-  #         channels:
-  #           - main
-  #           - 9.0
-  #           - 8.0
-  #         ${{ each parameter in parameters.jobParameters }}:
-  #           ${{ parameter.key }}: ${{ parameter.value }}
+  # Maui scenario benchmarks
+  - ${{ if false }}:
+    - template: /eng/pipelines/templates/build-machine-matrix.yml
+      parameters:
+        jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+        buildMachines:
+          - win-x64
+          - ubuntu-x64
+          - win-x64-viper
+          - ubuntu-x64-viper
+          - win-arm64
+          - ubuntu-arm64-ampere
+        isPublic: false
+        jobParameters:
+          runKind: maui_scenarios
+          projectFileName: maui_scenarios.proj
+          channels:
+            - main
+            - 9.0
+            - 8.0
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # NativeAOT scenario benchmarks
-  # - template: /eng/pipelines/templates/build-machine-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-  #     buildMachines:
-  #       - win-x64
-  #       - ubuntu-x64
-  #       - win-x64-viper
-  #       - ubuntu-x64-viper
-  #       - win-arm64
-  #     isPublic: false
-  #     jobParameters:
-  #       runKind: nativeaot_scenarios
-  #       projectFileName: nativeaot_scenarios.proj
-  #       channels:
-  #         - main
-  #         - 9.0
-  #         - 8.0
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # NativeAOT scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64
+        - ubuntu-x64
+        - win-x64-viper
+        - ubuntu-x64-viper
+        - win-arm64
+      isPublic: false
+      jobParameters:
+        runKind: nativeaot_scenarios
+        projectFileName: nativeaot_scenarios.proj
+        channels:
+          - main
+          - 9.0
+          - 8.0
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
 ################################################
 # Scheduled Private jobs

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -931,11 +931,13 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
             # PreparePayloadWorkItems is only available for scenarios runs defined inside the performance repo
             if args.performance_repo_ci:
+                artifacts_log_dir = os.path.join(args.performance_repo_dir, 'artifacts', 'log', build_config)
                 RunCommand([
                     "dotnet", "msbuild", args.project_file, 
                     "/restore", 
                     "/t:PreparePayloadWorkItems",
-                    f"/bl:{os.path.join(args.performance_repo_dir, 'artifacts', 'log', build_config, 'PrepareWorkItemPayloads.binlog')}"],
+                    f"/bl:{os.path.join(artifacts_log_dir, 'PrepareWorkItemPayloads.binlog')}",
+                    f"/p:ArtifactsLogDir={artifacts_log_dir}"],
                     verbose=True).run()
 
             # restore env vars


### PR DESCRIPTION
Add standard parameter for binlog save location to PrepareWorkloadItemItems call for use in the projects that create binlogs so that they are instead uploaded in the pipeline steps and viewable in the pipeline run artifacts. The approach used in this PR is to check whether the ArtifactsLogDirectory parameter was set, such as when called from the run_performance_job.py script, and to use it rather than the previous hard coded binlog save location if it is set.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2767900&view=results (The binlogs properly showed up in the Azure Artifacts)
