### PR TITLE
Make GC regression/improvement categorization direction-aware

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GCPerfSim/ComparisonCategorization.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GCPerfSim/ComparisonCategorization.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using GC.Analysis.API;
+using GC.Infrastructure.Core.Analysis;
+using GC.Infrastructure.Core.Presentation.GCPerfSim;
+
+namespace GC.Infrastructure.Core.UnitTests.GCPerfSim
+{
+    // Integration test that exercises the real GCPerfSim analysis pipeline end-to-end against
+    // recorded GC traces: it loads the traces, computes the same ResultItem / GCTraceMetrics that
+    // the `gcperfsim` and `gcperfsim-compare` commands produce, runs the comparison, and verifies
+    // that the regression / improvement categorization is direction-aware (Speed_MBPerMSec is
+    // higher-is-better) while the displayed delta keeps its real sign.
+    [TestClass]
+    public sealed class ComparisonCategorization
+    {
+        // The recorded traces capture a managed process named "Benchmarks" with real GC data.
+        private const string ProcessName = "Benchmarks";
+
+        private static string? FindTracesDirectory()
+        {
+            DirectoryInfo? dir = new(AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                foreach (string relative in new[]
+                {
+                    Path.Combine("Notebooks", "Examples", "Traces"),
+                    Path.Combine("src", "benchmarks", "gc", "GC.Infrastructure", "Notebooks", "Examples", "Traces"),
+                })
+                {
+                    string candidate = Path.Combine(dir.FullName, relative);
+                    if (File.Exists(Path.Combine(candidate, "CPU_Baseline.etl.zip")))
+                    {
+                        return candidate;
+                    }
+                }
+
+                dir = dir.Parent;
+            }
+
+            return null;
+        }
+
+        [TestMethod]
+        public void GCPerfSimRun_Comparison_CategorizesSpeedMetricByDirection()
+        {
+            string? tracesDirectory = FindTracesDirectory();
+            if (tracesDirectory == null)
+            {
+                Assert.Inconclusive("Could not locate the example GC traces required for this test.");
+                return;
+            }
+
+            string baselinePath = Path.Combine(tracesDirectory, "CPU_Baseline.etl.zip");
+            string comparandPath = Path.Combine(tracesDirectory, "CPU_Comparand.etl.zip");
+
+            using Analyzer baselineAnalyzer = AnalyzerManager.GetAnalyzer(baselinePath);
+            using Analyzer comparandAnalyzer = AnalyzerManager.GetAnalyzer(comparandPath);
+
+            GCProcessData? baselineData = baselineAnalyzer.GetProcessGCData(ProcessName).FirstOrDefault();
+            GCProcessData? comparandData = comparandAnalyzer.GetProcessGCData(ProcessName).FirstOrDefault();
+
+            if (baselineData == null || comparandData == null)
+            {
+                Assert.Inconclusive($"The traces did not contain GC data for the '{ProcessName}' process.");
+                return;
+            }
+
+            // Ensure the GCPerfSim run actually produced GC data to analyze.
+            baselineData.GCs.Count.Should().BeGreaterThan(0, "the baseline trace should contain GCs");
+            comparandData.GCs.Count.Should().BeGreaterThan(0, "the comparand trace should contain GCs");
+
+            // Build the same ResultItem the gcperfsim / gcperfsim-compare commands build.
+            ResultItem baselineItem = new(baselineData, "Run", "baseline");
+            ResultItem comparandItem = new(comparandData, "Run", "comparand");
+
+            ResultItemComparison comparison = new(baselineItem, comparandItem);
+
+            // --- Speed_MBPerMSec is higher-is-better ---
+            ComparisonResult speed = comparison.GetComparison("Speed_MBPerMSec");
+
+            // The run produced real, finite values.
+            double.IsNaN(speed.BaselineMetric).Should().BeFalse("the run should compute a baseline Speed_MBPerMSec");
+            double.IsNaN(speed.ComparandMetric).Should().BeFalse("the run should compute a comparand Speed_MBPerMSec");
+            speed.BaselineMetric.Should().BeGreaterThan(0);
+            speed.ComparandMetric.Should().BeGreaterThan(0);
+
+            // Displayed delta uses the real, unflipped data.
+            speed.Delta.Should().Be(speed.ComparandMetric - speed.BaselineMetric);
+
+            // Categorization is direction-aware: for a higher-is-better metric the regression-oriented
+            // delta is the negation of the displayed percentage delta.
+            speed.PercentageDelta.Should().NotBe(double.NaN);
+            speed.RegressionPercentageDelta.Should().BeApproximately(-speed.PercentageDelta, 1e-9);
+
+            // --- A lower-is-better metric keeps the same sign for categorization ---
+            ComparisonResult pause = comparison.GetComparison("PauseDurationMSec_Sum");
+            pause.PercentageDelta.Should().NotBe(double.NaN);
+            pause.RegressionPercentageDelta.Should().BeApproximately(pause.PercentageDelta, 1e-9);
+
+            // --- End-to-end categorization through the analyze pipeline ---
+            GCTraceMetrics[] baselineMetrics = { new(baselineData, "Run", "baseline") };
+            GCTraceMetrics[] comparandMetrics = { new(comparandData, "Run", "comparand") };
+
+            GCTraceMetricComparisonResult speedComparison =
+                GCTraceMetricComparison.CompareGCTraceMetric(baselineMetrics, comparandMetrics, "Speed_MBPerMSec");
+            GCTraceMetricComparisonResults results = new("Run", new[] { speedComparison });
+
+            // A faster comparand (higher Speed_MBPerMSec) must be categorized as an improvement, never a regression.
+            bool isFaster = speedComparison.AveragedComparandMetric > speedComparison.AveragedBaselineMetric;
+            IEnumerable<GCTraceMetricComparisonResult> regressionBuckets =
+                results.LargeRegressions.Concat(results.Regressions).Concat(results.StaleRegressions);
+            IEnumerable<GCTraceMetricComparisonResult> improvementBuckets =
+                results.LargeImprovements.Concat(results.Improvements).Concat(results.StaleImprovements);
+
+            if (isFaster)
+            {
+                regressionBuckets.Should().NotContain(speedComparison, "a faster Speed_MBPerMSec is an improvement, not a regression");
+                improvementBuckets.Should().Contain(speedComparison);
+            }
+            else if (speedComparison.AveragedComparandMetric < speedComparison.AveragedBaselineMetric)
+            {
+                improvementBuckets.Should().NotContain(speedComparison, "a slower Speed_MBPerMSec is a regression, not an improvement");
+                regressionBuckets.Should().Contain(speedComparison);
+            }
+        }
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GCPerfSim/ComparisonCategorization.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core.UnitTests/GCPerfSim/ComparisonCategorization.cs
@@ -89,12 +89,12 @@ namespace GC.Infrastructure.Core.UnitTests.GCPerfSim
 
             // Categorization is direction-aware: for a higher-is-better metric the regression-oriented
             // delta is the negation of the displayed percentage delta.
-            speed.PercentageDelta.Should().NotBe(double.NaN);
+            double.IsNaN(speed.PercentageDelta).Should().BeFalse("the run should compute a finite Speed_MBPerMSec percentage delta");
             speed.RegressionPercentageDelta.Should().BeApproximately(-speed.PercentageDelta, 1e-9);
 
             // --- A lower-is-better metric keeps the same sign for categorization ---
             ComparisonResult pause = comparison.GetComparison("PauseDurationMSec_Sum");
-            pause.PercentageDelta.Should().NotBe(double.NaN);
+            double.IsNaN(pause.PercentageDelta).Should().BeFalse("the run should compute a finite PauseDurationMSec_Sum percentage delta");
             pause.RegressionPercentageDelta.Should().BeApproximately(pause.PercentageDelta, 1e-9);
 
             // --- End-to-end categorization through the analyze pipeline ---

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/GCTraceMetricComparisonResult.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/GCTraceMetricComparisonResult.cs
@@ -111,5 +111,9 @@ namespace GC.Infrastructure.Core.Analysis
                 }
             }
         }
