### PR TITLE
.NET projects cleanup + set minimum dependency to net472 for microbenchmarks

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -130,23 +130,6 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # net462 micro benchmarks # Disable until I have time to properly fix the issues and can merge https://github.com/dotnet/performance/pull/4741
-  - ${{ if false }}:
-    - template: /eng/pipelines/templates/build-machine-matrix.yml
-      parameters:
-        jobTemplate: /eng/pipelines/templates/run-performance-job.yml
-        buildMachines:
-          - win-rs5-x64
-        isPublic: true
-        jobParameters:
-          runKind: micro_net462
-          targetCsproj: src\benchmarks\micro\MicroBenchmarks.csproj
-          runCategories: 'runtime libraries'
-          channels:
-            - net462
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
   # ML.NET benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -159,8 +159,8 @@ class ChannelMap():
             'branch': '3.1.4xx',
             'quality': 'daily'
         },
-        'net462': {
-            'tfm': 'net462',
+        'net472': {
+            'tfm': 'net472',
             'branch': '9.0',
             'quality': 'daily'
         },

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -516,7 +516,7 @@ def get_work_item_command(os_group: str, target_csproj: str, architecture: str, 
     if internal:
         work_item_command += ["--upload-to-perflab-container"]
 
-    if perf_lab_framework != "net462":
+    if perf_lab_framework != "net472":
         if os_group == "windows":
             work_item_command += ["--dotnet-versions", "%DOTNET_VERSION%"]
         else:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,7 @@
     
     <!-- every warning is important, we want to enforce best practices here to keep high quality of the code and avoid common mistakes -->
     <NoWarn>$(NoWarn);NU1507</NoWarn> <!-- Darc does not seem to support auto updating of packageSourceMapping causing tool publishes to fail without manual updating of the NuGet.config with package mappings, disable this check so we don't have to manually update the source mappings. -->
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn> <!-- Disable warning about EOL target frameworks as we target them to test them -->
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Supported target frameworks -->
+    <SupportedTargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(SupportedTargetFrameworks);net472</SupportedTargetFrameworks>
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' == 'Windows_NT'">net462;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' AND '$(OS)' != 'Windows_NT'">net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(SupportedTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
@@ -82,12 +83,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '8.0'" />
-    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '5.0'" />
+    <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '8.0')" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="4.5.5" />
@@ -96,12 +97,7 @@
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '10.0'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion)" />
-    <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
-    <PackageReference Include="System.Threading.Channels" Version="$(SystemVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '8.0'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <!-- we want both net8.0 and net9.0 targets to use the 9.0.0 version of the NuGet package (since this is where the generic math APIs were first added) -->
     <PackageReference Include="System.Numerics.Tensors" Version="$(SystemThreadingChannelsPackageVersion)" />
   </ItemGroup>
@@ -149,7 +145,7 @@
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '3.1')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1')))">
     <Compile Remove="runtime\Math\Functions\Double\CopySign.cs" />
     <Compile Remove="runtime\Math\Functions\Double\FusedMultiplyAdd.cs" />
     <Compile Remove="runtime\Math\Functions\Double\ILogB.cs" />
@@ -170,7 +166,7 @@
     <Compile Remove="libraries\Common\MultiArrayBuffer.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '5.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')))">
     <Compile Remove="runtime\Interop\ComWrappers.cs" />
     <Compile Remove="libraries\System.Diagnostics\Perf_Activity.cs" />
     <Compile Remove="libraries\System.Text.Json\Serializer\ReadPreservedReferences.cs" />
@@ -180,7 +176,7 @@
     <Compile Remove="libraries\System.Runtime\Perf.Half.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '6.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')))">
     <Compile Remove="runtime\Math\Functions\Double\SinCos.cs" />
     <Compile Remove="runtime\Math\Functions\Single\SinCos.cs" />
     <Compile Remove="libraries\System.Collections\PriorityQueue\Perf_PriorityQueue.cs" />
