### PR TITLE
[android] Disable MemoryConsumption except Blazor due to flakiness

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -103,7 +103,11 @@
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
       <Command>$(Python) test.py devicememoryconsumption --device-type android --package-path pub\%(HelixWorkItem.ApkName).apk --package-name %(HelixWorkItem.PackageName) --scenario-name &quot;%(Identity)&quot; --runtime 30 --test-iteration 2 $(ScenarioArgs)</Command>
     </HelixWorkItem>
-    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Build Time - %(Identity)')">
+    <!-- Strip non-Blazor memory consumption work items due to instability, see https://github.com/dotnet/performance/issues/4867  -->
+    <HelixWorkItem Remove="Memory Consumption - .NET Android Default Template" />
+    <HelixWorkItem Remove="Memory Consumption - MAUI Android Default Template" />
+    <HelixWorkItem Remove="Memory Consumption - MAUI Android Sample Content Template" />
+    <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Build Time - %(Identity)')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('galaxy'))">
       <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y &amp;&amp; mkdir %HELIX_WORKITEM_ROOT%\traces &amp;&amp; copy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog %HELIX_WORKITEM_ROOT%\traces\</PreCommands>
       <Command>$(Python) test.py buildtime --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs) --binlog-path .\%(HelixWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog</Command>
     </HelixWorkItem>


### PR DESCRIPTION
The memory consumption measurements are highly instable on all except MAUI blazor scenarios. Disabling these tests until https://github.com/dotnet/performance/issues/4867 resolved to improve CI monitoring.
 
+ Limiting build runs to only pixel devices (we don't need build time to run for both pixel/galaxy since it's not dependent on the connected tethered devices but the host)

Internal job: https://dev.azure.com/dnceng/internal/_build/results?buildId=2787121