### PR TITLE
Add NoR2R runs

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -270,7 +270,6 @@ jobs:
       platforms:
       - linux_x64
       - windows_x64
-      - windows_x86
       jobParameters:
         liveLibrariesBuildConfig: Release
         runKind: micro

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -278,6 +278,7 @@ jobs:
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         r2rRunType: nor2r
+        additionalJobIdentifier: 'NoR2R'
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -261,6 +261,26 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+  # run coreclr perfviper microbenchmarks perf job with NoR2R
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runKind: micro
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        r2rRunType: nor2r
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
   # run coreclr crossgen perf job
   - ${{ if false }}: # Disabling as all crossgen jobs are failing at the moment - https://github.com/dotnet/performance/issues/4819
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}


### PR DESCRIPTION
Add back NoR2R runs as we are seeing more static PGO issues, and would like to have a way to see the impact.

Test run here: https://dev.azure.com/dnceng/internal/_build/results?buildId=2789675&view=results

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


