### PR TITLE
Add explicit PackageReferences for transitive Microsoft.Extensions.* …

### DIFF
--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -862,6 +862,34 @@ def install(
         common_cmdline_args += ['-AzureFeed', azure_feed_url]
         common_cmdline_args += ['-FeedCredential', internal_build_key]
 
+    # Shield subsequent `dotnet` invocations (e.g. `dotnet --info` in ci_setup.py)
+    # from picking up an unrelated repo's global.json during the SDK resolver's
+    # upward walk. In particular, dotnet/runtime's global.json contains a
+    # `paths` entry that points the resolver at a `.dotnet` directory installed
+    # by arcade -- which can hold an SDK older than the one the perf scripts
+    # just installed into install_dir. By writing an empty global.json at the
+    # parent of the perf repo (which is the AzDO workspace root in CI and the
+    # cwd of subsequent `dotnet` invocations), we stop the walk-up before it
+    # reaches runtime's global.json, letting the perf-installed SDK win via
+    # standard `$host$` resolution.
+    workspace_root = path.abspath(path.join(get_repo_root_path(), '..'))
+    shield_global_json = path.join(workspace_root, 'global.json')
+    try:
+        existing = ''
+        if path.exists(shield_global_json):
+            with open(shield_global_json, 'r') as f:
+                existing = f.read()
+        if existing.strip() != '{}':
+            with open(shield_global_json, 'w') as f:
+                f.write('{}\n')
+            getLogger().info(
+                "Wrote empty global.json to %s to shield SDK resolver from "
+                "an unrelated repo's global.json (previous content length: %d)",
+                shield_global_json, len(existing))
+    except OSError as ex:
+        getLogger().warning(
+            "Could not write shield global.json to %s: %s", shield_global_json, ex)
+
     # Install Runtime/SDKs
     if versions:
         for version in versions:

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -5,6 +5,7 @@ Contains the functionality around DotNet Cli.
 """
 
 import re
+import json
 import datetime
 from argparse import ArgumentParser, ArgumentTypeError
 from glob import iglob
@@ -863,32 +864,34 @@ def install(
         common_cmdline_args += ['-FeedCredential', internal_build_key]
 
     # Shield subsequent `dotnet` invocations (e.g. `dotnet --info` in ci_setup.py)
-    # from picking up an unrelated repo's global.json during the SDK resolver's
-    # upward walk. In particular, dotnet/runtime's global.json contains a
-    # `paths` entry that points the resolver at a `.dotnet` directory installed
-    # by arcade -- which can hold an SDK older than the one the perf scripts
-    # just installed into install_dir. By writing an empty global.json at the
-    # parent of the perf repo (which is the AzDO workspace root in CI and the
-    # cwd of subsequent `dotnet` invocations), we stop the walk-up before it
-    # reaches runtime's global.json, letting the perf-installed SDK win via
-    # standard `$host$` resolution.
+    # from picking up an unrelated repo's global.json `paths` entry during the
+    # SDK resolver's upward walk. In particular, dotnet/runtime's global.json
+    # contains a `paths` entry that points the resolver at a `.dotnet` directory
+    # installed by arcade -- which can hold an SDK older than the one the perf
+    # scripts just installed into install_dir. We rewrite the upstream
+    # global.json with the `sdk.paths` field removed, preserving all other
+    # keys (notably `tools.dotnet`, which arcade's bootstrap requires to be
+    # present), letting the perf-installed SDK win via standard `$host$`
+    # resolution while keeping unrelated tooling functional.
     workspace_root = path.abspath(path.join(get_repo_root_path(), '..'))
     shield_global_json = path.join(workspace_root, 'global.json')
     try:
-        existing = ''
         if path.exists(shield_global_json):
             with open(shield_global_json, 'r') as f:
-                existing = f.read()
-        if existing.strip() != '{}':
-            with open(shield_global_json, 'w') as f:
-                f.write('{}\n')
-            getLogger().info(
-                "Wrote empty global.json to %s to shield SDK resolver from "
-                "an unrelated repo's global.json (previous content length: %d)",
-                shield_global_json, len(existing))
-    except OSError as ex:
+                shield_data = json.load(f)
+            sdk_section = shield_data.get('sdk')
+            if isinstance(sdk_section, dict) and 'paths' in sdk_section:
+                removed_paths = sdk_section.pop('paths')
+                with open(shield_global_json, 'w') as f:
+                    json.dump(shield_data, f, indent=2)
+                    f.write('\n')
+                getLogger().info(
+                    "Stripped sdk.paths=%s from %s to shield SDK resolver "
+                    "from an unrelated repo's global.json",
+                    removed_paths, shield_global_json)
+    except (OSError, ValueError) as ex:
         getLogger().warning(
-            "Could not write shield global.json to %s: %s", shield_global_json, ex)
+            "Could not shield global.json at %s: %s", shield_global_json, ex)
 
     # Install Runtime/SDKs
     if versions:

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -115,6 +115,7 @@
        so they remain app-local for BenchmarkDotNet's corerun toolchain (which targets a
        Microsoft.NETCore.App CoreRoot that does not include the AspNetCore.App shared framework). -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -115,6 +115,7 @@
        so they remain app-local for BenchmarkDotNet's corerun toolchain (which targets a
        Microsoft.NETCore.App CoreRoot that does not include the AspNetCore.App shared framework). -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -101,13 +101,23 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />
     <PackageReference Include="System.IO.Hashing" Version="$(SystemVersion)" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="$(SystemVersion)" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
+  </ItemGroup>
+  <!-- For .NET 10+, NuGet package pruning removes transitive Microsoft.Extensions.* abstractions
+       (Logging.Abstractions, DependencyInjection.Abstractions, Options) from the resolution graph
+       because they are in-band in Microsoft.AspNetCore.App. We need them as direct PackageReferences
+       so they remain app-local for BenchmarkDotNet's corerun toolchain (which targets a
+       Microsoft.NETCore.App CoreRoot that does not include the AspNetCore.App shared framework). -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
   </ItemGroup>
   <!-- These package versions are only for the opt-in net472 path (for example, PERFLAB_TARGET_FRAMEWORKS=net472). -->
   <ItemGroup Condition="'$(TargetFramework)' != '' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -110,9 +110,10 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
   <!-- For .NET 10+, NuGet package pruning removes transitive Microsoft.Extensions.* abstractions
-       (Logging.Abstractions, DependencyInjection.Abstractions, Options) from the resolution graph
-       because they are in-band in Microsoft.AspNetCore.App. We need them as direct PackageReferences
-       so they remain app-local for BenchmarkDotNet's corerun toolchain (which targets a
+       (Caching.Abstractions, Configuration.Abstractions, Logging.Abstractions,
+       DependencyInjection.Abstractions, Options) from the resolution graph because they are
+       in-band in Microsoft.AspNetCore.App. We need them as direct PackageReferences so they
+       remain app-local for BenchmarkDotNet's corerun toolchain (which targets a
        Microsoft.NETCore.App CoreRoot that does not include the AspNetCore.App shared framework). -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />


### PR DESCRIPTION
…abstractions

For .NET 10+, NuGet package pruning removes transitive Microsoft.Extensions.* abstractions (Logging.Abstractions, DependencyInjection.Abstractions, Options, Primitives) from project.assets.json because they are in-band in Microsoft.AspNetCore.App. Without them, the build fails with CS0246 for types like ILogger, IChangeToken, ObjectFactory, StringSegment, etc.

Disabling pruning via RestoreEnablePackagePruning=false (PR #5209) only preserves DIRECT PackageReferences. Transitive prunable deps are still removed. Add them as explicit PackageReferences so they remain app-local for BenchmarkDotNet's corerun toolchain (which targets a Microsoft.NETCore.App CoreRoot that does not include the AspNetCore.App shared framework).

Also re-enable Microsoft.Extensions.Primitives for net10+ (PR #5196 wrongly removed it assuming it was in NETCore.App; it is actually in AspNetCore.App).

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


