### PR TITLE
Generalize BCS upload + register-build templates with repoName parameter

### DIFF
--- a/eng/pipelines/register-build-jobs.yml
+++ b/eng/pipelines/register-build-jobs.yml
@@ -3,6 +3,13 @@ parameters:
   performanceRepoAlias: self
   buildType: []
   mauiFramework: ''
+  # repoName is forwarded into each register-build-job invocation so the
+  # buildInfo.json marker lands under builds/{repoName}/buildArtifacts/...,
+  # matching the layout written by upload-build-artifacts-job.yml. Defaults
+  # to 'runtime' for back-compat with the existing dotnet/runtime perf-build
+  # pipeline; callers from other tenants (e.g. dotnet/aspnetcore) pass
+  # repoName explicitly.
+  repoName: 'runtime'
 
 jobs:
 - ${{ each type in parameters.buildType }}:
@@ -10,3 +17,4 @@ jobs:
     parameters:
       buildType: ${{ type }}
       buildId: $(Build.BuildId)
+      repoName: ${{ parameters.repoName }}

--- a/eng/pipelines/templates/register-build-job.yml
+++ b/eng/pipelines/templates/register-build-job.yml
@@ -1,6 +1,12 @@
 parameters:
   buildType: ''
   buildId: ''
+  # repoName is forwarded into the BCS blob path
+  # (builds/{repoName}/buildArtifacts/...). Defaults to 'runtime' for
+  # back-compat with the existing dotnet/runtime perf-build pipeline;
+  # callers from other tenants (e.g. dotnet/aspnetcore) pass repoName
+  # explicitly.
+  repoName: 'runtime'
 
 jobs:
   - job: RegisterBuild_${{ parameters.buildType }}
@@ -14,4 +20,4 @@ jobs:
         scriptType: 'pscore'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --data '{"buildId":"${{ parameters.buildId }}"}' --name "builds/runtime/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/buildInfo.json" --overwrite true
+          az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --data '{"buildId":"${{ parameters.buildId }}"}' --name "builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/buildInfo.json" --overwrite true

--- a/eng/pipelines/templates/upload-build-artifacts-job.yml
+++ b/eng/pipelines/templates/upload-build-artifacts-job.yml
@@ -8,29 +8,12 @@ parameters:
   # Callers building a different repo (e.g. dotnet/aspnetcore) pass repoName explicitly
   # so that the upload lands at a tenant-specific path the indexer/crank then read.
   repoName: 'runtime'
-  # Optional pool. When poolName is omitted the upload job inherits the pipeline
-  # default (the historical runtime perf-build behavior). Callers that extend the
-  # 1ES.Official template (e.g. aspnetcore perf-build) must specify a pool because
-  # 1ES.Official requires every job to declare one; for those callers pass:
-  #   poolName: $(DncEngInternalBuildPool)
-  #   poolImage: 1es-ubuntu-2204
-  #   poolOs: linux
-  poolName: ''
-  poolImage: ''
-  poolOs: ''
 
 jobs:
 - ${{ each artifact in parameters.artifacts }}:
   - job: UploadBuildArtifact_${{ artifact.artifactName }}
     displayName: 'Upload Build Artifact ${{ artifact.artifactName }}\'
     condition: eq(stageDependencies.Build.${{ parameters.dependencyJobName }}.result, 'Succeeded')
-    ${{ if parameters.poolName }}:
-      pool:
-        name: ${{ parameters.poolName }}
-        ${{ if parameters.poolImage }}:
-          image: ${{ parameters.poolImage }}
-        ${{ if parameters.poolOs }}:
-          os: ${{ parameters.poolOs }}
     steps:
     - checkout: none
     - download: current

--- a/eng/pipelines/templates/upload-build-artifacts-job.yml
+++ b/eng/pipelines/templates/upload-build-artifacts-job.yml
@@ -47,18 +47,3 @@ jobs:
           scriptLocation: 'inlineScript'
           inlineScript: |
             az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --file "$(Pipeline.Workspace)/${{ artifact.artifactName }}/${{ fileName }}" --name "builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}" --overwrite true