@@ -190,7 +186,7 @@
     <Compile Remove="libraries\System.Text.Json\Node\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '7.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0')))">
     <Compile Remove="runtime\Math\Functions\Double\AcosPi.cs" />
     <Compile Remove="runtime\Math\Functions\Double\AsinPi.cs" />
     <Compile Remove="runtime\Math\Functions\Double\AtanPi.cs" />
@@ -228,24 +224,24 @@
     <Compile Remove="libraries\System.Runtime\Perf.Int128.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '8.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))">
     <Compile Remove="libraries\System.Buffers\SearchValuesByteTests.cs" />
     <Compile Remove="libraries\System.Buffers\SearchValuesCharTests.cs" />
     <Compile Remove="libraries\System.Text.Encoding\Perf.Ascii.cs" />
     <Compile Remove="libraries\System.Numerics.Tensors\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '9.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')))">
     <Compile Remove="libraries\System.Reflection.Metadata\*.cs" />
   </ItemGroup>
 
   <!-- Remove Sve microbenchmarks when running on net versions < 9.0 -->
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &lt; '9.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')))">
     <Compile Remove="sve\*.cs" />
   </ItemGroup>
 
   <!-- This is not removing things from older Net versions, it is removing from newer Net versions -->
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' &gt;= '8.0')">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))">
     <Compile Remove="libraries\System.Drawing\*.cs" />
   </ItemGroup>
 

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -145,7 +145,7 @@
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Compile Remove="runtime\Math\Functions\Double\CopySign.cs" />
     <Compile Remove="runtime\Math\Functions\Double\FusedMultiplyAdd.cs" />
     <Compile Remove="runtime\Math\Functions\Double\ILogB.cs" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -84,11 +84,11 @@
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />
+    <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Memory" Version="4.5.5" />
@@ -97,7 +97,7 @@
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <!-- we want both net8.0 and net9.0 targets to use the 9.0.0 version of the NuGet package (since this is where the generic math APIs were first added) -->
     <PackageReference Include="System.Numerics.Tensors" Version="$(SystemThreadingChannelsPackageVersion)" />
   </ItemGroup>
@@ -145,7 +145,7 @@
     <Compile Remove="runtime\Math\Functions\Single\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netcoreapp3.1'))">
     <Compile Remove="runtime\Math\Functions\Double\CopySign.cs" />
     <Compile Remove="runtime\Math\Functions\Double\FusedMultiplyAdd.cs" />
     <Compile Remove="runtime\Math\Functions\Double\ILogB.cs" />
@@ -166,7 +166,7 @@
     <Compile Remove="libraries\Common\MultiArrayBuffer.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">
     <Compile Remove="runtime\Interop\ComWrappers.cs" />
     <Compile Remove="libraries\System.Diagnostics\Perf_Activity.cs" />
     <Compile Remove="libraries\System.Text.Json\Serializer\ReadPreservedReferences.cs" />
@@ -176,7 +176,7 @@
     <Compile Remove="libraries\System.Runtime\Perf.Half.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <Compile Remove="runtime\Math\Functions\Double\SinCos.cs" />
     <Compile Remove="runtime\Math\Functions\Single\SinCos.cs" />
     <Compile Remove="libraries\System.Collections\PriorityQueue\Perf_PriorityQueue.cs" />
@@ -186,7 +186,7 @@
     <Compile Remove="libraries\System.Text.Json\Node\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <Compile Remove="runtime\Math\Functions\Double\AcosPi.cs" />
     <Compile Remove="runtime\Math\Functions\Double\AsinPi.cs" />
     <Compile Remove="runtime\Math\Functions\Double\AtanPi.cs" />
