### PR TITLE
Run iOS performance measurements on CoreCLR

### DIFF
--- a/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+++ b/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
@@ -7,6 +7,7 @@ jobs:
   - template: /eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       mono: true
+      coreclr: true
       nativeAot: true
 
   # run iOS scenarios - Mono FullAOT
@@ -134,6 +135,27 @@ jobs:
         logicalMachine: 'perfiphone12mini'
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run iOS scenarios - CoreCLR
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+        - osx_x64
+      jobParameters:
+        runtimeType: iOSCoreCLR
+        codeGenType: JIT
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
+        runKind: ios_scenarios
+        isScenario: true
+        logicalMachine: 'perfiphone12mini'
+        iOSStripSymbols: false
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -198,8 +198,8 @@ jobs:
               artifactName: 'iOSSampleAppLLVMNoSymbols'
               artifactFileName: 'iOSSampleAppLLVMNoSymbols.zip'
             ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'JIT')) }}:
-              artifactName: 'iOSCoreCLRSample'
-              artifactFileName: 'iOSCoreCLRSampleApp.zip'
+              artifactName: 'iOSSampleApp'
+              artifactFileName: 'iOSSampleApp.zip'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
               artifactName: 'iOSSampleAppSymbols'
               artifactFileName: 'iOSSampleAppSymbols.zip'

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -36,7 +36,7 @@ jobs:
     # Test job depends on the corresponding build job
     ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
       dependsOn:
-        - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSNativeAOT', 'wasm', 'mono')) }}:
+        - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSCoreCLR', 'iOSNativeAOT', 'wasm', 'mono')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'coreclr') }}
         - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}
@@ -51,6 +51,8 @@ jobs:
           - ${{ 'build_android_arm64_release_AndroidCoreCLR' }}
         - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
           - ${{ 'build_ios_arm64_release_iOSMono' }}
+        - ${{ if eq(parameters.runtimeType, 'iOSCoreCLR')}}:
+          - ${{ 'build_ios_arm64_release_iOSCoreCLR' }}
         - ${{ if eq(parameters.runtimeType, 'iOSNativeAOT')}}:
           - ${{ 'build_ios_arm64_release_iOSNativeAOT' }}
 
@@ -177,7 +179,7 @@ jobs:
         #     artifactFileName: 'AndroidBDNApk.tar.gz'
         #     artifactName: 'AndroidBDNApk'
         #     displayName: 'Mono Android BDN Apk'
-      - ${{ elseif or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:
+      - ${{ elseif or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:
         # Download iOS Mono and CoreCLR (NativeAOT) tests
         - template: /eng/pipelines/templates/download-artifact-step.yml
           parameters:
@@ -195,6 +197,9 @@ jobs:
             ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppLLVMNoSymbols'
               artifactFileName: 'iOSSampleAppLLVMNoSymbols.zip'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'JIT')) }}:
+              artifactName: 'iOSCoreCLRSample'
+              artifactFileName: 'iOSCoreCLRSampleApp.zip'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
               artifactName: 'iOSSampleAppSymbols'
               artifactFileName: 'iOSSampleAppSymbols.zip'
@@ -217,6 +222,8 @@ jobs:
               artifactName: 'iOSSampleAppLLVMSymbols'
             ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppLLVMNoSymbols'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'JIT')) }}:
+              artifactName: 'iOSSampleApp'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
               artifactName: 'iOSSampleAppSymbols'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
@@ -236,6 +243,8 @@ jobs:
               artifactName: 'iOSMonoArm64LLVMNoStripSymbolsBuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSMonoArm64LLVMStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'JIT')) }}:
+              artifactName: 'iOSCoreCLRArm64BuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
               artifactName: 'iOSNativeAOTArm64NoStripSymbolsBuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -147,3 +147,12 @@ jobs:
           files: [ 'iOSSampleAppSymbols.zip' ]
         - artifactName: 'iOSSampleAppNoSymbols'
           files: [ 'iOSSampleAppNoSymbols.zip' ]
+
+  - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_ios') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'coreclr_arm64_ios'
+        dependencyJobName: build_ios_arm64_release_iOSCoreCLR
+        artifacts:
+        - artifactName: 'iOSSampleApp'
+          files: [ 'iOSSampleApp.zip' ]

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -576,6 +576,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         args.libraries_download_dir = os.path.join(args.runtime_repo_dir, "artifacts")
     
     ios_mono = args.runtime_type == "iOSMono"
+    ios_coreclr = args.runtime_type == "iOSCoreCLR"
     ios_nativeaot = args.runtime_type == "iOSNativeAOT"
     is_aot = args.codegen_type.lower() == "aot"
     is_mono = args.runtime_type == "mono"
@@ -636,6 +637,8 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if args.run_kind == "ios_scenarios":
         if args.runtime_type == "iOSMono":
             args.runtime_flavor = "mono"
+        if args.runtime_type == "iOSCoreCLR":
+            args.runtime_flavor = "coreclr"
         elif args.runtime_type == "iOSNativeAOT":
             args.runtime_flavor = "coreclr"
         else:
@@ -841,7 +844,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
             # shutil.copy(os.path.join(args.built_app_dir, "MonoBenchmarksDroid.apk"), os.path.join(root_payload_dir, "MonoBenchmarksDroid.apk"))
         ci_setup_arguments.architecture = "arm64"
 
-    if ios_mono or ios_nativeaot:
+    if ios_mono or ios_coreclr or ios_nativeaot:
         if args.built_app_dir is None:
             raise Exception("Built apps directory must be present for IOS Mono or IOS Native AOT benchmarks")
         


### PR DESCRIPTION
## Description

This PR runs ios_scenarios (build time, startup, and size)measurements for iOS on CoreCLR.

Depends on https://github.com/dotnet/runtime/pull/120139. 

