### PR TITLE
Update iOS CoreCLR build job to use release configuration

### DIFF
--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -52,7 +52,7 @@ jobs:
         - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
           - ${{ 'build_ios_arm64_release_iOSMono' }}
         - ${{ if eq(parameters.runtimeType, 'iOSCoreCLR')}}:
-          - ${{ 'build_ios_arm64_checked_iOSCoreCLR' }}
+          - ${{ 'build_ios_arm64_release_iOSCoreCLR' }}
         - ${{ if eq(parameters.runtimeType, 'iOSNativeAOT')}}:
           - ${{ 'build_ios_arm64_release_iOSNativeAOT' }}
 

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -148,7 +148,7 @@ jobs:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_arm64_ios'
-        dependencyJobName: build_ios_arm64_checked_iOSCoreCLR
+        dependencyJobName: build_ios_arm64_release_iOSCoreCLR
         artifacts:
         - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
           files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]


### PR DESCRIPTION
## Description

This PR updates iOS CoreCLR build job to use release configuration.

Depends on https://github.com/dotnet/runtime/pull/121117