@@ -224,24 +224,24 @@
     <Compile Remove="libraries\System.Runtime\Perf.Int128.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <Compile Remove="libraries\System.Buffers\SearchValuesByteTests.cs" />
     <Compile Remove="libraries\System.Buffers\SearchValuesCharTests.cs" />
     <Compile Remove="libraries\System.Text.Encoding\Perf.Ascii.cs" />
     <Compile Remove="libraries\System.Numerics.Tensors\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
     <Compile Remove="libraries\System.Reflection.Metadata\*.cs" />
   </ItemGroup>
 
   <!-- Remove Sve microbenchmarks when running on net versions < 9.0 -->
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
     <Compile Remove="sve\*.cs" />
   </ItemGroup>
 
   <!-- This is not removing things from older Net versions, it is removing from newer Net versions -->
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')))">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <Compile Remove="libraries\System.Drawing\*.cs" />
   </ItemGroup>
 

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,7 +12,7 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net9.0|net10.0|net462`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net10.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net9.0|net10.0|net472`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net10.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 

--- a/src/benchmarks/real-world/ILLink/ILLinkBenchmarks.csproj
+++ b/src/benchmarks/real-world/ILLink/ILLinkBenchmarks.csproj
@@ -5,7 +5,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-		<TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net9.0</TargetFrameworks>
+		<TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net10.0</TargetFrameworks>
 		<IsShipping>false</IsShipping>
 		<!-- ignore warning about BenchmarkDotNet.Extensions being not signed -->
 		<NoWarn>$(NoWarn);8002</NoWarn>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>

--- a/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
+++ b/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BenchmarkDotNetSources)' != ''">
     <_BenchmarkDotNetSourcesN>$([MSBuild]::NormalizeDirectory('$(BenchmarkDotNetSources)'))</_BenchmarkDotNetSourcesN>

--- a/src/harness/BenchmarkDotNet.Extensions/ExclusionFilter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ExclusionFilter.cs
@@ -8,9 +8,9 @@ namespace BenchmarkDotNet.Extensions
 {
     class ExclusionFilter : IFilter
     {
-        private readonly GlobFilter globFilter;
+        private readonly GlobFilter? globFilter;
 
-        public ExclusionFilter(List<string> _filter)
+        public ExclusionFilter(List<string>? _filter)
         {
             if (_filter != null && _filter.Count != 0)
             {
@@ -30,9 +30,9 @@ namespace BenchmarkDotNet.Extensions
 
     class CategoryExclusionFilter : IFilter
     {
-        private readonly AnyCategoriesFilter filter;
+        private readonly AnyCategoriesFilter? filter;
 
-        public CategoryExclusionFilter(List<string> patterns)
+        public CategoryExclusionFilter(List<string>? patterns)
         {
             if (patterns != null)
             {

--- a/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/PerfLabExporter.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
 using Reporting;
+using System;
 using System.Linq;
 
 namespace BenchmarkDotNet.Extensions
@@ -26,8 +27,8 @@ namespace BenchmarkDotNet.Extensions
 
             var hasCriticalErrors = summary.HasCriticalValidationErrors;
 
-            DisassemblyDiagnoser disassemblyDiagnoser = summary.Reports
-                .FirstOrDefault()? // dissasembler was either enabled for all or none of them (so we use the first one)
+            DisassemblyDiagnoser? disassemblyDiagnoser = summary.Reports
+                .FirstOrDefault()? // disassembler was either enabled for all or none of them (so we use the first one)
                 .BenchmarkCase.Config.GetDiagnosers().OfType<DisassemblyDiagnoser>().FirstOrDefault();
 
             foreach (var report in summary.Reports)
@@ -122,7 +123,9 @@ namespace BenchmarkDotNet.Extensions
                 reporter.AddTest(test);
             }
 
-            logger.WriteLine(reporter.GetJson());
+            var jsonOutput = reporter.GetJson();
+            if (jsonOutput is not null)
+                logger.WriteLine(jsonOutput);
         }
     }
 }

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -25,9 +25,9 @@ namespace BenchmarkDotNet.Extensions
             ImmutableHashSet<string> mandatoryCategories,
             int? partitionCount = null,
             int? partitionIndex = null,
-            List<string> exclusionFilterValue = null,
-            List<string> categoryExclusionFilterValue = null,
-            Job job = null,
+            List<string>? exclusionFilterValue = null,
+            List<string>? categoryExclusionFilterValue = null,
+            Job? job = null,
             bool getDiffableDisasm = false)
         {
             if (job is null)

--- a/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/ValuesGenerator.cs
@@ -23,9 +23,9 @@ namespace BenchmarkDotNet.Extensions
         public static T GetNonDefaultValue<T>()
         {
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)) // we can't use ArrayOfUniqueValues for byte/sbyte (but they have the same range)
-                return Array<T>(byte.MaxValue).First(value => !value.Equals(default(T)));
+                return Array<T>(byte.MaxValue).First(value => !value!.Equals(default(T)));
             else
-                return ArrayOfUniqueValues<T>(2).First(value => !value.Equals(default(T)));
+                return ArrayOfUniqueValues<T>(2).First(value => !value!.Equals(default(T)));
         }
 
         /// <summary>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
-    <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
-    <!-- Supported target frameworks -->
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/PartitionFilterTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/PartitionFilterTests.cs
@@ -61,7 +61,7 @@ namespace BenchmarkDotNet.Extensions.Tests
         {
             ILogger nullLogger = new NullLogger();
             IConfig recommendedConfig = RecommendedConfig.Create(
-                artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(PartitionFilterTests).Assembly.Location), "BenchmarkDotNet.Artifacts")),
+                artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(PartitionFilterTests).Assembly.Location)!, "BenchmarkDotNet.Artifacts")),
                 mandatoryCategories: ImmutableHashSet.Create(Categories.Libraries, Categories.Runtime, Categories.ThirdParty));
             (bool isSuccess, IConfig parsedConfig, var _) = ConfigParser.Parse(new string[] { "--filter", "*" }, nullLogger, recommendedConfig);
             Assert.True(isSuccess);

