### PR TITLE
Update DnsSafeHost test to be properly formatted

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
@@ -67,7 +67,7 @@ namespace System.Tests
         public string ParseAbsoluteUri() => new Uri("http://127.0.0.1:80").AbsoluteUri;
 
         [Benchmark]
-        public string DnsSafeHost() => new Uri("http://[fe80::3]%1").DnsSafeHost;
+        public string DnsSafeHost() => new Uri("http://[fe80::3%251]").DnsSafeHost;
 
         [Benchmark]
         [MemoryRandomization]


### PR DESCRIPTION
Update DnsSafeHost test to be properly formatted by moving the scopeid inside the brackets and making sure it is escaped properly.

This test was broken after some correctness fixes: https://github.com/dotnet/runtime/pull/120908. Based on the docs for [System.Uri](https://learn.microsoft.com/en-us/dotnet/api/system.uri.dnssafehost?view=net-9.0), the correct format is an escaped string with the ScopeID inside the brackets.

@MihaZupan Just to double check, this seems to be a correct fix for the url?


