### PR TITLE
Update Galaxy perf queue to Windows.11.Amd64.Galaxy.Lowend.Perf

### DIFF
--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -142,7 +142,7 @@ jobs:
       osVersion: 22H2
       pool:
         vmImage: 'windows-2022'
-      queue: Windows.11.Amd64.Galaxy.Perf
+      queue: Windows.11.Amd64.Galaxy.Lowend.Perf
       machinePool: Galaxy
       ${{ insert }}: ${{ parameters.jobParameters }}
 

--- a/helix.yml
+++ b/helix.yml
@@ -104,7 +104,7 @@ profiles:
       benchmark:
         variables:
           osGroup: windows
-          queue: Windows.10.Amd64.Galaxy.Perf
+          queue: Windows.11.Amd64.Galaxy.Lowend.Perf
   
   win-arm64:
     jobs:


### PR DESCRIPTION
Update to using Windows.11.Amd64.Galaxy.Lowend.Perf for our Galaxy runs.