-    - checkout: none
-    - download: current
-      displayName: Download Build Artifact ${{ artifact.artifactName }}
-      artifact: ${{ artifact.artifactName }}
-    - ${{ each fileName in artifact.files }}:
-      - script: echo "pvscmdupload/\$web/builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}"
-        displayName: 'Artifact upload path'
-      - task: AzureCLI@2
-        displayName: 'Upload ${{ fileName }} file'
-        inputs:
-          azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
-          scriptType: 'pscore'
-          scriptLocation: 'inlineScript'
-          inlineScript: |
-            az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --file "$(Pipeline.Workspace)/${{ artifact.artifactName }}/${{ fileName }}" --name "builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}" --overwrite true

--- a/eng/pipelines/templates/upload-build-artifacts-job.yml
+++ b/eng/pipelines/templates/upload-build-artifacts-job.yml
@@ -2,19 +2,42 @@ parameters:
   buildType: ''
   dependencyJobName: ''
   artifacts: []
+  # repoName controls the {repoName} segment of the BCS blob path:
+  #   builds/{repoName}/buildArtifacts/{sha}/{buildType}/{file}
+  # Defaults to 'runtime' for back-compat with the existing runtime perf-build pipeline.
+  # Callers building a different repo (e.g. dotnet/aspnetcore) pass repoName explicitly
+  # so that the upload lands at a tenant-specific path the indexer/crank then read.
+  repoName: 'runtime'
+  # Optional pool. When poolName is omitted the upload job inherits the pipeline
+  # default (the historical runtime perf-build behavior). Callers that extend the
+  # 1ES.Official template (e.g. aspnetcore perf-build) must specify a pool because
+  # 1ES.Official requires every job to declare one; for those callers pass:
+  #   poolName: $(DncEngInternalBuildPool)
+  #   poolImage: 1es-ubuntu-2204
+  #   poolOs: linux
+  poolName: ''
+  poolImage: ''
+  poolOs: ''
 
 jobs:
 - ${{ each artifact in parameters.artifacts }}:
   - job: UploadBuildArtifact_${{ artifact.artifactName }}
     displayName: 'Upload Build Artifact ${{ artifact.artifactName }}\'
     condition: eq(stageDependencies.Build.${{ parameters.dependencyJobName }}.result, 'Succeeded')
+    ${{ if parameters.poolName }}:
+      pool:
+        name: ${{ parameters.poolName }}
+        ${{ if parameters.poolImage }}:
+          image: ${{ parameters.poolImage }}
+        ${{ if parameters.poolOs }}:
+          os: ${{ parameters.poolOs }}
     steps:
     - checkout: none
     - download: current
       displayName: Download Build Artifact ${{ artifact.artifactName }}
       artifact: ${{ artifact.artifactName }}
     - ${{ each fileName in artifact.files }}:
-      - script: echo "pvscmdupload/\$web/builds/runtime/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}"
+      - script: echo "pvscmdupload/\$web/builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}"
         displayName: 'Artifact upload path'
       - task: AzureCLI@2
         displayName: 'Upload ${{ fileName }} file'
@@ -23,4 +46,19 @@ jobs:
           scriptType: 'pscore'
           scriptLocation: 'inlineScript'
           inlineScript: |
-            az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --file "$(Pipeline.Workspace)/${{ artifact.artifactName }}/${{ fileName }}" --name "builds/runtime/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}" --overwrite true
+            az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --file "$(Pipeline.Workspace)/${{ artifact.artifactName }}/${{ fileName }}" --name "builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}" --overwrite true
+    - checkout: none
+    - download: current
+      displayName: Download Build Artifact ${{ artifact.artifactName }}
+      artifact: ${{ artifact.artifactName }}
+    - ${{ each fileName in artifact.files }}:
+      - script: echo "pvscmdupload/\$web/builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}"
+        displayName: 'Artifact upload path'
+      - task: AzureCLI@2
+        displayName: 'Upload ${{ fileName }} file'
+        inputs:
+          azureSubscription: '.NET Performance (790c4451-dad9-4fda-af8b-10bd9ca328fa)'
+          scriptType: 'pscore'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            az storage blob upload --auth-mode login --account-name pvscmdupload --container-name '$web' --file "$(Pipeline.Workspace)/${{ artifact.artifactName }}/${{ fileName }}" --name "builds/${{ parameters.repoName }}/buildArtifacts/${{ variables['Build.SourceVersion'] }}/${{ parameters.buildType }}/${{ fileName }}" --overwrite true

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -3,6 +3,21 @@ parameters:
   performanceRepoAlias: self
   buildType: []
   mauiFramework: ''
