### PR TITLE
Implement runtime member info benchmarks

### DIFF
--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeEventInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeEventInfo.cs
@@ -22,7 +22,7 @@ namespace System.Reflection
             var eventsPerType = baseType.GetEvents().Length;
 
             var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
-            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
             var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
 
             for (var i = 0; i < Iterations; i += eventsPerType)
@@ -34,8 +34,14 @@ namespace System.Reflection
             }
         }
 
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _events.Clear();
+        }
+
         [Benchmark(OperationsPerInvoke = Iterations)]
-        public void AddToHashSet()
+        public HashSet<EventInfo> AddToHashSet()
         {
             var set = new HashSet<EventInfo>();
 
@@ -43,6 +49,8 @@ namespace System.Reflection
             {
                 set.Add(_events[i]);
             }
+
+            return set;
         }
     }
 

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeEventInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeEventInfo.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
+    public class RuntimeEventInfo
+    {
+        private const int Iterations = 1200;
+        private readonly List<EventInfo> _events = new(Iterations);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var baseType = typeof(RuntimeEventInfoTestClass);
+            var eventsPerType = baseType.GetEvents().Length;
+
+            var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+
+            for (var i = 0; i < Iterations; i += eventsPerType)
+            {
+                var typeBuilder = moduleBuilder.DefineType($"RuntimeDerivedClass{i}", TypeAttributes.Public, baseType);
+
+                var derivedType = typeBuilder.CreateType();
+                _events.AddRange(derivedType.GetEvents());
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void AddToHashSet()
+        {
+            var set = new HashSet<EventInfo>();
+
+            for (int i = 0; i < _events.Count; i++)
+            {
+                set.Add(_events[i]);
+            }
+        }
+    }
+
+    public class RuntimeEventInfoTestClass
+    {
+        public event EventHandler event1;
+        public event EventHandler event2;
+        public event EventHandler event3;
+
+        protected virtual void OnEvent1() => event1?.Invoke(this, EventArgs.Empty);
+
+        protected virtual void OnEvent2() => event2?.Invoke(this, EventArgs.Empty);
+
+        protected virtual void OnEvent3() => event3?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeFieldInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeFieldInfo.cs
@@ -22,7 +22,7 @@ namespace System.Reflection
             var fieldsPerType = baseType.GetFields().Length;
 
             var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
-            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
             var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
 
             for (var i = 0; i < Iterations; i += fieldsPerType)
@@ -34,8 +34,14 @@ namespace System.Reflection
             }
         }
 
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _fields.Clear();
+        }
+
         [Benchmark(OperationsPerInvoke = Iterations)]
-        public void AddToHashSet()
+        public HashSet<FieldInfo> AddToHashSet()
         {
             var set = new HashSet<FieldInfo>();
 
@@ -43,6 +49,8 @@ namespace System.Reflection
             {
                 set.Add(_fields[i]);
             }
+
+            return set;
         }
     }
 

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeFieldInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeFieldInfo.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
+    public class RuntimeFieldInfo
+    {
+        private const int Iterations = 1200;
+        private readonly List<FieldInfo> _fields = new(Iterations);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var baseType = typeof(RuntimeFieldInfoTestClass);
+            var fieldsPerType = baseType.GetFields().Length;
+
+            var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+
+            for (var i = 0; i < Iterations; i += fieldsPerType)
+            {
+                var typeBuilder = moduleBuilder.DefineType($"RuntimeDerivedClass{i}", TypeAttributes.Public, baseType);
+
+                var derivedType = typeBuilder.CreateType();
+                _fields.AddRange(derivedType.GetFields());
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void AddToHashSet()
+        {
+            var set = new HashSet<FieldInfo>();
+
+            for (int i = 0; i < _fields.Count; i++)
+            {
+                set.Add(_fields[i]);
+            }
+        }
+    }
+
+    public class RuntimeFieldInfoTestClass
+    {
+        public int Field1;
+        public string Field2;
+        public DateTime Field3;
+    }
+}

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
+    public class RuntimeMethodInfo
+    {
+        private const int Iterations = 1200;
+        private readonly List<MethodInfo> _methods = new(Iterations);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var baseType = typeof(RuntimeMethodInfoTestClass);
+            var methodsPerType = baseType.GetMethods().Length;
+
+            var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+
+            for (var i = 0; i < Iterations; i += methodsPerType)
+            {
+                var typeBuilder = moduleBuilder.DefineType($"RuntimeDerivedClass{i}", TypeAttributes.Public, baseType);
+
+                var derivedType = typeBuilder.CreateType();
+                _methods.AddRange(derivedType.GetMethods());
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void AddToHashSet()
+        {
+            var set = new HashSet<MethodInfo>();
+
+            for (int i = 0; i < _methods.Count; i++)
+            {
+                set.Add(_methods[i]);
+            }
+        }
+    }
+
+    public class RuntimeMethodInfoTestClass
+    {
+        public int Method1() => throw new NotImplementedException();
+        public string Method2() => throw new NotImplementedException();
+        public DateTime Method3() => throw new NotImplementedException();
+    }
+}

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimeMethodInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection.Emit;
 using BenchmarkDotNet.Attributes;
 using MicroBenchmarks;
