### PR TITLE
Clean up unused parameter and stray escape in upload template

### DIFF
--- a/eng/pipelines/templates/upload-build-artifacts-job.yml
+++ b/eng/pipelines/templates/upload-build-artifacts-job.yml
@@ -6,7 +6,7 @@ parameters:
 jobs:
 - ${{ each artifact in parameters.artifacts }}:
   - job: UploadBuildArtifact_${{ artifact.artifactName }}
-    displayName: 'Upload Build Artifact ${{ artifact.artifactName }}\'
+    displayName: 'Upload Build Artifact ${{ artifact.artifactName }}'
     condition: eq(stageDependencies.Build.${{ parameters.dependencyJobName }}.result, 'Succeeded')
     steps:
     - checkout: none

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -2,7 +2,6 @@ parameters:
   runtimeRepoAlias: runtime
   performanceRepoAlias: self
   buildType: []
-  mauiFramework: ''
 
 jobs:
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_linux') }}:


### PR DESCRIPTION
## What

Two small unrelated cleanups in the existing BCS upload pipeline templates. No behavioral change.

### 1. `eng/pipelines/templates/upload-build-artifacts-job.yml`

Drop the trailing backslash in the per-artifact job displayName:

```diff
-    displayName: 'Upload Build Artifact ${{ artifact.artifactName }}\'
+    displayName: 'Upload Build Artifact ${{ artifact.artifactName }}'
```

YAML single-quoted strings treat `\` as a literal character (the only escape inside a single-quoted string is `''` for a single quote). With the current `\'`, the AzDO Web UI literally renders the job name as `Upload Build Artifact <name>\`. Cosmetic only — the job still runs.

### 2. `eng/pipelines/upload-build-artifacts-jobs.yml`

Remove the unused `mauiFramework` template parameter:

```diff
 parameters:
   runtimeRepoAlias: runtime
   performanceRepoAlias: self
   buildType: []
-  mauiFramework: ''
```

The parameter is declared on the dispatcher but never referenced in the dispatcher body, and **no current caller passes it to this template**. `dotnet/runtime`'s `perf-build.yml` passes `mauiFramework` only to the sibling `runtime-perf-build-jobs.yml` template (used by the Build stage), not to `upload-build-artifacts-jobs.yml` (used by the UploadArtifacts stage). Dropping it removes a confusing dead parameter that suggests upload behavior depends on the MAUI framework version (it doesn't).

## Why

Both items surfaced during code review of #5241 (the dispatcher generalization for multi-tenant uploads). Splitting them into this small, easily reviewed PR keeps #5241 focused on the generalization story.

## Intentionally NOT removed

The `runtimeRepoAlias` parameter on `upload-build-artifacts-jobs.yml` is also unused in the dispatcher body — but `dotnet/runtime`'s `perf-build.yml` does explicitly pass `runtimeRepoAlias: self` to this template. Removing the parameter here would fail template expansion on the runtime side at the next pipeline run with `Unexpected parameter 'runtimeRepoAlias'`. Cleaning that up requires a coordinated `dotnet/runtime` tenant update first, and is left for a follow-up PR.

## Validation

- Both files still parse as valid YAML (`yaml.safe_load`).
- `git --no-pager grep mauiFramework` in `dotnet/runtime` confirms no UploadArtifacts caller passes the parameter.
- No callers in `dotnet/performance` itself (this template has no internal callers — only external tenants like `dotnet/runtime`).
