### PR TITLE
add corerun build tool for MCP server

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
@@ -92,7 +92,7 @@ namespace GC.Infrastructure.MCPServer
             string workingDirectory = Path.Combine(runtimeRoot, "src", "tests");
             if (!Directory.Exists(workingDirectory))
             {
-                throw new DirectoryNotFoundException($"The directory {workingDirectory} does not exist.");
+                return $"The directory {workingDirectory} does not exist.";
             }
             string fileName = "cmd.exe";
             string arguments = $"/C build.cmd generatelayoutonly {arch} {buildConfig}";

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
@@ -26,6 +26,7 @@ namespace GC.Infrastructure.MCPServer
             string arguments = $"/C build.cmd clr+libs -runtimeConfiguration {buildConfig} -librariesConfiguration Release -arch {arch}";
             try
             {
+                bool isSuccess = true;
                 using (var process = new Process())
                 {
                     process.StartInfo.FileName = fileName;
@@ -35,26 +36,39 @@ namespace GC.Infrastructure.MCPServer
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.WorkingDirectory = runtimeRoot;
+                    process.OutputDataReceived += (sender, e) =>
+                    {
+                        if (!string.IsNullOrEmpty(e.Data))
+                        {
+                            if (e.Data.ToLower().Contains("build failed with exit code"))
+                            {
+                                isSuccess = false;
+                            }
+                        }
+                    };
+                    process.ErrorDataReceived += (sender, e) =>
+                    {
+                        if (!string.IsNullOrEmpty(e.Data))
+                        {
+                            if (e.Data.ToLower().Contains("build failed with exit code"))
+                            {
+                                isSuccess = false;
+                            }
+                        }
+                    };
                     process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
                     await process.WaitForExitAsync();
 
-                    while (process.StandardOutput.EndOfStream == false)
+                    if (!isSuccess)
                     {
-                        var line = process.StandardOutput.ReadLine();
-                        if (line!.ToLower().Contains("build failed with exit code"))
-                        {
-                            return $"Fail to build clr and libs, please check the build log for more details.";
-                        }
+                        return "Fail to build coreclr and libs, please check the build log for more details.";
                     }
-                    while (process.StandardError.EndOfStream == false)
+                    else
                     {
-                        var line = process.StandardError.ReadLine();
-                        if (line!.ToLower().Contains("build failed with exit code"))
-                        {
-                            return $"Fail to build clr and libs, please check the build log for more details.";
-                        }
+                        return "Successfully build coreclr and libs";
                     }
-                    return "Successfully build coreclr and libs";
                 }
             }
             catch (Exception ex)
