### PR TITLE
Set System.Net.SecurityProtocolType on Windows Prior to Executing Install Script

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -846,7 +846,8 @@ def install(
         'powershell.exe',
         '-NoProfile',
         '-ExecutionPolicy', 'Bypass',
-        dotnetInstallScriptPath
+        '-Command',
+        f'[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; & "{dotnetInstallScriptPath}"'
     ] if platform == 'win32' else [dotnetInstallScriptPath]
 
     # If Version is supplied, pull down the specified version


### PR DESCRIPTION
`scripts/dotnet.py install` will fail on slightly older windows hosts due to the TLS defaulting to an older version. This PR changes the install command to set the version to what is required to execute `dotnet-install.ps1` (reference here: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script). Without this fix there does not seem to be an easy workaround to use `dotnet.py install` on systems without TLS1.2 set as default.