### PR TITLE
Remove an invalid coherency parent

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -72,7 +72,7 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
     </Dependency>
     <!-- Previous .NET Android version(s) -->
-    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.92" CoherentParentDependency="Microsoft.Android.Sdk.Windows">
+    <Dependency Name="Microsoft.NET.Sdk.Android.Manifest-9.0.100" Version="35.0.92">
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>be1cab92326783479054e72990da08008e5be819</Sha>
     </Dependency>


### PR DESCRIPTION
This breaks dependency flow as the service can't figure out the correct coherency parent. The dependency `Microsoft.Android.Sdk.Windows` is not defined anywhere else in the file.



