### PR TITLE
Fix `wasm_coreclr runtime` type  missing from the exclusion list.

### DIFF
--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -36,12 +36,14 @@ jobs:
     # Test job depends on the corresponding build job
     ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
       dependsOn:
-        - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSCoreCLR', 'iOSNativeAOT', 'wasm', 'mono')) }}:
+        - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'AndroidCoreCLR', 'iOSMono', 'iOSCoreCLR', 'iOSNativeAOT', 'wasm', 'wasm_coreclr', 'mono')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'coreclr') }}
         - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}
         - ${{ if eq(parameters.runtimeType, 'wasm')}}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}_{5}', 'browser', '', 'wasm', 'linux', parameters.buildConfig, parameters.runtimeType) }}
+        - ${{ if eq(parameters.runtimeType, 'wasm_coreclr')}}:
+          - ${{ format('build_{0}{1}_{2}_{3}_{4}_{5}', 'browser', '', 'wasm', 'linux', parameters.buildConfig, 'wasm_coreclr') }}
         - ${{ if and(eq(parameters.codeGenType, 'AOT'), not(in(parameters.runtimeType, 'wasm', 'AndroidMono'))) }}:
           - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.codeGenType) }}
         - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:


### PR DESCRIPTION
PRs that trigger perf job on runtime (they touch browser version file), e.g. https://github.com/dotnet/runtime/pull/124714 did not get the job triggered.

Error:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1312956&view=results

```
Stage Build job run_performance_test_micro_wasm_coreclr_wasm_coreclr_v8linux__x64_perfviper depends on unknown job build_linux_x64_release_coreclr.
```

Analysis:

When `runtimeType` is `wasm_coreclr` `dependsOn` logic does not match any exclusions (wasm/mono etc) and fails into the default case, generating `build_linux_x64_release_coreclr`. But the actual build job is named with `nameSuffix: wasm_coreclr` which produces something like `build_browser_wasm_linux_release_wasm_coreclr`.

From what I understand:
- `mono` - mono runtime not targeting wasm
- `wasm` - mono runtime targeting wasm
- `wasm_coreclr` - coreclr runtime targeting wasm

This naming is not best and should follow some conventions but this is not a PR for this, we want to have the performance running soon.