### PR TITLE
Condition Microsoft.Extensions.* package refs for net10+ and add Micr…

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -16,6 +16,13 @@
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
     <!-- Suppress Sve experimental feature warning -->
     <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
+    <!-- Disable NuGet package pruning (.NET 10+) so Microsoft.Extensions.* and other
+         in-band but still-published packages remain app-local. The benchmarks are run
+         via BenchmarkDotNet's corerun option against a NetCoreApp CoreRoot that does
+         not include the Microsoft.AspNetCore.App shared framework, so app-local copies
+         of these assemblies are required. Also suppresses NU1510. -->
+    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
+    <NoWarn>$(NoWarn);NU1510</NoWarn>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
…osoft.AspNetCore.App FrameworkReference

The Microsoft.Extensions.* libraries (Configuration, Configuration.Binder/Json/Xml, Caching.Memory, DependencyInjection, Http, Logging, Logging.EventSource) are now in-band in the Microsoft.AspNetCore.App shared framework for net10.0+. Direct PackageReferences raise NU1510 (promoted to error by TreatWarningsAsErrors), and without the framework reference the compiler fails with CS0246 for IConfiguration, ObjectFactory, IChangeToken, etc.

Follows the pattern from #5196 (which handled Microsoft.Extensions.Primitives, in-band in Microsoft.NETCore.App), and adds a FrameworkReference to Microsoft.AspNetCore.App for net10.0+ so the in-band assemblies resolve.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


