### PR TITLE
Add TCPChecksum to SVE microbenchmark

### DIFF
--- a/src/benchmarks/micro/sve/TCPChecksum.cs
+++ b/src/benchmarks/micro/sve/TCPChecksum.cs
@@ -167,26 +167,27 @@ namespace SveBenchmarks
                 byte* lmt = p + _psize;
 
                 Vector<ushort> ones = Vector<ushort>.One;
-                Vector<byte> pTrue = Sve.CreateTrueMaskByte();
+                Vector<ushort> pTrue = Sve.CreateTrueMaskUInt16();
 
                 while (p < lmt)
                 {
                     ushort* plength = (ushort*)(p + 1);
                     ushort length = (ushort)(*plength & 0xfe);
+                    int lengthWords = length / 2;
 
                     int i = 0;
                     Vector<ulong> acc = Vector<ulong>.Zero;
-                    Vector<byte> pLoop = Sve.CreateWhileLessThanMask8Bit(0, length);
+                    Vector<ushort> pLoop = Sve.CreateWhileLessThanMask16Bit(0, lengthWords);
                     while (Sve.TestAnyTrue(pTrue, pLoop))
                     {
-                        Vector<ushort> d = (Vector<ushort>)Sve.LoadVector(pLoop, p + i);
+                        Vector<ushort> d = Sve.LoadVector(pLoop, ((ushort*)p) + i);
                         // Compute dot product of the data and a vector of 1.
                         // The result is widened to 64-bit.
                         acc = Sve.DotProduct(acc, d, ones);
 
                         // Handle loop predicate.
-                        i += (int)Sve.Count8BitElements();
-                        pLoop = Sve.CreateWhileLessThanMask8Bit(i, length);
+                        i += (int)Sve.Count16BitElements();
+                        pLoop = Sve.CreateWhileLessThanMask16Bit(i, lengthWords);
                     }
                     // Reduce result to scalar.
                     ulong sum = Sve.AddAcross(acc).ToScalar();


### PR DESCRIPTION
## Performance Results

Run on Neoverse-V2

| Method               | Size  | Mean        | Error    | StdDev   | Median      | Min         | Max         | Allocated |
|--------------------- |------ |------------:|---------:|---------:|------------:|------------:|------------:|----------:|
| Scalar               | 527   |   105.68 ns | 0.105 ns | 0.088 ns |   105.65 ns |   105.62 ns |   105.93 ns |         - |
| Vector128TCPChecksum | 527   |    13.82 ns | 0.017 ns | 0.013 ns |    13.82 ns |    13.79 ns |    13.83 ns |         - |
| SveTCPChecksum       | 527   |    26.27 ns | 0.236 ns | 0.220 ns |    26.35 ns |    25.87 ns |    26.59 ns |         - |
| Scalar               | 1234  |   213.40 ns | 0.096 ns | 0.080 ns |   213.40 ns |   213.28 ns |   213.59 ns |         - |
| Vector128TCPChecksum | 1234  |    30.98 ns | 0.393 ns | 0.307 ns |    30.88 ns |    30.85 ns |    31.94 ns |         - |
| SveTCPChecksum       | 1234  |    58.24 ns | 0.249 ns | 0.233 ns |    58.25 ns |    57.77 ns |    58.51 ns |         - |
| Scalar               | 10015 | 2,036.12 ns | 1.814 ns | 1.697 ns | 2,036.36 ns | 2,033.20 ns | 2,038.84 ns |         - |
| Vector128TCPChecksum | 10015 |   285.82 ns | 0.885 ns | 0.739 ns |   285.58 ns |   285.20 ns |   287.46 ns |         - |
| SveTCPChecksum       | 10015 |   475.23 ns | 0.922 ns | 0.770 ns |   474.84 ns |   474.68 ns |   477.21 ns |         - |

cc @dotnet/arm64-contrib @SwapnilGaikwad @LoopedBard3