### PR TITLE
Improve argument handling in ProcessHelper and use read-only store access in CertHelper

### DIFF
--- a/src/tools/CertHelper/Program.cs
+++ b/src/tools/CertHelper/Program.cs
@@ -55,7 +55,7 @@ internal class Program
             Console.Error.WriteLine(ex.StackTrace);
         }
 
-        using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite))
+        using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadOnly))
         {
             foreach(var cert in store.Certificates.Find(X509FindType.FindBySubjectName, "dotnetperf.microsoft.com", false))
             {

--- a/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
+++ b/src/tools/ScenarioMeasurement/Util/ProcessHelper.cs
@@ -74,7 +74,7 @@ public class RawProcessHelper : IProcessHelper
         if (!Util.IsWindows() && RootAccess)
         {
             psi.FileName = "sudo";
-            psi.Arguments = Executable + " " + Arguments;
+            psi.Arguments = "-- " + Executable + " " + Arguments;
         }
         else
         {
@@ -191,7 +191,7 @@ public class ManagedProcessHelper : IProcessHelper
         if (!Util.IsWindows() && RootAccess)
         {
             psi.FileName = "sudo";
-            psi.Arguments = Executable + " " + Arguments;
+            psi.Arguments = "-- " + Executable + " " + Arguments;
         }
         else
         {


### PR DESCRIPTION
Improve argument handling in ProcessHelper and use read-only store access in CertHelper

- Add -- separator to sudo invocations in RawProcessHelper and ManagedProcessHelper to properly delimit the command from sudo options
- Change certificate store open from ReadWrite to ReadOnly when only reading certificates in CertHelper
