### PR TITLE
Move iOS SDK perf jobs to macos-26

### DIFF
--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -151,9 +151,9 @@ jobs:
     parameters:
       osGroup: osx
       archType: x64
-      osVersion: 15
+      osVersion: 26
       pool:
-        vmImage: 'macos-15'
+        vmImage: 'macos-26'
       queue: Mac.iPhone.17.Perf
       machinePool: iPhone17
       ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
Bumps the iOS SDK perf job pool (`osx-x64-ios-arm64` in `build-machine-matrix.yml`) from `macos-15` to `macos-26` so the jobs can pick up the latest Xcode and iOS workloads. Previously they were pinned to macOS 15, which capped us at Xcode 26.2.

Validated on the internal dotnet-performance mirror — workload install and `dotnet publish` succeed end-to-end with the latest `Microsoft.iOS.Sdk.net11.0_26.5` workload manifest. Helix work items reach the iPhone 17 devices and run.

Note: there is a separate iOS CoreCLR runtime startup crash on iOS 26.0 that is now visible after this change because we're no longer pinned to Xcode 26.2. That's tracked separately in dotnet/macios#25542 and is not a regression caused by this PR.