### PR TITLE
Update BlazorLocalized.csproj to allow references to prerelease net10.0 packages

### DIFF
--- a/src/scenarios/blazorlocalized/src/BlazorLocalized/BlazorLocalized.csproj
+++ b/src/scenarios/blazorlocalized/src/BlazorLocalized/BlazorLocalized.csproj
@@ -10,28 +10,9 @@
 
   <Import Project="$(BuildCommonPath)\Blazor.PackageVersions.props" />
 
-  <!-- Workaround: Explicit Microsoft.Extensions pre-release versions for net10.0.
-       The WebAssembly SDK depends on Microsoft.Extensions packages with version >=10.0.0.
-       Only pre-release (rtm/rc) builds are presently available in internal feeds; since
-       NuGet treats pre-release < stable, transitive resolution fails. We force a floating
-       pre-release selection via explicit PackageReferences conditioned on net10.0. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))">
-    <ExtensionsVersion>10.0.0-*</ExtensionsVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(AspNetCoreVersion)" />
     <ProjectReference Include="..\BlazorLocalized.ClassLibrary\BlazorLocalized.ClassLibrary.csproj" />
-    <!-- Explicit extensions packages (conditional) -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
   </ItemGroup>
 </Project>

--- a/src/scenarios/build-common/Blazor.PackageVersions.props
+++ b/src/scenarios/build-common/Blazor.PackageVersions.props
@@ -26,4 +26,26 @@
         <BlazorVersion Condition="'$(BlazorVersion)' == ''">6.0.0-preview*</BlazorVersion>
         <SystemNetHttpJsonVersion Condition="'$(SystemNetHttpJsonVersion)' == ''">6.0.0-preview*</SystemNetHttpJsonVersion>
     </PropertyGroup>
+
+      <!-- Workaround: Explicit Microsoft.Extensions pre-release versions for net10.0.
+       The WebAssembly SDK depends on Microsoft.Extensions packages with version >=10.0.0.
+       Only pre-release (rtm/rc) builds are presently available in internal feeds; since
+       NuGet treats pre-release < stable, transitive resolution fails. We force a floating
+       pre-release selection via explicit PackageReferences conditioned on net10.0. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))">
+    <ExtensionsVersion>10.0.0-*</ExtensionsVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Explicit extensions packages (conditional) -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Update BlazorLocalized.csproj to allow references to prerelease net10.0 Microsoft.Extensions packages while we wait for stable packages.

This should fix the BlazorLocalized performance-ci errors we are seeing. Tested successfully locally.