### PR TITLE
MCP Server for GC.Infrastructure

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.sln
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GC.Infrastructure.MCPServer", "GC.Infrastructure.MCPServer\GC.Infrastructure.MCPServer.csproj", "{B32EE1B6-F037-4E8C-A33D-334696A2912D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{2A7F5822-08D8-4D13-8FE1-8CB1428C166E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A7F5822-08D8-4D13-8FE1-8CB1428C166E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A7F5822-08D8-4D13-8FE1-8CB1428C166E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B32EE1B6-F037-4E8C-A33D-334696A2912D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B32EE1B6-F037-4E8C-A33D-334696A2912D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B32EE1B6-F037-4E8C-A33D-334696A2912D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B32EE1B6-F037-4E8C-A33D-334696A2912D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/AspNetBenchmarks.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/AspNetBenchmarks.cs
@@ -1,0 +1,36 @@
+﻿using GC.Infrastructure.Commands.ASPNetBenchmarks;
+using ModelContextProtocol.Server;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class AspNetBenchmarks
+    {
+        private CommandApp _app = new CommandApp();
+        public AspNetBenchmarks()
+        {
+            _app.Configure(configuration =>
+            {
+                // ASP.NET Benchmarks
+                configuration.AddCommand<AspNetBenchmarksCommand>("aspnetbenchmarks");
+                configuration.AddCommand<AspNetBenchmarksAnalyzeCommand>("aspnetbenchmarks-analyze");
+            });
+        }
+
+        [McpServerTool(Name = "run_aspnetbenchmarks_command"), Description("Run aspnetbenchmarks Command.")]
+        public void RunAspNetBenchmarksCommand(string configurationPath)
+        {
+            string[] args = { "aspnetbenchmarks", "-c", configurationPath };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_aspnetbenchmarks_analyze_command"), Description("Run aspnetbenchmarks-analyze Command.")]
+        public void RunAspNetBenchmarksAnalyzeCommand(string configurationPath)
+        {
+            string[] args = { "aspnetbenchmarks-analyze", "-c", configurationPath };
+            _app.Run(args);
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/AspNetBenchmarks.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/AspNetBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using GC.Infrastructure.Commands.ASPNetBenchmarks;
+using GC.Infrastructure.Core.Configurations.ASPNetBenchmarks;
 using ModelContextProtocol.Server;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -20,17 +21,21 @@ namespace GC.Infrastructure.MCPServer
         }
 
         [McpServerTool(Name = "run_aspnetbenchmarks_command"), Description("Run aspnetbenchmarks Command.")]
-        public void RunAspNetBenchmarksCommand(string configurationPath)
+        public string RunAspNetBenchmarksCommand(string configurationPath)
         {
             string[] args = { "aspnetbenchmarks", "-c", configurationPath };
             _app.Run(args);
+            ASPNetBenchmarksConfiguration configuration = ASPNetBenchmarksConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
 
         [McpServerTool(Name = "run_aspnetbenchmarks_analyze_command"), Description("Run aspnetbenchmarks-analyze Command.")]
-        public void RunAspNetBenchmarksAnalyzeCommand(string configurationPath)
+        public string RunAspNetBenchmarksAnalyzeCommand(string configurationPath)
         {
             string[] args = { "aspnetbenchmarks-analyze", "-c", configurationPath };
             _app.Run(args);
+            ASPNetBenchmarksConfiguration configuration = ASPNetBenchmarksConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GC.Infrastructure.MCPServer.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GC.Infrastructure.MCPServer.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.7.25380.108" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
+	  <ProjectReference Include="..\GC.Infrastructure\GC.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GCPerfsim.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GCPerfsim.cs
@@ -1,4 +1,6 @@
 ﻿using GC.Infrastructure.Commands.GCPerfSim;
+using GC.Infrastructure.Core.Configurations;
+using GC.Infrastructure.Core.Configurations.GCPerfSim;
 using ModelContextProtocol.Server;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -21,8 +23,8 @@ namespace GC.Infrastructure.MCPServer
             });
         }
 
-        [McpServerTool(Name = "run_gcperfsim_command"), Description("Run gcperfsim Command.")]
-        public void RunGCPerfSimCommand(string configurationPath, bool serverRun=false)
+        [McpServerTool(Name = "run_gcperfsim_command"), Description("Run gcperfsim Command And Return Output Path.")]
+        public string RunGCPerfSimCommand(string configurationPath, bool serverRun=false)
         {
             string[] args = { "gcperfsim", "-c", configurationPath };
             if (serverRun)
@@ -30,13 +32,17 @@ namespace GC.Infrastructure.MCPServer
                 args = args.Append("-s").ToArray();
             }
             _app.Run(args);
+            GCPerfSimConfiguration configuration = GCPerfSimConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
 
-        [McpServerTool(Name = "run_gcperfsim_analyze_command"), Description("Run gcperfsim-analyze Command.")]
-        public void RunGCPerfSimAnalyzeCommand(string configurationPath)
+        [McpServerTool(Name = "run_gcperfsim_analyze_command"), Description("Run gcperfsim-analyze Command And Return Output Path.")]
+        public string RunGCPerfSimAnalyzeCommand(string configurationPath)
         {
             string[] args = { "gcperfsim-analyze", "-c", configurationPath };
             _app.Run(args);
+            GCPerfSimConfiguration configuration = GCPerfSimConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
 
         [McpServerTool(Name = "run_gcperfsim_compare_command"), Description("Run gcperfsim-compare Command.")]
@@ -46,8 +52,8 @@ namespace GC.Infrastructure.MCPServer
             _app.Run(args);
         }
 
-        [McpServerTool(Name = "run_gcperfsim_functional_command"), Description("Run gcperfsim-functional Command.")]
-        public void RunGCPerfSimFunctionalCommand(string configurationPath, bool serverRun = false)
+        [McpServerTool(Name = "run_gcperfsim_functional_command"), Description("Run gcperfsim-functional Command And Return Output Path.")]
+        public string RunGCPerfSimFunctionalCommand(string configurationPath, bool serverRun = false)
         {
             string[] args = { "gcperfsim-functional", "-c", configurationPath };
             if (serverRun)
@@ -55,6 +61,8 @@ namespace GC.Infrastructure.MCPServer
                 args = args.Append("-s").ToArray();
             }
             _app.Run(args);
+            GCPerfSimFunctionalConfiguration configuration = GCPerfSimFunctionalConfigurationParser.Parse(configurationPath);
+            return configuration.output_path;
         }
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GCPerfsim.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GCPerfsim.cs
@@ -1,0 +1,60 @@
+﻿using GC.Infrastructure.Commands.GCPerfSim;
+using ModelContextProtocol.Server;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class GCPerfsim
+    {
+        private CommandApp _app = new CommandApp();
+        public GCPerfsim()
+        {
+            _app.Configure(configuration =>
+            {
+                // GC PerfSim
+                configuration.AddCommand<GCPerfSimCommand>("gcperfsim");
+                configuration.AddCommand<GCPerfSimAnalyzeCommand>("gcperfsim-analyze");
+                configuration.AddCommand<GCPerfSimCompareCommand>("gcperfsim-compare");
+                configuration.AddCommand<GCPerfSimFunctionalCommand>("gcperfsim-functional");
+            });
+        }
+
+        [McpServerTool(Name = "run_gcperfsim_command"), Description("Run gcperfsim Command.")]
+        public void RunGCPerfSimCommand(string configurationPath, bool serverRun=false)
+        {
+            string[] args = { "gcperfsim", "-c", configurationPath };
+            if (serverRun)
+            {
+                args = args.Append("-s").ToArray();
+            }
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_gcperfsim_analyze_command"), Description("Run gcperfsim-analyze Command.")]
+        public void RunGCPerfSimAnalyzeCommand(string configurationPath)
+        {
+            string[] args = { "gcperfsim-analyze", "-c", configurationPath };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_gcperfsim_compare_command"), Description("Run gcperfsim-compare Command.")]
+        public void RunGCPerfSimCompareCommand(string baselinePath, string comparandPath, string output)
+        {
+            string[] args = { "gcperfsim-compare", "-b", baselinePath, "-c", comparandPath, "-o", output };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_gcperfsim_functional_command"), Description("Run gcperfsim-functional Command.")]
+        public void RunGCPerfSimFunctionalCommand(string configurationPath, bool serverRun = false)
+        {
+            string[] args = { "gcperfsim-functional", "-c", configurationPath };
+            if (serverRun)
+            {
+                args = args.Append("-s").ToArray();
+            }
+            _app.Run(args);
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Microbenchmarks.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Microbenchmarks.cs
@@ -1,0 +1,36 @@
+﻿using GC.Infrastructure.Commands.Microbenchmark;
+using ModelContextProtocol.Server;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class Microbenchmarks
+    {
+        private CommandApp _app = new CommandApp();
+        public Microbenchmarks()
+        {
+            _app.Configure(configuration =>
+            {
+                // Microbenchmarks
+                configuration.AddCommand<MicrobenchmarkCommand>("microbenchmarks");
+                configuration.AddCommand<MicrobenchmarkAnalyzeCommand>("microbenchmarks-analyze");
+            });
+        }
+
+        [McpServerTool(Name = "run_microbenchmarks_command"), Description("Run microbenchmarks Command.")]
+        public void RunMicrobenchmarksCommand(string configurationPath)
+        {
+            string[] args = { "microbenchmarks", "-c", configurationPath };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_microbenchmarks_analyze_command"), Description("Run microbenchmarks-analyze Command.")]
+        public void RunMicrobenchmarksAnalyzeCommand(string configurationPath)
+        {
+            string[] args = { "microbenchmarks-analyze", "-c", configurationPath };
+            _app.Run(args);
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Microbenchmarks.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Microbenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using GC.Infrastructure.Commands.Microbenchmark;
+using GC.Infrastructure.Core.Configurations.Microbenchmarks;
 using ModelContextProtocol.Server;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -20,17 +21,21 @@ namespace GC.Infrastructure.MCPServer
         }
 
         [McpServerTool(Name = "run_microbenchmarks_command"), Description("Run microbenchmarks Command.")]
-        public void RunMicrobenchmarksCommand(string configurationPath)
+        public string RunMicrobenchmarksCommand(string configurationPath)
         {
             string[] args = { "microbenchmarks", "-c", configurationPath };
             _app.Run(args);
+            MicrobenchmarkConfiguration configuration = MicrobenchmarkConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
 
         [McpServerTool(Name = "run_microbenchmarks_analyze_command"), Description("Run microbenchmarks-analyze Command.")]
-        public void RunMicrobenchmarksAnalyzeCommand(string configurationPath)
+        public string RunMicrobenchmarksAnalyzeCommand(string configurationPath)
         {
             string[] args = { "microbenchmarks-analyze", "-c", configurationPath };
             _app.Run(args);
+            MicrobenchmarkConfiguration configuration = MicrobenchmarkConfigurationParser.Parse(configurationPath);
+            return configuration.Output!.Path;
         }
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Program.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Program.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GC.Infrastructure.MCPServer
+{
+    public class MCPServer
+    {
+        public static int Main(string[] args)
+        {
+            var builder = Host.CreateApplicationBuilder(args);
+            builder.Logging.AddConsole(consoleLogOptions =>
+            {
+                // Configure all logs to go to stderr
+                consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
+            });
+            builder.Services
+                .AddMcpServer()
+                .WithStdioServerTransport()
+                .WithToolsFromAssembly();
+            builder.Build().Run();
+
+            return 0;
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Program.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Program.cs
@@ -1,13 +1,35 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+using Spectre.Console;
+using System.Runtime.Versioning;
+using System.Security.Principal;
 
 namespace GC.Infrastructure.MCPServer
 {
     public class MCPServer
     {
-        public static int Main(string[] args)
+        public static void Main(string[] args)
         {
+            RegistryKey? registrykeyHKLM = null;
+            string? keyPath = null;
+            string? oldValue = null;
+
+            if (OperatingSystem.IsWindows())
+            {
+                if (!IsAdministrator)
+                {
+                    AnsiConsole.WriteLine("Not running in admin mode - please elevate privileges to run this process.");
+                    return;
+                }
+
+                registrykeyHKLM = Registry.CurrentUser;
+                keyPath = @"Software\Microsoft\Windows\Windows Error Reporting\DontShowUI";
+                oldValue = registrykeyHKLM.GetValue(keyPath)?.ToString() ?? 0x0.ToString();
+                registrykeyHKLM.SetValue(keyPath, 0x1, RegistryValueKind.DWord);
+            }
+
             var builder = Host.CreateApplicationBuilder(args);
             builder.Logging.AddConsole(consoleLogOptions =>
             {
@@ -19,8 +41,10 @@ namespace GC.Infrastructure.MCPServer
                 .WithStdioServerTransport()
                 .WithToolsFromAssembly();
             builder.Build().Run();
-
-            return 0;
         }
+
+        [SupportedOSPlatform("windows")]
+        internal static bool IsAdministrator =>
+            new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Run.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Run.cs
@@ -1,4 +1,6 @@
 ﻿using GC.Infrastructure.Commands.RunCommand;
+using GC.Infrastructure.Core.Configurations;
+using Microsoft.Extensions.Configuration;
 using ModelContextProtocol.Server;
 using Spectre.Console.Cli;
 using System.ComponentModel;
@@ -21,10 +23,12 @@ namespace GC.Infrastructure.MCPServer
         }
 
         [McpServerTool(Name = "run_run_command"), Description("Run run Command.")]
-        public void RunRunCommand(string configurationPath)
+        public string RunRunCommand(string configurationPath)
         {
             string[] args = { "run", "-c", configurationPath };
             _app.Run(args);
+            InputConfiguration configuration = InputConfigurationParser.Parse(configurationPath);
+            return configuration.output_path;
         }
 
         [McpServerTool(Name = "run_createsuites_command"), Description("Run createsuites Command.")]
@@ -35,10 +39,12 @@ namespace GC.Infrastructure.MCPServer
         }
 
         [McpServerTool(Name = "run_run-suite_command"), Description("Run run-suite Command.")]
-        public void RunRunSuiteCommand(string suiteBasePath)
+        public string RunRunSuiteCommand(string suiteBasePath)
         {
             string[] args = { "run-suite", "-p", suiteBasePath };
             _app.Run(args);
+            string outputPath = Path.GetDirectoryName(suiteBasePath)!;
+            return outputPath;
         }
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Run.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/Run.cs
@@ -1,0 +1,44 @@
+﻿using GC.Infrastructure.Commands.RunCommand;
+using ModelContextProtocol.Server;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class Run
+    {
+        private CommandApp _app = new CommandApp();
+        public Run()
+        {
+            _app.Configure(configuration =>
+            {
+                // Run 
+                configuration.AddCommand<RunCommand>("run");
+                configuration.AddCommand<CreateSuitesCommand>("createsuites");
+                configuration.AddCommand<RunSuiteCommand>("run-suite");
+            });
+        }
+
+        [McpServerTool(Name = "run_run_command"), Description("Run run Command.")]
+        public void RunRunCommand(string configurationPath)
+        {
+            string[] args = { "run", "-c", configurationPath };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_createsuites_command"), Description("Run createsuites Command.")]
+        public void RunCreateSuitesCommand(string configurationPath)
+        {
+            string[] args = { "createsuites", "-c", configurationPath };
+            _app.Run(args);
+        }
+
+        [McpServerTool(Name = "run_run-suite_command"), Description("Run run-suite Command.")]
+        public void RunRunSuiteCommand(string suiteBasePath)
+        {
+            string[] args = { "run-suite", "-p", suiteBasePath };
+            _app.Run(args);
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimAnalyzeCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimAnalyzeCommand.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace GC.Infrastructure.Commands.GCPerfSim
 {
-    internal sealed class GCPerfSimAnalyzeCommand : Command<GCPerfSimAnalyzeCommand.GCPerfSimAnalyzeSettings>
+    public sealed class GCPerfSimAnalyzeCommand : Command<GCPerfSimAnalyzeCommand.GCPerfSimAnalyzeSettings>
     {
         public sealed class GCPerfSimAnalyzeSettings : CommandSettings
         {

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/GCPerfSim/GCPerfSimCommand.cs
@@ -25,7 +25,7 @@ namespace GC.Infrastructure.Commands.GCPerfSim
         public IReadOnlyList<ComparisonResult> AnalysisResults { get; }
     }
 
-    internal sealed class GCPerfSimCommand : Command<GCPerfSimCommand.GCPerfSimSettings>
+    public sealed class GCPerfSimCommand : Command<GCPerfSimCommand.GCPerfSimSettings>
     {
         public sealed class GCPerfSimSettings : CommandSettings
         {

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -28,7 +28,7 @@ namespace GC.Infrastructure.Commands.Microbenchmark
         public IReadOnlyList<MicrobenchmarkComparisonResults> AnalysisResults { get; }
     }
 
-    internal sealed class MicrobenchmarkCommand : Command<MicrobenchmarkCommand.MicrobenchmarkSettings>
+    public sealed class MicrobenchmarkCommand : Command<MicrobenchmarkCommand.MicrobenchmarkSettings>
     {
         public static string ReplaceInvalidChars(string filename)
         {


### PR DESCRIPTION
This PR makes GC.Infrastructure a MCP server and provides several tools:
1. run all gcperfsim related commands and return output path
2. run all microbenchmarks related commands and return output path
3. run all aspnetbenchmarks related commands and return output path

Since there are many sections in `Results.md`, we still need an additional prompt to display result like:
<img width="916" height="876" alt="image" src="https://github.com/user-attachments/assets/315e8885-df69-440e-b730-d090a4a3960d" />