### PR TITLE
Enable Android NativeAOT MAUI runs

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -59,7 +59,7 @@
       <ApkName>com.companyname.mauisamplecontentandroid-Signed</ApkName>
       <PackageName>com.companyname.mauisamplecontentandroid</PackageName>
     </MAUIAndroidScenario>
-    <MAUIAndroidScenario Include="MAUI Blazor Android Default Template">
+    <MAUIAndroidScenario Include="MAUI Blazor Android Default Template" Condition="'$(CodegenType)' != 'NativeAOT'">
       <ScenarioDirectoryName>mauiblazorandroid</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <ApkName>com.companyname.mauiblazorandroiddefault-Signed</ApkName>


### PR DESCRIPTION
Enabling NativeAOT MAUI (+ --sample-content) runs. Blazor still disabled due to errors.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2806909