### PR TITLE
Switch all benchmark runners from BenchmarkSwitcher.Run to RunAsync

### DIFF
--- a/src/benchmarks/real-world/Akade.IndexedSet.Benchmarks/Program.cs
+++ b/src/benchmarks/real-world/Akade.IndexedSet.Benchmarks/Program.cs
@@ -3,6 +3,9 @@ using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Running;
 using System.Collections.Immutable;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, RecommendedConfig.Create(
+// Use RunAsync (not Run) so BDN does not install its single-threaded
+// BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+await BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAsync(args, RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location)!, "BenchmarkDotNet.Artifacts")),
-                    mandatoryCategories: ImmutableHashSet.Create(Categories.AkadeIndexedSet)));
+                    mandatoryCategories: ImmutableHashSet.Create(Categories.AkadeIndexedSet)))
+    .ConfigureAwait(false);

--- a/src/benchmarks/real-world/Akade.IndexedSet.Benchmarks/Program.cs
+++ b/src/benchmarks/real-world/Akade.IndexedSet.Benchmarks/Program.cs
@@ -5,7 +5,8 @@ using System.Collections.Immutable;
 
 // Use RunAsync (not Run) so BDN does not install its single-threaded
 // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
-await BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAsync(args, RecommendedConfig.Create(
+var summaries = await BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).RunAsync(args, RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location)!, "BenchmarkDotNet.Artifacts")),
                     mandatoryCategories: ImmutableHashSet.Create(Categories.AkadeIndexedSet)))
     .ConfigureAwait(false);
+return summaries.ToExitCode();

--- a/src/benchmarks/real-world/ILLink/Program.cs
+++ b/src/benchmarks/real-world/ILLink/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Jobs;
@@ -13,7 +14,9 @@ namespace ILLinkBenchmarks;
 
 public class ILLinkBench
 {
-    public static int Main(string[] args)
+    // Use RunAsync (not Run) so BDN does not install its single-threaded
+    // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+    public static async Task<int> Main(string[] args)
     {
         string thisAssembly = Assembly.GetExecutingAssembly().Location;
         string sampleProjectFile = Path.Combine(Path.GetDirectoryName(thisAssembly), "SampleProject", "HelloWorld.csproj");
@@ -29,13 +32,14 @@ public class ILLinkBench
             .WithStrategy(RunStrategy.Monitoring)
             .WithMaxRelativeError(0.01);
 
-        return BenchmarkSwitcher
+        var summaries = await BenchmarkSwitcher
             .FromAssembly(typeof(BasicBenchmark).Assembly)
-            .Run(args, RecommendedConfig.Create(
+            .RunAsync(args, RecommendedConfig.Create(
                            artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(BasicBenchmark).Assembly.Location),
                                                                          "BenchmarkDotNet.Artifacts")),
                            mandatoryCategories: ImmutableHashSet.Create("ILLink"),
                            job: job))
-            .ToExitCode();
+            .ConfigureAwait(false);
+        return summaries.ToExitCode();
     }
 }

--- a/src/benchmarks/real-world/ImageSharp/Program.cs
+++ b/src/benchmarks/real-world/ImageSharp/Program.cs
@@ -19,14 +19,15 @@ namespace SixLabors.ImageSharp.Benchmarks
         /// </param>
         // Use RunAsync (not Run) so BDN does not install its single-threaded
         // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            await BenchmarkSwitcher
+            var summaries = await BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
                 .RunAsync(args, RecommendedConfig.Create(
                         artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
                         mandatoryCategories: ImmutableHashSet.Create(Categories.ImageSharp)))
                 .ConfigureAwait(false);
+            return summaries.ToExitCode();
         }
     }
 }

