### PR TITLE
Add test coverage for ResultsComparer and CLI helper paths

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -50,7 +50,7 @@ jobs:
           dotnet test src\tools\ResultsComparer.Tests\ResultsComparer.Tests.csproj --configuration Release --framework net11.0 --nologo --verbosity minimal
           dotnet test src\tools\Reporting\Reporting.Tests\Reporting.Tests.csproj --configuration Release --framework net11.0 --nologo --verbosity minimal
           dotnet test src\tools\CertHelperTests\CertRotatorTests.csproj --configuration Release --framework net10.0 --nologo --verbosity minimal
-          dotnet test src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj --configuration Release --framework net11.0 -p:PERFLAB_TARGET_FRAMEWORKS=net11.0 --nologo --verbosity minimal
+          dotnet test src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj --configuration Release --framework net11.0 -p:PERFLAB_TARGET_FRAMEWORKS=net10.0 --nologo --verbosity minimal
           dotnet test src\tools\ScenarioMeasurement\Startup.Tests\Startup.Tests.csproj --configuration Release --nologo --verbosity minimal
         displayName: Run tooling tests
 

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -21,6 +21,7 @@ jobs:
   - job: Tooling_Tests_Windows
     displayName: Tooling Tests (Windows)
     timeoutInMinutes: 30
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/main'))
     pool:
       vmImage: windows-2022
 

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -17,7 +17,7 @@ jobs:
 # Public correctness jobs
 ######################################################
 
-- ${{ if or(parameters.runPublicJobs, parameters.runPrivateJobs, parameters.runScheduledPrivateJobs) }}:
+- ${{ if parameters.runPublicJobs }}:
   - job: Tooling_Tests_Windows
     displayName: Tooling Tests (Windows)
     timeoutInMinutes: 30

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -17,6 +17,42 @@ jobs:
 # Public correctness jobs
 ######################################################
 
+- ${{ if or(parameters.runPublicJobs, parameters.runPrivateJobs, parameters.runScheduledPrivateJobs) }}:
+  - job: Tooling_Tests_Windows
+    displayName: Tooling Tests (Windows)
+    timeoutInMinutes: 30
+    pool:
+      vmImage: windows-2022
+
+    steps:
+      - task: UseDotNet@2
+        displayName: Install .NET 8.0
+        inputs:
+          version: 8.0.x
+
+      - task: UseDotNet@2
+        displayName: Install .NET 10.0
+        inputs:
+          version: 10.0.x
+          includePreviewVersions: true
+
+      - task: UseDotNet@2
+        displayName: Install .NET 11.0
+        inputs:
+          version: 11.0.x
+          includePreviewVersions: true
+
+      - pwsh: |
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          dotnet test src\tools\ResultsComparer.Tests\ResultsComparer.Tests.csproj --configuration Release --framework net11.0 --nologo --verbosity minimal
+          dotnet test src\tools\Reporting\Reporting.Tests\Reporting.Tests.csproj --configuration Release --framework net11.0 --nologo --verbosity minimal
+          dotnet test src\tools\CertHelperTests\CertRotatorTests.csproj --configuration Release --framework net10.0 --nologo --verbosity minimal
+          dotnet test src\tests\harness\BenchmarkDotNet.Extensions.Tests\BenchmarkDotNet.Extensions.Tests.csproj --configuration Release --framework net11.0 -p:PERFLAB_TARGET_FRAMEWORKS=net11.0 --nologo --verbosity minimal
+          dotnet test src\tools\ScenarioMeasurement\Startup.Tests\Startup.Tests.csproj --configuration Release --nologo --verbosity minimal
+        displayName: Run tooling tests
+
 - ${{ if parameters.runPublicJobs }}:
 
   # Scenario benchmarks

--- a/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/CommandLineOptions.cs
@@ -35,7 +35,7 @@ namespace BenchmarkDotNet.Extensions
             int parameterIndex = argsList.IndexOf(parameter);
             parameterValue = new List<string>();
 