--- a/src/tools/CertHelperTests/CertRotatorTests.csproj
+++ b/src/tools/CertHelperTests/CertRotatorTests.csproj
@@ -14,13 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageReference Include="Moq" Version="4.18.4"/>
-    <PackageReference Include="xunit" Version="2.9.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tools/Reporting/Reporting/Build.cs
+++ b/src/tools/Reporting/Reporting/Build.cs
@@ -9,17 +9,17 @@ namespace Reporting;
 
 public sealed class Build
 {
-    public string Repo { get; set; }
+    public string? Repo { get; set; }
 
-    public string Branch { get; set; }
+    public string? Branch { get; set; }
 
-    public string Architecture { get; set; }
+    public string? Architecture { get; set; }
 
-    public string Locale { get; set; }
+    public string? Locale { get; set; }
 
-    public string GitHash { get; set; }
+    public string? GitHash { get; set; }
 
-    public string BuildName { get; set; }
+    public string? BuildName { get; set; }
 
     public DateTime TimeStamp { get; set; }
 

--- a/src/tools/Reporting/Reporting/Counter.cs
+++ b/src/tools/Reporting/Reporting/Counter.cs
@@ -8,7 +8,7 @@ namespace Reporting;
 
 public class Counter
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = "Counter";
 
     public bool TopCounter { get; set; }
 
@@ -16,9 +16,9 @@ public class Counter
 
     public bool HigherIsBetter { get; set; }
 
-    public string MetricName { get; set; }
+    public string MetricName { get; set; } = "Count";
 
-    public IList<double> Results { get; set; }
+    public IList<double>? Results { get; set; }
 
     public override string ToString() => $"{nameof(Name)}: {Name}, {nameof(TopCounter)}: {TopCounter}, {nameof(DefaultCounter)}: {DefaultCounter}, {nameof(MetricName)}: {MetricName}";
 }

