### PR TITLE
Modify unique name generation in upload.py

### DIFF
--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -25,7 +25,7 @@ class QueueMessage:
 def get_unique_name(filename: str, unique_id: str) -> str:
     newname = "{0}-{1}".format(unique_id, os.path.basename(filename))
     if len(newname) > 1024:
-        newname = "{0}-perf-lab-report.json".format(randint(1000, 9999))
+        newname = "{0}-{1}-perf-lab-report.json".format(unique_id, randint(1000, 9999))
     return newname
 
 def get_credential():


### PR DESCRIPTION
Fixes a bug for really long file names where we would use only a random int in the name without including the unique id. This will cause a collision when trying to upload the file as, after enough random files are uploaded, the randint would be the same as one from a different job.

It is not clear whether we are actually hitting this at the moment.