### PR TITLE
Fix Windows Helix work item exit code and prerequisite error handling

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -157,8 +157,10 @@ def get_pre_commands(
             ]
 
         # Clear the PYTHONPATH first so that modules installed elsewhere are not used
+        # Note: On Windows, 'set PYTHONPATH=' must be a separate command, not chained with &&,
+        # otherwise Python fails with "OSError: failed to make path absolute"
         if os_group == "windows":
-            install_prerequisites += ["set PYTHONPATH="]
+            helix_pre_commands += ["set PYTHONPATH="]
         else:
             install_prerequisites += ["export PYTHONPATH="]
 


### PR DESCRIPTION
- Use 'call deactivate' instead of 'deactivate' in PostCommands on Windows. Without 'call', the batch file transfers control to deactivate.bat and never returns, causing EXIT /b %_commandExitCode% to never execute.

- Chain Windows prerequisite install commands with && and add error checking. Previously, pip install failures were silently ignored, causing ModuleNotFoundError for azure packages during upload.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


