### PR TITLE
Fix broken CI -- update python command for Linux Helix work items

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -595,7 +595,7 @@ def get_work_item_command(os_group: str, target_csproj: str, architecture: str, 
             "--csproj", f"%HELIX_WORKITEM_ROOT%\\performance\\{target_csproj}"]
     else:
         work_item_command = [
-            "python",
+            "python3",
             "$HELIX_WORKITEM_ROOT/performance/scripts/benchmarks_ci.py", 
             "--csproj", f"$HELIX_WORKITEM_ROOT/performance/{target_csproj}"]
         
@@ -1312,7 +1312,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         download_files_from_helix=True,
         targets_windows=args.os_group == "windows",
         helix_results_destination_dir=helix_results_destination_dir,
-        python="python",
+        python=agent_python,
         affinity=args.affinity,
         compare=args.compare,
         compare_command=compare_command,


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Fix `python: not found` on Linux Helix work items

The updated Ubuntu 22.04 Helix image (`Helix-Ubuntu-2204-2026-03-23`) no longer provides a `python` command — only `python3` is available. This broke **all** Linux Helix work items in public CI with exit code 127.

Main branch has been red since March 26 (build [1354108](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1354108) onward; last green was [1353009](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1353009) on March 25).

### Changes

- **`get_work_item_command()`**: Change the non-Windows command from `python` to `python3` (line 598). The Windows path (`python`, line 593) is correct as-is.
- **`PerfSendToHelixArgs`**: Use the existing `agent_python` variable (`python3` on Linux, `py -3` on Windows) for the `$(Python)` env var passed to `.proj` files, instead of unconditionally using `"python"`.

Internal builds were unaffected because they create a Python venv first, which provides a `python` symlink.

### Why this is safe

`$(Python)` is consumed by all the scenario `.proj` files (`pre.py`, `test.py`, `post.py`, etc.). The new values (`python3` on Linux, `py -3` on Windows) are the same values already used by the agent itself — see line 1157 (`os.environ["Python"] = agent_python`) and `run-performance-job-script-step.yml` line 6. Python venvs create both `python` and `python3` symlinks, so internal builds (which use a venv) are also unaffected. The hardcoded `"python"` was the oddball; this change makes the Helix work item value consistent with the rest of the infrastructure.
