### PR TITLE
Fix: Check upload return code in parsetraces methods

### DIFF
--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -93,7 +93,10 @@ class DevicePowerConsumptionHelper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("DevicePowerConsumption Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtestsandroid(self, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
         getLogger().info("Clearing potential previous run nettraces")

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -86,7 +86,10 @@ class MemoryConsumptionWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("MemoryConsumption Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtests(self, traits: TestTraits):
         '''

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -88,7 +88,10 @@ class StartupWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("Startup Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtests(self, traits: TestTraits):
         '''


### PR DESCRIPTION
Several parsetraces methods were ignoring the return code from upload.upload(), causing scripts to continue executing even when uploads failed. This change ensures all upload calls properly check the return code and exit with the appropriate error code on failure.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


