### PR TITLE
Remove micro_mono runs on perfcobalt queue

### DIFF
--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -31,27 +31,6 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    # run arm64 interpreter jobs for mono on perfcobalt
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: mono
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runtimeType: mono
-          codeGenType: 'Interpreter'
-          runKind: micro_mono
-          logicalMachine: 'perfcobalt'
-          osDistro: 'azurelinux'
-          timeoutInMinutes: 720
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
     # run arm64 jit jobs for mono
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
@@ -65,26 +44,6 @@ jobs:
           runtimeType: mono
           runKind: micro_mono
           logicalMachine: 'perfampere'
-          timeoutInMinutes: 720
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
-    # run arm64 jit jobs for mono on perfcobalt
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: mono
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runtimeType: mono
-          runKind: micro_mono
-          logicalMachine: 'perfcobalt'
-          osDistro: 'azurelinux'
           timeoutInMinutes: 720
           runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