@@ -22,7 +23,7 @@ namespace System.Reflection
             var methodsPerType = baseType.GetMethods().Length;
 
             var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
-            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
             var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
 
             for (var i = 0; i < Iterations; i += methodsPerType)
@@ -34,8 +35,14 @@ namespace System.Reflection
             }
         }
 
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _methods.Clear();
+        }
+
         [Benchmark(OperationsPerInvoke = Iterations)]
-        public void AddToHashSet()
+        public HashSet<MethodInfo> AddToHashSet()
         {
             var set = new HashSet<MethodInfo>();
 
@@ -43,6 +50,8 @@ namespace System.Reflection
             {
                 set.Add(_methods[i]);
             }
+
+            return set;
         }
     }
 

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimePropertyInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimePropertyInfo.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Reflection
+{
+    [BenchmarkCategory(Categories.Runtime, Categories.Reflection)]
+    public class RuntimePropertyInfo
+    {
+        private const int Iterations = 1200;
+        private readonly List<PropertyInfo> _properties = new(Iterations);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var baseType = typeof(RuntimePropertyInfoTestClass);
+            var propertiesPerType = baseType.GetProperties().Length;
+
+            var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
+
+            for (var i = 0; i < Iterations; i += propertiesPerType)
+            {
+                var typeBuilder = moduleBuilder.DefineType($"RuntimeDerivedClass{i}", TypeAttributes.Public, baseType);
+
+                var derivedType = typeBuilder.CreateType();
+                _properties.AddRange(derivedType.GetProperties());
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Iterations)]
+        public void AddToHashSet()
+        {
+            var set = new HashSet<PropertyInfo>();
+
+            for (int i = 0; i < _properties.Count; i++)
+            {
+                set.Add(_properties[i]);
+            }
+        }
+    }
+
+    public class RuntimePropertyInfoTestClass
+    {
+        public int Property1 { get; set; }
+        public string Property2 { get; set; }
+        public DateTime Property3 { get; set; }
+    }
+}

--- a/src/benchmarks/micro/runtime/System.Reflection/RuntimePropertyInfo.cs
+++ b/src/benchmarks/micro/runtime/System.Reflection/RuntimePropertyInfo.cs
@@ -22,7 +22,7 @@ namespace System.Reflection
             var propertiesPerType = baseType.GetProperties().Length;
 
             var assemblyName = new AssemblyName(baseType.Namespace + ".DynamicAssembly");
-            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndCollect);
             var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name);
 
             for (var i = 0; i < Iterations; i += propertiesPerType)
@@ -34,8 +34,14 @@ namespace System.Reflection
             }
         }
 
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _properties.Clear();
+        }
+
         [Benchmark(OperationsPerInvoke = Iterations)]
-        public void AddToHashSet()
+        public HashSet<PropertyInfo> AddToHashSet()
         {
             var set = new HashSet<PropertyInfo>();
 
@@ -43,6 +49,8 @@ namespace System.Reflection
             {
                 set.Add(_properties[i]);
             }
+
+            return set;
         }
     }
 


### PR DESCRIPTION
Add benchmarks for the runtime member info (`RuntimePropertyInfo`, `RuntimeMethodInfo`, `RuntimeEventInfo`, `RuntimeFieldInfo`) classes used in a hashset (i.e. `GetHashCode` + `Equals`) to record the initial status, as requested in https://github.com/dotnet/runtime/issues/114280