+
+        // Regression-oriented delta used for classification: positive => regression, negative => improvement,
+        // regardless of whether the metric is higher-is-better (e.g. Speed_MBPerMSec) or lower-is-better.
+        public double RegressionPercentageDelta => MetricDirection.GetRegressionDelta(MetricName, PercentageDelta);
     }
 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/GCTraceMetricComparisonResults.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/GCTraceMetricComparisonResults.cs
@@ -12,23 +12,23 @@ namespace GC.Infrastructure.Core.Analysis
             ComparisonResults = comparisonResults;
             Ordered = ComparisonResults
                 .Where(c => !double.IsNaN(c.PercentageDelta))
-                .OrderByDescending(c => c.PercentageDelta);
+                .OrderByDescending(c => c.RegressionPercentageDelta);
 
             LargeRegressions = Ordered
-                .Where(c => c.PercentageDelta >= 20);
+                .Where(c => c.RegressionPercentageDelta >= 20);
             LargeImprovements = Ordered
-                .Where(c => c.PercentageDelta <= -20)
-                .OrderBy(g => g.PercentageDelta);
+                .Where(c => c.RegressionPercentageDelta <= -20)
+                .OrderBy(g => g.RegressionPercentageDelta);
             Regressions = Ordered
-                .Where(c => c.PercentageDelta >= 5 && c.PercentageDelta < 20);
+                .Where(c => c.RegressionPercentageDelta >= 5 && c.RegressionPercentageDelta < 20);
             Improvements = Ordered
