### PR TITLE
Fix local run default

### DIFF
--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -63,6 +63,8 @@ In order to build or run the benchmarks you will need the **.NET Core command-li
 
 To build the benchmarks you need the appropriate `dotnet` SDKs for the target frameworks you plan to run. By default, the microbenchmarks target current supported TFMs (`net8.0`, `net9.0`, and newer TFMs when your installed SDK supports them).
 
+In practice, local runs need the SDK for the runtime you want to test **and** the SDK version required by the repo's `global.json` file (or a newer SDK that satisfies that requirement). If you want to drive the repo with a different SDK locally, an alternative is to update `global.json` to the SDK version you want to use for the test run.
+
 All you need to do is run the following command:
 
 ```cmd

--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -61,7 +61,7 @@ In order to build or run the benchmarks you will need the **.NET Core command-li
 
 ### Using .NET Cli
 
-To build the benchmarks you need to have the right `dotnet cli`. This repository allows you to benchmark .NET Core 3.1, .NET 6.0, .NET 7.0, and .NET 8.0 so you need to install all of them.
+To build the benchmarks you need the appropriate `dotnet` SDKs for the target frameworks you plan to run. By default, the microbenchmarks target current supported TFMs (`net8.0`, `net9.0`, and newer TFMs when your installed SDK supports them).
 
 All you need to do is run the following command:
 
@@ -72,11 +72,11 @@ dotnet build -c Release
 If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [MicroBenchmarks.csproj](../src/benchmarks/micro/MicroBenchmarks.csproj) file.
 
 ```diff
--<TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
-+<TargetFrameworks>net9.0</TargetFrameworks>
+-<SupportedTargetFrameworks>net8.0;net9.0;net10.0</SupportedTargetFrameworks>
++<SupportedTargetFrameworks>net9.0</SupportedTargetFrameworks>
 ```
 
-The alternative is to set `PERFLAB_TARGET_FRAMEWORKS` environment variable to selected Target Framework Moniker.
+The alternative is to set `PERFLAB_TARGET_FRAMEWORKS` environment variable to selected Target Framework Moniker. For the common `dotnet run -c Release -f <tfm>` flow, the selected `-f` value is picked up automatically, so you don't need to set the environment variable just to run one target framework interactively.
 
 ### Using Python script
 

--- a/docs/benchmarkdotnet.md
+++ b/docs/benchmarkdotnet.md
@@ -69,14 +69,14 @@ All you need to do is run the following command:
 dotnet build -c Release
 ```
 
-If you don't want to install all of them and just run the benchmarks for selected runtime(s), you need to manually edit the [MicroBenchmarks.csproj](../src/benchmarks/micro/MicroBenchmarks.csproj) file.
+If you only want to build or run the benchmarks for selected runtime(s), set `PERFLAB_TARGET_FRAMEWORKS` to the TFM or semicolon-delimited TFM list you want to use.
 
-```diff
--<SupportedTargetFrameworks>net8.0;net9.0;net10.0</SupportedTargetFrameworks>
-+<SupportedTargetFrameworks>net9.0</SupportedTargetFrameworks>
+```powershell
+$env:PERFLAB_TARGET_FRAMEWORKS = "net9.0"
+dotnet build -c Release
 ```
 
-The alternative is to set `PERFLAB_TARGET_FRAMEWORKS` environment variable to selected Target Framework Moniker. For the common `dotnet run -c Release -f <tfm>` flow, the selected `-f` value is picked up automatically, so you don't need to set the environment variable just to run one target framework interactively.
+For the common `dotnet run -c Release -f <tfm>` flow, the selected `-f` value is picked up automatically, so you don't need to set the environment variable just to run one target framework interactively.
 
 ### Using Python script
 

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -2,10 +2,14 @@
 
   <PropertyGroup>
     <!-- Supported target frameworks -->
-    <SupportedTargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0;net11.0</SupportedTargetFrameworks>
-    <SupportedTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(SupportedTargetFrameworks);net472</SupportedTargetFrameworks>
+    <MaximumNetCoreTargetFramework Condition="'$(NETCoreAppMaximumVersion)' != ''">net$(NETCoreAppMaximumVersion)</MaximumNetCoreTargetFramework>
+    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net8.0'))">net8.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net9.0'))">$(SupportedTargetFrameworks);net9.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net10.0'))">$(SupportedTargetFrameworks);net10.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net11.0'))">$(SupportedTargetFrameworks);net11.0</SupportedTargetFrameworks>
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(TargetFramework)' != ''">$(TargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(SupportedTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
@@ -97,13 +101,13 @@
     <PackageReference Include="System.IO.Hashing" Version="$(SystemVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.*-*" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.*-*" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.IO.Pipelines" Version="$(SystemVersion)" />
+  <ItemGroup Condition="'$(TargetFramework)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.6.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.3" />
     <PackageReference Include="System.Threading.Channels" Version="$(SystemVersion)" />
   </ItemGroup>
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <!-- Supported target frameworks -->
-    <MaximumNetCoreTargetFramework Condition="'$(NETCoreAppMaximumVersion)' != ''">net$(NETCoreAppMaximumVersion)</MaximumNetCoreTargetFramework>
-    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net8.0'))">net8.0</SupportedTargetFrameworks>
-    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net9.0'))">$(SupportedTargetFrameworks);net9.0</SupportedTargetFrameworks>
-    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net10.0'))">$(SupportedTargetFrameworks);net10.0</SupportedTargetFrameworks>
-    <SupportedTargetFrameworks Condition="'$(MaximumNetCoreTargetFramework)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('$(MaximumNetCoreTargetFramework)', 'net11.0'))">$(SupportedTargetFrameworks);net11.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('net$(NETCoreAppMaximumVersion)', 'net8.0'))">net8.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('net$(NETCoreAppMaximumVersion)', 'net9.0'))">$(SupportedTargetFrameworks);net9.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('net$(NETCoreAppMaximumVersion)', 'net10.0'))">$(SupportedTargetFrameworks);net10.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks Condition="'$(NETCoreAppMaximumVersion)' != '' and $([MSBuild]::IsTargetFrameworkCompatible('net$(NETCoreAppMaximumVersion)', 'net11.0'))">$(SupportedTargetFrameworks);net11.0</SupportedTargetFrameworks>
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(TargetFramework)' != ''">$(TargetFramework)</TargetFrameworks>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -100,7 +100,6 @@
     <PackageReference Include="System.IO.Hashing" Version="$(SystemVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.*-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Memory" Version="4.6.3" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -10,6 +10,7 @@
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(TargetFramework)' != ''">$(TargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">$(SupportedTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -102,6 +102,7 @@
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
+  <!-- These package versions are only for the opt-in net472 path (for example, PERFLAB_TARGET_FRAMEWORKS=net472). -->
   <ItemGroup Condition="'$(TargetFramework)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.6.1" />


### PR DESCRIPTION
Make the default MicroBenchmarks target list SDK-compatible and remove EOL net6.0/net7.0 defaults so dotnet run -f <tfm> works without PERFLAB_TARGET_FRAMEWORKS. Keep explicit overrides working for specific TFMs like net472.