--- a/src/tools/Reporting/Reporting/Os.cs
+++ b/src/tools/Reporting/Reporting/Os.cs
@@ -6,11 +6,11 @@ namespace Reporting;
 
 public class Os
 {
-    public string Locale { get; set; }
+    public string? Locale { get; set; }
 
-    public string Architecture { get; set; }
+    public string? Architecture { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public string MachineName { get; set; }
+    public string? MachineName { get; set; }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -18,6 +18,7 @@ namespace Reporting;
 
 public class Reporter
 {
+    private readonly static CultureInfo _culture = CultureInfo.InvariantCulture;
     private readonly static JsonSerializerSettings _jsonSerializerSettings = new()
     {
         ContractResolver = new DefaultContractResolver
@@ -27,15 +28,13 @@ public class Reporter
         Culture = _culture
     };
 
-    private readonly static CultureInfo _culture = CultureInfo.InvariantCulture;
-
     public List<Test> Tests { get; private set; } = [];
-    public Run Run { get; private set; }
-    public Os Os { get; private set; }
-    public Build Build { get; private set; }
+    public Run? Run { get; private set; }
+    public Os? Os { get; private set; }
+    public Build? Build { get; private set; }
     public bool InLab { get; }
 
-    public Reporter(IEnvironment environment = null)
+    public Reporter(IEnvironment? environment = null)
     {
         environment ??= new EnvironmentProvider();
         InLab = environment.IsLabEnvironment();
@@ -65,7 +64,7 @@ public class Reporter
         Tests.Add(test);
     }
 
-    public string GetJson()
+    public string? GetJson()
         => InLab ? JsonConvert.SerializeObject(this, Formatting.Indented, _jsonSerializerSettings) : null;
 
     public string WriteResultTable()
@@ -151,7 +150,7 @@ public class Reporter
         return build;
     }
 
-    private static (string installerHash, string sdkVersion) GetDotNetVersionInfo(string dotnetRoot)
+    private static (string? installerHash, string? sdkVersion) GetDotNetVersionInfo(string dotnetRoot)
     {
         if (Path.Combine(dotnetRoot, "sdk") is string sdkRootPath && Directory.Exists(sdkRootPath))
         {

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tools/Reporting/Reporting/Run.cs
+++ b/src/tools/Reporting/Reporting/Run.cs
@@ -10,15 +10,15 @@ public class Run
 {
     public bool Hidden { get; set; }
 
-    public string CorrelationId { get; set; }
+    public string? CorrelationId { get; set; }
 
-    public string PerfRepoHash { get; set; }
+    public string? PerfRepoHash { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public string Queue { get; set; }
+    public string? Queue { get; set; }
 
-    public string WorkItemName { get; set; }
+    public string? WorkItemName { get; set; }
 
     public IDictionary<string, string> Configurations { get; set; } = new Dictionary<string, string>();
 }

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -12,7 +12,7 @@ public class Test
 {
     public IList<string> Categories { get; set; } = [];
 
-    public string Name { get; set; }
+    public string Name { get; set; } = "Test";
 
     public Dictionary<string, string> AdditionalData { get; set; } = [];
 


### PR DESCRIPTION
This PR does a few things:

- Resolves all warnings in our .NET projects (excluding those in src/scenarios). 
  - This includes the NU1510 warnings reported in #4975.
- Updates the minimum dependency of Microbenchmarks from .NET 4.6.2 to .NET 4.7.2, which allows us to safely target netstandard2.0 in BenchmarkDotNet.Extensions without requiring an additional net462 target.
  - I have removed the net462 job from the yml files, if we need automated .NET Framework runs in the future, we will need to revisit it anyways
- Enabled nullable for all the projects and updated the code accordingly
- Disabled NETSDK1138 which was being reported every time because we build for older .NET versions
- Updated the .NET framework conditioning logic in the MSBuild project files to use the new [TargetFramework functions](https://learn.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2022#msbuild-targetframework-and-targetplatform-functions)
- Enabled ProduceReferenceAssembly in the netstandard2.0 projects so that we can have incremental compilation working. Without this, every time a change is made to BenchmarkDotNet.Extensions or Reporting it would recompile Microbenchmarks.