### PR TITLE
Avoid failures when `dpkg` is locked for wasm runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -219,6 +219,8 @@ def get_pre_commands(
         else:
             install_prerequisites += [
                 "export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets",
+                'echo "** Waiting for dpkg to unlock (up to 2 minutes) **"',
+                'timeout 2m bash -c \'while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do if [ -z "$printed" ]; then echo "Waiting for dpkg lock to be released... Lock is held by: $(ps -o cmd= -p $(sudo fuser /var/lib/dpkg/lock-frontend))"; printed=1; fi; echo "Waiting 5 seconds to check again"; sleep 5; done;\'',
                 "sudo apt-get -y remove nodejs",
                 "sudo apt-get update",
                 "sudo apt-get install -y ca-certificates curl gnupg",


### PR DESCRIPTION
On some WASM perf runs we hit
```
+ sudo apt-get -y remove nodejs
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2031 (dpkg)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
+ export PERF_PREREQS_INSTALL_FAILED=1
+ test x1 = x1
+ echo ** Error: Failed to install prerequites **
** Error: Failed to install prerequites **
.....
+ export PYTHONPATH=/datadisks/disk1/work/A1700924/p/scripts:/datadisks/disk1/work/A1700924/p
+ [ x1 = x1 ]
+ echo \n\n** Error: Failed to install prerequisites **\n\n


** Error: Failed to install prerequisites **
```

 [log](https://[helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-126270-merge-2a58916f99374c519b/wasm.x64.micro.net11.0.Partition0/1/console.ad2f1026.log?helixlogtype=result&skoid=8eda00af-b5ec-4be9-b69b-0919a2338892&sktid=72f988bf-86f1-41af-91ab-2d7cd011db47&skt=2026-03-30T08%3A07%3A02Z&ske=2026-03-30T09%3A07%3A02Z&sks=b&skv=2026-02-06&sv=2026-02-06&se=2026-03-30T09%3A07%3A02Z&sr=b&sp=rl&sig=10adWy2SiJ2U926%2F5NVHkXkH3RauCg7Q5oVh2%2BktHSs%3D](https://helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-126270-merge-2a58916f99374c519b/wasm.x64.micro.net11.0.Partition0/1/console.ad2f1026.log?helixlogtype=result&skoid=8eda00af-b5ec-4be9-b69b-0919a2338892&sktid=72f988bf-86f1-41af-91ab-2d7cd011db47&skt=2026-03-30T08%3A07%3A02Z&ske=2026-03-30T09%3A07%3A02Z&sks=b&skv=2026-02-06&sv=2026-02-06&se=2026-03-30T09%3A07%3A02Z&sr=b&sp=rl&sig=10adWy2SiJ2U926%2F5NVHkXkH3RauCg7Q5oVh2%2BktHSs%3D))

`install_prerequisites` for wasm do not have same "waiting to unlock" command as internal runs have:
https://github.com/dotnet/performance/blob/2beb447d33e2b69046d14ad0f05f9f7bf60c8a80/scripts/run_performance_job.py#L159

Without it, the only recovery path is to rerun the job.