### PR TITLE
Fix GC pipeline

### DIFF
--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -59,8 +59,10 @@ jobs:
         includePreviewVersions: true
     - script: dotnet tool restore
     - script: dotnet tool install --global dotnet-repl 
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj --configuration Debug --framework net8.0
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj --configuration Debug --framework net8.0
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Release --framework net8.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj --configuration Release --framework net8.0
 
     # Run tests. Template installed from: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/vstest-v3?view=azure-pipelines
     - task: VSTest@3
@@ -70,14 +72,34 @@ jobs:
         # -------------- #
         testAssemblyVer2: GC.Infrastructure.Core.UnitTests.dll
         searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.Core.UnitTests/Debug/net8.0'
+	otherConsoleOptions: '--Framework:net8.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 
         # ----------------- #
         # Reporting options #
         # ----------------- #
-        testRunTitle: 'GC Infrastructure Unit Test'
+        testRunTitle: 'GC Infrastructure Core Unit Test'
         # TODO: Double Check.
         platform: 'Windows' ## string. Build platform. 
         # TODO: Double Check.
-        configuration: 'Test GC Infrastructure' # string. Build configuration.
+        configuration: 'Test GC Infrastructure Core' # string. Build configuration.
+    - task: VSTest@3
+      inputs:
+        # -------------- #
+        # Test selection #
+        # -------------- #
+        testAssemblyVer2: GC.Analysis.API.UnitTests.dll
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Analysis.API.UnitTests/Debug/net8.0'
+	otherConsoleOptions: '--Framework:net8.0'
+        # Uncomment to save results in the future.
+        # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
+
+        # ----------------- #
+        # Reporting options #
+        # ----------------- #
+        testRunTitle: 'GC Analysis API Unit Test'
+        # TODO: Double Check.
+        platform: 'Windows' ## string. Build platform.
+        # TODO: Double Check.
+        configuration: 'Test GC Analysis API' # string. Build configuration.

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
   # TODO: Add.
   - job: GCNotebookValidation_Windows 
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2025
  
     steps:
     # Install dotnet. We temporarily need both .NET 8 (for building and running the projects) and .NET 9 (for installing deps).

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -1,5 +1,5 @@
-# Project: src\benchmarks\gc\GC.Infrastructure\GC.Infrastructure.NotebookTests\GC.Infrastructure.NotebookTests.csproj. 
-# Output: artifacts\bin\GC.Infrastructure.NotebookTests\Debug\net8.0\GC.Infrastructure.NotebookTests.dll
+# Project: src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj.
+# Output: artifacts\bin\GC.Infrastructure.Core.UnitTests\Debug\net8.0\GC.Infrastructure.Core.UnitTests.dll
 
 resources:
   containers:
@@ -26,13 +26,13 @@ pr:
 jobs:
 
   # TODO: Add back once we have validated windows.
-  # - job: GCNotebookValidation_Ubuntu
+  # - job: GCInfrastructureValidation_Ubuntu
   #     pool:
   #       vmImage: ubuntu-latest
   #     container: ubuntu_x64_build_container
 
   # TODO: Add.
-  - job: GCNotebookValidation_Windows 
+  - job: GCInfrastructureValidation_Windows
     pool:
       vmImage: windows-2025
  
@@ -59,7 +59,7 @@ jobs:
         includePreviewVersions: true
     - script: dotnet tool restore
     - script: dotnet tool install --global dotnet-repl 
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.NotebookTests/GC.Infrastructure.NotebookTests.csproj --configuration Debug --framework net8.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj --configuration Debug --framework net8.0
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Release --framework net8.0
 
     # Run tests. Template installed from: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/vstest-v3?view=azure-pipelines
@@ -68,16 +68,16 @@ jobs:
         # -------------- #
         # Test selection #
         # -------------- #
-        testAssemblyVer2: GC.Infrastructure.NotebookTests.dll
-        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.NotebookTests/Debug/net8.0'
+        testAssemblyVer2: GC.Infrastructure.Core.UnitTests.dll
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.Core.UnitTests/Debug/net8.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 
         # ----------------- #
         # Reporting options #
         # ----------------- #
-        testRunTitle: 'GC Notebook Test' 
+        testRunTitle: 'GC Infrastructure Unit Test'
         # TODO: Double Check.
         platform: 'Windows' ## string. Build platform. 
         # TODO: Double Check.
