### PR TITLE
Remove 10.0 runs from sdk jobs

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -32,7 +32,6 @@ jobs:
         projectFileName: scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -52,7 +51,6 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -71,7 +69,6 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -90,7 +87,6 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -110,7 +106,6 @@ jobs:
         runCategories: 'runtime libraries' 
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
 
@@ -129,7 +124,6 @@ jobs:
           - main
           # - nativeaot9.0 # Disable until I have time to properly fix the issues and can merge https://github.com/dotnet/performance/pull/4741
           # - nativeaot8.0
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -149,7 +143,6 @@ jobs:
         runCategories: 'mldotnet' 
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -170,7 +163,6 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -189,7 +181,6 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -209,7 +200,6 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -229,7 +219,6 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -249,7 +238,6 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -269,7 +257,6 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -291,7 +278,6 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -310,7 +296,6 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -330,7 +315,6 @@ jobs:
         runCategories: 'Public'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -357,7 +341,6 @@ jobs:
         projectFileName: scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -377,7 +360,6 @@ jobs:
         projectFileName: scenarios_affinitized.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         additionalJobIdentifier: 'Affinity_85'
@@ -573,7 +555,6 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -593,7 +574,6 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -620,7 +600,6 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -638,7 +617,6 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -661,7 +639,6 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -682,7 +659,6 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -704,7 +680,6 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -726,7 +701,6 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -748,7 +722,6 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
-          - 10.0
           - 9.0
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
@@ -770,7 +743,6 @@ jobs:
         runCategories: 'mldotnet'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -798,7 +770,6 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -826,7 +797,6 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
-            - 10.0
             - 9.0
             - 8.0
 
@@ -846,7 +816,6 @@ jobs:
         runCategories: 'Public Internal'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:


### PR DESCRIPTION
Remove 10.0 runs from sdk jobs as we are hitting failures due to new packages not yet being available in public feeds.


