### PR TITLE
Update target framework for micro benchmarks

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
@@ -232,6 +232,9 @@ namespace GC.Infrastructure.Commands.RunCommand
             configuration.MicrobenchmarkConfigurations.Filter = null;
             configuration.MicrobenchmarkConfigurations.FilterPath = microbenchmarkFilterFile;
 
+            // Microbenchmark dotnet installer.
+            configuration.MicrobenchmarkConfigurations.DotnetInstaller = "net8.0";
+
             // Microbenchmark Invocation Count Path.
             configuration.MicrobenchmarkConfigurations.InvocationCountPath = microbenchmarkInvocationCountFile;
 

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -4,7 +4,7 @@
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Since `xunit.runner.visualstudio` supports .NET 8.0+, we update target framework of `BenchmarkDotNet.Extensions.Tests.csproj` to net8.0.

