### PR TITLE
Disable dsymutil for iOS Debug builds to fix mauiios scenario failure

### DIFF
--- a/src/scenarios/Directory.Build.props
+++ b/src/scenarios/Directory.Build.props
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
+  <PropertyGroup>
+    <!-- Workaround for https://github.com/dotnet/macios/issues/24949 -->
+    <NoDSymUtil Condition="'$(Configuration)' == 'Debug'">true</NoDSymUtil>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Problem

The `mauiios` scenario build fails during `dotnet publish` in Debug configuration because `dsymutil` cannot find the `MauiPlatformInterop` native framework binary:

```
error: cannot parse the debug map for '...MauiiOSDefault.app/Frameworks/MauiPlatformInterop.framework/MauiPlatformInterop': No such file or directory
dsymutil exited with code 1
```

Failed build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2931067&view=logs&j=c0226f6b-6837-573d-efe9-6b9a5d36b7a9&t=9c9882ab-d0d0-58ab-a350-4c4340c4acd6&s=d654deb9-056d-50a2-1717-90c08683d50a

## Fix

Set `<NoDSymUtil>true</NoDSymUtil>` for Debug configuration in `src/scenarios/Directory.Build.props` to skip dsymutil during Debug builds. Debug symbols are not needed for these performance measurement scenarios.

## Tracking

Upstream issue: https://github.com/dotnet/macios/issues/24949

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2931345&view=results