### PR TITLE
Disable PublishReadyToRunStripDebugInfo/StripInliningInfo for iOS CoreCLR R2R

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -16,6 +16,9 @@
 
     <!-- Mono FullAOT and CoreCLR R2R are considered as default configurations, so no need for explicit properties -->
     
+    <!--  We have to set the following two variables until https://github.com/dotnet/runtime/pull/124604 flows to us -->
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">$(_MSBuildArgs);/p:PublishReadyToRunStripDebugInfo=false;/p:PublishReadyToRunStripInliningInfo=false</_MSBuildArgs>
+
     <!-- CoreCLR Interpreter -->
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'Interpreter'">$(_MSBuildArgs);/p:PublishReadyToRun=false</_MSBuildArgs>
     <!-- CoreCLR NativeAOT -->


### PR DESCRIPTION
## Summary

Workaround for dotnet/sdk#53514 adding `--strip-debug-info` and `--strip-inlining-info` to crossgen2 args for Apple mobile RIDs before crossgen2 support (dotnet/runtime#124604) has flowed into the SDK.

This causes `CrossGen.targets` to fail with:
```
System.CommandLine.CommandLineException: No files matching --strip-debug-info --instruction-set:apple-m1
```

## Fix

Set `PublishReadyToRunStripDebugInfo=false` and `PublishReadyToRunStripInliningInfo=false` in iOS CoreCLR build args until the crossgen2 changes flow in.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2939329&view=results