### PR TITLE
Auto-detect runtime_flavor for wasm_coreclr micro benchmarks

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -735,7 +735,8 @@ def run_performance_job(args: RunPerformanceJobArgs):
             raise Exception("iOS scenarios only support Mono and CoreCLR runtimes")
 
     if args.run_kind == "micro" and args.runtime_type == "wasm_coreclr":
-        args.runtime_flavor = "coreclr"
+        if not args.runtime_flavor:
+            args.runtime_flavor = "coreclr"
 
     branch = os.environ.get("BUILD_SOURCEBRANCH")
     cleaned_branch_name = "main"


### PR DESCRIPTION
For wasm_coreclr micro benchmark runs, runtime_flavor is not passed via YAML, causing RuntimeType to be set to 'None' in configurations. This means results never appear in test history or the perf autofiler.

Add auto-detection of runtime_flavor for wasm_coreclr micro benchmarks, setting it to 'coreclr', following the existing pattern used by Android and iOS scenarios. This fix does not modify wasm (mono) behavior to avoid breaking existing test history reports.

Fixes the same root cause as dotnet/performance#5153 but with a more targeted approach that only affects wasm_coreclr.

This will fix the RunConfigurations from saving as `{"CompilationMode":"wasm","RunKind":"micro","RuntimeType":"None"}` to saving as `{"CompilationMode":"wasm","RunKind":"micro","RuntimeType":"coreclr"}`