### PR TITLE
Don't use thread-free python version 3.13t on Windows

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -24,28 +24,28 @@ parameters:
       enabled: true
       configs:
         - windows_x64
-        #- linux_x64
+        - linux_x64
   - name: viperMicro
     type: object
     default:
       enabled: true
       configs:
         - windows_x64
-        #- linux_x64
+        - linux_x64
   - name: owlMicro
     type: object
     default:
       enabled: true
       configs:
         - windows_x64
-        #- linux_x64
+        - linux_x64
   - name: tigerMicro
     type: object
     default:
       enabled: true
       configs:
         - windows_x64
-        #- linux_x64
+        - linux_x64
   - name: androidMono
     type: object
     default:
@@ -59,12 +59,12 @@ jobs:
       perfBranch: ${{ parameters.perfBranch }}
 
   - ${{ if not(startswith(variables['Build.SourceBranch'], 'refs/heads/release')) }}:
-    # # Build and run iOS Mono and NativeAOT scenarios
-    # - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
-    #   parameters:
-    #     runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-    #     performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-    #     jobParameters: ${{ parameters.jobParameters }}
+    # Build and run iOS Mono and NativeAOT scenarios
+    - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+      parameters:
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        jobParameters: ${{ parameters.jobParameters }}
 
     # run android scenarios - Mono JIT
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -86,25 +86,25 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    # # run android scenarios - Mono AOT
-    # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-    #     buildConfig: release
-    #     runtimeFlavor: mono
-    #     platforms:
-    #       - windows_x64
-    #     jobParameters:
-    #       runtimeType: AndroidMono
-    #       codeGenType: AOT
-    #       projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-    #       runKind: android_scenarios
-    #       isScenario: true
-    #       logicalMachine: 'perfpixel4a'
-    #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-    #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-    #       ${{ each parameter in parameters.jobParameters }}:
-    #         ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - Mono AOT
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidMono
+          codeGenType: AOT
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
     # run android scenarios - CoreCLR JIT
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -126,121 +126,121 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    # # run android scenarios - CoreCLR JIT Static Linking
-    # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-    #     buildConfig: release
-    #     runtimeFlavor: coreclr
-    #     platforms:
-    #       - windows_x64
-    #     jobParameters:
-    #       runtimeType: AndroidCoreCLR
-    #       codeGenType: JIT
-    #       linkingType: static
-    #       projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-    #       runKind: android_scenarios
-    #       isScenario: true
-    #       logicalMachine: 'perfpixel4a'
-    #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-    #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-    #       ${{ each parameter in parameters.jobParameters }}:
-    #         ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - CoreCLR JIT Static Linking
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidCoreCLR
+          codeGenType: JIT
+          linkingType: static
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-    # # run android scenarios - CoreCLR R2R
-    # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    #   parameters:
-    #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-    #     buildConfig: release
-    #     runtimeFlavor: coreclr
-    #     platforms:
-    #       - windows_x64
-    #     jobParameters:
-    #       runtimeType: AndroidCoreCLR
-    #       codeGenType: R2R
-    #       projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-    #       runKind: android_scenarios
-    #       isScenario: true
-    #       logicalMachine: 'perfpixel4a'
-    #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-    #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-    #       ${{ each parameter in parameters.jobParameters }}:
-    #         ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - CoreCLR R2R
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidCoreCLR
+          codeGenType: R2R
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     #- linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
 
-  # # run mono interpreter perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     #- linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run mono aot microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     #- linux_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       runKind: micro_mono
-  #       logicalMachine: 'perfviper'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        runKind: micro_mono
+        logicalMachine: 'perfviper'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
-  # # run coreclr perftiger microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     #- linux_x64
-  #     # - windows_x64
-  #     jobParameters:
-  #       liveLibrariesBuildConfig: Release
-  #       runKind: micro
-  #       logicalMachine: 'perftiger'
-  #       runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-  #       performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-  #       ${{ each parameter in parameters.jobParameters }}:
-  #         ${{ parameter.key }}: ${{ parameter.value }}
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      # - windows_x64
+      jobParameters:
+        liveLibrariesBuildConfig: Release
+        runKind: micro
+        logicalMachine: 'perftiger'
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
 
   # run coreclr perfviper microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
