### PR TITLE
Add overhead calculation back to WASM runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -1000,6 +1000,10 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if args.affinity != "0":
         ci_setup_arguments.affinity = args.affinity
 
+    # Enable overhead evaluation for WASM jobs where method-call overhead is significant (1-10ns)
+    if wasm:
+        args.run_env_vars["PERFLAB_EVALUATE_OVERHEAD"] = "1"
+
     if args.run_env_vars:
         ci_setup_arguments.run_env_vars = [f"{k}={v}" for k, v in args.run_env_vars.items()]
 

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -32,12 +32,15 @@ namespace BenchmarkDotNet.Extensions
         {
             if (job is null)
             {
+                #pragma warning disable CS0618 // WithEvaluateOverhead is obsolete but needed for WASM accuracy
                 job = Job.Default
                     .WithWarmupCount(1) // 1 warmup is enough for our purpose
                     .WithIterationTime(TimeInterval.FromMilliseconds(250)) // the default is 0.5s per iteration, which is slighlty too much for us
                     .WithMinIterationCount(15)
                     .WithMaxIterationCount(20) // we don't want to run more that 20 iterations
+                    .WithEvaluateOverhead(Environment.GetEnvironmentVariable("PERFLAB_EVALUATE_OVERHEAD") == "1") // WASM has significant method-call overhead (1-10ns); subtract it when enabled
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
+                #pragma warning restore CS0618
             }
 
             var config = ManualConfig.CreateEmpty()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


