### PR TITLE
Migrate GC benchmarks to .NET10 runtime

### DIFF
--- a/gc-azure-pipelines.yml
+++ b/gc-azure-pipelines.yml
@@ -39,15 +39,6 @@ jobs:
     steps:
     # Install dotnet. We temporarily need both .NET 8 (for building and running the projects) and .NET 9 (for installing deps).
     - task: UseDotNet@2
-      displayName: Install .NET 8.0 
-      inputs:
-        version: 8.0.x
-    - task: UseDotNet@2
-      displayName: Install .NET 9.0 
-      inputs:
-        version: 9.0.x
-        includePreviewVersions: true
-    - task: UseDotNet@2
       displayName: Install .NET 10.0 
       inputs:
         version: 10.0.x
@@ -59,10 +50,10 @@ jobs:
         includePreviewVersions: true
     - script: dotnet tool restore
     - script: dotnet tool install --global dotnet-repl 
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj --configuration Debug --framework net8.0
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj --configuration Debug --framework net8.0
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Debug --framework net8.0
-    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj --configuration Debug --framework net8.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj --configuration Debug --framework net10.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj --configuration Debug --framework net10.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj --configuration Debug --framework net10.0
+    - script: dotnet build src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj --configuration Debug --framework net10.0
 
     # Run tests. Template installed from: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/vstest-v3?view=azure-pipelines
     - task: VSTest@3
@@ -71,8 +62,8 @@ jobs:
         # Test selection #
         # -------------- #
         testAssemblyVer2: GC.Infrastructure.Core.UnitTests.dll
-        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.Core.UnitTests/Debug/net8.0'
-        otherConsoleOptions: '--Framework:net8.0'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Infrastructure.Core.UnitTests/Debug/net10.0'
+        otherConsoleOptions: '--Framework:net10.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 
@@ -90,8 +81,8 @@ jobs:
         # Test selection #
         # -------------- #
         testAssemblyVer2: GC.Analysis.API.UnitTests.dll
-        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Analysis.API.UnitTests/Debug/net8.0'
-        otherConsoleOptions: '--Framework:net8.0'
+        searchFolder: '$(System.DefaultWorkingDirectory)/artifacts/bin/GC.Analysis.API.UnitTests/Debug/net10.0'
+        otherConsoleOptions: '--Framework:net10.0'
         # Uncomment to save results in the future.
         # resultsFolder: '$(Agent.TempDirectory)\TestResults' # string. Test results folder. Default: $(Agent.TempDirectory)\TestResults.
 

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/GCPerfSimFunctionalRun.yaml
@@ -1,5 +1,5 @@
 output_path: C:\Outputs\GCPerfsimFunctionalTest
-gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 
 coreruns:
   segments:

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/HighMemory.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/HighMemory.yaml
@@ -33,7 +33,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: "C:\\performance\\artifacts\\bin\\GCPerfSim\\release\\net7.0\\GCPerfSim.dll"
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 
 coreruns:
   baseline:

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_NormalServer.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_NormalServer.yaml
@@ -45,7 +45,7 @@
       pohfi: 0
       allocType: reference
       testKind: time
-    gcperfsim_path: "C:\\performance\\artifacts\\bin\\GCPerfSim\\release\\net7.0\\GCPerfSim.dll"
+    gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
     coreruns:
       baseline : "C:\\array_init\\windows\\before\\corerun.exe"
       andrew_fix: "C:\\array_init\\windows\\fixed\\corerun.exe"

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Server.yaml
@@ -41,7 +41,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 environment:
   environment_variables:
     DOTNET_gcServer: 1

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LargePages_Workstation.yaml
@@ -41,7 +41,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 environment:
   environment_variables:
     DOTNET_gcServer: 0

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowMemoryContainer.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowMemoryContainer.yaml
@@ -35,7 +35,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: "C:\\performance\\artifacts\\bin\\GCPerfSim\\release\\net7.0\\GCPerfSim.dll"
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 
 coreruns:
   baseline:

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/LowVolatilityRuns.yaml
@@ -48,7 +48,7 @@ gcperfsim_configurations:
     rlmb: 2
     allocType: reference
     testKind: time
