### PR TITLE
Fix GC performance infrastructure tests on Linux

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultComparison.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultComparison.cs
@@ -9,7 +9,43 @@ namespace GC.Infrastructure.Core.Analysis.Microbenchmarks
     public static class MicrobenchmarkResultComparison
     {
         private static readonly int _CPUCount = System.Environment.ProcessorCount;
-        private static readonly Dictionary<string, string> _benchmarkNameToTraceFilePatternMap = new(StringComparer.OrdinalIgnoreCase)
+
+        private static readonly Dictionary<string, string> _benchmarkNameToTraceFilePatternMap = OperatingSystem.IsLinux() ? 
+        // Linux
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "ByteMark.BenchBitOps", "ByteMark.BenchBitOps"},
+            { "System.Collections.CtorGivenSize<String>.Array(Size: 512)", "System.Collections.CtorGivenSizeString.Array_size:512_"},
+            { "System.Collections.Tests.Perf_BitArray.BitArrayByteArrayCtor(Size: 512)", "System.Collections.Tests.Perf_BitArray.BitArrayByteArrayCtor_size:512_"},
+            { "System.IO.Tests.Perf_File.ReadAllBytes(size: 104857600)", "System.IO.Tests.Perf_File.ReadAllBytes_size:104857600_"},
+            { "System.IO.Tests.Perf_File.ReadAllBytesAsync(size: 104857600)", "System.IO.Tests.Perf_File.ReadAllBytesAsync_size:104857600_"},
+            { "System.Linq.Tests.Perf_Enumerable.ToArray(input: ICollection)", "System.Linq.Tests.Perf_Enumerable.ToArray_"},
+            { "System.Linq.Tests.Perf_Enumerable.ToArray(input: IEnumerable)", "System.Linq.Tests.Perf_Enumerable.ToArray_"},
+            { "System.Numerics.Tests.Perf_BigInteger.Add(arguments: 65536,65536 bits)", "System.Numerics.Tests.Perf_BigInteger.Add_arguments:65536_"},
+            { "System.Numerics.Tests.Perf_BigInteger.Subtract(arguments: 65536,65536 bits)", "System.Numerics.Tests.Perf_BigInteger.Subtract_arguments:65536_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateArray(length: 1000, pinned: False)", "System.Tests.Perf_GCByte.AllocateArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateArray(length: 1000, pinned: True)", "System.Tests.Perf_GCByte.AllocateArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateArray(length: 10000, pinned: False)", "System.Tests.Perf_GCByte.AllocateArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateArray(length: 10000, pinned: True)", "System.Tests.Perf_GCByte.AllocateArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateUninitializedArray(length: 1000, pinned: False)", "System.Tests.Perf_GCByte.AllocateUninitializedArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateUninitializedArray(length: 1000, pinned: True)", "System.Tests.Perf_GCByte.AllocateUninitializedArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateUninitializedArray(length: 10000, pinned: False)", "System.Tests.Perf_GCByte.AllocateUninitializedArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Byte>.AllocateUninitializedArray(length: 10000, pinned: True)", "System.Tests.Perf_GCByte.AllocateUninitializedArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Byte>.NewOperator_Array(length: 1000)", "System.Tests.Perf_GCByte.NewOperator_Array_length:1000_"},
+            { "System.Tests.Perf_GC<Byte>.NewOperator_Array(length: 10000)", "System.Tests.Perf_GCByte.NewOperator_Array_length:10000_"},
+            { "System.Tests.Perf_GC<Char>.AllocateArray(length: 1000, pinned: False)", "System.Tests.Perf_GCChar.AllocateArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateArray(length: 1000, pinned: True)", "System.Tests.Perf_GCChar.AllocateArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateArray(length: 10000, pinned: False)", "System.Tests.Perf_GCChar.AllocateArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateArray(length: 10000, pinned: True)", "System.Tests.Perf_GCChar.AllocateArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateUninitializedArray(length: 1000, pinned: False)", "System.Tests.Perf_GCChar.AllocateUninitializedArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateUninitializedArray(length: 1000, pinned: True)", "System.Tests.Perf_GCChar.AllocateUninitializedArray_length:1000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateUninitializedArray(length: 10000, pinned: False)", "System.Tests.Perf_GCChar.AllocateUninitializedArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Char>.AllocateUninitializedArray(length: 10000, pinned: True)", "System.Tests.Perf_GCChar.AllocateUninitializedArray_length:10000,_"},
+            { "System.Tests.Perf_GC<Char>.NewOperator_Array(length: 1000)", "System.Tests.Perf_GCChar.NewOperator_Array_length:1000_"},
+            { "System.Tests.Perf_GC<Char>.NewOperator_Array(length: 10000)", "System.Tests.Perf_GCChar.NewOperator_Array_length:10000_"},
+        }
+        : // Windows
+        new(StringComparer.OrdinalIgnoreCase)
         {
             { "ByteMark.BenchBitOps", "ByteMark.BenchBitOps"},
             { "System.Collections.CtorGivenSize<String>.Array(Size: 512)", "System.Collections.CtorGivenSize_String_.Array_size_512_"},
@@ -86,11 +122,14 @@ namespace GC.Infrastructure.Core.Analysis.Microbenchmarks
                         continue;
                     }
                     var traceFileNameTemplate = _benchmarkNameToTraceFilePatternMap[benchmarkName];
+
                     string outputPathForRun = Path.Combine(outputPath, run.Name!);
