### PR TITLE
Exclude Perf_String.Split_Csv from WASM runs

### DIFF
--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.String.cs
@@ -321,6 +321,7 @@ namespace System.Tests
             => File.ReadAllLines(Path.Combine(AppContext.BaseDirectory, "libraries", "System.Runtime", "TestData", name));
 
         [Benchmark]
+        [BenchmarkCategory(Categories.NoWASM)] // CSV files in TestData are not available in WASM filesystem
         [ArgumentsSource(nameof(CsvCorpus))]
         public string[] Split_Csv(string testName, string[] lines)
         {


### PR DESCRIPTION
The Split_Csv benchmark reads CSV test data files via File.ReadAllLines from AppContext.BaseDirectory. These files are not bundled into the WASM publish output, so CsvCorpus() throws DirectoryNotFoundException when BDN extracts arguments in the spawned WASM benchmark process.

Add [BenchmarkCategory(Categories.NoWASM)] to skip the benchmark on WASM, matching the existing pattern used for other filesystem-dependent benchmarks in this repo.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