-  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 environment:
   environment_variables:
     DOTNET_gcServer: 1

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Server.yaml
@@ -41,7 +41,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 environment:
   environment_variables:
     DOTNET_gcServer: 1

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Workstation.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/GCPerfSim/Normal_Workstation.yaml
@@ -41,7 +41,7 @@ gcperfsim_configurations:
     pohfi: 0
     allocType: reference
     testKind: time
-  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+  gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 environment:
   environment_variables:
     DOTNET_gcServer: 0

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/ReliabilityFramework/ReliabilityFramework_CreateTestSuite.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/ReliabilityFramework/ReliabilityFramework_CreateTestSuite.yaml
@@ -4,7 +4,7 @@ EnableStressMode: false
 
 Core_Root: Q:\runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root
 ReliabilityFrameworkDll: Q:\runtime\artifacts\tests\coreclr\windows.x64.Release\GC\Stress\Framework\ReliabilityFramework\ReliabilityFramework.dll
-GCPerfSimDll: Q:\performance\artifacts\bin\GCPerfSim\Release\net7.0\GCPerfSim.dll
+GCPerfSimDll: Q:\performance\artifacts\bin\GCPerfSim\Release\net10.0\GCPerfSim.dll
 TestFolder: Q:\runtime\artifacts\tests\coreclr\windows.x64.Release\GC\Stress\Framework\ReliabilityFramework\Tests
 
 

--- a/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
+++ b/src/benchmarks/gc/GC.Infrastructure/Configurations/Run.yaml
@@ -1,5 +1,5 @@
 output_path: C:\InfraRuns\RunNew
-gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net7.0\GCPerfSim.dll
+gcperfsim_path: C:\performance\artifacts\bin\GCPerfSim\release\net10.0\GCPerfSim.dll
 microbenchmark_path: C:\performance\src\benchmarks\micro
 
 coreruns:

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API.UnitTests/GC.Analysis.API.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/GC.Analysis.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GC.Infrastructure.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/GC.Infrastructure.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GC.Infrastructure.MCPServer.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.MCPServer/GC.Infrastructure.MCPServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.NotebookTests/GC.Infrastructure.NotebookTests.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.NotebookTests/GC.Infrastructure.NotebookTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/benchmarks/gc/GC.Infrastructure/README.md
+++ b/src/benchmarks/gc/GC.Infrastructure/README.md
@@ -43,7 +43,7 @@ To run all the test suites, do the following steps:
             1. ``cd C:\performance\src\benchmarks\gc\src\exec\GCPerfSim``.
             2. ``dotnet build -c Release``.
             3. The path of GCPerfSim.dll will be available in: ``C:\performance\artifacts\bin\GCPerfSim\Release\{.NET Version}\GCPerfSim.dll``.
-                1. For example: C:\Performance\artifacts\bin\GCPerfSim\Release\net7.0\GCPerfSim.dll.
+                1. For example: C:\Performance\artifacts\bin\GCPerfSim\Release\net10.0\GCPerfSim.dll.
     3. The path to the microbenchmark folder or the root path of the Microbenchmarks projects which, will be in: ``C:\performance\src\benchmarks\micro``.
         1. Ensure that the microbenchmarks have been compiled using: ``dotnet build -c Release``.
     4. The corerun path for the baseline and the run.

--- a/src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
+++ b/src/benchmarks/gc/GCPerfSim/GCPerfSim.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- For a desktop build, you could add e.g. `net472;` here. -->
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <RootNamespace>gcperfsim_core</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
The benchmarks / infra was using .NET 7 and .NET 8, this change moves them all to .NET 10

