### PR TITLE
Add NoWasmCoreCLR category to benchmarks that timeout on WasmCoreCLR

### DIFF
--- a/src/benchmarks/micro/libraries/System.Collections/Sort.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Sort.cs
@@ -48,6 +48,7 @@ namespace System.Collections
         public void Array_ComparerClass() => System.Array.Sort(_arrays[_iterationIndex++], 0, Size, _comparableComparerClass);
 
         [Benchmark]
+        [BenchmarkCategory(Categories.NoWasmCoreCLR)]
         public void Array_ComparerStruct() => System.Array.Sort(_arrays[_iterationIndex++], 0, Size, new ComparableComparerStruct());
 
         [Benchmark]

--- a/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.StreamWriter.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime.Extensions/Perf.StreamWriter.cs
@@ -48,7 +48,7 @@ namespace System.IO.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(WriteLengthMemberData))]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoWasmCoreCLR)]
         public void WriteCharArray(int writeLength)
         {
             char[] buffer = writeLength == 2 ? _buffer2 : _buffer100;
@@ -71,7 +71,7 @@ namespace System.IO.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(WriteLengthMemberData))]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoWasmCoreCLR)]
         [MemoryRandomization]
         public void WritePartialCharArray(int writeLength)
         {
@@ -95,7 +95,7 @@ namespace System.IO.Tests
 
         [Benchmark]
         [ArgumentsSource(nameof(WriteLengthMemberData))]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoWasmCoreCLR)]
         public void WriteString(int writeLength)
         {
             string value = writeLength == 2 ? _string2 : _string100;

--- a/src/benchmarks/micro/runtime/BenchmarksGame/mandelbrot-7.cs
+++ b/src/benchmarks/micro/runtime/BenchmarksGame/mandelbrot-7.cs
@@ -91,7 +91,7 @@ namespace BenchmarksGame
         // Commented out data left in source to provide checksums for each case
 
         [Benchmark(Description = nameof(MandelBrot_7))]
-        [BenchmarkCategory(Categories.NoInterpreter)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoWasmCoreCLR)]
         //[InlineData(1000, 125, "B2-13-51-CE-B0-29-2C-4E-75-5E-91-19-18-E4-0C-D9")]
         //[InlineData(2000, 250, "5A-21-55-9B-7B-18-2F-34-9B-33-C5-F9-B5-2C-40-56")]
         //[InlineData(3000, 375, "E5-82-85-0A-3C-89-69-B1-A8-21-63-52-75-B3-C8-33")]

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInProd.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDInProd.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace Benchstone.MDBenchF
 {
-[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF, Categories.NoWasmCoreCLR)]
 public class MDInProd
 {
     public const int Iterations = 70;

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDSqMtx.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchF/MDSqMtx.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace Benchstone.MDBenchF
 {
-[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF)]
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchF, Categories.NoWasmCoreCLR)]
 public class MDSqMtx
 {
     public const int Iterations = 4000;

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDArray2.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDArray2.cs
@@ -9,7 +9,7 @@ using MicroBenchmarks;
 
 namespace Benchstone.MDBenchI
 {
-[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI, Categories.NoWasmCoreCLR)]
 public class MDArray2
 {
     public const int Iterations = 500000;

--- a/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMulMatrix.cs
+++ b/src/benchmarks/micro/runtime/Benchstones/MDBenchI/MDMulMatrix.cs
@@ -8,7 +8,7 @@ using MicroBenchmarks;
 
 namespace Benchstone.MDBenchI
 {
-[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI)]
+[BenchmarkCategory(Categories.Runtime, Categories.Benchstones, Categories.JIT, Categories.MDBenchI, Categories.NoWasmCoreCLR)]
 public class MDMulMatrix
 {
     public const int Iterations = 100;

--- a/src/benchmarks/micro/runtime/Burgers/Burgers.cs
+++ b/src/benchmarks/micro/runtime/Burgers/Burgers.cs
@@ -192,7 +192,7 @@ public class Burgers
     public double[] Test2() => GetCalculated2(nt, nx, dx, dt, nu, initial);
 
     [Benchmark(Description = "Burgers_3")]
-    [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+    [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
     public double[] Test3() => GetCalculated3(nt * 2, nx, dx, dt, nu, initial);
 }
 

--- a/src/benchmarks/micro/runtime/Bytemark/ByteMark.cs
+++ b/src/benchmarks/micro/runtime/Bytemark/ByteMark.cs
@@ -381,6 +381,7 @@ public class ByteMark
     const int NumericSortRectangularIterations = 5;
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public void BenchNumericSortRectangular()
     {
         NumericSortRect t = new NumericSortRect();
@@ -471,6 +472,7 @@ public class ByteMark
     const int AssignRectangularIterations = 5;
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public void BenchAssignRectangular()
     {
         AssignStruct t = new AssignRect();

--- a/src/benchmarks/micro/runtime/Linq/Linq.cs
+++ b/src/benchmarks/micro/runtime/Linq/Linq.cs
@@ -125,6 +125,7 @@ public class LinqBenchmarks
     #region Where00
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool Where00LinqQueryX()
     {
         List<Product> products = Product.GetProductList();
@@ -146,6 +147,7 @@ public class LinqBenchmarks
     }
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool Where00LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
@@ -216,6 +218,7 @@ public class LinqBenchmarks
 
     [Benchmark]
     [MemoryRandomization]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool Where01LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
@@ -234,6 +237,7 @@ public class LinqBenchmarks
     }
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool Where01LinqMethodNestedX()
     {
         List<Product> products = Product.GetProductList();
@@ -368,6 +372,7 @@ public class LinqBenchmarks
 
 #if NET9_0_OR_GREATER
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool CountBy00LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
@@ -383,6 +388,7 @@ public class LinqBenchmarks
     }
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool CountBy00AggregateByX()
     {
         List<Product> products = Product.GetProductList();
@@ -399,6 +405,7 @@ public class LinqBenchmarks
 #endif
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool CountBy00GroupByX()
     {
         List<Product> products = Product.GetProductList();
@@ -415,6 +422,7 @@ public class LinqBenchmarks
     }
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool CountBy00LookupX()
     {
         List<Product> products = Product.GetProductList();
@@ -435,6 +443,7 @@ public class LinqBenchmarks
 
 #if NET9_0_OR_GREATER
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool AggregateBy00LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
@@ -451,6 +460,7 @@ public class LinqBenchmarks
 #endif
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool AggregateBy00GroupByX()
     {
         List<Product> products = Product.GetProductList();
@@ -471,6 +481,7 @@ public class LinqBenchmarks
     #region GroupBy00
 
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool GroupBy00LinqMethodX()
     {
         List<Product> products = Product.GetProductList();
@@ -487,6 +498,7 @@ public class LinqBenchmarks
 
 #if NET9_0_OR_GREATER
     [Benchmark]
+    [BenchmarkCategory(Categories.NoWasmCoreCLR)]
     public bool GroupBy00AggregateByX()
     {
         List<Product> products = Product.GetProductList();

--- a/src/benchmarks/micro/runtime/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/benchmarks/micro/runtime/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -61,23 +61,23 @@ namespace SIMD
         public void ScalarDoubleSinglethreadRaw() => XBench(10, 4);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
         public void ScalarDoubleSinglethreadADT() => XBench(10, 5);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
         public void VectorFloatSinglethreadRaw() => XBench(10, 16);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
         public void VectorFloatSinglethreadADT() => XBench(10, 17);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
         public void VectorDoubleSinglethreadRaw() => XBench(10, 20);
 
         [Benchmark]
-        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT)]
+        [BenchmarkCategory(Categories.NoInterpreter, Categories.NoAOT, Categories.NoWasmCoreCLR)]
         public void VectorDoubleSinglethreadADT() => XBench(10, 21);
     }
 }

--- a/src/benchmarks/micro/runtime/SIMD/RayTracer/RayTracerBench.cs
+++ b/src/benchmarks/micro/runtime/SIMD/RayTracer/RayTracerBench.cs
@@ -16,7 +16,7 @@ using Benchmarks.SIMD.RayTracer;
 
 namespace SIMD
 {
-[BenchmarkCategory(Categories.Runtime, Categories.SIMD, Categories.JIT)]
+[BenchmarkCategory(Categories.Runtime, Categories.SIMD, Categories.JIT, Categories.NoWasmCoreCLR)]
 public class RayTracerBench
 {
     private const int Width = 250;

--- a/src/benchmarks/micro/runtime/SIMD/SeekUnroll/SeekUnroll.cs
+++ b/src/benchmarks/micro/runtime/SIMD/SeekUnroll/SeekUnroll.cs
@@ -58,7 +58,7 @@ public class SeekUnroll
 
     [Benchmark(Description = nameof(SeekUnroll))]
     [ArgumentsSource(nameof(ArrayedBoxedIndicesToTest))]
-    [BenchmarkCategory(Categories.NoInterpreter)]
+    [BenchmarkCategory(Categories.NoInterpreter, Categories.NoWasmCoreCLR)]
     [MemoryRandomization]
     public bool Test(int boxedIndex) 
     {

--- a/src/benchmarks/micro/runtime/Span/Sorting.cs
+++ b/src/benchmarks/micro/runtime/Span/Sorting.cs
@@ -39,7 +39,7 @@ namespace Span
         [Benchmark]
         public void QuickSortSpan() => TestQuickSortSpan(new Span<int>(_arrays[_iterationIndex++]));
 
-        [BenchmarkCategory(Categories.Span)]
+        [BenchmarkCategory(Categories.Span, Categories.NoWasmCoreCLR)]
         [Benchmark]
         public void BubbleSortSpan() => TestBubbleSortSpan(new Span<int>(_arrays[_iterationIndex++]));
 


### PR DESCRIPTION
Add Categories.NoWasmCoreCLR to 32 benchmarks across 14 files that were timing out (exceeding 20 minute limit) during WasmCoreCLR BDN test runs. The affected benchmarks span Burgers, ByteMark, ConsoleMandel, LinqBenchmarks, MandelBrot_7, MDArray2, MDInProd, MDMulMatrix, MDSqMtx, Perf_StreamWriter, RayTracerBench, SeekUnroll, Sort, and Sorting tests.

Some of our tests are timing out in the recently added Wasm CoreCLR tests: https://dev.azure.com/dnceng/internal/_build/results?buildId=2915976&view=results. This PR adds these timing out tests to the NoWasmCoreCLR category. We may still hit timeouts on some other tests that just managed to squeak by under the 20-minute timeout limit, but this should be a good start.

Wasm Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2916496&view=results