-                    var sortedTraceFiles = Directory.GetFiles(outputPathForRun, $"{traceFileNameTemplate}*.etl.zip", SearchOption.TopDirectoryOnly)
+                    string traceFileSuffix = OperatingSystem.IsWindows() ? ".etl.zip" : ".nettrace";
+                    var sortedTraceFiles = Directory.GetFiles(outputPathForRun, $"{traceFileNameTemplate}*{traceFileSuffix}", SearchOption.TopDirectoryOnly)
                         .OrderBy(traceFile =>
                         {
-                            var match = Regex.Match(Path.GetFileName(traceFile), @"_(\d+)\.etl\.zip$");
+                            Console.WriteLine($"Extracting timestamp from trace file name: {traceFile}");
+                            var match = Regex.Match(Path.GetFileName(traceFile), OperatingSystem.IsWindows() ? @"_(\d+)\.etl\.zip$" : @"_(\d+)\.nettrace$");
                             return match.Success ? int.Parse(match.Groups[1].Value) : 0;
                         })
                         .ToArray();
@@ -167,14 +206,22 @@ namespace GC.Infrastructure.Core.Analysis.Microbenchmarks
 
                             MicrobenchmarkResult? microbenchmarkResult = null;
                             GCProcessData? benchmarkGCData = null;
-                            foreach (var process in allPertinentProcesses)
+
+                            if (OperatingSystem.IsLinux() && allPertinentProcesses.Count == 1)
                             {
-                                string commandLine = process.CommandLine.Replace("\"", "").Replace("\\", "");
-                                string runCleaned = benchmark.FullName.Replace("\"", "").Replace("\\", "");
-                                if (commandLine.Contains(runCleaned) && commandLine.Contains("--benchmarkName"))
+                                benchmarkGCData = allPertinentProcesses.First();
+                            }
+                            else
+                            {
+                                foreach (var process in allPertinentProcesses)
                                 {
-                                    benchmarkGCData = process;
-                                    break;
+                                    string commandLine = process.CommandLine.Replace("\"", "").Replace("\\", "");
+                                    string runCleaned = benchmark.FullName.Replace("\"", "").Replace("\\", "");
+                                    if (commandLine.Contains(runCleaned) && commandLine.Contains("--benchmarkName"))
+                                    {
+                                        benchmarkGCData = process;
+                                        break;
+                                    }
                                 }
                             }
                             if (benchmarkGCData != null)

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultComparison.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/Microbenchmarks/MicrobenchmarkResultComparison.cs
@@ -128,7 +128,6 @@ namespace GC.Infrastructure.Core.Analysis.Microbenchmarks
                     var sortedTraceFiles = Directory.GetFiles(outputPathForRun, $"{traceFileNameTemplate}*{traceFileSuffix}", SearchOption.TopDirectoryOnly)
                         .OrderBy(traceFile =>
                         {
-                            Console.WriteLine($"Extracting timestamp from trace file name: {traceFile}");
                             var match = Regex.Match(Path.GetFileName(traceFile), OperatingSystem.IsWindows() ? @"_(\d+)\.etl\.zip$" : @"_(\d+)\.nettrace$");
                             return match.Success ? int.Parse(match.Groups[1].Value) : 0;
                         })

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItem.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItem.cs
@@ -48,7 +48,15 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
             ExecutionTimeMSec = processData.DurationMSec;
 
             PctTimePausedInGC = processData.Stats.GetGCPauseTimePercentage();
-            FirstToLastGCSeconds = (processData.GCs.Last().StartRelativeMSec - processData.GCs.First().StartRelativeMSec) / 1000;
+            if (processData.GCs.Count != 0)
+            {
+                FirstToLastGCSeconds = (processData.GCs.Last().StartRelativeMSec - processData.GCs.First().StartRelativeMSec) / 1000;
+            }
+            else
+            {
+                FirstToLastGCSeconds = double.NaN;
+            }
+
             HeapSizeAfter_Mean = GoodLinq.Average(processData.GCs, (gc => gc.HeapSizeAfterMB));
             HeapSizeBeforeMB_Mean = GoodLinq.Average(processData.GCs, (gc => gc.HeapSizeBeforeMB));
 

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/TraceCollection/TraceCollector.cs
@@ -136,6 +136,7 @@ namespace GC.Infrastructure.Core.TraceCollection
 
             name = name.Replace("<", "");
             name = name.Replace(">", "");
+            name = name.Replace("*", "");
 
             if (OperatingSystem.IsWindows())
             {

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/Microbenchmark/MicrobenchmarkCommand.cs
@@ -176,9 +176,18 @@ namespace GC.Infrastructure.Commands.Microbenchmark
                             };
 
                             string traceName = $"{benchmarkCleanedName}_{index}";
-                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath))
+                            int? processId = null;
+                            if (!OperatingSystem.IsWindows())
                             {
                                 bdnProcess.Start();
+                                processId = bdnProcess.Id;
+                            }
+                            using (TraceCollector traceCollector = new TraceCollector(traceName, collectType, runPath, processId))
+                            {
+                                if (OperatingSystem.IsWindows())
+                                {
+                                    bdnProcess.Start();
+                                }
                                 bdnProcess.BeginOutputReadLine();
                                 bdnProcess.BeginErrorReadLine();
                                 bdnProcess.WaitForExit((int)configuration.Environment.default_max_seconds * 1000);


### PR DESCRIPTION
There were couple of issues that prevented GC performance tests work on Linux:
* The trace capture needed to be passed the PID of the traced process due to the way dotnet-trace works
* The trace always contains only single process trace
* The benchmark name to trace file pattern mapping is different
* The extension of the trace file on linux is different and it was not handled at one place

