### PR TITLE
Add MultiplyAdd and AddReduction to SVE microbenchmark

### DIFF
--- a/src/benchmarks/micro/sve/AddReduction.cs
+++ b/src/benchmarks/micro/sve/AddReduction.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class AddReduction
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private double[] _source;
+        private double _result;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            _source = ValuesGenerator.Array<double>(Size);
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            double current = _result;
+            Setup();
+            Scalar();
+            double scalar = _result;
+            // Check that the result is the same as scalar (within 10ULP).
+            // Error is due to rounding floating-point additions in different
+            // orderings (for Vector128AddReduction and SveAddReduction).
+            // SveAddSequential has the same ordering as Scalar.
+            int e = (int)(BitConverter.DoubleToUInt64Bits(scalar) >> 52 & 0x7ff);
+            if (e == 0) e++;
+            double ulpScale = Math.ScaleB(1.0f, e - 1023 - 52);
+            double ulpError = Math.Abs(current - scalar) / ulpScale;
+            Debug.Assert(ulpError <= 10);
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (double* a = _source)
+            {
+                double res = 0.0;
+                for (int i = 0; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128AddReduction()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                double res = 0.0;
+                for (; i <= Size - 2; i += 2)
+                {
+                    Vector128<double> data = AdvSimd.LoadVector128(a + i);
+                    // Sum up all lanes and reduce to scalar.
+                    res += AdvSimd.Arm64.AddPairwiseScalar(data).ToScalar();
+                }
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveAddSequential()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                int cntd = (int)Sve.Count64BitElements();
+
+                Vector<double> resVec = Vector<double>.Zero;
+                Vector<double> pTrue = Sve.CreateTrueMaskDouble();
+                for (; i <= Size - cntd; i += cntd)
+                {
+                    Vector<double> data = Sve.LoadVector(pTrue, a + i);
+                    // Sum up all lanes sequentially and add to scalar.
+                    resVec = Sve.AddSequentialAcross(resVec, data);
+                }
+                // Get the scalar result from the first lane.
+                double res = resVec.ToScalar();
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveAddReduction()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                int cntd = (int)Sve.Count64BitElements();
+                double res = 0.0;
+
+                Vector<double> pTrue = Sve.CreateTrueMaskDouble();
+                for (; i <= Size - cntd; i += cntd)
+                {
+                    Vector<double> data = Sve.LoadVector(pTrue, a + i);
+                    // Sum up all lanes and reduce to scalar.
+                    res += Sve.AddAcross(data).ToScalar();
+                }
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/sve/MultiplyAdd.cs
+++ b/src/benchmarks/micro/sve/MultiplyAdd.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class MultiplyAdd
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private int[] _source1;
+        private int[] _source2;
+        private int _result;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            _source1 = ValuesGenerator.Array<int>(Size);
+            _source2 = ValuesGenerator.Array<int>(Size);
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            int current = _result;
+            Setup();
+            Scalar();
+            int scalar = _result;
+            // Check that the result is the same as the scalar result.
+            Debug.Assert(current == scalar);
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int res = 0;
+                for (int i = 0; i < Size; i++)
+                {
+                    res += (int)(a[i] * b[i]);
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128MultiplyAdd()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int incr = sizeof(Vector128<int>) / sizeof(int);
+                int i = 0;
+
+                // The length of the tail is Size modulo 4 * element count.
+                int lmt = Size - (Size % (incr << 2));
+
+                Vector128<int> res1 = Vector128<int>.Zero;
+                Vector128<int> res2 = Vector128<int>.Zero;
+                Vector128<int> res3 = Vector128<int>.Zero;
+                Vector128<int> res4 = Vector128<int>.Zero;
+
+                for (; i < lmt; i += incr << 2)
+                {
+                    // Unroll loop by 4.
+                    Vector128<int> aVec1 = AdvSimd.LoadVector128(a + i);
+                    Vector128<int> bVec1 = AdvSimd.LoadVector128(b + i);
+                    Vector128<int> aVec2 = AdvSimd.LoadVector128(a + i + incr);
+                    Vector128<int> bVec2 = AdvSimd.LoadVector128(b + i + incr);
+                    Vector128<int> aVec3 = AdvSimd.LoadVector128(a + i + incr * 2);
+                    Vector128<int> bVec3 = AdvSimd.LoadVector128(b + i + incr * 2);
+                    Vector128<int> aVec4 = AdvSimd.LoadVector128(a + i + incr * 3);
+                    Vector128<int> bVec4 = AdvSimd.LoadVector128(b + i + incr * 3);
+
+                    // Calculate 4 vectors at a time.
+                    res1 = AdvSimd.MultiplyAdd(res1, aVec1, bVec1);
+                    res2 = AdvSimd.MultiplyAdd(res2, aVec2, bVec2);
+                    res3 = AdvSimd.MultiplyAdd(res3, aVec3, bVec3);
+                    res4 = AdvSimd.MultiplyAdd(res4, aVec4, bVec4);
+                }
+
+                // Sum all the results between the 4 vectors.
+                res1 = Vector128.Add(res1, res2);
+                res3 = Vector128.Add(res3, res4);
+                res1 = Vector128.Add(res1, res3);
+                int res = AdvSimd.Arm64.AddAcross(res1).ToScalar();
+
+                // Process any remaining elements.
+                for (; i < Size; i++)
+                {
+                    res += (int)(a[i] * b[i]);
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveMultiplyAdd()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int i = 0;
+                int cntw = (int)Sve.Count32BitElements();
+
+                // The length of the tail is Size modulo 4 * element count.
+                int lmt = (int)Size - (Size % (cntw << 2));
+
+                Vector<int> res1 = Vector<int>.Zero;
+                Vector<int> res2 = Vector<int>.Zero;
+                Vector<int> res3 = Vector<int>.Zero;
+                Vector<int> res4 = Vector<int>.Zero;
+                Vector<int> pTrue = Sve.CreateTrueMaskInt32();
+
+                while (i < lmt)
+                {
+                    // Unroll loop by 4.
+                    Vector<int> aVec1 = Sve.LoadVector(pTrue, a + i);
+                    Vector<int> bVec1 = Sve.LoadVector(pTrue, b + i);
+                    Vector<int> aVec2 = Sve.LoadVector(pTrue, a + i + cntw);
+                    Vector<int> bVec2 = Sve.LoadVector(pTrue, b + i + cntw);
+                    Vector<int> aVec3 = Sve.LoadVector(pTrue, a + i + cntw * 2);
+                    Vector<int> bVec3 = Sve.LoadVector(pTrue, b + i + cntw * 2);
+                    Vector<int> aVec4 = Sve.LoadVector(pTrue, a + i + cntw * 3);
+                    Vector<int> bVec4 = Sve.LoadVector(pTrue, b + i + cntw * 3);
+
+                    // Calculate 4 vectors at a time.
+                    res1 = Sve.MultiplyAdd(res1, aVec1, bVec1);
+                    res2 = Sve.MultiplyAdd(res2, aVec2, bVec2);
+                    res3 = Sve.MultiplyAdd(res3, aVec3, bVec3);
+                    res4 = Sve.MultiplyAdd(res4, aVec4, bVec4);
+
+                    // Increment counter by 4 times the element count.
+                    i = Sve.SaturatingIncrementBy32BitElementCount(i, 4);
+                }
+
+                // Handle remaining elements using predicates.
+                lmt = Size;
+                Vector<int> pLoop = (Vector<int>)Sve.CreateWhileLessThanMask32Bit(i, lmt);
+                while (Sve.TestAnyTrue(pTrue, pLoop))
+                {
+                    Vector<int> aVec = Sve.LoadVector(pLoop, a + i);
+                    Vector<int> bVec = Sve.LoadVector(pLoop, b + i);
+
+                    // Apply pLoop mask on the result.
+                    res1 = Sve.ConditionalSelect(pLoop, Sve.MultiplyAdd(res1, aVec, bVec), res1);
+
+                    // Increment by a vector length.
+                    i += cntw;
+                    pLoop = (Vector<int>)Sve.CreateWhileLessThanMask32Bit(i, lmt);
+                }
+
+                // Sum up all elements in the 4 result vectors.
+                res1 = Sve.Add(res1, res2);
+                res3 = Sve.Add(res3, res4);
+                _result = (int)Sve.AddAcross(Sve.Add(res1, res3)).ToScalar();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds two new SVE benchmark routines:

## MultiplyAdd
| Method               | Size  | Mean         | Error       | StdDev      | Median       | Min          | Max          | Allocated |
|--------------------- |------ |-------------:|------------:|------------:|-------------:|-------------:|-------------:|----------:|
| Scalar               | 15    |     5.290 ns |   0.0524 ns |   0.0491 ns |     5.312 ns |     5.142 ns |     5.330 ns |         - |
| Vector128MultiplyAdd | 15    |     5.853 ns |   0.0085 ns |   0.0079 ns |     5.855 ns |     5.834 ns |     5.868 ns |         - |
| SveMultiplyAdd       | 15    |     2.195 ns |   0.0015 ns |   0.0012 ns |     2.196 ns |     2.193 ns |     2.197 ns |         - |
| Scalar               | 127   |    47.884 ns |   0.1814 ns |   0.1608 ns |    47.908 ns |    47.540 ns |    48.135 ns |         - |
| Vector128MultiplyAdd | 127   |    14.713 ns |   0.0159 ns |   0.0149 ns |    14.705 ns |    14.699 ns |    14.741 ns |         - |
| SveMultiplyAdd       | 127   |    10.685 ns |   0.0176 ns |   0.0156 ns |    10.680 ns |    10.670 ns |    10.718 ns |         - |
| Scalar               | 527   |   196.012 ns |   0.1077 ns |   0.0899 ns |   195.988 ns |   195.914 ns |   196.249 ns |         - |
| Vector128MultiplyAdd | 527   |    36.220 ns |   0.0485 ns |   0.0430 ns |    36.202 ns |    36.180 ns |    36.325 ns |         - |
| SveMultiplyAdd       | 527   |    46.452 ns |   0.0213 ns |   0.0200 ns |    46.448 ns |    46.424 ns |    46.490 ns |         - |
| Scalar               | 10015 | 4,067.699 ns | 215.4742 ns | 248.1404 ns | 4,177.928 ns | 3,633.769 ns | 4,379.597 ns |         - |
| Vector128MultiplyAdd | 10015 |   883.944 ns |   0.7217 ns |   0.6751 ns |   883.908 ns |   882.907 ns |   885.086 ns |         - |
| SveMultiplyAdd       | 10015 |   779.697 ns |   3.1572 ns |   2.9533 ns |   779.144 ns |   776.029 ns |   786.284 ns |         - |


## AddReduction

This includes two variants for SVE with different addition orders. `Scalar` and `SveAddSequential` add the floating point values in the same order as the array; `Vector128AddReduction` and `SveAddReduction` add floating point values one vector at a time, then add across the vector elements at last.

Due to floating point rounding errors, the results are not exactly the same depending on the order of operations. In the `Verify` check, 10ULP is set as a rough bound for the expected results. Please let me know if there is a better solution.

| Method                | Size  | Mean         | Error     | StdDev    | Median       | Min          | Max          | Allocated |
|---------------------- |------ |-------------:|----------:|----------:|-------------:|-------------:|-------------:|----------:|
| Scalar                | 15    |     3.856 ns | 0.0164 ns | 0.0154 ns |     3.850 ns |     3.848 ns |     3.894 ns |         - |
| Vector128AddReduction | 15    |     1.605 ns | 0.1221 ns | 0.1406 ns |     1.512 ns |     1.510 ns |     1.829 ns |         - |
| SveAddSequential      | 15    |     1.857 ns | 0.0309 ns | 0.0258 ns |     1.846 ns |     1.845 ns |     1.921 ns |         - |
| SveAddReduction       | 15    |     1.976 ns | 0.1917 ns | 0.2208 ns |     1.831 ns |     1.827 ns |     2.328 ns |         - |
| Scalar                | 127   |    50.328 ns | 0.2659 ns | 0.2076 ns |    50.298 ns |    50.004 ns |    50.867 ns |         - |
| Vector128AddReduction | 127   |    23.907 ns | 0.0397 ns | 0.0371 ns |    23.908 ns |    23.833 ns |    23.954 ns |         - |
| SveAddSequential      | 127   |    44.752 ns | 0.0449 ns | 0.0398 ns |    44.741 ns |    44.711 ns |    44.831 ns |         - |
| SveAddReduction       | 127   |    28.662 ns | 0.0091 ns | 0.0076 ns |    28.663 ns |    28.648 ns |    28.673 ns |         - |
| Scalar                | 527   |   285.850 ns | 0.0880 ns | 0.0780 ns |   285.860 ns |   285.739 ns |   286.006 ns |         - |
| Vector128AddReduction | 527   |   131.408 ns | 0.0437 ns | 0.0409 ns |   131.394 ns |   131.353 ns |   131.492 ns |         - |
| SveAddSequential      | 527   |   285.207 ns | 0.0687 ns | 0.0609 ns |   285.194 ns |   285.133 ns |   285.343 ns |         - |
| SveAddReduction       | 527   |   143.885 ns | 0.1405 ns | 0.1314 ns |   143.811 ns |   143.784 ns |   144.142 ns |         - |
| Scalar                | 10015 | 6,024.445 ns | 1.2299 ns | 1.0270 ns | 6,024.217 ns | 6,022.966 ns | 6,026.060 ns |         - |
| Vector128AddReduction | 10015 | 3,008.501 ns | 1.3304 ns | 1.1110 ns | 3,008.437 ns | 3,007.183 ns | 3,011.463 ns |         - |
| SveAddSequential      | 10015 | 6,026.151 ns | 4.2718 ns | 3.9959 ns | 6,025.293 ns | 6,022.252 ns | 6,034.714 ns |         - |
| SveAddReduction       | 10015 | 3,026.546 ns | 2.3406 ns | 2.0749 ns | 3,025.740 ns | 3,024.234 ns | 3,030.865 ns |         - |


@dotnet/arm64-contrib @SwapnilGaikwad