--- a/src/benchmarks/real-world/ImageSharp/Program.cs
+++ b/src/benchmarks/real-world/ImageSharp/Program.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Extensions;
 using BenchmarkDotNet.Running;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace SixLabors.ImageSharp.Benchmarks
 {
@@ -16,10 +17,16 @@ namespace SixLabors.ImageSharp.Benchmarks
         /// <param name="args">
         /// The arguments to pass to the program.
         /// </param>
-        public static void Main(string[] args) => BenchmarkSwitcher
-            .FromAssembly(typeof(Program).Assembly)
-            .Run(args, RecommendedConfig.Create(
-                    artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
-                    mandatoryCategories: ImmutableHashSet.Create(Categories.ImageSharp)));
+        // Use RunAsync (not Run) so BDN does not install its single-threaded
+        // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+        public static async Task Main(string[] args)
+        {
+            await BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .RunAsync(args, RecommendedConfig.Create(
+                        artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
+                        mandatoryCategories: ImmutableHashSet.Create(Categories.ImageSharp)))
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Program.cs
+++ b/src/benchmarks/real-world/Microsoft.ML.Benchmarks/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Extensions;
 
@@ -17,13 +18,18 @@ namespace Microsoft.ML.Benchmarks
         /// execute dotnet run -c Release and choose the benchmarks you want to run
         /// </summary>
         /// <param name="args"></param>
-        static int Main(string[] args)
-            => BenchmarkSwitcher
+        // Use RunAsync (not Run) so BDN does not install its single-threaded
+        // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+        static async Task<int> Main(string[] args)
+        {
+            var summaries = await BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(args, RecommendedConfig.Create(
-                    artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")), 
+                .RunAsync(args, RecommendedConfig.Create(
+                    artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
                     mandatoryCategories: ImmutableHashSet.Create(Categories.MachineLearning)))
-                .ToExitCode();
+                .ConfigureAwait(false);
+            return summaries.ToExitCode();
+        }
 
         internal static string GetInvariantCultureDataPath(string name)
         {

--- a/src/benchmarks/real-world/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
+++ b/src/benchmarks/real-world/Microsoft.ML.Benchmarks/StochasticDualCoordinateAscentClassifierBench.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Microsoft.ML.Data;
@@ -75,39 +76,51 @@ namespace Microsoft.ML.Benchmarks
         [Benchmark]
         public void TrainSentiment()
         {
-            // Pipeline
-            var arguments = new TextLoader.Options()
+            // BDN 0.16 installs BenchmarkDotNetSynchronizationContext in the child process.
+            // ML.NET's ApplyWordEmbedding downloads a pretrained model using sync-over-async
+            // I/O that deadlocks on the single-threaded SyncCtx. Clear it for this benchmark.
+            var savedCtx = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
             {
-                Columns = new TextLoader.Column[]
+                // Pipeline
+                var arguments = new TextLoader.Options()
                 {
-                    new TextLoader.Column("Label", DataKind.Single, new[] { new TextLoader.Range() { Min = 0, Max = 0 } }),
-                    new TextLoader.Column("SentimentText", DataKind.String, new[] { new TextLoader.Range() { Min = 1, Max = 1 } })
-                },
-                HasHeader = true,
-                AllowQuoting = false,
-                AllowSparse = false
-            };
+                    Columns = new TextLoader.Column[]
+                    {
+                        new TextLoader.Column("Label", DataKind.Single, new[] { new TextLoader.Range() { Min = 0, Max = 0 } }),
+                        new TextLoader.Column("SentimentText", DataKind.String, new[] { new TextLoader.Range() { Min = 1, Max = 1 } })
+                    },
+                    HasHeader = true,
+                    AllowQuoting = false,
+                    AllowSparse = false
+                };
 
-            var loader = mlContext.Data.LoadFromTextFile(_sentimentDataPath, arguments);
-            var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new TextFeaturizingEstimator.Options
+                var loader = mlContext.Data.LoadFromTextFile(_sentimentDataPath, arguments);
+                var text = mlContext.Transforms.Text.FeaturizeText("WordEmbeddings", new TextFeaturizingEstimator.Options
+                {
+                    OutputTokensColumnName = "WordEmbeddings_TransformedText",
+                    KeepPunctuations = false,
+                    StopWordsRemoverOptions = new StopWordsRemovingEstimator.Options(),
+                    Norm = TextFeaturizingEstimator.NormFunction.None,
+                    CharFeatureExtractor = null,
+                    WordFeatureExtractor = null,
+                }, "SentimentText").Fit(loader).Transform(loader);
+
+                var trans = mlContext.Transforms.Text.ApplyWordEmbedding("Features", "WordEmbeddings_TransformedText",
+                    WordEmbeddingEstimator.PretrainedModelKind.SentimentSpecificWordEmbedding)
+                    .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
+                    .Fit(text).Transform(text);
+
+                // Train
+                var trainer = mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy();
+                var predicted = trainer.Fit(trans);
+                _consumer.Consume(predicted);
+            }
+            finally
             {
-                OutputTokensColumnName = "WordEmbeddings_TransformedText",
-                KeepPunctuations = false,
-                StopWordsRemoverOptions = new StopWordsRemovingEstimator.Options(),
-                Norm = TextFeaturizingEstimator.NormFunction.None,
-                CharFeatureExtractor = null,
-                WordFeatureExtractor = null,
-            }, "SentimentText").Fit(loader).Transform(loader);
-
-            var trans = mlContext.Transforms.Text.ApplyWordEmbedding("Features", "WordEmbeddings_TransformedText",
-                WordEmbeddingEstimator.PretrainedModelKind.SentimentSpecificWordEmbedding)
-                .Append(mlContext.Transforms.Conversion.MapValueToKey("Label"))
-                .Fit(text).Transform(text);
-
-            // Train
-            var trainer = mlContext.MulticlassClassification.Trainers.SdcaMaximumEntropy();
-            var predicted = trainer.Fit(trans);
-            _consumer.Consume(predicted);
+                SynchronizationContext.SetSynchronizationContext(savedCtx);
+            }
         }
 
         [GlobalSetup(Targets = new string[] { nameof(PredictIris), nameof(PredictIrisBatchOf1), nameof(PredictIrisBatchOf2), nameof(PredictIrisBatchOf5) })]

--- a/src/benchmarks/real-world/PowerShell.Benchmarks/Program.cs
+++ b/src/benchmarks/real-world/PowerShell.Benchmarks/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Extensions;
 
@@ -12,7 +13,9 @@ namespace MicroBenchmarks
 {
     public sealed class Program
     {
-        public static int Main(string[] args)
+        // Use RunAsync (not Run) so BDN does not install its single-threaded
+        // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+        public static async Task<int> Main(string[] args)
         {
             var argsList = new List<string>(args);
             int? partitionCount;
@@ -38,9 +41,9 @@ namespace MicroBenchmarks
                 return 1;
             }
 
-            return BenchmarkSwitcher
+            var summaries = await BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(
+                .RunAsync(
                     argsList.ToArray(),
                     RecommendedConfig.Create(
                         artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location), "BenchmarkDotNet.Artifacts")),
@@ -50,7 +53,8 @@ namespace MicroBenchmarks
                         exclusionFilterValue: exclusionFilterValue,
                         categoryExclusionFilterValue: categoryExclusionFilterValue,
                         getDiffableDisasm: getDiffableDisasm))
-                .ToExitCode();
+                .ConfigureAwait(false);
+            return summaries.ToExitCode();
         }
     }
 }

