### PR TITLE
[wasm] Pass --experimental-wasm-exnref to V8 for perf runs

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -443,6 +443,12 @@ def get_bdn_arguments(
             "--wasmProcessTimeout", "20",
         ]
 
+        # The runtime now uses the standardized exnref WASM exception-handling proposal,
+        # which V8 keeps behind --experimental-wasm-exnref. Pass it through to the engine
+        # via BDN's --wasmArgs (the escaped quotes keep it a single token on the Helix shell).
+        if javascript_engine == "v8":
+            bdn_arguments += ["\\\"--wasmArgs=--experimental-wasm-exnref\\\""]
+
         if is_aot:
             bdn_arguments += [
                 "--aotcompilermode", "wasm",
@@ -459,6 +465,12 @@ def get_bdn_arguments(
             "--buildTimeout", "1200",
             "--wasmProcessTimeout", "20"
         ]
+
+        # The runtime now uses the standardized exnref WASM exception-handling proposal,
+        # which V8 keeps behind --experimental-wasm-exnref. Pass it through to the engine
+        # via BDN's --wasmArgs (the escaped quotes keep it a single token on the Helix shell).
+        if javascript_engine == "v8":
+            bdn_arguments += ["\\\"--wasmArgs=--experimental-wasm-exnref\\\""]
 
     if runtime_type == "coreclr_r2r_interpreter":
         if os_group == "windows":


### PR DESCRIPTION
## Problem

WASM dotnet performance runs began failing at startup:

```
MONO_WASM: Assert failed: This browser/engine doesn't support WASM exception handling.
main.mjs: Error: Top-level await promise never resolved
```

## Root cause

dotnet/runtime#129851 (`[browser] WASM exception handling to use the standardized exnref`) switched the runtime to the standardized **exnref** exception-handling proposal. V8 keeps exnref behind the `--experimental-wasm-exnref` flag.

The perf wasm v8 leg installs V8 via `jsvu` (version read from the runtime's `BrowserVersions.props`, already at `15.1.103`) and runs benchmarks through BenchmarkDotNet. BDN was **not** passing `--experimental-wasm-exnref`, so the runtime's startup feature check (`exceptionsFinal`) fails and the benchmark process aborts.

## Fix

Pass the flag through BDN's existing `--wasmArgs` option for the `v8` engine, on both the `wasm` and `wasm_coreclr` legs. This mirrors the previous `--wasmArgs` pattern removed in #5134.

- Gated on `javascript_engine == "v8"` so JavaScriptCore is unaffected.
- Harmless (warning only) on V8 builds that enable exnref by default, so it is forward-compatible with the eventual engine bump in dotnet/runtime#129849.

No BenchmarkDotNet change is required (`--wasmArgs` already exists in the consumed nightly), and no separate jsvu pin change is needed (the version is authoritative from `BrowserVersions.props`).

Refs dotnet/runtime#129849, dotnet/runtime#129851.