### PR TITLE
Stop doing certhelper build on WASM runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -950,7 +950,9 @@ def run_performance_job(args: RunPerformanceJobArgs):
             "-p:DisableTransitiveFrameworkReferenceDownloads=true"],
             verbose=True).run()
 
-    publish_dotnet_app_to_payload("certhelper", os.path.join(args.performance_repo_dir, "src", "tools", "CertHelper", "CertHelper.csproj"))
+    # Skip publishing CertHelper for WASM runs as a bug is breaking the build https://github.com/dotnet/runtime/issues/120901
+    if not wasm:
+        publish_dotnet_app_to_payload("certhelper", os.path.join(args.performance_repo_dir, "src", "tools", "CertHelper", "CertHelper.csproj"))
 
     if args.is_scenario:
         set_environment_variable("DOTNET_ROOT", ci_setup_arguments.install_dir, save_to_pipeline=True)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


