### PR TITLE
Remove Tiger SDK jobs + reenable Windows CI

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -24,7 +24,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -44,7 +44,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -63,7 +63,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -82,7 +82,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         #- win-x86
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: true
@@ -102,8 +101,8 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        #- win-x86
+        - win-x64
+        - win-x86
       isPublic: true
       jobParameters:
         runKind: micro
@@ -141,7 +140,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -162,7 +161,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -181,7 +180,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -201,7 +200,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -221,7 +220,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -241,7 +240,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -261,7 +260,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -283,7 +282,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -303,7 +302,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -322,7 +321,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -348,8 +347,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -371,7 +368,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
         - win-arm64
         - win-arm64-ampere
@@ -567,8 +563,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           - win-arm64
@@ -590,8 +584,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -619,9 +611,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
-        #- win-x86
         - win-x86-viper
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: false
@@ -641,7 +631,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
       isPublic: false
       jobParameters:
@@ -661,8 +650,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           - win-arm64
@@ -684,8 +671,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -708,8 +693,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -732,8 +715,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -756,8 +737,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -779,8 +758,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -809,8 +786,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -841,8 +816,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
@@ -862,8 +835,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64


### PR DESCRIPTION
Remove the Tiger SDK jobs (Windows and Ubuntu) as we have gotten a bit of overlap with the Viper machines. Also reenable previously disabled Windows CI jobs.