-                .Where(c => c.PercentageDelta <= -5 && c.PercentageDelta > -20)
-                .OrderBy(g => g.PercentageDelta);
+                .Where(c => c.RegressionPercentageDelta <= -5 && c.RegressionPercentageDelta > -20)
+                .OrderBy(g => g.RegressionPercentageDelta);
             StaleRegressions = Ordered
-                .Where(c => c.PercentageDelta > 0 && c.PercentageDelta < 5);
+                .Where(c => c.RegressionPercentageDelta > 0 && c.RegressionPercentageDelta < 5);
             StaleImprovements = Ordered
-                .Where(c => c.PercentageDelta <= 0 && c.PercentageDelta > -5)
-                .OrderBy(g => g.PercentageDelta);
+                .Where(c => c.RegressionPercentageDelta <= 0 && c.RegressionPercentageDelta > -5)
+                .OrderBy(g => g.RegressionPercentageDelta);
         }
 
         public string RunName { get; }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/MetricDirection.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Analysis/MetricDirection.cs
@@ -1,0 +1,27 @@
+namespace GC.Infrastructure.Core.Analysis
+{
+    /// <summary>
+    /// Encapsulates whether a higher or lower value is better for a given metric so that
+    /// regression / improvement classification stays correct regardless of metric direction.
+    /// By default a metric is treated as "lower is better" (e.g. pause times, heap sizes, GC counts).
+    /// </summary>
+    public static class MetricDirection
+    {
+        // Metrics for which a higher value is an improvement rather than a regression.
+        private static readonly HashSet<string> s_higherIsBetterMetrics = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Speed_MBPerMSec",
+        };
+
+        public static bool IsHigherBetter(string metricName) => s_higherIsBetterMetrics.Contains(metricName);
+
+        /// <summary>
+        /// Returns a regression-oriented percentage delta where a positive value always means a
+        /// regression and a negative value always means an improvement, irrespective of whether the
+        /// metric is higher-is-better or lower-is-better. The original <paramref name="percentageDelta"/>
+        /// is still used for display; only classification uses this value.
+        /// </summary>
+        public static double GetRegressionDelta(string metricName, double percentageDelta)
+            => IsHigherBetter(metricName) ? -percentageDelta : percentageDelta;
+    }
+}

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Json.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Json.cs
@@ -9,12 +9,12 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
     public static class Json
     {
         private static readonly Dictionary<string, Func<ComparisonResult, bool>> diffLevelPredicate = new() {
-            { "LargeRegressions", c => c.PercentageDelta > 20 },
-            { "LargeImprovements", c => c.PercentageDelta < -20 },
-            { "Regressions", c => c.PercentageDelta > 5 && c.PercentageDelta < 20 },
-            { "Improvements", c => c.PercentageDelta < -5 && c.PercentageDelta > -20 },
-            { "StaleRegressions", c => c.PercentageDelta >= 0 && c.PercentageDelta < 5 },
-            { "StaleImprovements", c => c.PercentageDelta < 0 && c.PercentageDelta > -5 },
+            { "LargeRegressions", c => c.RegressionPercentageDelta > 20 },
+            { "LargeImprovements", c => c.RegressionPercentageDelta < -20 },
+            { "Regressions", c => c.RegressionPercentageDelta > 5 && c.RegressionPercentageDelta < 20 },
+            { "Improvements", c => c.RegressionPercentageDelta < -5 && c.RegressionPercentageDelta > -20 },
+            { "StaleRegressions", c => c.RegressionPercentageDelta >= 0 && c.RegressionPercentageDelta < 5 },
+            { "StaleImprovements", c => c.RegressionPercentageDelta < 0 && c.RegressionPercentageDelta > -5 },
         };
 
         public static void GenerateComparisonDictionary(ResultItem baseResultItem, ResultItem comparandResultItem, string path)

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/Markdown.cs
@@ -87,7 +87,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
 
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta > 20)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta > 20)))
                 {
                     sb.AppendLine($"| {r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }
@@ -98,7 +98,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
 
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta < -20)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta < -20)))
                 {
                     sb.AppendLine($"| {r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }
@@ -108,7 +108,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 sb.AppendLine();
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta > 5 && c.PercentageDelta < 20)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta > 5 && c.RegressionPercentageDelta < 20)))
                 {
                     sb.AppendLine($"| {r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }
@@ -118,7 +118,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 sb.AppendLine();
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta < -5 && c.PercentageDelta > -20)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta < -5 && c.RegressionPercentageDelta > -20)))
                 {
                     sb.AppendLine($"| {r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }
@@ -128,7 +128,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 sb.AppendLine();
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta >= 0 && c.PercentageDelta < 5)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta >= 0 && c.RegressionPercentageDelta < 5)))
                 {
                     sb.AppendLine($"| {r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }
@@ -138,7 +138,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 sb.AppendLine();
                 sb.AppendLine($" | Metric | Base | Comparand | Δ%  |  Δ |");
                 sb.AppendLine($" | -----  | ---- | ------  | ---  |  --- |");
-                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.PercentageDelta < 0 && c.PercentageDelta > -5)))
+                foreach (var r in GoodLinq.Where(comparisonResults, (c => c.RegressionPercentageDelta < 0 && c.RegressionPercentageDelta > -5)))
                 {
                     sb.AppendLine($"|{r.MetricName} | {r.BaselineMetric:N2} | {r.ComparandMetric:N2} | {r.PercentageDelta:N2} | {r.Delta:N2} |");
                 }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItemComparison.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItemComparison.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Diagnostics.Tracing.Analysis.GC;
