### PR TITLE
Rename MicroBenchmarks.Serializers.BinaryData to BinaryDataPayload

### DIFF
--- a/src/benchmarks/micro/Serializers/DataGenerator.cs
+++ b/src/benchmarks/micro/Serializers/DataGenerator.cs
@@ -32,7 +32,7 @@ namespace MicroBenchmarks.Serializers
                 return (T)(object)CreateIndexViewModel();
             if (typeof(T) == typeof(MyEventsListerViewModel))
                 return (T)(object)CreateMyEventsListerViewModel();
-            if (typeof(T) == typeof(BinaryData))
+            if (typeof(T) == typeof(BinaryDataPayload))
                 return (T)(object)CreateBinaryData(1024);
             if (typeof(T) == typeof(CollectionsOfPrimitives))
                 return (T)(object)CreateCollectionsOfPrimitives(1024); // 1024 values was copied from CoreFX benchmarks
@@ -163,8 +163,8 @@ namespace MicroBenchmarks.Serializers
                     }, 4).ToList()
             };
 
-        private static BinaryData CreateBinaryData(int size)
-            => new BinaryData
+        private static BinaryDataPayload CreateBinaryData(int size)
+            => new BinaryDataPayload
             {
                 ByteArray = CreateByteArray(size)
             };
@@ -383,7 +383,13 @@ namespace MicroBenchmarks.Serializers
     [Serializable]
     [ProtoContract]
     [MessagePackObject]
-    public class BinaryData
+    // Renamed from BinaryData to avoid name collision with System.BinaryData
+    // (introduced in net6+ via System.Memory.Data, transitive via Azure.Core).
+    // The collision caused [GenericTypeArguments(typeof(BinaryData))] to resolve
+    // to System.BinaryData in some compile contexts (e.g. when the harness targets
+    // net8.0 instead of netstandard2.0), bypassing the data generator and producing
+    // NotImplementedException at runtime.
+    public class BinaryDataPayload
     {
         [ProtoMember(1)] [Key(0)] public byte[] ByteArray { get; set; }
     }
@@ -496,7 +502,7 @@ namespace MicroBenchmarks.Serializers
     [JsonSerializable(typeof(Location))]
     [JsonSerializable(typeof(IndexViewModel))]
     [JsonSerializable(typeof(MyEventsListerViewModel))]
-    [JsonSerializable(typeof(BinaryData))]
+    [JsonSerializable(typeof(BinaryDataPayload))]
     [JsonSerializable(typeof(CollectionsOfPrimitives))]
     [JsonSerializable(typeof(XmlElement))]
     [JsonSerializable(typeof(SimpleStructWithProperties))]

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/ReadJson.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
-    [GenericTypeArguments(typeof(BinaryData))]
+    [GenericTypeArguments(typeof(BinaryDataPayload))]
     [GenericTypeArguments(typeof(Dictionary<string, string>))]
     [GenericTypeArguments(typeof(ImmutableDictionary<string, string>))]
     [GenericTypeArguments(typeof(ImmutableSortedDictionary<string, string>))]

--- a/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
+++ b/src/benchmarks/micro/libraries/System.Text.Json/Serializer/WriteJson.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization.Tests
     [GenericTypeArguments(typeof(Location))]
     [GenericTypeArguments(typeof(IndexViewModel))]
     [GenericTypeArguments(typeof(MyEventsListerViewModel))]
-    [GenericTypeArguments(typeof(BinaryData))]
+    [GenericTypeArguments(typeof(BinaryDataPayload))]
     [GenericTypeArguments(typeof(Dictionary<string, string>))]
     [GenericTypeArguments(typeof(ImmutableDictionary<string, string>))]
     [GenericTypeArguments(typeof(ImmutableSortedDictionary<string, string>))]


### PR DESCRIPTION
Description from copilot.

The serialization-test helper class `MicroBenchmarks.Serializers.BinaryData` shadowed the in-box `System.BinaryData` type (introduced in net6+ via `System.Memory.Data`, brought in transitively by Azure.Core).

Inside `DataGenerator.cs` (namespace MicroBenchmarks.Serializers) the unqualified `typeof(BinaryData)` always bound to the local helper class. Inside `ReadJson.cs` / `WriteJson.cs` (namespace System.Text.Json.Serialization.Tests) C# enclosing-namespace lookup found `System.BinaryData` first, so the `[GenericTypeArguments(typeof(BinaryData))]` attribute resolved to a DIFFERENT type than the `Generate<T>()` switch was checking. The mismatch was latent on main (where System.Memory.Data wasn't compile-visible to ReadJson.cs) but surfaced as `System.NotImplementedException` in `DataGenerator.Generate<T>()` whenever the reference closure changed (e.g. retargeting BenchmarkDotNet.Extensions from netstandard2.0 to net8.0).

Renaming the helper class to `BinaryDataPayload` removes the shadowing once and for all. No behavior change on main; future-proofs against reference-closure churn.

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


