### PR TITLE
 Set RuntimeType explicitly for `wasm` and `wasm_coreclr` micro benchmarks

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -520,6 +520,7 @@ def get_run_configurations(
 
     if runtime_type == "wasm":
         configurations["CompilationMode"] = "wasm"
+        configurations["RuntimeType"] = str(runtime_flavor)
         if is_aot:
             configurations["AOT"] = "true"
 
@@ -716,6 +717,12 @@ def run_performance_job(args: RunPerformanceJobArgs):
         build_config = f"wasmaot.{build_config}"
     elif wasm:
         build_config = f"wasm.{build_config}"
+
+    if args.run_kind == "micro":
+        if args.runtime_type == "wasm":
+            args.runtime_flavor = "mono"
+        elif args.runtime_type == "wasm_coreclr":
+            args.runtime_flavor = "coreclr"
 
     if args.run_kind == "android_scenarios":
         if args.runtime_type == "AndroidMono":


### PR DESCRIPTION
## Problem
Coreclr jobs are running fine, see: https://github.com/dotnet/runtime/pull/125566 `runtime-wasm-perf (Build Performance micro wasm_coreclr wasm coreclr_v8 linux x64 perfviper net11.0)` but we don't get autofilling issues on them, like we do for mono.

## Root cause
`wasm_coreclr` benchmark results are never reported to the perf autofiling system. The `allTestHistory` [dashboard](https://pvscmdupload.z22.web.core.windows.net/reports/allTestHistory/TestHistoryIndexIndex.html) has zero `wasm_coreclr` entries despite the job running in CI.

 `--runtime-flavor` is only passed via YAML for MAUI scenarios, so for wasm micro benchmarks `runtime_flavor` is `None`. This means:
   - `wasm_coreclr`: `RuntimeType=None` in configurations -> data lands in the wrong blob storage path and is never picked up by the autofiler,
   - `wasm`: `RuntimeType` not set at all in configurations ->happens to work but is implicit.

## Fix

   Auto-detect `runtime_flavor` from `runtime_type` for wasm micro benchmarks in `run_performance_job.py`, matching the existing pattern used by Android and iOS scenarios.

   Set `RuntimeType` in `get_run_configurations()` for both `wasm` and `wasm_coreclr` so the configuration metadata is explicit.

## Impact

 - **`wasm_coreclr`**: Fixes broken reporting — results will now appear in allTestHistory and be picked up by the perf autofiler
 - **`wasm` (Mono)**: Adds explicit `RuntimeType=mono` to configurations. This changes the blob storage path for new data (previously had no `RuntimeType` key), but makes the metadata correct and future-proof
 - No impact on non-wasm scenarios