### PR TITLE
Update iOS perf tests from iPhone 12 to iPhone 17

### DIFF
--- a/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+++ b/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
@@ -24,7 +24,7 @@ jobs:
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true
-        logicalMachine: 'perfiphone12mini'
+        logicalMachine: 'perfiphone17'
         iOSLlvmBuild: False
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
@@ -47,7 +47,7 @@ jobs:
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true
-        logicalMachine: 'perfiphone12mini'
+        logicalMachine: 'perfiphone17'
         iOSLlvmBuild: True
         iOSStripSymbols: True
         additionalJobIdentifier: iOSLlvmBuild iOSStripSymbols
@@ -70,7 +70,7 @@ jobs:
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true
-        logicalMachine: 'perfiphone12mini'
+        logicalMachine: 'perfiphone17'
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
@@ -92,7 +92,7 @@ jobs:
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true
-        logicalMachine: 'perfiphone12mini'
+        logicalMachine: 'perfiphone17'
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
@@ -114,7 +114,7 @@ jobs:
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true
-        logicalMachine: 'perfiphone12mini'
+        logicalMachine: 'perfiphone17'
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -146,7 +146,7 @@ jobs:
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if and(containsValue(parameters.buildMachines, 'osx-x64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 12mini only used in private builds currently
+- ${{ if and(containsValue(parameters.buildMachines, 'osx-x64-ios-arm64'), not(eq(parameters.isPublic, true))) }}: # iPhone ARM64 17 only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:
       osGroup: osx
@@ -154,8 +154,8 @@ jobs:
       osVersion: 15
       pool:
         vmImage: 'macos-15'
-      queue: OSX.13.Amd64.Iphone.Perf
-      machinePool: iPhoneMini12
+      queue: Mac.iPhone.17.Perf
+      machinePool: iPhone17
       ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if and(containsValue(parameters.buildMachines, 'win-x64-viper'), not(eq(parameters.isPublic, true))) }}: # Windows x64 Viper only used in private builds

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -370,7 +370,7 @@ def logical_machine_to_queue(logical_machine: str, internal: bool, os_group: str
             queue_map = {
                 "perfampere": "Ubuntu.2204.Arm64.Perf",
                 "perfcobalt": "AzureLinux.3.Cobalt.Arm64.Perf",
-                "perfiphone12mini": "OSX.13.Amd64.Iphone.Perf",
+                "perfiphone17": "Mac.iPhone.17.Perf",
                 "perftiger_crossgen": "Ubuntu.1804.Amd64.Tiger.Perf",
                 "perfviper": "Ubuntu.2204.Amd64.Viper.Perf",
                 "cloudvm": "Ubuntu.2204.Amd64"


### PR DESCRIPTION
Update logicalMachine from perfiphone12mini to perfiphone17 and Helix queue from OSX.13.Amd64.Iphone.Perf to Mac.iPhone.17.Perf across runtime-perf and dotnet-performance pipeline configurations.