+﻿using GC.Infrastructure.Core.Analysis;
+using Microsoft.Diagnostics.Tracing.Analysis.GC;
 using System.Reflection;
 using System.Text;
 
@@ -90,7 +91,7 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
 
         // Regression-oriented delta used for classification: positive => regression, negative => improvement,
         // regardless of whether the metric is higher-is-better (e.g. Speed_MBPerMSec) or lower-is-better.
-        public double RegressionPercentageDelta => Analysis.MetricDirection.GetRegressionDelta(MetricName, PercentageDelta);
+        public double RegressionPercentageDelta => MetricDirection.GetRegressionDelta(MetricName, PercentageDelta);
         public string Key => $"{Baseline.ConfigurationName}_{RunName}";
         public ResultItem Baseline { get; }
         public ResultItem Comparand { get; }

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItemComparison.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure.Core/Presentation/GCPerfSim/ResultItemComparison.cs
@@ -87,6 +87,10 @@ namespace GC.Infrastructure.Core.Presentation.GCPerfSim
                 }
             }
         }
+
+        // Regression-oriented delta used for classification: positive => regression, negative => improvement,
+        // regardless of whether the metric is higher-is-better (e.g. Speed_MBPerMSec) or lower-is-better.
+        public double RegressionPercentageDelta => Analysis.MetricDirection.GetRegressionDelta(MetricName, PercentageDelta);
         public string Key => $"{Baseline.ConfigurationName}_{RunName}";
         public ResultItem Baseline { get; }
         public ResultItem Comparand { get; }


### PR DESCRIPTION
Speed_MBPerMSec is higher-is-better, so an increase was being mis-categorized as a regression (and a slowdown as an improvement). Add MetricDirection helper and a RegressionPercentageDelta on the comparison-result types that flips sign only for higher-is-better metrics. Classification predicates (Json, Markdown, GCTraceMetricComparisonResults) now use it; displayed Delta/PercentageDelta keep their real sign.

Adds an integration test that loads recorded GC traces and verifies the comparison + categorization end-to-end.
