### PR TITLE
Fix package version mismatch

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/Notebooks/DataManager.dib
+++ b/src/benchmarks/gc/GC.Infrastructure/Notebooks/DataManager.dib
@@ -6,7 +6,7 @@
 
 #i "nuget: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
 
-#r "nuget: Microsoft.Diagnostics.Tracing.TraceEvent, 3.1.13"
+#r "nuget: Microsoft.Diagnostics.Tracing.TraceEvent, 3.1.23"
 #r "nuget: Microsoft.Data.Analysis, 0.19.1"
 //#r "nuget: Newtonsoft.Json"
 #r "nuget: XPlot.Plotly"


### PR DESCRIPTION
### Fix the version mismatch between two assemblies that depend on Microsoft.Diagnostics.Tracing.TraceEvent:
- GC.Analysis.API assembly was compiled against Microsoft.Diagnostics.Tracing.TraceEvent version 3.1.23.0
- The notebook runtime is trying to load Microsoft.Diagnostics.Tracing.TraceEvent version 3.1.13.0 (an older version)


