### PR TITLE
Use net9.0_18.5 version 18.5.9219 instead of 18.5.9223.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,7 +9,8 @@
     <!--  Begin: Package sources from dotnet-android -->
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-dc209fe" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-dc209fe5/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-60f5c7b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-60f5c7b1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-60f5c7b-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-60f5c7b1-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -94,21 +94,21 @@
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9223">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_18.5" Version="18.5.9219">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>dc209fe5a14f181a062a91d5875fb252b4bef399</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9223">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_15.5" Version="15.5.9219">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>dc209fe5a14f181a062a91d5875fb252b4bef399</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9223">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_18.5" Version="18.5.9219">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>dc209fe5a14f181a062a91d5875fb252b4bef399</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9223">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_18.5" Version="18.5.9219">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>dc209fe5a14f181a062a91d5875fb252b4bef399</Sha>
+      <Sha>60f5c7b1b6e359df6fefe197b5736a29a6be1001</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Use net9.0_18.5 version 18.5.9219 instead of 18.5.9223. This should fix the following error we are hitting in our pipeline: `Workload installation failed: One or more errors occurred. (Version 18.5.9219 of package microsoft.ios.sdk.net9.0_18.5 is not found in NuGet feeds`