-            if (parameterIndex + 1 < argsList.Count)
+            if (parameterIndex != -1 && parameterIndex + 1 < argsList.Count)
             {
                 while (parameterIndex + 1 < argsList.Count && !argsList[parameterIndex + 1].StartsWith("-"))
                 {

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net11.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\benchmarks\micro\MicroBenchmarks.csproj" />
+    <ProjectReference Include="..\..\..\benchmarks\micro\MicroBenchmarks.csproj"
+                      SetTargetFramework="TargetFramework=net10.0"
+                      AdditionalProperties="PERFLAB_TARGET_FRAMEWORKS=net10.0" />
     <ProjectReference Include="..\..\..\harness\BenchmarkDotNet.Extensions\BenchmarkDotNet.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net11.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/CommandLineOptionsTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/CommandLineOptionsTests.cs
@@ -128,5 +128,89 @@ namespace Tests
 
             Assert.Throws<ArgumentException>(() => CommandLineOptions.ValidatePartitionParameters(count, index));
         }
+
+        [Fact]
+        public void ParseAndRemoveStringsParameterCollectsValuesUntilNextFlag()
+        {
+            List<string> argsList = new List<string> {
+                "--exclusion-filter",
+                "System.*",
+                "Microsoft.*",
+                "--partition-count",
+                "4"
+            };
+
+            var remaining = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out List<string> filters);
+
+            Assert.Equal(new[] { "System.*", "Microsoft.*" }, filters);
+            Assert.Equal(new[] { "--partition-count", "4" }, remaining);
+        }
+
+        [Fact]
+        public void ParseAndRemoveBooleanParameterRemovesSwitchWhenPresent()
+        {
+            List<string> argsList = new List<string> {
+                "--wasm",
+                "--filter",
+                "*"
+            };
+
+            CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--wasm", out bool enabled);
+
+            Assert.True(enabled);
+            Assert.Equal(new[] { "--filter", "*" }, argsList);
+        }
+
+        [Fact]
+        public void ParseAndRemoveStringsParameterLeavesArgsUntouchedWhenSwitchIsMissing()
+        {
+            List<string> argsList = new List<string> {
+                "literal-value",
+                "--filter",
+                "*"
+            };
+
+            var remaining = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out List<string> filters);
+
+            Assert.Empty(filters);
+            Assert.Equal(new[] { "literal-value", "--filter", "*" }, remaining);
+        }
+
+        [Fact]
+        public void ParseAndRemoveBooleanParameterReturnsFalseWhenSwitchIsMissing()
+        {
+            List<string> argsList = new List<string> {
+                "--filter",
+                "*"
+            };
+
+            CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--wasm", out bool enabled);
+
+            Assert.False(enabled);
+            Assert.Equal(new[] { "--filter", "*" }, argsList);
+        }
+
+        [Theory]
+        [InlineData("--partition-count")]
+        [InlineData("--partition-index")]
+        public void ParseAndRemoveIntParameterThrowsWhenValueIsMissing(string parameter)
+        {
+            List<string> argsList = new List<string> { parameter };
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ParseAndRemoveIntParameter(argsList, parameter, out int? _));
+        }
+
+        [Theory]
+        [InlineData("--partition-count", "abc")]
+        [InlineData("--partition-index", "3.14")]
+        public void ParseAndRemoveIntParameterThrowsWhenValueIsNotAnInteger(string parameter, string value)
+        {
+            List<string> argsList = new List<string> {
+                parameter,
+                value
+            };
+
+            Assert.Throws<ArgumentException>(() => CommandLineOptions.ParseAndRemoveIntParameter(argsList, parameter, out int? _));
+        }
     }
 }

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/PartitionFilterTests.cs
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/PartitionFilterTests.cs
@@ -63,8 +63,9 @@ namespace BenchmarkDotNet.Extensions.Tests
             IConfig recommendedConfig = RecommendedConfig.Create(
                 artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(PartitionFilterTests).Assembly.Location)!, "BenchmarkDotNet.Artifacts")),
                 mandatoryCategories: ImmutableHashSet.Create(Categories.Libraries, Categories.Runtime, Categories.ThirdParty));
-            (bool isSuccess, IConfig parsedConfig, var _) = ConfigParser.Parse(new string[] { "--filter", "*" }, nullLogger, recommendedConfig);
+            (bool isSuccess, IConfig? parsedConfig, var _) = ConfigParser.Parse(new string[] { "--filter", "*" }, nullLogger, recommendedConfig);
             Assert.True(isSuccess);
+            Assert.NotNull(parsedConfig);
 
             Assembly microbenchmarksAssembly = typeof(Categories).Assembly;
             (bool allTypesValid, IReadOnlyList<Type> runnable) = Running.TypeFilter.GetTypesWithRunnableBenchmarks(
@@ -73,7 +74,7 @@ namespace BenchmarkDotNet.Extensions.Tests
                 nullLogger);
             Assert.True(allTypesValid);
 
-            BenchmarkRunInfo[] allBenchmarks = GetAllBenchmarks(parsedConfig, runnable);
+            BenchmarkRunInfo[] allBenchmarks = GetAllBenchmarks(parsedConfig!, runnable);
             Dictionary<string, int> idToPartitionIndex = new ();
 
             for (int i = 0; i < 10; i++)
