### PR TITLE
Ensure cross build param is passed when creating core root

### DIFF
--- a/eng/pipelines/templates/run-performance-job.yml
+++ b/eng/pipelines/templates/run-performance-job.yml
@@ -57,6 +57,7 @@ parameters:
   iOSStripSymbols: false            # optional -- Whether to strip symbols from the iOS build
   additionalSetupParameters: ''     # optional -- Additional arguments to pass to the script
   liveLibrariesBuildConfig: ''      # optional -- Build configuration when generating Core_Root for libraries
+  crossBuild: false                 # optional -- Whether the Core_Root is being cross-compiled
 
 jobs:
 - template: ${{ parameters.jobTemplate }}
@@ -231,6 +232,8 @@ jobs:
               - '--build-config ${{ parameters.buildConfig }}'
             - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
               - '--live-libraries-build-config ${{ parameters.liveLibrariesBuildConfig }}'
+            - ${{ if eq(parameters.crossBuild, true) }}:
+              - '--cross-build'
             - ${{ if ne(parameters.additionalSetupParameters, '') }}:
               - '${{ parameters.additionalSetupParameters }}'
       - template: /eng/pipelines/templates/send-to-helix-step.yml

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -16,6 +16,7 @@ parameters:
   hybridGlobalization: 'False'
   isScenario: false
   downloadSpecificBuild: null # buildId, pipeline, branchName, project
+  crossBuild: false
   runtimeRepoAlias: runtime
   performanceRepoAlias: self
   selfIsRuntime: true

--- a/scripts/build_runtime_payload.py
+++ b/scripts/build_runtime_payload.py
@@ -130,6 +130,7 @@ def build_coreroot_payload(
     architecture: str,
     coreclr_archive_or_dir: Optional[str] = None,
     libraries_config: Optional[str] = None,
+    cross_build: bool = False,
     clean_artifacts: bool = False,
 ) -> None:
     """Generate a CoreCLR `Core_Root` payload by re-running test layout script.
@@ -177,6 +178,9 @@ def build_coreroot_payload(
 
     if not iswin():
         generate_layout_command.extend(["-os", os_group])
+
+    if cross_build:
+        generate_layout_command.append("-cross")
 
     if libraries_config:
         generate_layout_command.append(f"/p:LibrariesConfiguration={libraries_config}")

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -115,6 +115,7 @@ class RunPerformanceJobArgs:
     target_csproj: Optional[str] = None
     build_config: str = "Release"
     live_libraries_build_config: Optional[str] = None
+    cross_build: bool = False
 
 def get_pre_commands(
         os_group: str,
@@ -796,7 +797,8 @@ def run_performance_job(args: RunPerformanceJobArgs):
                 core_root_dest=coreroot_payload_dir, 
                 os_group=args.os_group, 
                 architecture=args.architecture,
-                libraries_config=args.live_libraries_build_config)
+                libraries_config=args.live_libraries_build_config,
+                cross_build=args.cross_build)
         else:
             getLogger().info("Copying Core_Root directory to payload directory")
             shutil.copytree(args.core_root_dir, coreroot_payload_dir, ignore=shutil.ignore_patterns("*.pdb"))
@@ -1194,6 +1196,7 @@ def main(argv: List[str]):
                 "--performance-repo-ci": "performance_repo_ci",
                 "--only-sanity": "only_sanity_check",
                 "--use-local-commit-time": "use_local_commit_time",
+                "--cross-build": "cross_build"
             }
 
             if key in bool_args:


### PR DESCRIPTION
Fixes bug introduced in #4911 where -cross was not being passed when building for other architectures