### PR TITLE
Drop daily quality from release/10.0 and 10.0 channels

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -9,13 +9,11 @@ class ChannelMap():
         },
         '10.0': {
             'tfm': 'net10.0',
-            'branch': '10.0',
-            'quality': 'daily'
+            'branch': '10.0'
         },
         'release/10.0': {
             'tfm': 'net10.0',
-            'branch': '10.0',
-            'quality': 'daily'
+            'branch': '10.0'
         },
         'nativeaot10.0': {
             'tfm': 'nativeaot10.0',


### PR DESCRIPTION
After .NET 10 GA, `-Quality daily` on the `release/10.0` (and bare `10.0`) channels resolves to internal-only servicing SDK builds (e.g. SDK 10.0.9-flavored bits) whose matching `Microsoft.NETCore.App.Runtime.<rid>` runtime pack has not yet shipped publicly on the `dotnet10` / `dotnet-public` NuGet feeds.

That breaks the CertHelper `--self-contained` publish in `run_performance_job.py`:

```
performance\src\tools\CertHelper\CertHelper.csproj : error NU1102:
  Unable to find package Microsoft.NETCore.App.Runtime.win-x64
  with version (= 10.0.9)
```

(Example failing run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2969704)

### Fix

Remove `'quality': 'daily'` from the `release/10.0` and `10.0` entries in `channel_map.py`. With no quality specified, `dotnet.py` omits the `-Quality` flag (it already handles `None` correctly), so `dotnet-install` hits the public `aka.ms/dotnet/10.0/` GA endpoint — currently SDK `10.0.203` / runtime `10.0.7` — whose runtime packs are publicly available, so the publish step succeeds and the SDK rolls forward automatically with each public servicing release.

### What's unchanged

- `main` (net11) stays on `quality: daily` — net11 is pre-release and its dailies are public, so that's still the right choice.
- `nativeaot10.0` is unchanged in this PR but has the same shape (`branch: 10.0`, `quality: daily`) and would hit the same NU1102 if exercised today. Happy to fold it in if reviewers prefer; left out for now since it's not the failing path.
- No changes to `sdk-perf-jobs.yml`; this is purely a fix for runs that already use `release/10.0` / `10.0`.

### Trade-off

The net10 leg now baselines against the latest publicly-released servicing build (e.g. runtime 10.0.7) instead of the freshest internal daily. For BDN regression work this is actually the more reproducible baseline; runtime perf jobs that build their own Core_Root use the SDK only as build-time tooling, so a slightly older public SDK is fine.

### Validation

Verified manually by triggering perf runs from this branch against `release/10.0` and confirming the CertHelper publish succeeds and the runs upload results end-to-end.