@@ -86,7 +87,7 @@ namespace BenchmarkDotNet.Extensions.Tests
                 {
                     PartitionFilter filter = new(PartitionCount, partitionIndex);
 
-                    foreach (BenchmarkCase benchmark in GetAllBenchmarks(parsedConfig, runnable).SelectMany(benchmark => benchmark.BenchmarksCases))
+                    foreach (BenchmarkCase benchmark in GetAllBenchmarks(parsedConfig!, runnable).SelectMany(benchmark => benchmark.BenchmarksCases))
                     {
                         if (filter.Predicate(benchmark))
                         {

--- a/src/tools/Reporting/Directory.Packages.props
+++ b/src/tools/Reporting/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net11.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net11.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tools/ResultsComparer.Tests/ConsoleOutputCollection.cs
+++ b/src/tools/ResultsComparer.Tests/ConsoleOutputCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace ResultsComparer.Tests;
+
+[CollectionDefinition("Console output", DisableParallelization = true)]
+public sealed class ConsoleOutputCollection
+{
+}

--- a/src/tools/ResultsComparer.Tests/DataTests.cs
+++ b/src/tools/ResultsComparer.Tests/DataTests.cs
@@ -1,0 +1,160 @@
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace ResultsComparer.Tests;
+
+public class DataTests
+{
+    [Fact]
+    public void DecompressExtractsJsonFilesFromNestedZipArchives()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var outerZipPath = Path.Combine(tempDir.FullName, "results.zip");
+            var outputDirectory = new DirectoryInfo(Path.Combine(tempDir.FullName, "output"));
+            outputDirectory.Create();
+
+            var innerZipBytes = CreateInnerZip(("net10.0/SampleBenchmark.full.json", ResultsComparerTestData.CreateBdnJson()));
+
+            using (var fileStream = File.Create(outerZipPath))
+            using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("Performance-Runs/net10.0/testuser/results.zip");
+                using var entryStream = entry.Open();
+                entryStream.Write(innerZipBytes, 0, innerZipBytes.Length);
+            }
+
+            global::ResultsComparer.Data.Decompress(new FileInfo(outerZipPath), outputDirectory);
+
+            var extractedFiles = Directory.GetFiles(outputDirectory.FullName, "*.full.json", SearchOption.AllDirectories);
+            var extractedFile = Assert.Single(extractedFiles);
+            var directoryName = Path.GetFileName(Path.GetDirectoryName(extractedFile));
+
+            Assert.Contains("testuser", directoryName, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("net10.0", directoryName, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("SampleBenchmark", File.ReadAllText(extractedFile));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DecompressExtractsJsonFilesFromTarGzArchives()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var outerZipPath = Path.Combine(tempDir.FullName, "results.zip");
+            var outputDirectory = new DirectoryInfo(Path.Combine(tempDir.FullName, "output"));
+            outputDirectory.Create();
+
+            var tarGzBytes = CreateTarGzArchive(
+                ("payload/SampleBenchmark.full.json", ResultsComparerTestData.CreateBdnJson()),
+                ("payload/README.md", "ignored"));
+
+            using (var fileStream = File.Create(outerZipPath))
+            using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("Performance-Runs/nativeaot10.0/testuser/arm64_win10-nativeaot10.0.tar.gz");
+                using var entryStream = entry.Open();
+                entryStream.Write(tarGzBytes, 0, tarGzBytes.Length);
+            }
+
+            global::ResultsComparer.Data.Decompress(new FileInfo(outerZipPath), outputDirectory);
+
+            var extractedFiles = Directory.GetFiles(outputDirectory.FullName, "*.full.json", SearchOption.AllDirectories);
+            var extractedFile = Assert.Single(extractedFiles);
+            var directoryName = Path.GetFileName(Path.GetDirectoryName(extractedFile));
+
+            Assert.Contains("nativeaot10.0", directoryName, System.StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DecompressPrefersNewestBenchmarkDotNetVersionWhenDuplicatesExist()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var outerZipPath = Path.Combine(tempDir.FullName, "results.zip");
+            var outputDirectory = new DirectoryInfo(Path.Combine(tempDir.FullName, "output"));
+            outputDirectory.Create();
+
+            var innerZipBytes = CreateInnerZip(
+                ("net10.0/SampleBenchmark-a.full.json", ResultsComparerTestData.CreateBdnJson(benchmarkDotNetVersion: "0.13.9")),
+                ("net10.0/SampleBenchmark-b.full.json", ResultsComparerTestData.CreateBdnJson(benchmarkDotNetVersion: "0.13.10")));
+
+            using (var fileStream = File.Create(outerZipPath))
+            using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("Performance-Runs/net10.0/testuser/results.zip");
+                using var entryStream = entry.Open();
+                entryStream.Write(innerZipBytes, 0, innerZipBytes.Length);
+            }
+
+            global::ResultsComparer.Data.Decompress(new FileInfo(outerZipPath), outputDirectory);
+
+            var extractedFile = Assert.Single(Directory.GetFiles(outputDirectory.FullName, "*.full.json", SearchOption.AllDirectories));
+            var json = File.ReadAllText(extractedFile);
+
+            Assert.Contains("\"BenchmarkDotNetVersion\": \"0.13.10\"", json);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    private static byte[] CreateInnerZip(params (string EntryName, string Content)[] entries)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (entryName, content) in entries)
+            {
+                var entry = archive.CreateEntry(entryName);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(content);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateTarGzArchive(params (string EntryName, string Content)[] entries)
+    {
+        using var tarStream = new MemoryStream();
+        using (var tarWriter = new TarWriter(tarStream, leaveOpen: true))
+        {
+            foreach (var (entryName, content) in entries)
+            {
+                var tarEntry = new UstarTarEntry(TarEntryType.RegularFile, entryName)
+                {
+                    DataStream = new MemoryStream(Encoding.UTF8.GetBytes(content))
+                };
+
+                tarWriter.WriteEntry(tarEntry);
+            }
+        }
+
+        tarStream.Position = 0;
+
+        using var gzipStream = new MemoryStream();
+        using (var compressor = new GZipStream(gzipStream, CompressionLevel.SmallestSize, leaveOpen: true))
+        {
+            tarStream.CopyTo(compressor);
+        }
+
+        return gzipStream.ToArray();
+    }
+}

--- a/src/tools/ResultsComparer.Tests/DataTests.cs
+++ b/src/tools/ResultsComparer.Tests/DataTests.cs
@@ -138,9 +138,10 @@ public class DataTests
         {
             foreach (var (entryName, content) in entries)
             {
+                using var dataStream = new MemoryStream(Encoding.UTF8.GetBytes(content));
                 var tarEntry = new UstarTarEntry(TarEntryType.RegularFile, entryName)
                 {
-                    DataStream = new MemoryStream(Encoding.UTF8.GetBytes(content))
+                    DataStream = dataStream
                 };
 
                 tarWriter.WriteEntry(tarEntry);

--- a/src/tools/ResultsComparer.Tests/HelperTests.cs
+++ b/src/tools/ResultsComparer.Tests/HelperTests.cs
@@ -1,0 +1,137 @@
+using System.IO;
+using System.Text;
+using DataTransferContracts;
+using Xunit;
+
+namespace ResultsComparer.Tests;
+
+public class HelperTests
+{
+    [Fact]
+    public void GetFilesToParseReturnsAllFullJsonFilesFromDirectory()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var nestedDirectory = Directory.CreateDirectory(Path.Combine(tempDir.FullName, "nested"));
+            var expectedA = Path.Combine(tempDir.FullName, "first.full.json");
+            var expectedB = Path.Combine(nestedDirectory.FullName, "second.full.json");
+
+            File.WriteAllText(expectedA, "{}");
+            File.WriteAllText(expectedB, "{}");
+            File.WriteAllText(Path.Combine(tempDir.FullName, "ignored.json"), "{}");
+
+            var result = global::ResultsComparer.Helper.GetFilesToParse(tempDir.FullName);
+
+            Assert.Equal(2, result.Length);
+            Assert.Contains(expectedA, result);
+            Assert.Contains(expectedB, result);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetFilesToParseThrowsForMissingFullJsonPath()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var missingPath = Path.Combine(tempDir.FullName, "missing.full.json");
+
+            Assert.Throws<FileNotFoundException>(() => global::ResultsComparer.Helper.GetFilesToParse(missingPath));
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReadFromStreamDeserializesBenchmarkResults()
+    {
+        var json = ResultsComparerTestData.CreateBdnJson(originalValues: [1.0, 1.1, 1.2], median: 1.1);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        BdnResult result = global::ResultsComparer.Helper.ReadFromStream(stream);
+
+        Assert.Equal("SampleBenchmark-20240504-182513", result.Title);
+        Assert.Equal("X64", result.HostEnvironmentInfo.Architecture);
+        Assert.Single(result.Benchmarks);
+        Assert.Equal("Demo.Namespace.SampleBenchmark", result.Benchmarks[0].FullName);
+    }
+
+    [Fact]
+    public void ReadFromFileDeserializesBenchmarkResults()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var filePath = Path.Combine(tempDir.FullName, "sample.full.json");
+            File.WriteAllText(filePath, ResultsComparerTestData.CreateBdnJson());
+
+            BdnResult result = global::ResultsComparer.Helper.ReadFromFile(filePath);
+
+            Assert.Equal("SampleBenchmark-20240504-182513", result.Title);
+            Assert.Single(result.Benchmarks);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetFilesToParseReturnsExplicitFilePath()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var filePath = Path.Combine(tempDir.FullName, "custom-name.json");
+            File.WriteAllText(filePath, ResultsComparerTestData.CreateBdnJson());
+
+            var result = global::ResultsComparer.Helper.GetFilesToParse(filePath);
+
+            Assert.Equal([filePath], result);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void GetModalInfoReturnsNullForSmallSampleSets()
+    {
+        var benchmark = new Benchmark
+        {
+            Statistics = new Statistics
+            {
+                N = 3,
+                OriginalValues = [1.0, 1.1, 1.2]
+            }
+        };
+
+        Assert.Null(global::ResultsComparer.Helper.GetModalInfo(benchmark));
+    }
+
+    [Fact]
+    public void GetModalInfoDetectsMultiClusterData()
+    {
+        var benchmark = new Benchmark
+        {
+            Statistics = new Statistics
+            {
+                N = 16,
+                OriginalValues = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0]
+            }
+        };
+
+        var modality = global::ResultsComparer.Helper.GetModalInfo(benchmark);
+
+        Assert.Equal("bimodal", modality);
+    }
+}

--- a/src/tools/ResultsComparer.Tests/ProgramTests.cs
+++ b/src/tools/ResultsComparer.Tests/ProgramTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace ResultsComparer.Tests;
 
+[Collection("Console output")]
 public class ProgramTests
 {
     [Fact]

--- a/src/tools/ResultsComparer.Tests/ProgramTests.cs
+++ b/src/tools/ResultsComparer.Tests/ProgramTests.cs
@@ -83,6 +83,31 @@ public class ProgramTests
         }
     }
 
+    [Fact]
+    public void MatrixCommandTreatsEquivalentInputsAsSameNotNoise()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputDirectory = Directory.CreateDirectory(Path.Combine(tempDir.FullName, "input"));
+            var baseDirectory = Directory.CreateDirectory(Path.Combine(inputDirectory.FullName, "run-base"));
+            var diffDirectory = Directory.CreateDirectory(Path.Combine(inputDirectory.FullName, "run-diff"));
+            var identicalJson = ResultsComparerTestData.CreateBdnJson();
+
+            File.WriteAllText(Path.Combine(baseDirectory.FullName, "SampleBenchmark.full.json"), identicalJson);
+            File.WriteAllText(Path.Combine(diffDirectory.FullName, "SampleBenchmark.full.json"), identicalJson);
+
+            var output = InvokeProgram(["matrix", "--input", inputDirectory.FullName, "--base", "base", "--diff", "diff", "--threshold", "5%", "--ratio-only"]);
+
+            Assert.Contains("Same", output);
+            Assert.DoesNotContain("Noise", output);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
     private static string InvokeProgram(string[] args)
     {
         using var writer = new StringWriter();

--- a/src/tools/ResultsComparer.Tests/ProgramTests.cs
+++ b/src/tools/ResultsComparer.Tests/ProgramTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using Xunit;
 
@@ -109,10 +110,38 @@ public class ProgramTests
         }
     }
 
+    [Fact]
+    public void InvokeProgramRestoresCurrentCulture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var expectedCulture = new CultureInfo("fr-FR");
+            var expectedUICulture = new CultureInfo("de-DE");
+
+            CultureInfo.CurrentCulture = expectedCulture;
+            CultureInfo.CurrentUICulture = expectedUICulture;
+
+            _ = InvokeProgram(["--base", "base.json", "--diff", "diff.json", "--threshold", "not-a-threshold"]);
+
+            Assert.Equal(expectedCulture.Name, CultureInfo.CurrentCulture.Name);
+            Assert.Equal(expectedUICulture.Name, CultureInfo.CurrentUICulture.Name);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    }
+
     private static string InvokeProgram(string[] args)
     {
         using var writer = new StringWriter();
         var originalOut = Console.Out;
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUICulture = CultureInfo.CurrentUICulture;
         Console.SetOut(writer);
         try
         {
@@ -121,6 +150,8 @@ public class ProgramTests
         }
         finally
         {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
             Console.SetOut(originalOut);
         }
     }

--- a/src/tools/ResultsComparer.Tests/ProgramTests.cs
+++ b/src/tools/ResultsComparer.Tests/ProgramTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace ResultsComparer.Tests;
+
+public class ProgramTests
+{
+    [Fact]
+    public void MainReportsInvalidThreshold()
+    {
+        var output = InvokeProgram(["--base", "base.json", "--diff", "diff.json", "--threshold", "not-a-threshold"]);
+
+        Assert.Contains("Invalid Threshold", output);
+    }
+
+    [Fact]
+    public void MainReportsMissingMatrixInputDirectory()
+    {
+        var missingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        var output = InvokeProgram(["matrix", "--input", missingDirectory, "--base", "base", "--diff", "diff", "--threshold", "5%"]);
+
+        Assert.Contains("does NOT exist", output);
+    }
+
+    [Fact]
+    public void MainPrintsNoDifferencesForEquivalentInputs()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var baseFile = Path.Combine(tempDir.FullName, "base.full.json");
+            var diffFile = Path.Combine(tempDir.FullName, "diff.full.json");
+            var json = ResultsComparerTestData.CreateBdnJson();
+
+            File.WriteAllText(baseFile, json);
+            File.WriteAllText(diffFile, json);
+
+            var output = InvokeProgram(["--base", baseFile, "--diff", diffFile, "--threshold", "5%"]);
+
+            Assert.Contains("No differences found", output);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MatrixCommandPrintsLegendAndBenchmarkTable()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        try
+        {
+            var inputDirectory = Directory.CreateDirectory(Path.Combine(tempDir.FullName, "input"));
+            var baseDirectory = Directory.CreateDirectory(Path.Combine(inputDirectory.FullName, "run-base"));
+            var diffDirectory = Directory.CreateDirectory(Path.Combine(inputDirectory.FullName, "run-diff"));
+
+            File.WriteAllText(
+                Path.Combine(baseDirectory.FullName, "SampleBenchmark.full.json"),
+                ResultsComparerTestData.CreateBdnJson(
+                    originalValues: [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111],
+                    median: 106,
+                    allocatedBytes: 10));
+            File.WriteAllText(
+                Path.Combine(diffDirectory.FullName, "SampleBenchmark.full.json"),
+                ResultsComparerTestData.CreateBdnJson(
+                    originalValues: [200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211],
+                    median: 206,
+                    allocatedBytes: 30));
+
+            var output = InvokeProgram(["matrix", "--input", inputDirectory.FullName, "--base", "base", "--diff", "diff", "--threshold", "5%", "--ratio-only"]);
+
+            Assert.Contains("# Legend", output);
+            Assert.Contains("Demo.Namespace.SampleBenchmark", output);
+            Assert.Contains("Slower", output);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    private static string InvokeProgram(string[] args)
+    {
+        using var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            Program.Main(args);
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/src/tools/ResultsComparer.Tests/ProgramTests.cs
+++ b/src/tools/ResultsComparer.Tests/ProgramTests.cs
@@ -98,9 +98,10 @@ public class ProgramTests
             File.WriteAllText(Path.Combine(diffDirectory.FullName, "SampleBenchmark.full.json"), identicalJson);
 
             var output = InvokeProgram(["matrix", "--input", inputDirectory.FullName, "--base", "base", "--diff", "diff", "--threshold", "5%", "--ratio-only"]);
+            var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 
-            Assert.Contains("Same", output);
-            Assert.DoesNotContain("Noise", output);
+            Assert.Contains(lines, line => line.TrimStart().StartsWith("| Same", StringComparison.Ordinal));
+            Assert.DoesNotContain(lines, line => line.TrimStart().StartsWith("| Noise", StringComparison.Ordinal));
         }
         finally
         {

--- a/src/tools/ResultsComparer.Tests/ResultsComparer.Tests.csproj
+++ b/src/tools/ResultsComparer.Tests/ResultsComparer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/tools/ResultsComparer.Tests/ResultsComparer.Tests.csproj
+++ b/src/tools/ResultsComparer.Tests/ResultsComparer.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ResultsComparer\ResultsComparer.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tools/ResultsComparer.Tests/ResultsComparerTestData.cs
+++ b/src/tools/ResultsComparer.Tests/ResultsComparerTestData.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Linq;
+
+namespace ResultsComparer.Tests;
+
+internal static class ResultsComparerTestData
+{
+    internal static string CreateBdnJson(
+        string title = "SampleBenchmark-20240504-182513",
+        string fullName = "Demo.Namespace.SampleBenchmark",
+        string? benchmarkNamespace = "Demo.Namespace",
+        double[]? originalValues = null,
+        double? median = null,
+        long? allocatedBytes = 42,
+        string benchmarkDotNetVersion = "0.13.10",
+        string osVersion = "Windows 11 (10.0.26100)",
+        string processorName = "Intel Core i7-8700",
+        string architecture = "X64")
+    {
+        originalValues ??= [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
+        median ??= originalValues.OrderBy(v => v).ElementAt(originalValues.Length / 2);
+        string values = string.Join(", ", originalValues.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+        string namespaceField = benchmarkNamespace is null ? "null" : $"\"{benchmarkNamespace}\"";
+        string memoryField = allocatedBytes is null
+            ? "\"Memory\": {}"
+            : $"\"Memory\": {{ \"BytesAllocatedPerOperation\": {allocatedBytes.Value.ToString(CultureInfo.InvariantCulture)} }}";
+
+        return $$"""
+            {
+              "Title": "{{title}}",
+              "HostEnvironmentInfo": {
+                "BenchmarkDotNetVersion": "{{benchmarkDotNetVersion}}",
+                "OsVersion": "{{osVersion}}",
+                "ProcessorName": "{{processorName}}",
+                "Architecture": "{{architecture}}"
+              },
+              "Benchmarks": [
+                {
+                  "Namespace": {{namespaceField}},
+                  "FullName": "{{fullName}}",
+                  "Statistics": {
+                    "OriginalValues": [{{values}}],
+                    "N": {{originalValues.Length}},
+                    "Median": {{median.Value.ToString(CultureInfo.InvariantCulture)}}
+                  },
+                  {{memoryField}}
+                }
+              ]
+            }
+            """;
+    }
+}

--- a/src/tools/ResultsComparer.Tests/StatsTests.cs
+++ b/src/tools/ResultsComparer.Tests/StatsTests.cs
@@ -6,12 +6,13 @@ using Xunit;
 
 namespace ResultsComparer.Tests;
 
+[Collection("Console output")]
 public class StatsTests
 {
     [Fact]
     public void GetSimplifiedOSNameRemovesParentheticalSuffix()
     {
-        Assert.Equal("Windows 11 ", global::ResultsComparer.Stats.GetSimplifiedOSName("Windows 11 (10.0.26100)"));
+        Assert.Equal("Windows 11", global::ResultsComparer.Stats.GetSimplifiedOSName("Windows 11 (10.0.26100)"));
     }
 
     [Fact]

--- a/src/tools/ResultsComparer.Tests/StatsTests.cs
+++ b/src/tools/ResultsComparer.Tests/StatsTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using DataTransferContracts;
+using Perfolizer.Mathematics.SignificanceTesting;
+using Xunit;
+
+namespace ResultsComparer.Tests;
+
+public class StatsTests
+{
+    [Fact]
+    public void GetSimplifiedOSNameRemovesParentheticalSuffix()
+    {
+        Assert.Equal("Windows 11 ", global::ResultsComparer.Stats.GetSimplifiedOSName("Windows 11 (10.0.26100)"));
+    }
+
+    [Fact]
+    public void PrintAggregatesTotalsAndEmitsSectionsOnce()
+    {
+        var stats = new global::ResultsComparer.Stats();
+        var environment = new HostEnvironmentInfo
+        {
+            Architecture = "X64",
+            OsVersion = "Windows 11 (10.0.26100)",
+            ProcessorName = "Intel Core i7-8700"
+        };
+        var benchmark = new Benchmark
+        {
+            Namespace = "Demo.Namespace",
+            Statistics = new Statistics
+            {
+                OriginalValues = new[] { 1.0, 1.1, 1.2 },
+                N = 3,
+                Median = 1.1
+            },
+            Memory = new Memory()
+        };
+
+        stats.Record(EquivalenceTestConclusion.Same, environment, benchmark);
+        stats.Record(EquivalenceTestConclusion.Faster, environment, benchmark);
+        stats.Record(EquivalenceTestConclusion.Slower, environment, benchmark);
+        stats.Record(EquivalenceTestConclusion.Unknown, environment, benchmark);
+        stats.Record(global::ResultsComparer.Stats.Noise, environment, benchmark);
+
+        using var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+        try
+        {
+            stats.Print();
+            var firstOutput = writer.ToString();
+
+            Assert.Contains("## Statistics", firstOutput);
+            Assert.Contains("Total:   5", firstOutput);
+            Assert.Contains("## Statistics per Architecture", firstOutput);
+            Assert.Contains("## Statistics per Operating System", firstOutput);
+            Assert.Contains("## Statistics per Namespace", firstOutput);
+            Assert.Contains("Demo.Namespace", firstOutput);
+
+            writer.GetStringBuilder().Clear();
+            stats.Print();
+
+            Assert.Equal(string.Empty, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void RecordThrowsForUnsupportedConclusion()
+    {
+        var stats = new global::ResultsComparer.Stats();
+        var environment = new HostEnvironmentInfo { Architecture = "X64", OsVersion = "Windows 11 (10.0.26100)" };
+        var benchmark = new Benchmark { Statistics = new Statistics { OriginalValues = [1.0], N = 1, Median = 1.0 }, Memory = new Memory() };
+
+        Assert.Throws<NotSupportedException>(() => stats.Record((EquivalenceTestConclusion)999, environment, benchmark));
+    }
+}

--- a/src/tools/ResultsComparer/Data.cs
+++ b/src/tools/ResultsComparer/Data.cs
@@ -130,6 +130,9 @@ namespace ResultsComparer
 
         private static string GetMoniker(string key)
         {
+            if (string.IsNullOrEmpty(key))
+                return null;
+
             if (key.Contains("net6")) // some files are net6.0, some are missing the dot (net60)
                 return "net6.0";
             if (key.Contains("nativeaot6"))
@@ -158,13 +161,13 @@ namespace ResultsComparer
                 return "nativeaot9.0-preview" + key[key.IndexOf("nativeaot9.0-preview") + "nativeaot9.0-preview".Length];
             if (key.Contains("net9.0"))
                 return "net9.0";
-            if (key.StartsWith("net10.0"))
+            if (key.Contains("net10.0"))
                 return "net10.0";
-            if (key.StartsWith("nativeaot10.0"))
+            if (key.Contains("nativeaot10.0"))
                 return key;
-            if (key.StartsWith("net11.0"))
+            if (key.Contains("net11.0"))
                 return "net11.0";
-            if (key.StartsWith("nativeaot11.0"))
+            if (key.Contains("nativeaot11.0"))
                 return key;
 
             return null;

--- a/src/tools/ResultsComparer/Data.cs
+++ b/src/tools/ResultsComparer/Data.cs
@@ -164,11 +164,11 @@ namespace ResultsComparer
             if (key.Contains("net10.0"))
                 return "net10.0";
             if (key.Contains("nativeaot10.0"))
-                return key;
+                return "nativeaot10.0";
             if (key.Contains("net11.0"))
                 return "net11.0";
             if (key.Contains("nativeaot11.0"))
-                return key;
+                return "nativeaot11.0";
 
             return null;
         }

--- a/src/tools/ResultsComparer/Directory.Packages.props
+++ b/src/tools/ResultsComparer/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="MarkdownLog.NS20" Version="0.10.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageVersion Include="Perfolizer" Version="0.2.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -141,13 +141,13 @@ namespace ResultsComparer
                 var baseValues = info.baseResult.Statistics.OriginalValues;
                 var diffValues = info.diffResult.Statistics.OriginalValues;
 
-                var userTresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
+                var userThresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
                 var noiseResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.NoiseThreshold);
 
                 // filter noise (0.20 ns vs 0.25ns is 25% difference)
-                var conclusion = userTresholdResult.Conclusion != EquivalenceTestConclusion.Same && noiseResult.Conclusion == EquivalenceTestConclusion.Same
+                var conclusion = userThresholdResult.Conclusion != EquivalenceTestConclusion.Same && noiseResult.Conclusion == EquivalenceTestConclusion.Same
                     ? Stats.Noise
-                    : userTresholdResult.Conclusion == EquivalenceTestConclusion.Base ? EquivalenceTestConclusion.Same : userTresholdResult.Conclusion;
+                    : userThresholdResult.Conclusion == EquivalenceTestConclusion.Base ? EquivalenceTestConclusion.Same : userThresholdResult.Conclusion;
 
                 stats.Record(conclusion, info.baseEnv, info.baseResult);
 

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -143,11 +143,13 @@ namespace ResultsComparer
 
                 var userThresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
                 var noiseResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.NoiseThreshold);
+                var userConclusion = userThresholdResult.Conclusion == EquivalenceTestConclusion.Base ? EquivalenceTestConclusion.Same : userThresholdResult.Conclusion;
+                var noiseConclusion = noiseResult.Conclusion == EquivalenceTestConclusion.Base ? EquivalenceTestConclusion.Same : noiseResult.Conclusion;
 
                 // filter noise (0.20 ns vs 0.25ns is 25% difference)
-                var conclusion = userThresholdResult.Conclusion != EquivalenceTestConclusion.Same && noiseResult.Conclusion == EquivalenceTestConclusion.Same
+                var conclusion = userConclusion != EquivalenceTestConclusion.Same && noiseConclusion == EquivalenceTestConclusion.Same
                     ? Stats.Noise
-                    : userThresholdResult.Conclusion == EquivalenceTestConclusion.Base ? EquivalenceTestConclusion.Same : userThresholdResult.Conclusion;
+                    : userConclusion;
 
                 stats.Record(conclusion, info.baseEnv, info.baseResult);
 

--- a/src/tools/ResultsComparer/Program.cs
+++ b/src/tools/ResultsComparer/Program.cs
@@ -172,7 +172,9 @@ namespace ResultsComparer
         }
 
         private static Regex[] GetFilters(string[] filters)
-            =>  filters.Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
+            => (filters ?? Array.Empty<string>())
+                .Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                .ToArray();
 
         // https://stackoverflow.com/a/6907849/5852046 not perfect but should work for all we need
         private static string WildcardToRegex(string pattern) => $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$";

--- a/src/tools/ResultsComparer/Properties/AssemblyInfo.cs
+++ b/src/tools/ResultsComparer/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ResultsComparer.Tests")]

--- a/src/tools/ResultsComparer/ResultsComparer.sln
+++ b/src/tools/ResultsComparer/ResultsComparer.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResultsComparer", "ResultsComparer.csproj", "{00859394-44F8-466B-8624-41578CA94009}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResultsComparer.Tests", "..\ResultsComparer.Tests\ResultsComparer.Tests.csproj", "{F1CA7160-F99B-484F-975E-04C4638BCFAF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{00859394-44F8-466B-8624-41578CA94009}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{00859394-44F8-466B-8624-41578CA94009}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Debug|x64.Build.0 = Debug|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Debug|x86.Build.0 = Debug|Any CPU
 		{00859394-44F8-466B-8624-41578CA94009}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00859394-44F8-466B-8624-41578CA94009}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Release|x64.ActiveCfg = Release|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Release|x64.Build.0 = Release|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Release|x86.ActiveCfg = Release|Any CPU
+		{00859394-44F8-466B-8624-41578CA94009}.Release|x86.Build.0 = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|x64.Build.0 = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1CA7160-F99B-484F-975E-04C4638BCFAF}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/tools/ResultsComparer/Stats.cs
+++ b/src/tools/ResultsComparer/Stats.cs
@@ -77,7 +77,7 @@ namespace ResultsComparer
             }
         }
 
-        internal static string GetSimplifiedOSName(string text) => text.Split('(')[0];
+        internal static string GetSimplifiedOSName(string text) => text.Split('(')[0].TrimEnd();
 
         private class PerConclusion
         {

--- a/src/tools/ResultsComparer/TwoInputsComparer.cs
+++ b/src/tools/ResultsComparer/TwoInputsComparer.cs
@@ -36,11 +36,13 @@ namespace ResultsComparer
                 var diffValues = diffResult.Statistics.OriginalValues.ToArray();
 
                 var userTresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
-                if (userTresholdResult.Conclusion == EquivalenceTestConclusion.Same)
+                if (userTresholdResult.Conclusion == EquivalenceTestConclusion.Same
+                    || userTresholdResult.Conclusion == EquivalenceTestConclusion.Base)
                     continue;
 
                 var noiseResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.NoiseThreshold);
-                if (noiseResult.Conclusion == EquivalenceTestConclusion.Same)
+                if (noiseResult.Conclusion == EquivalenceTestConclusion.Same
+                    || noiseResult.Conclusion == EquivalenceTestConclusion.Base)
                     continue;
 
                 yield return (id, baseResult, diffResult, userTresholdResult.Conclusion);

--- a/src/tools/ResultsComparer/TwoInputsComparer.cs
+++ b/src/tools/ResultsComparer/TwoInputsComparer.cs
@@ -35,9 +35,9 @@ namespace ResultsComparer
                 var baseValues = baseResult.Statistics.OriginalValues.ToArray();
                 var diffValues = diffResult.Statistics.OriginalValues.ToArray();
 
-                var userTresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
-                if (userTresholdResult.Conclusion == EquivalenceTestConclusion.Same
-                    || userTresholdResult.Conclusion == EquivalenceTestConclusion.Base)
+                var userThresholdResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.StatisticalTestThreshold);
+                if (userThresholdResult.Conclusion == EquivalenceTestConclusion.Same
+                    || userThresholdResult.Conclusion == EquivalenceTestConclusion.Base)
                     continue;
 
                 var noiseResult = StatisticalTestHelper.CalculateTost(MannWhitneyTest.Instance, baseValues, diffValues, args.NoiseThreshold);
@@ -45,7 +45,7 @@ namespace ResultsComparer
                     || noiseResult.Conclusion == EquivalenceTestConclusion.Base)
                     continue;
 
-                yield return (id, baseResult, diffResult, userTresholdResult.Conclusion);
+                yield return (id, baseResult, diffResult, userThresholdResult.Conclusion);
             }
         }
 

