### PR TITLE
Update log parse loop to continue on error

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -853,7 +853,7 @@ ex: C:\repos\performance;C:\repos\runtime
                         if 'Now monitoring resource allowance' in lineData['eventMessage'] or 'Stopped monitoring' in lineData['eventMessage']:
                             events.append(lineData)
                     except:
-                        break
+                        continue
 
                 
                 if i == 0: # Use the warmup iteration to get the current device time


### PR DESCRIPTION
## Description

The log show command outputs a warning as the first line instead of valid json:
```
Wall Clock adjustment detected - results might be strange while using --end
```

This PR updates the loop to continue so warnings are skipped and valid json event lines are still processed.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2902282&view=logs&j=007c6ee1-d4e8-565e-80d2-5b93cbca4c6a