### PR TITLE
Add Cobalt SVE microbenchmarks run to runtime-perf-jobs

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -56,6 +56,12 @@ parameters:
     type: object
     default:
       enabled: true
+  - name: cobaltSveMicro
+    type: object
+    default:
+      enabled: true
+      configs:
+        - linux_arm64
   - name: androidCoreclrR2r
     type: object
     default:
@@ -269,6 +275,26 @@ jobs:
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
           r2rRunType: nor2r
           additionalJobIdentifier: 'NoR2R'
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
+  # CoreCLR Cobalt SVE microbenchmarks — controlled by cobaltSveMicro toggle.
+  - ${{ if eq(parameters.cobaltSveMicro.enabled, true) }}:
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms: ${{ parameters.cobaltSveMicro.configs }}
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runKind: micro
+          logicalMachine: 'perfcobalt'
+          osDistro: 'azurelinux'
+          runCategories: 'SVE'
+          additionalJobIdentifier: 'SVE'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -45,7 +45,7 @@ namespace MicroBenchmarks
                 .Run(argsList.ToArray(), 
                     RecommendedConfig.Create(
                         artifactsPath: new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, "BenchmarkDotNet.Artifacts")), 
-                        mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty]),
+                        mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty, Categories.Sve]),
                         partitionCount: partitionCount,
                         partitionIndex: partitionIndex,
                         exclusionFilterValue: exclusionFilterValue,

--- a/src/benchmarks/micro/Properties/AssemblyInfo.cs
+++ b/src/benchmarks/micro/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ namespace MicroBenchmarks
                 ? ManualConfig.CreateEmpty()
                 : RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, "BenchmarkDotNet.Artifacts")),
-                    mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty]));
+                    mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty, Categories.Sve]));
         }
 
         public IConfig Config { get; }


### PR DESCRIPTION
Add a new coreclr micro run targeting the Azure Linux 3 Cobalt ARM64 queue with runCategories set to SVE instead of the default Runtime and Libraries categories. Also adds the arm64 build job dependency.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