@@ -84,6 +98,7 @@ namespace GC.Infrastructure.MCPServer
             string arguments = $"/C build.cmd generatelayoutonly {arch} {buildConfig}";
             try
             {
+                bool isSuccess = true;
                 using (var process = new Process())
                 {
                     process.StartInfo.FileName = fileName;
@@ -93,26 +108,39 @@ namespace GC.Infrastructure.MCPServer
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.WorkingDirectory = workingDirectory;
+                    process.OutputDataReceived += (sender, e) =>
+                    {
+                        if (!string.IsNullOrEmpty(e.Data))
+                        {
+                            if (e.Data.ToLower().Contains("build failed with exit code"))
+                            {
+                                isSuccess = false;
+                            }
+                        }
+                    };
+                    process.ErrorDataReceived += (sender, e) =>
+                    {
+                        if (!string.IsNullOrEmpty(e.Data))
+                        {
+                            if (e.Data.ToLower().Contains("build failed with exit code"))
+                            {
+                                isSuccess = false;
+                            }
+                        }
+                    };
                     process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
                     await process.WaitForExitAsync();
 
-                    while (process.StandardOutput.EndOfStream == false)
+                    if (!isSuccess)
                     {
-                        var line = process.StandardOutput.ReadLine();
-                        if (line!.ToLower().Contains("build failed with exit code"))
-                        {
-                            return $"Fail to build clr and libs, please check the build log for more details.";
-                        }
+                        return "Fail to build corerun, please check the build log for more details.";
                     }
-                    while (process.StandardError.EndOfStream == false)
+                    else
                     {
-                        var line = process.StandardError.ReadLine();
-                        if (line!.ToLower().Contains("build failed with exit code"))
-                        {
-                            return $"Fail to build clr and libs, please check the build log for more details.";
-                        }
+                        return "Successfully build corerun";
                     }
-                    return "Successfully build corerun";
                 }
             }
             catch (Exception ex)

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/CoreRun.cs
@@ -1,0 +1,88 @@
+﻿using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class CoreRun
+    {
+        [McpServerTool(Name = "build_clr_libs"), Description("Build clr and libs.")]
+        public int BuildCLRAndLibs(string runtimeRoot, string buildConfig, string arch = "x64")
+        {
+            if (!CheckBuildConfig(buildConfig))
+            {
+                throw new ArgumentException($"Invalid build configuration: {buildConfig}. Valid options are Debug, Release, Checked.");
+            }
+            if (!CheckArch(arch))
+            {
+                throw new ArgumentException($"Invalid arch: {arch}. Valid options are x64, x86, arm64.");
+            }
+            using (var process = new Process())
+            {
+                process.StartInfo.FileName = "cmd.exe";
+                process.StartInfo.Arguments = $"/C build.cmd clr+libs -runtimeConfiguration {buildConfig} -librariesConfiguration Release -arch {arch}";
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.WorkingDirectory = runtimeRoot;
+                process.OutputDataReceived += (sender, args) => Console.WriteLine(args.Data);
+                process.ErrorDataReceived += (sender, args) => Console.Error.WriteLine(args.Data);
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+                return process.ExitCode;
+            }
+        }
+
+        [McpServerTool(Name = "generate_core_root"), Description("Generate Core_Root.")]
+        public int GenerateCoreRoot(string runtimeRoot, string buildConfig, string arch = "x64")
+        {
+            if (!CheckBuildConfig(buildConfig))
+            {
+                throw new ArgumentException($"Invalid build configuration: {buildConfig}. Valid options are Debug, Release, Checked.");
+            }
+            if (!CheckArch(arch))
+            {
+                throw new ArgumentException($"Invalid arch: {arch}. Valid options are x64, x86, arm64.");
+            }
+
+            string workingDirectory = Path.Combine(runtimeRoot, "src", "tests");
+            if (!Directory.Exists(workingDirectory))
+            {
+                throw new DirectoryNotFoundException($"The directory {workingDirectory} does not exist.");
+            }
+            using (var process = new Process())
+            {
+                process.StartInfo.FileName = "cmd.exe";
+                process.StartInfo.Arguments = $"/C build.cmd generatelayoutonly {arch} {buildConfig}";
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.WorkingDirectory = workingDirectory;
+                process.OutputDataReceived += (sender, args) => Console.WriteLine(args.Data);
+                process.ErrorDataReceived += (sender, args) => Console.Error.WriteLine(args.Data);
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+                return process.ExitCode;
+            }
+        }
+
+        private bool CheckBuildConfig(string buildConfig)
+        {
+            string[] validConfigs = { "Debug", "Release", "Checked" };
+            return validConfigs.Contains(buildConfig);
+        }
+
+        private bool CheckArch(string arch)
+        {
+            string[] validArchs = { "x64", "x86", "arm64" };
+            return validArchs.Contains(arch);
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/VersionControl.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/VersionControl.cs
@@ -1,0 +1,44 @@
+﻿using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace GC.Infrastructure.MCPServer
+{
+    [McpServerToolType]
+    internal class VersionControl
+    {
+        [McpServerTool(Name = "checkout_branch"), Description("Switch to specific branch.")]
+        public async Task<string> CheckoutBranch(
+            [Description("The root directory of the runtime.")] string runtimeRoot,
+            [Description("The name of branch.")] string branchName)
+        {
+            string fileName = "git";
+            string arguments = $"checkout {branchName}";
+            try
+            {
+                using (var process = new Process())
+                {
+                    process.StartInfo.FileName = fileName;
+                    process.StartInfo.Arguments = arguments;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+                    process.StartInfo.UseShellExecute = false;
+                    process.StartInfo.CreateNoWindow = true;
+                    process.StartInfo.WorkingDirectory = runtimeRoot;
+                    process.Start();
+                    await process.WaitForExitAsync();
+
+                    if (process.StandardOutput.ReadToEnd().Contains("error:") || process.ExitCode != 0)
+                    {
+                        return $"Fail to switch to {branchName}, please check if the branch exists.";
+                    }
+                    return $"Successfully switch to {branchName}";
+                }
+            }
+            catch (Exception ex)
+            {
+                return $"Fail to run command `{fileName} {arguments}`: {ex.Message}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds corerun build tool for MCP server. Currently we support following arguments:
- buildConfig(Debug, Checked, Release)
- arch(x64, x86, arm64)

