### PR TITLE
Add logcat dump on Android Device Startup failure

### DIFF
--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -517,6 +517,19 @@ ex: C:\repos\performance;C:\repos\runtime
             memoryconsumption.parsetraces(self.traits)
 
         elif self.testtype == const.DEVICESTARTUP and self.devicetype == 'android':
+            def dump_logcat_on_failure(iteration: int):
+                upload_root = helixworkitemroot()
+                if not upload_root:
+                    getLogger().warning("HELIX_WORKITEM_UPLOAD_ROOT not set; skipping logcat dump.")
+                    return
+                logcat_cmd = xharness_adb() + ['logcat', '-d']
+                logcat_result = RunCommand(logcat_cmd, verbose=False)
+                logcat_result.run()
+                dump_path = os.path.join(upload_root, f"logcat_failure_iter{iteration}.txt")
+                with open(dump_path, "w") as f:
+                    f.write(logcat_result.stdout)
+                getLogger().info(f"Logcat dump written to {dump_path}")
+
             # ADB Key Event corresponding numbers: https://gist.github.com/arjunv/2bbcca9a1a1c127749f8dcb6d36fb0bc
             # Regex used to split the response from starting the activity and saving each value
             #Example:
@@ -566,6 +579,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     # Make sure we cold started (TODO Add other starts)
                     if "LaunchState: COLD" not in startStats.stdout:
                         getLogger().error("App Start not COLD!")
+                        dump_logcat_on_failure(i)
                         
                     # Save the results and get them from the log
                     if self.usefullydrawntime: time.sleep(self.fullyDrawnDelaySecMax) # Start command doesn't wait for fully drawn report, force a wait for it. -W in the start command waits for the app to finish initial draw.
@@ -577,6 +591,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     retrieveTimeCmd.run()
                     dirtyCapture = re.search(r"\+(\d*s?\d+)ms", retrieveTimeCmd.stdout)
                     if not dirtyCapture:
+                        dump_logcat_on_failure(i)
                         raise Exception("Failed to capture the reported start time!")
                     captureList = dirtyCapture.group(1).split('s')
                     if len(captureList) == 1: # Only have the ms, everything should be good

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -526,7 +526,7 @@ ex: C:\repos\performance;C:\repos\runtime
                 logcat_result = RunCommand(logcat_cmd, verbose=True)
                 logcat_result.run()
                 dump_path = os.path.join(upload_root, f"logcat_failure_iter{iteration}.txt")
-                with open(dump_path, "w") as f:
+                with open(dump_path, "w", encoding="utf-8", errors="replace") as f:
                     f.write(logcat_result.stdout)
                 getLogger().info(f"Logcat dump written to {dump_path}")
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -25,7 +25,7 @@ from shared.memoryconsumption import MemoryConsumptionWrapper
 from shared.util import publishedexe, pythoncommand, appfolder, xharnesscommand, xharness_adb, publisheddll
 from shared.sod import SODWrapper
 from shared import const
-from performance.common import RunCommand, iswin, extension, helixworkitemroot
+from performance.common import RunCommand, iswin, extension, helixworkitemroot, helixuploadroot
 from performance.logger import setup_loggers
 from shared.testtraits import TestTraits, testtypes
 from subprocess import CalledProcessError
@@ -518,7 +518,7 @@ ex: C:\repos\performance;C:\repos\runtime
 
         elif self.testtype == const.DEVICESTARTUP and self.devicetype == 'android':
             def dump_logcat_on_failure(iteration: int):
-                upload_root = helixworkitemroot()
+                upload_root = helixuploadroot()
                 if not upload_root:
                     getLogger().warning("HELIX_WORKITEM_UPLOAD_ROOT not set; skipping logcat dump.")
                     return

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -522,13 +522,16 @@ ex: C:\repos\performance;C:\repos\runtime
                 if not upload_root:
                     getLogger().warning("HELIX_WORKITEM_UPLOAD_ROOT not set; skipping logcat dump.")
                     return
-                logcat_cmd = xharness_adb() + ['logcat', '-d']
-                logcat_result = RunCommand(logcat_cmd, verbose=True)
-                logcat_result.run()
                 dump_path = os.path.join(upload_root, f"logcat_failure_iter{iteration}.txt")
-                with open(dump_path, "w", encoding="utf-8", errors="replace") as f:
-                    f.write(logcat_result.stdout)
-                getLogger().info(f"Logcat dump written to {dump_path}")
+                try:
+                    logcat_cmd = xharness_adb() + ['logcat', '-d']
+                    logcat_result = RunCommand(logcat_cmd, verbose=True, echo=False)
+                    logcat_result.run()
+                    with open(dump_path, "w", encoding="utf-8", errors="replace") as f:
+                        f.write(logcat_result.stdout)
+                    getLogger().info(f"Logcat dump written to {dump_path}")
+                except Exception as ex:
+                    getLogger().warning(f"Failed to dump logcat to {dump_path}: {ex}")
 
             # ADB Key Event corresponding numbers: https://gist.github.com/arjunv/2bbcca9a1a1c127749f8dcb6d36fb0bc
             # Regex used to split the response from starting the activity and saving each value

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -523,7 +523,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     getLogger().warning("HELIX_WORKITEM_UPLOAD_ROOT not set; skipping logcat dump.")
                     return
                 logcat_cmd = xharness_adb() + ['logcat', '-d']
-                logcat_result = RunCommand(logcat_cmd, verbose=False)
+                logcat_result = RunCommand(logcat_cmd, verbose=True)
                 logcat_result.run()
                 dump_path = os.path.join(upload_root, f"logcat_failure_iter{iteration}.txt")
                 with open(dump_path, "w") as f:


### PR DESCRIPTION
## Summary

When an Android Device Startup scenario test fails — either because the app did not cold-start (wrong `LaunchState`) or because the `Displayed` line is missing from logcat — there is currently no diagnostic artifact to help investigate the cause. This has made it difficult to triage recurring Mobile Perf CI failures.

This PR adds a `dump_logcat_on_failure()` helper inside the Android Device Startup branch of `runner.py`. When a failure is detected the helper runs `adb logcat -d` and writes the full device log to `$HELIX_WORKITEM_UPLOAD_ROOT/logcat_failure_iter{N}.txt`, making it available as a Helix upload artifact. If the upload root is not set (local runs) the helper logs a warning and skips silently.

## Changes

- **`src/scenarios/shared/runner.py`**
  - Added nested helper `dump_logcat_on_failure(iteration)` in the `DEVICESTARTUP` / Android branch of `run()`
  - Called when `"LaunchState: COLD" not in startStats.stdout` (wrong launch state)
  - Called when `dirtyCapture` regex fails to match (missing `Displayed` line), before the exception is raised

## Testing

No YAML pipeline files were modified. The change is limited to `runner.py` and is defensive (no-op outside Helix).