--- a/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
+++ b/src/tools/ScenarioMeasurement/Startup.Tests/StartupTests.cs
@@ -3,7 +3,9 @@ using ScenarioMeasurement;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Principal;
 using System.Threading;
+using System.Runtime.Versioning;
 using Xunit;
 
 
@@ -131,10 +133,27 @@ public class StartupTests
     {
         public WindowsOnly()
         {
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            if (!OperatingSystem.IsWindows())
             {
                 Skip = "Skip on non-windows platform";
             }
+            else if (!IsRunningAsAdministrator())
+            {
+                Skip = "Requires administrator privileges to start ETW sessions";
+            }
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static bool IsRunningAsAdministrator()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return false;
+            }
+
+            using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+            WindowsPrincipal principal = new(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
         }
     }
 
@@ -142,7 +161,7 @@ public class StartupTests
     {
         public LinuxOnly()
         {
-            if(Environment.OSVersion.Platform != PlatformID.Unix)
+            if (!OperatingSystem.IsLinux())
             {
                 Skip = "Skip on non-linux platform";
             }


### PR DESCRIPTION
## Summary

This expands automated coverage in the repo’s tooling-focused test surface without large production refactors.

### What changed

- Added a new `ResultsComparer.Tests` project covering:
  - file and directory input handling
  - JSON deserialization from file/stream
  - stats aggregation and output behavior
  - zip/tar.gz decompression flows
  - duplicate-result/version-selection behavior
  - CLI paths for invalid thresholds, missing inputs, and matrix output

- Expanded `BenchmarkDotNet.Extensions` command-line option tests to cover:
  - string parameter parsing
  - boolean switch parsing
  - missing/invalid integer argument paths
  - absent-switch behavior

- Improved `Startup.Tests` reliability by skipping ETW-dependent Windows tests when not running elevated, instead of aborting the run

### Small correctness fixes found while adding coverage

The new tests exposed a few edge-case bugs, which are fixed in this PR:

- `CommandLineOptions.ParseAndRemoveStringsParameter` now handles missing switches safely
- `ResultsComparer.Program` now tolerates a missing optional `--filter`
- `TwoInputsComparer` now treats `EquivalenceTestConclusion.Base` as a no-diff case
- `ResultsComparer.Data` moniker parsing is now null-safe for additional archive path shapes

## Validation

Validated the affected suites in the available environment:

- `ResultsComparer.Tests` passing
- targeted `BenchmarkDotNet.Extensions` command-line tests passing
- `Startup.Tests` now skip environment-dependent cases cleanly

> **Note:** test projects are kept at `net11.0`; full execution of those targets requires a local/CI environment with the .NET 11 SDK installed.