### PR TITLE
Add SobelFilter to SVE microbenchmark

### DIFF
--- a/src/benchmarks/micro/sve/SobelFilter.cs
+++ b/src/benchmarks/micro/sve/SobelFilter.cs
@@ -73,7 +73,7 @@ namespace SveBenchmarks
             fixed (float* kx = _kx, ky = _ky)
             {
                 // Convolve the horizontal component first.
-                // The result is save to the temp array.
+                // The result is saved to the temp array.
                 for (int j = 0; j < imgSize; j++)
                 {
                     for (int i = 0; i < outSize; i++)


### PR DESCRIPTION
## Performance Results

Run on Neoverse-V2

| Method               | Size | Mean          | Error        | StdDev       | Median        | Min           | Max           | Allocated |
|--------------------- |----- |--------------:|-------------:|-------------:|--------------:|--------------:|--------------:|----------:|
| Scalar               | 9    |     106.89 ns |     0.027 ns |     0.023 ns |     106.89 ns |     106.86 ns |     106.94 ns |         - |
| Vector128SobelFilter | 9    |      47.21 ns |     0.007 ns |     0.006 ns |      47.21 ns |      47.20 ns |      47.22 ns |         - |
| SveSobelFilter       | 9    |      28.89 ns |     0.134 ns |     0.125 ns |      28.81 ns |      28.77 ns |      29.07 ns |         - |
| Scalar               | 64   |   7,125.25 ns |     2.823 ns |     2.503 ns |   7,124.19 ns |   7,122.83 ns |   7,130.43 ns |         - |
| Vector128SobelFilter | 64   |   1,255.35 ns |     0.913 ns |     0.854 ns |   1,255.21 ns |   1,254.21 ns |   1,256.87 ns |         - |
| SveSobelFilter       | 64   |   1,339.70 ns |     0.280 ns |     0.219 ns |   1,339.65 ns |   1,339.41 ns |   1,340.14 ns |         - |
| Scalar               | 527  | 507,148.17 ns |   324.567 ns |   287.720 ns | 507,050.40 ns | 506,733.19 ns | 507,636.12 ns |         - |
| Vector128SobelFilter | 527  |  73,998.18 ns |   166.540 ns |   147.634 ns |  73,971.34 ns |  73,795.42 ns |  74,256.96 ns |         - |
| SveSobelFilter       | 527  | 100,770.21 ns | 1,836.759 ns | 1,628.239 ns | 100,470.79 ns |  96,333.15 ns | 103,294.79 ns |         - |

cc @dotnet/arm64-contrib @SwapnilGaikwad @LoopedBard3