### PR TITLE
Move arm64 cobalt micro run to regular perf pipeline and fix SVE runKind

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -56,6 +56,12 @@ parameters:
     type: object
     default:
       enabled: true
+  - name: cobaltMicro
+    type: object
+    default:
+      enabled: true
+      configs:
+        - linux_arm64
   - name: cobaltSveMicro
     type: object
     default:
@@ -284,6 +290,25 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
+  # CoreCLR Cobalt microbenchmarks — controlled by cobaltMicro toggle.
+  # Excluded on release branches — the arm64 coreclr build doesn't exist in older runtime branches.
+  - ${{ if and(eq(parameters.cobaltMicro.enabled, true), not(startswith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}:
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms: ${{ parameters.cobaltMicro.configs }}
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runKind: micro
+          logicalMachine: 'perfcobalt'
+          osDistro: 'azurelinux'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
   # CoreCLR Cobalt SVE microbenchmarks — controlled by cobaltSveMicro toggle.
   # Excluded on release branches — the arm64 coreclr build doesn't exist in older runtime branches.
   - ${{ if and(eq(parameters.cobaltSveMicro.enabled, true), not(startswith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}:
@@ -295,7 +320,7 @@ jobs:
         platforms: ${{ parameters.cobaltSveMicro.configs }}
         jobParameters:
           liveLibrariesBuildConfig: Release
-          runKind: micro
+          runKind: SVE
           logicalMachine: 'perfcobalt'
           osDistro: 'azurelinux'
           runCategories: 'SVE'

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -320,7 +320,7 @@ jobs:
         platforms: ${{ parameters.cobaltSveMicro.configs }}
         jobParameters:
           liveLibrariesBuildConfig: Release
-          runKind: SVE
+          runKind: sve
           logicalMachine: 'perfcobalt'
           osDistro: 'azurelinux'
           runCategories: 'SVE'

--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -94,25 +94,6 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    # run coreclr Linux arm64 cobalt microbenchmarks perf job
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: coreclr
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runKind: micro
-          logicalMachine: 'perfcobalt'
-          osDistro: 'azurelinux'
-          timeoutInMinutes: 780
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
     # run coreclr Windows arm64 ampere microbenchmarks perf job
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:


### PR DESCRIPTION
- Move coreclr Linux arm64 cobalt microbenchmarks from perf_slow to regular perf pipeline with toggle parameter
- Change runKind from 'micro' to 'SVE' for the cobalt SVE job to give it a distinct run configuration

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


