### PR TITLE
Update Maui iOS scenario benchmarks to use CoreCLR default codegen

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -489,7 +489,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS scenario benchmarks (CoreCLR Interpreter) - Release
+  # Maui iOS scenario benchmarks (CoreCLR Default) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -502,7 +502,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: coreclr
-        codeGenType: Interpreter
+        codeGenType: Default
         buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:


### PR DESCRIPTION
## Description

This PR updates MAUI iOS scenarios to use the default codegen (Full R2R + Interpreter). This will require updating the dashboard to collect Default codegen.

Fixes https://github.com/dotnet/runtime/issues/120054