### PR TITLE
Remove disabled NuGet feeds from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -32,18 +32,10 @@
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 MAUI -->
     <add key="darc-pub-dotnet-maui-7c4f71ad" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-7c4f71ad/nuget/v3/index.json" />
-    <!-- Added manually for .NET 8 MAUI -->
-    <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 8.0.18 -->
-    <add key="darc-pub-dotnet-runtime-c0390586" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-c0390586/nuget/v3/index.json" />
-    <!-- Added manually for dotnet/runtime 9.0.8 -->
-    <add key="darc-pub-dotnet-runtime-b4fb3656" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-89d42fdf/nuget/v3/index.json" />
-    <!-- Added manually for .NET 9 Android -->
-    <add key="darc-pub-dotnet-android-1719a35" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1719a35b/nuget/v3/index.json" />
+
     <add key="darc-pub-dotnet-android-a618557" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a618557d/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-a618557-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-a618557d-1/nuget/v3/index.json" />
-    <!-- Added manually for .NET 8 Android -->
-    <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
+
     <!-- Added manually for .NET 9 macios -->
     <add key="darc-pub-dotnet-macios-8d30875" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-8d308759/nuget/v3/index.json" />
     <!-- Added manually for .NET 10 macios (microsoft.ios.sdk.net10.0_26.2 etc.) -->


### PR DESCRIPTION
Remove 5 darc-pub feeds that have been disabled and return 404:
- darc-pub-dotnet-maui-a33a875e
- darc-pub-dotnet-runtime-c0390586
- darc-pub-dotnet-runtime-89d42fdf
- darc-pub-dotnet-android-1719a35b
- darc-pub-dotnet-android-cdb777a0

