### PR TITLE
Re-enable EvaluateOverhead to subtract method-call overhead from benchmark results

### DIFF
--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -34,6 +34,7 @@ namespace BenchmarkDotNet.Extensions
                     .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slighlty too much for us
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
+                    .WithEvaluateOverhead(true) // BDN changed the default to false; re-enable to subtract method-call overhead from results
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
 
                 // See https://github.com/dotnet/roslyn/issues/42393


### PR DESCRIPTION
## Summary

Re-enable `EvaluateOverhead` in the default benchmark job configuration. BenchmarkDotNet [PR #3007](https://github.com/dotnet/BenchmarkDotNet/pull/3007) (merged Feb 16, 2026) changed the `EvaluateOverhead` default from `true` to `false`, which means BDN no longer runs idle/overhead iterations to measure and subtract the cost of the benchmark method call itself from workload measurements.

## Problem

This one-line default change, combined with a 2.5-month WASM perf data gap (Dec 5, 2025 – Feb 26, 2026), caused the auto-filer to report **2,300+ false regressions**:

- [dotnet/perf-autofiling-issues#69444](https://github.com/dotnet/perf-autofiling-issues/issues/69444): **1,416 interpreted WASM** regressions
- [dotnet/perf-autofiling-issues#69430](https://github.com/dotnet/perf-autofiling-issues/issues/69430): **864 AOT WASM** regressions

On native JIT platforms the method-call overhead is <1ns (imperceptible), but on WASM interpreter it's ~8-10ns and on AOT WASM ~1-3ns. Without overhead subtraction, every WASM microbenchmark reports raw time including this call overhead, creating an additive bias that makes short-baseline benchmarks appear dramatically regressed:

| Baseline | +8ns overhead | Apparent regression |
|----------|--------------|-------------------|
| 10 ns | → 18 ns | **1.80x** |
| 50 ns | → 58 ns | **1.16x** |
| 150 ns | → 158 ns | **1.05x** (at detection threshold) |
| 500 ns | → 508 ns | 1.02x (below threshold) |

## Evidence

The regression distribution across all 2,300+ benchmarks perfectly matches an additive constant, not a multiplicative factor. Time-series data from the perf portal confirms a step function coinciding exactly with the BDN methodology change — no gradual drift, and no runtime code changes in the window. See the detailed analysis in the [issue comments](https://github.com/dotnet/perf-autofiling-issues/issues/69444#issuecomment-4007676721).

## Fix

One-line change in `RecommendedConfig.cs` to explicitly set `.WithEvaluateOverhead(true)` in the default Job configuration, restoring the previous measurement methodology for all platforms.

This is arguably the right default for a performance lab anyway — overhead subtraction gives more accurate results for the actual workload being measured, especially for sub-microsecond benchmarks.

/cc @AaronRobinsonMSFT @AaronRobinsonMSFT