+  # repoName is forwarded into the BCS blob path (builds/{repoName}/buildArtifacts/...)
+  # by each upload-build-artifacts-job.yml invocation. Defaults to 'runtime' for
+  # back-compat with the existing dotnet/runtime perf-build pipeline; callers from
+  # other tenants (e.g. dotnet/aspnetcore) pass repoName explicitly.
+  repoName: 'runtime'
+  # Optional pool. When poolName is omitted the upload job inherits the pipeline
+  # default (the historical runtime callers' behavior). Callers that extend the
+  # 1ES.Official template (e.g. aspnetcore perf-build) must specify a pool because
+  # 1ES.Official requires every job to declare one; for those callers pass:
+  #   poolName: $(DncEngInternalBuildPool)
+  #   poolImage: 1es-ubuntu-2204
+  #   poolOs: linux
+  poolName: ''
+  poolImage: ''
+  poolOs: ''
 
 jobs:
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_linux') }}:
@@ -10,134 +25,194 @@ jobs:
       parameters:
         buildType: 'coreclr_arm64_linux'
         dependencyJobName: build_linux_arm64_release_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_arm64_Release_coreclr'
           files: [ 'BuildArtifacts_linux_arm64_Release_coreclr.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_windows') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_arm64_windows'
         dependencyJobName: build_windows_arm64_release_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_arm64_Release_coreclr'
           files: [ 'BuildArtifacts_windows_arm64_Release_coreclr.zip' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'coreclr_x64_linux') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_x64_linux'
         dependencyJobName: build_linux_x64_release_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_coreclr'
           files: [ 'BuildArtifacts_linux_x64_Release_coreclr.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'coreclr_x64_windows') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_x64_windows'
         dependencyJobName: build_windows_x64_release_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x64_Release_coreclr'
           files: [ 'BuildArtifacts_windows_x64_Release_coreclr.zip' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'coreclr_x86_windows') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_x86_windows'
         dependencyJobName: build_windows_x86_release_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x86_Release_coreclr'
           files: [ 'BuildArtifacts_windows_x86_Release_coreclr.zip' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_android') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_arm64_android'
         dependencyJobName: build_android_arm64_release_AndroidCoreCLR
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidHelloWorldArm64CoreCLR'
           files: [ 'AndroidHelloWorldArm64CoreCLR.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'wasm') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'wasm'
         dependencyJobName: build_browser_wasm_linux_Release_wasm
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BrowserWasm'
           files: [ 'BrowserWasm.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'monoAot_arm64_linux') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'monoAot_arm64_linux'
         dependencyJobName: build_linux_arm64_release_AOT
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'LinuxMonoAOTarm64'
           files: [ 'LinuxMonoAOTarm64.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'monoAot_x64_linux') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'monoAot_x64_linux'
         dependencyJobName: build_linux_x64_release_AOT
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'LinuxMonoAOTx64'
           files: [ 'LinuxMonoAOTx64.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'mono_x64_linux') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'mono_x64_linux'
         dependencyJobName: build_linux_x64_release_mono
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_mono'
           files: [ 'BuildArtifacts_linux_x64_Release_mono.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'mono_arm64_linux') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'mono_arm64_linux'
         dependencyJobName: build_linux_arm64_release_mono
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_arm64_Release_mono'
           files: [ 'BuildArtifacts_linux_arm64_Release_mono.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'mono_arm64_android') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'mono_arm64_android'
         dependencyJobName: build_android_arm64_release_AndroidMono
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidHelloWorldArm64Mono'
           files: [ 'AndroidHelloWorldArm64Mono.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'mono_arm64_ios') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'mono_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSMono
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
           files: [ 'iOSSampleAppMonoFullAOTLLVMNoSymbols.zip' ]
         - artifactName: 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols'
           files: [ 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols.zip' ]
-                    
+
   - ${{ if containsValue(parameters.buildType, 'monoBDN_arm64_android') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'monoBDN_arm64_android'
         dependencyJobName: build_ios_arm64_release_PerfBDNApp #build_android_arm64_release_Mono_Packs
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidBDNApk'
           files: [ 'AndroidBDNApk.tar.gz' ]
-          
+
   - ${{ if containsValue(parameters.buildType, 'nativeAot_arm64_ios') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'nativeAot_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSNativeAOT
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppNativeAOTNoSymbols'
           files: [ 'iOSSampleAppNativeAOTNoSymbols.zip' ]
@@ -147,6 +222,10 @@ jobs:
       parameters:
         buildType: 'coreclr_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSCoreCLR
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
           files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]
@@ -158,6 +237,10 @@ jobs:
       parameters:
         buildType: 'wasm_coreclr'
         dependencyJobName: build_browser_wasm_linux_Release_wasm_coreclr
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BrowserWasmCoreCLR'
           files: [ 'BrowserWasmCoreCLR.tar.gz' ]
@@ -167,6 +250,82 @@ jobs:
       parameters:
         buildType: 'coreclr_r2r_interpreter'
         dependencyJobName: build_linux_x64_release_coreclr_r2r_interpreter
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_coreclr_r2r_interpreter'
           files: [ 'BuildArtifacts_linux_x64_Release_coreclr_r2r_interpreter.tar.gz' ]
+
+  # ===========================================================================
+  # ASP.NET Core upload cases (consumed by dotnet/aspnetcore's perf-build
+  # pipeline). The dependencyJobName values mirror the jobName parameters used
+  # in dotnet/aspnetcore/.azure/pipelines/perf-build.yml. The artifactName
+  # values must match the artifact `name:` field published by those build jobs.
+  # ===========================================================================
+
+  - ${{ if containsValue(parameters.buildType, 'aspnetcore_x64_linux') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'aspnetcore_x64_linux'
+        dependencyJobName: Linux_x64_build
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
+        artifacts:
+        - artifactName: 'BuildArtifacts_linux_x64_Release_aspnetcore'
+          files: [ 'BuildArtifacts_linux_x64_Release_aspnetcore.tar.gz' ]
+
+  - ${{ if containsValue(parameters.buildType, 'aspnetcore_arm64_linux') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'aspnetcore_arm64_linux'
+        dependencyJobName: Linux_arm64_build
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
+        artifacts:
+        - artifactName: 'BuildArtifacts_linux_arm64_Release_aspnetcore'
+          files: [ 'BuildArtifacts_linux_arm64_Release_aspnetcore.tar.gz' ]
+
+  - ${{ if containsValue(parameters.buildType, 'aspnetcore_x64_windows') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'aspnetcore_x64_windows'
+        dependencyJobName: Windows_build
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
+        artifacts:
+        - artifactName: 'BuildArtifacts_windows_x64_Release_aspnetcore'
+          files: [ 'BuildArtifacts_windows_x64_Release_aspnetcore.zip' ]
+
+  - ${{ if containsValue(parameters.buildType, 'aspnetcore_arm64_windows') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'aspnetcore_arm64_windows'
+        dependencyJobName: Windows_build
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
+        artifacts:
+        - artifactName: 'BuildArtifacts_windows_arm64_Release_aspnetcore'
+          files: [ 'BuildArtifacts_windows_arm64_Release_aspnetcore.zip' ]
+
+  - ${{ if containsValue(parameters.buildType, 'aspnetcore_x86_windows') }}:
+    - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
+      parameters:
+        buildType: 'aspnetcore_x86_windows'
+        dependencyJobName: Windows_build
+        repoName: ${{ parameters.repoName }}
+        poolName: ${{ parameters.poolName }}
+        poolImage: ${{ parameters.poolImage }}
+        poolOs: ${{ parameters.poolOs }}
+        artifacts:
+        - artifactName: 'BuildArtifacts_windows_x86_Release_aspnetcore'
+          files: [ 'BuildArtifacts_windows_x86_Release_aspnetcore.zip' ]

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -8,16 +8,6 @@ parameters:
   # back-compat with the existing dotnet/runtime perf-build pipeline; callers from
   # other tenants (e.g. dotnet/aspnetcore) pass repoName explicitly.
   repoName: 'runtime'
-  # Optional pool. When poolName is omitted the upload job inherits the pipeline
-  # default (the historical runtime callers' behavior). Callers that extend the
-  # 1ES.Official template (e.g. aspnetcore perf-build) must specify a pool because
-  # 1ES.Official requires every job to declare one; for those callers pass:
-  #   poolName: $(DncEngInternalBuildPool)
-  #   poolImage: 1es-ubuntu-2204
-  #   poolOs: linux
-  poolName: ''
-  poolImage: ''
-  poolOs: ''
 
 jobs:
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_linux') }}:
@@ -26,9 +16,6 @@ jobs:
         buildType: 'coreclr_arm64_linux'
         dependencyJobName: build_linux_arm64_release_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_arm64_Release_coreclr'
           files: [ 'BuildArtifacts_linux_arm64_Release_coreclr.tar.gz' ]
@@ -39,9 +26,6 @@ jobs:
         buildType: 'coreclr_arm64_windows'
         dependencyJobName: build_windows_arm64_release_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_arm64_Release_coreclr'
           files: [ 'BuildArtifacts_windows_arm64_Release_coreclr.zip' ]
@@ -52,9 +36,6 @@ jobs:
         buildType: 'coreclr_x64_linux'
         dependencyJobName: build_linux_x64_release_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_coreclr'
           files: [ 'BuildArtifacts_linux_x64_Release_coreclr.tar.gz' ]
@@ -65,9 +46,6 @@ jobs:
         buildType: 'coreclr_x64_windows'
         dependencyJobName: build_windows_x64_release_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x64_Release_coreclr'
           files: [ 'BuildArtifacts_windows_x64_Release_coreclr.zip' ]
@@ -78,9 +56,6 @@ jobs:
         buildType: 'coreclr_x86_windows'
         dependencyJobName: build_windows_x86_release_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x86_Release_coreclr'
           files: [ 'BuildArtifacts_windows_x86_Release_coreclr.zip' ]
@@ -91,9 +66,6 @@ jobs:
         buildType: 'coreclr_arm64_android'
         dependencyJobName: build_android_arm64_release_AndroidCoreCLR
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidHelloWorldArm64CoreCLR'
           files: [ 'AndroidHelloWorldArm64CoreCLR.tar.gz' ]
@@ -104,9 +76,6 @@ jobs:
         buildType: 'wasm'
         dependencyJobName: build_browser_wasm_linux_Release_wasm
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BrowserWasm'
           files: [ 'BrowserWasm.tar.gz' ]
@@ -117,9 +86,6 @@ jobs:
         buildType: 'monoAot_arm64_linux'
         dependencyJobName: build_linux_arm64_release_AOT
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'LinuxMonoAOTarm64'
           files: [ 'LinuxMonoAOTarm64.tar.gz' ]
@@ -130,9 +96,6 @@ jobs:
         buildType: 'monoAot_x64_linux'
         dependencyJobName: build_linux_x64_release_AOT
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'LinuxMonoAOTx64'
           files: [ 'LinuxMonoAOTx64.tar.gz' ]
@@ -143,9 +106,6 @@ jobs:
         buildType: 'mono_x64_linux'
         dependencyJobName: build_linux_x64_release_mono
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_mono'
           files: [ 'BuildArtifacts_linux_x64_Release_mono.tar.gz' ]
@@ -156,9 +116,6 @@ jobs:
         buildType: 'mono_arm64_linux'
         dependencyJobName: build_linux_arm64_release_mono
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_arm64_Release_mono'
           files: [ 'BuildArtifacts_linux_arm64_Release_mono.tar.gz' ]
@@ -169,9 +126,6 @@ jobs:
         buildType: 'mono_arm64_android'
         dependencyJobName: build_android_arm64_release_AndroidMono
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidHelloWorldArm64Mono'
           files: [ 'AndroidHelloWorldArm64Mono.tar.gz' ]
@@ -182,9 +136,6 @@ jobs:
         buildType: 'mono_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSMono
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
           files: [ 'iOSSampleAppMonoFullAOTLLVMNoSymbols.zip' ]
@@ -197,9 +148,6 @@ jobs:
         buildType: 'monoBDN_arm64_android'
         dependencyJobName: build_ios_arm64_release_PerfBDNApp #build_android_arm64_release_Mono_Packs
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'AndroidBDNApk'
           files: [ 'AndroidBDNApk.tar.gz' ]
@@ -210,9 +158,6 @@ jobs:
         buildType: 'nativeAot_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSNativeAOT
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppNativeAOTNoSymbols'
           files: [ 'iOSSampleAppNativeAOTNoSymbols.zip' ]
@@ -223,9 +168,6 @@ jobs:
         buildType: 'coreclr_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSCoreCLR
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
           files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]
@@ -238,9 +180,6 @@ jobs:
         buildType: 'wasm_coreclr'
         dependencyJobName: build_browser_wasm_linux_Release_wasm_coreclr
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BrowserWasmCoreCLR'
           files: [ 'BrowserWasmCoreCLR.tar.gz' ]
@@ -251,9 +190,6 @@ jobs:
         buildType: 'coreclr_r2r_interpreter'
         dependencyJobName: build_linux_x64_release_coreclr_r2r_interpreter
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_coreclr_r2r_interpreter'
           files: [ 'BuildArtifacts_linux_x64_Release_coreclr_r2r_interpreter.tar.gz' ]
@@ -271,9 +207,6 @@ jobs:
         buildType: 'aspnetcore_x64_linux'
         dependencyJobName: Linux_x64_build
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_x64_Release_aspnetcore'
           files: [ 'BuildArtifacts_linux_x64_Release_aspnetcore.tar.gz' ]
@@ -284,9 +217,6 @@ jobs:
         buildType: 'aspnetcore_arm64_linux'
         dependencyJobName: Linux_arm64_build
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_linux_arm64_Release_aspnetcore'
           files: [ 'BuildArtifacts_linux_arm64_Release_aspnetcore.tar.gz' ]
@@ -297,9 +227,6 @@ jobs:
         buildType: 'aspnetcore_x64_windows'
         dependencyJobName: Windows_build
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x64_Release_aspnetcore'
           files: [ 'BuildArtifacts_windows_x64_Release_aspnetcore.zip' ]
@@ -310,9 +237,6 @@ jobs:
         buildType: 'aspnetcore_arm64_windows'
         dependencyJobName: Windows_build
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_arm64_Release_aspnetcore'
           files: [ 'BuildArtifacts_windows_arm64_Release_aspnetcore.zip' ]
@@ -323,9 +247,6 @@ jobs:
         buildType: 'aspnetcore_x86_windows'
         dependencyJobName: Windows_build
         repoName: ${{ parameters.repoName }}
-        poolName: ${{ parameters.poolName }}
-        poolImage: ${{ parameters.poolImage }}
-        poolOs: ${{ parameters.poolOs }}
         artifacts:
         - artifactName: 'BuildArtifacts_windows_x86_Release_aspnetcore'
           files: [ 'BuildArtifacts_windows_x86_Release_aspnetcore.zip' ]


### PR DESCRIPTION
Make the build registration and upload steps generalized by repo for the BuildCacheService so that we can manage the steps in the dotnet/performance repo instead of requiring each setup we end up with having to duplicate the work. This keeps the defaults to runtime so that the runtime ymls continue working.

AI Summary:
Companion to a forthcoming dotnet/aspnetcore PR (LoopedBard3/aspnetcore#2 in fork-staging) that wires aspnetcore per-commit perf builds into BCS using the templates this PR generalizes.

## Why

Today the BCS-upload templates in `eng/pipelines/` are hard-tied to dotnet/runtime: both `templates/upload-build-artifacts-job.yml` and `templates/register-build-job.yml` write to literal `builds/runtime/...` blob paths. To let dotnet/aspnetcore (and any future tenant) consume the same primitives — and produce a BCS layout that's uniform with runtime's, so a single dashboard / cleanup tool / future indexer code path can serve both — we just need to parameterize the path prefix.

## What changes

`eng/pipelines/templates/upload-build-artifacts-job.yml` (per-artifact upload primitive):
- Adds `repoName` (default `'runtime'`, back-compat for existing runtime callers).
- Replaces both occurrences of literal `builds/runtime/` with `builds/${{ parameters.repoName }}/`.

`eng/pipelines/templates/register-build-job.yml` (per-config `buildInfo.json` marker):
- Adds `repoName` (default `'runtime'`).
- Replaces literal `builds/runtime/` with `builds/${{ parameters.repoName }}/`.

`eng/pipelines/upload-build-artifacts-jobs.yml` and `eng/pipelines/register-build-jobs.yml` (dispatchers):
- Forward `repoName` into each per-config invocation.
- The upload dispatcher additionally gains 5 new dispatch cases for the aspnetcore configKeys (`aspnetcore_{x64,arm64}_linux` + `aspnetcore_{x64,arm64,x86}_windows`), each depending on the corresponding `Windows_build` / `Linux_x64_build` / `Linux_arm64_build` job that the aspnetcore perf-build defines via `default-build.yml@self`. (RegisterBuild's dispatcher is buildType-agnostic by construction so it needs no new cases.)

## What we deliberately did NOT add

- **No `poolName` / `poolImage` / `poolOs` params.** An earlier draft of this PR added optional pool params to the upload leaf so a 1ES.Official-extending tenant could declare a per-job pool (1ES requires every job to have one). aspnetcore's caller in #2 dropped 1ES.Official to match runtime's plain non-1ES shape (private cache content, not signed/redistributed), so no current or planned tenant needs them. Removed to keep the surface area minimal; if a future 1ES tenant ever lands, re-adding the params is ~10 lines of YAML.
- **No `runtimeRepoAlias` / `mauiFramework` cleanup.** Both are pre-existing dead params on the upload dispatcher. Cleanup is split into a separate small PR (#5242) to keep this one focused on generalization.

## Validation

- YAML re-validated via `python -c "import yaml; yaml.safe_load(...)"` for all four files.
- Runtime callsite (`dotnet/runtime` `eng/pipelines/performance/perf-build.yml`) is unchanged — it calls both dispatchers without `repoName`, the default `'runtime'` kicks in, output is identical to today.
- Aspnetcore callsite (LoopedBard3/aspnetcore#2) passes `repoName: aspnetcore` to both dispatchers.

## Why a single shared template (not a fork)

Earlier plan iterations considered duplicating the upload logic in dotnet/aspnetcore. After reading runtime's actual `perf-build.yml` structure, it's clear runtime ALREADY consumes a thin-wrapper-from-dotnet-performance architecture (`register-build-jobs.yml@performance`, `runtime-perf-build-jobs.yml@performance`, `upload-build-artifacts-jobs.yml@performance`). Generalizing the existing primitives instead of forking keeps a single source of truth for the BCS contract, and means future BCS-shape changes land once for all tenants.

## Sequencing

This PR must merge upstream before the aspnetcore perf-build pipeline can run end-to-end — the aspnetcore-side YAML resolves the templates via `@performance` (= `internal/dotnet-performance` AzDO mirror), which only updates after dotnet/performance's main branch advances.