### PR TITLE
Fix Sve benchmark warning and config

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -10,6 +10,8 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
+    <!-- Suppress Sve experimental feature warning -->
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
* Suppress Sve experimental warning in project config.
I am not sure if it is possible to suppress warning on specific files instead of the whole project. However, since `SYSLIB5003` is specific to the SVE experimental API, it should only affect the benchmarks inside the `src/benchmarks/micro/sve` directory. 

* Remove redundant Sve.IsSupported checks as it is already checked in the benchmark filter config. SVE benchmarks will be filtered out when executing on non-SVE machines.