### PR TITLE
Update channel mapping for 11 daily branch to use the net11 TFM

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -3,7 +3,7 @@ from typing import Optional
 class ChannelMap():
     channel_map = {
         'main': {
-            'tfm': 'net10.0',
+            'tfm': 'net11.0',
             'branch': '11.0',
             'quality': 'daily'
         },


### PR DESCRIPTION
Update channel mapping for 11 daily branch to use the net11 TFM now that it has switched to 11 alpha SDK.

Will need to rerun dotnet-runtime-perf from https://dev.azure.com/dnceng/internal/_build/results?buildId=2854822&view=logs&j=909ada5e-9b99-57ea-5db4-6842dbf85e5c&t=ab068bb5-f4e2-507d-8768-81cd2d5c0e7a (20251205.3) and perf-slow from https://dev.azure.com/dnceng/internal/_build/results?buildId=2854808&view=results (20251205.2).