--- a/src/benchmarks/real-world/Roslyn/Program.cs
+++ b/src/benchmarks/real-world/Roslyn/Program.cs
@@ -20,11 +20,14 @@ if (!Directory.Exists(sourceDir))
 // to communicate information is pass by environment variable
 Environment.SetEnvironmentVariable(Helpers.TestProjectEnvVarName, sourceDir);
 
-return BenchmarkSwitcher
+// Use RunAsync (not Run) so BDN does not install its single-threaded
+// BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+var summaries = await BenchmarkSwitcher
     .FromAssembly(typeof(Helpers).Assembly)
-    .Run(args, RecommendedConfig.Create(
+    .RunAsync(args, RecommendedConfig.Create(
                    artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(Helpers).Assembly.Location),
                                                                  "BenchmarkDotNet.Artifacts")),
                    mandatoryCategories: ImmutableHashSet.Create("Roslyn"),
                    job: Job.Default.WithMaxRelativeError(0.01)))
-    .ToExitCode();
+    .ConfigureAwait(false);
+return summaries.ToExitCode();

--- a/src/benchmarks/real-world/bepuphysics2/Program.cs
+++ b/src/benchmarks/real-world/bepuphysics2/Program.cs
@@ -3,14 +3,19 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using DemoBenchmarks;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 
 public class BepuPhysics2Benchmarks
 {
-    public static void Main(string[] args) =>
-        BenchmarkSwitcher
+    // Use RunAsync (not Run) so BDN does not install its single-threaded
+    // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
+    public static async Task Main(string[] args)
+    {
+        await BenchmarkSwitcher
             .FromAssembly(typeof(BepuPhysics2Benchmarks).Assembly)
-            .Run(args, RecommendedConfig.Create(
+            .RunAsync(args, RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(BepuPhysics2Benchmarks).Assembly.Location), "BenchmarkDotNet.Artifacts")),
                     mandatoryCategories: ImmutableHashSet.Create(Categories.BepuPhysics)))
-            .ToExitCode();
+            .ConfigureAwait(false);
+    }
 }

--- a/src/benchmarks/real-world/bepuphysics2/Program.cs
+++ b/src/benchmarks/real-world/bepuphysics2/Program.cs
@@ -9,13 +9,14 @@ public class BepuPhysics2Benchmarks
 {
     // Use RunAsync (not Run) so BDN does not install its single-threaded
     // BenchmarkDotNetSynchronizationContext on the entrypoint thread.
-    public static async Task Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
-        await BenchmarkSwitcher
+        var summaries = await BenchmarkSwitcher
             .FromAssembly(typeof(BepuPhysics2Benchmarks).Assembly)
             .RunAsync(args, RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(Path.GetDirectoryName(typeof(BepuPhysics2Benchmarks).Assembly.Location), "BenchmarkDotNet.Artifacts")),
                     mandatoryCategories: ImmutableHashSet.Create(Categories.BepuPhysics)))
             .ConfigureAwait(false);
+        return summaries.ToExitCode();
     }
 }


### PR DESCRIPTION
BDN 0.16's sync entrypoints install BenchmarkDotNetSynchronizationContext (a single-threaded message pump) before benchmark discovery. Any code that does sync-over-async (e.g. ML.NET internals, SslStream handshakes) deadlocks against that pump. The async entrypoint avoids this by not installing the SyncCtx on the caller thread.

This applies the same fix that was already made to MicroBenchmarks in c14e7c4a to all remaining real-world benchmark runners:
- Akade.IndexedSet.Benchmarks
- bepuphysics2
- ILLink
- ImageSharp
- Microsoft.ML.Benchmarks
- PowerShell.Benchmarks
- Roslyn

<!-- Thank you for submitting a pull request to our repo.

     It's critical that our microbenchmarks remain efficient, reliable and accurate.

     To that end, if this PR is adding or modifying any microbenchmark, you should ensure that you are familiar with the latest microbenchmark design guidelines found here:

     https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md

     and ensure that your changes in this PR comply with its requirements.

 -->