@@ -249,9 +249,9 @@ jobs:
       buildConfig: release
       runtimeFlavor: coreclr
       platforms:
-      #- linux_x64
+      - linux_x64
       - windows_x64
-      #- windows_x86
+      - windows_x86
       jobParameters:
         liveLibrariesBuildConfig: Release
         runKind: micro
@@ -268,7 +268,7 @@ jobs:
       buildConfig: release
       runtimeFlavor: coreclr
       platforms:
-      #- linux_x64
+      - linux_x64
       - windows_x64
       jobParameters:
         liveLibrariesBuildConfig: Release


### PR DESCRIPTION
If we would use the python version 3.13t, don't, instead use the non-thread-free version so we can successfully install all of the windows packages.

This will fix errors, such as the following, that are occurring because the packages we are trying to install are incompatible with the 3.13t version of python.

<summary>Incompatibility Error</summary>
<details>

```
(.venv) C:\h\w\AC0C096E\w\9CE4088C\e>python -m pip install azure.storage.blob==12.13.0 
Collecting azure.storage.blob==12.13.0
  Using cached azure_storage_blob-12.13.0-py3-none-any.whl.metadata (25 kB)
Collecting azure-core<2.0.0,>=1.23.1 (from azure.storage.blob==12.13.0)
  Using cached azure_core-1.37.0-py3-none-any.whl.metadata (47 kB)
Collecting msrest>=0.6.21 (from azure.storage.blob==12.13.0)
  Using cached msrest-0.7.1-py3-none-any.whl.metadata (21 kB)
Collecting cryptography>=2.1.4 (from azure.storage.blob==12.13.0)
  Using cached cryptography-46.0.3.tar.gz (749 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  error: subprocess-exited-with-error
  
  installing build dependencies for cryptography did not run successfully.
  exit code: 1
  
  [39 lines of output]
  Ignoring cffi: markers 'platform_python_implementation != "PyPy" and python_version == "3.8"' don't match your environment
  Collecting maturin<2,>=1.9.4
    Using cached maturin-1.11.2-py3-none-win_amd64.whl.metadata (16 kB)
  Collecting cffi>=2.0.0
    Using cached cffi-2.0.0.tar.gz (523 kB)
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
  
    Getting requirements to build wheel did not run successfully.
    exit code: 1
  
    [20 lines of output]
    Traceback (most recent call last):
      File "C:\h\w\AC0C096E\w\9CE4088C\e\.venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 389, in <module>
        main()
        ~~~~^^
      File "C:\h\w\AC0C096E\w\9CE4088C\e\.venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 373, in main
        json_out["return_val"] = hook(**hook_input["kwargs"])
                                 ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\h\w\AC0C096E\w\9CE4088C\e\.venv\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 143, in get_requires_for_build_wheel
        return hook(config_settings)
      File "C:\h\w\AC0C096E\t\pip-build-env-5_89x309\overlay\Lib\site-packages\setuptools\build_meta.py", line 331, in get_requires_for_build_wheel
        return self._get_build_requires(config_settings, requirements=[])
               ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\h\w\AC0C096E\t\pip-build-env-5_89x309\overlay\Lib\site-packages\setuptools\build_meta.py", line 301, in _get_build_requires
        self.run_setup()
        ~~~~~~~~~~~~~~^^
      File "C:\h\w\AC0C096E\t\pip-build-env-5_89x309\overlay\Lib\site-packages\setuptools\build_meta.py", line 317, in run_setup
        exec(code, locals())
        ~~~~^^^^^^^^^^^^^^^^
      File "<string>", line 22, in <module>
    RuntimeError: CFFI does not support the free-threaded build of CPython 3.13. Upgrade to free-threaded 3.14 or newer to use CFFI with the free-threaded build.
    [end of output]
  
    note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed to build 'cffi' when getting requirements to build wheel
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'cryptography' when installing build dependencies for cryptography
```

</details>

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2874993&view=results
Successfully ran microbenchmarks on machine PerfViper098 which had been failing before (only 1 run due to sanity check). Also successfully ran the android tests set to run.
