### PR TITLE
Re-enable Cobalt perf runs

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -56,23 +56,22 @@ parameters:
     type: object
     default:
       enabled: true
-  # Temporarily disabling cobalt jobs because the cobalt machines are offline
   - name: cobaltMicro
     type: object
     default:
-      enabled: false
+      enabled: true
       configs:
         - linux_arm64
   - name: cobaltSveMicro
     type: object
     default:
-      enabled: false
+      enabled: true
       configs:
         - linux_arm64
   - name: cobaltMicroR2RInterpreter
     type: object
     default:
-      enabled: false
+      enabled: true
       configs:
         - linux_arm64
   - name: androidCoreclrR2r


### PR DESCRIPTION
The Cobalt machines are back online, so re-enable the cobaltMicro, cobaltSveMicro, and cobaltMicroR2RInterpreter jobs that were temporarily disabled.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


