### PR TITLE
Fix GC ASPNet bnechmarks on Linux

### DIFF
--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/ASPNetBenchmarks-Linux.csv
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/BaseSuite/ASPNetBenchmarks-Linux.csv
@@ -1,0 +1,3 @@
+Legend,Base CommandLine
+JsonMin_Linux, --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/json.benchmarks.yml --scenario mapaction --application.framework net8.0 --application.options.collectCounters true --profile aspnet-gold-lin --property os=linux --property arch=x64
+FortunesEf_Linux, --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_ef --application.framework net8.0 --application.options.collectCounters true --profile aspnet-gold-lin --property os=linux --property arch=x64

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/Commands/RunCommand/CreateSuiteCommand.cs
@@ -108,7 +108,9 @@ namespace GC.Infrastructure.Commands.RunCommand
 
             // Copy over the pertinent resources.
             string destinationASPNetBenchmark = Path.Combine(aspnetBenchmarks, "ASPNetBenchmarks.csv");
-            Core.Utilities.TryCopyFile(sourcePath: Path.Combine(_baseSuitePath, "ASPNetBenchmarks.csv"),
+            string sourceASPNetBenchmark = Path.Combine(_baseSuitePath, OperatingSystem.IsWindows() ? "ASPNetBenchmarks.csv" : "ASPNetBenchmarks-Linux.csv");
+
+            Core.Utilities.TryCopyFile(sourcePath: sourceASPNetBenchmark,
                                        destinationPath: destinationASPNetBenchmark);
 
             string outputPath = Path.Combine(inputConfiguration.output_path, "ASPNetBenchmarks");

--- a/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
+++ b/src/benchmarks/gc/GC.Infrastructure/GC.Infrastructure/GC.Infrastructure.csproj
@@ -47,6 +47,9 @@
     <None Update="Commands\RunCommand\BaseSuite\ASPNetBenchmarks.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Commands\RunCommand\BaseSuite\ASPNetBenchmarks-Linux.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Commands\RunCommand\BaseSuite\ASPNetBenchmarks.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
When running those benchmarks on Linux, we need to use different profiles. This change adds a separate ASPNetBenchmarks-Linux.csv to use as a source when  generating the suite.