-        configuration: 'Test Notebooks' # string. Build configuration. 
+        configuration: 'Test GC Infrastructure' # string. Build configuration.

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -34,8 +34,7 @@ jobs:
   # TODO: Add.
   - job: GCNotebookValidation_Windows 
     pool:
-      name: NetCore-Public
-      demands: ImageOverride -equals windows.vs2022.amd64.open
+      vmImage: windows-2025
  
     steps:
     # Install dotnet. We temporarily need both .NET 8 (for building and running the projects) and .NET 9 (for installing deps).

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -52,6 +52,11 @@ jobs:
       inputs:
         version: 10.0.x
         includePreviewVersions: true
+    - task: UseDotNet@2
+      displayName: Install .NET 11.0 
+      inputs:
+        version: 11.0.x
+        includePreviewVersions: true
     - script: dotnet tool restore
     - script: dotnet tool install --global dotnet-repl 
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.NotebookTests/GC.Infrastructure.NotebookTests.csproj --configuration Debug --framework net8.0

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -34,7 +34,9 @@ jobs:
   # TODO: Add.
   - job: GCNotebookValidation_Windows 
     pool:
-      vmImage: windows-2025
+      name: NetCore-Public
+      demands:
+      - ImageOverride -equals windows.vs2022.amd64.open
  
     steps:
     # Install dotnet. We temporarily need both .NET 8 (for building and running the projects) and .NET 9 (for installing deps).

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -61,8 +61,8 @@ jobs:
     - script: dotnet tool install --global dotnet-repl 
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj --configuration Debug --framework net8.0
     - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj --configuration Debug --framework net8.0
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Release --framework net8.0
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj --configuration Release --framework net8.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Debug --framework net8.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj --configuration Debug --framework net8.0
 
     # Run tests. Template installed from: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/vstest-v3?view=azure-pipelines
     - task: VSTest@3
@@ -72,7 +72,7 @@ jobs:
         # -------------- #
         testAssemblyVer2: GC.Infrastructure.Core.UnitTests.dll
         searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.Core.UnitTests/Debug/net8.0'
-	otherConsoleOptions: '--Framework:net8.0'
+        otherConsoleOptions: '--Framework:net8.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 
@@ -91,7 +91,7 @@ jobs:
         # -------------- #
         testAssemblyVer2: GC.Analysis.API.UnitTests.dll
         searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Analysis.API.UnitTests/Debug/net8.0'
-	otherConsoleOptions: '--Framework:net8.0'
+        otherConsoleOptions: '--Framework:net8.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 

--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -35,8 +35,7 @@ jobs:
   - job: GCNotebookValidation_Windows 
     pool:
       name: NetCore-Public
-      demands:
-      - ImageOverride -equals windows.vs2022.amd64.open
+      demands: ImageOverride -equals windows.vs2022.amd64.open
  
     steps:
     # Install dotnet. We temporarily need both .NET 8 (for building and running the projects) and .NET 9 (for installing deps).

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -176,10 +176,10 @@ namespace GC.Infrastructure.Commands.Microbenchmark
                                 consoleError.AppendLine(e.Data);
                             };
 
-                            bdnProcess.Start();
                             string traceName = $"{benchmarkCleanedName}_{index}";
-                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, bdnProcess.Id))
+                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath))
                             {
+                                bdnProcess.Start();
                                 bdnProcess.BeginOutputReadLine();
                                 bdnProcess.BeginErrorReadLine();
                                 bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -176,10 +176,10 @@ namespace GC.Infrastructure.Commands.Microbenchmark
                                 consoleError.AppendLine(e.Data);
                             };
 
+                            bdnProcess.Start();
                             string traceName = $"{benchmarkCleanedName}_{index}";
-                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath))
+                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, bdnProcess.Id))
                             {
-                                bdnProcess.Start();
                                 bdnProcess.BeginOutputReadLine();
                                 bdnProcess.BeginErrorReadLine();
                                 bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);


### PR DESCRIPTION
The GC pipeline has been broken for some time, failing with `[error]No image label found to route agent pool Azure Pipelines`

That was caused by an obsolete vmImage that's not available anymore in Azure. 

After fixing it, I have found that one of the notebook tests is failing. The notebooks feature is actually deprecated, so after chatting with @mrsharm, I have switched the leg to run other unit tests, namely the GC.Analysis.API.UnitTests and GC.Infrastructure.Core.UnitTests.
