### PR TITLE
Fix mlnet performance benchmark timeouts by pre-provisioning the SSWE model into the Helix payload

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -150,8 +150,9 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
         "https://aka.ms/mlnet-resources/Text/Sswe/sentiment.emd",
     ]
 
-    # The model is ~70 MB; require at least this much so a truncated/early-closed response (which may
-    # not raise) is rejected instead of leaving a corrupt file in the payload.
+    # The model is ~70 MB. When the server doesn't send a Content-Length to validate against, require
+    # at least this much so a truncated/early-closed response (which may not raise) is rejected
+    # instead of leaving a corrupt file in the payload.
     min_expected_size = 60 * 1024 * 1024
 
     last_error: Optional[Exception] = None
@@ -167,9 +168,14 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
                         shutil.copyfileobj(response, f)
 
                 size = os.path.getsize(tmp_dest)
-                if expected_size is not None and size != expected_size:
-                    raise Exception(f"size {size} does not match Content-Length {expected_size}")
-                if size < min_expected_size:
+                if expected_size is not None:
+                    # Content-Length fully validates completeness, so trust it regardless of size
+                    # (the asset could legitimately shrink without becoming invalid).
+                    if size != expected_size:
+                        raise Exception(f"size {size} does not match Content-Length {expected_size}")
+                elif size < min_expected_size:
+                    # No Content-Length to validate against; fall back to a minimum-size floor to
+                    # reject an obviously truncated/early-closed response.
                     raise Exception(f"size {size} is smaller than the expected minimum {min_expected_size}")
 
                 os.replace(tmp_dest, dest)

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -156,12 +156,12 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
     min_expected_size = 60 * 1024 * 1024
 
     last_error: Optional[Exception] = None
-    for attempt in range(1, 6):
+    for attempt in range(1, 4):
         for url in urls:
             tmp_dest = dest + ".tmp"
             try:
                 getLogger().info(f"Downloading ML.NET SSWE model from {url} (attempt {attempt})")
-                with urllib.request.urlopen(url, timeout=300) as response:
+                with urllib.request.urlopen(url, timeout=60) as response:
                     content_length = response.getheader("Content-Length")
                     expected_size = int(content_length) if content_length else None
                     with open(tmp_dest, "wb") as f:

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -129,22 +129,15 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
     """
     Pre-download the ML.NET SSWE word-embedding model into the correlation payload.
 
-    The Microsoft.ML.Benchmarks (StochasticDualCoordinateAscentClassifierBench.TrainSentiment)
-    apply a pretrained word embedding (SSWE 'sentiment.emd', ~70 MB). ML.NET downloads this model
-    from https://aka.ms/mlnet-resources at benchmark runtime if it isn't already present on disk.
-    On the Helix machines that download regularly stalls, which hangs the entire mlnet work item
-    until it hits the work item timeout and is killed, discarding ALL mlnet results (so every mlnet
-    benchmark appears to fail).
-
-    To remove the runtime network dependency, we download the model here on the build agent (which
-    has reliable connectivity) into the correlation payload. The caller then points
-    MICROSOFTML_RESOURCE_PATH at it on the Helix machine so ML.NET loads the model from disk and
-    never makes the network call.
-
+    StochasticDualCoordinateAscentClassifierBench.TrainSentiment applies a pretrained word embedding
+    ('sentiment.emd', ~70 MB) that ML.NET otherwise downloads from https://aka.ms/mlnet-resources at
+    benchmark runtime. That download stalls on the Helix machines and hangs the whole mlnet work item
+    until it times out. Downloading it here on the build agent (reliable connectivity) and pointing
+    MICROSOFTML_RESOURCE_PATH at <payload>/mlnet-resources lets ML.NET load it from disk instead.
     ML.NET resolves the model at <MICROSOFTML_RESOURCE_PATH>/Text/Sswe/sentiment.emd.
 
-    This is best-effort: if the download fails the function returns False and the caller skips
-    setting the env var, leaving the previous (runtime-download) behavior unchanged.
+    Best-effort: returns False on failure so the caller skips the env var and the previous
+    (runtime-download) behavior is left unchanged.
     """
     resource_root = os.path.join(payload_dir, MLNET_RESOURCES_PAYLOAD_SUBDIR)
     dest = os.path.join(resource_root, "Text", "Sswe", "sentiment.emd")
@@ -157,21 +150,36 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
         "https://aka.ms/mlnet-resources/Text/Sswe/sentiment.emd",
     ]
 
+    # The model is ~70 MB; require at least this much so a truncated/early-closed response (which may
+    # not raise) is rejected instead of leaving a corrupt file in the payload.
+    min_expected_size = 60 * 1024 * 1024
+
     last_error: Optional[Exception] = None
     for attempt in range(1, 6):
         for url in urls:
+            tmp_dest = dest + ".tmp"
             try:
                 getLogger().info(f"Downloading ML.NET SSWE model from {url} (attempt {attempt})")
-                with urllib.request.urlopen(url, timeout=300) as response, open(dest, "wb") as f:
-                    shutil.copyfileobj(response, f)
-                size = os.path.getsize(dest)
-                if size <= 0:
-                    raise Exception("downloaded file is empty")
+                with urllib.request.urlopen(url, timeout=300) as response:
+                    content_length = response.getheader("Content-Length")
+                    expected_size = int(content_length) if content_length else None
+                    with open(tmp_dest, "wb") as f:
+                        shutil.copyfileobj(response, f)
+
+                size = os.path.getsize(tmp_dest)
+                if expected_size is not None and size != expected_size:
+                    raise Exception(f"size {size} does not match Content-Length {expected_size}")
+                if size < min_expected_size:
+                    raise Exception(f"size {size} is smaller than the expected minimum {min_expected_size}")
+
+                os.replace(tmp_dest, dest)
                 getLogger().info(f"Downloaded ML.NET SSWE model ({size} bytes) to {dest}")
                 return True
             except Exception as e:
                 last_error = e
                 getLogger().warning(f"Failed to download ML.NET SSWE model from {url}: {e}")
+                if os.path.exists(tmp_dest):
+                    os.remove(tmp_dest)
         time.sleep(10)
 
     getLogger().warning(

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import timedelta
 from glob import glob
+import hashlib
 import json
 import os
 import shutil
@@ -125,6 +126,12 @@ class RunPerformanceJobArgs:
 # On the Helix machine this is referenced as <HELIX_CORRELATION_PAYLOAD>/mlnet-resources.
 MLNET_RESOURCES_PAYLOAD_SUBDIR = "mlnet-resources"
 
+# Known-good SHA256 of the SSWE word-embedding model (sentiment.emd, 73,674,434 bytes). The asset is
+# a fixed pretrained model and is not expected to change; validating the hash guarantees we shipped a
+# complete, uncorrupted file (a truncated or proxy-mangled response won't match). If the upstream
+# asset is ever intentionally updated, recompute and update this value.
+MLNET_SSWE_MODEL_SHA256 = "a8062ef5d3a1ffc079a2b3c439a5533279f4ac6d85882ca8488fb8ff239fefdd"
+
 def try_provision_mlnet_resources(payload_dir: str) -> bool:
     """
     Pre-download the ML.NET SSWE word-embedding model into the correlation payload.
@@ -150,11 +157,6 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
         "https://aka.ms/mlnet-resources/Text/Sswe/sentiment.emd",
     ]
 
-    # The model is ~70 MB. When the server doesn't send a Content-Length to validate against, require
-    # at least this much so a truncated/early-closed response (which may not raise) is rejected
-    # instead of leaving a corrupt file in the payload.
-    min_expected_size = 60 * 1024 * 1024
-
     last_error: Optional[Exception] = None
     for attempt in range(1, 4):
         for url in urls:
@@ -162,24 +164,21 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
             try:
                 getLogger().info(f"Downloading ML.NET SSWE model from {url} (attempt {attempt})")
                 with urllib.request.urlopen(url, timeout=60) as response:
-                    content_length = response.getheader("Content-Length")
-                    expected_size = int(content_length) if content_length else None
                     with open(tmp_dest, "wb") as f:
                         shutil.copyfileobj(response, f)
 
-                size = os.path.getsize(tmp_dest)
-                if expected_size is not None:
-                    # Content-Length fully validates completeness, so trust it regardless of size
-                    # (the asset could legitimately shrink without becoming invalid).
-                    if size != expected_size:
-                        raise Exception(f"size {size} does not match Content-Length {expected_size}")
-                elif size < min_expected_size:
-                    # No Content-Length to validate against; fall back to a minimum-size floor to
-                    # reject an obviously truncated/early-closed response.
-                    raise Exception(f"size {size} is smaller than the expected minimum {min_expected_size}")
+                # The model is a fixed asset, so verify the exact hash to reject any truncated or
+                # corrupted download before it can be shipped in the payload.
+                sha256 = hashlib.sha256()
+                with open(tmp_dest, "rb") as f:
+                    for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                        sha256.update(chunk)
+                actual_hash = sha256.hexdigest()
+                if actual_hash != MLNET_SSWE_MODEL_SHA256:
+                    raise Exception(f"sha256 {actual_hash} does not match expected {MLNET_SSWE_MODEL_SHA256}")
 
                 os.replace(tmp_dest, dest)
-                getLogger().info(f"Downloaded ML.NET SSWE model ({size} bytes) to {dest}")
+                getLogger().info(f"Downloaded and verified ML.NET SSWE model to {dest}")
                 return True
             except Exception as e:
                 last_error = e

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -158,7 +158,8 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
     ]
 
     last_error: Optional[Exception] = None
-    for attempt in range(1, 4):
+    max_attempts = 3
+    for attempt in range(1, max_attempts + 1):
         for url in urls:
             tmp_dest = dest + ".tmp"
             try:
@@ -185,7 +186,9 @@ def try_provision_mlnet_resources(payload_dir: str) -> bool:
                 getLogger().warning(f"Failed to download ML.NET SSWE model from {url}: {e}")
                 if os.path.exists(tmp_dest):
                     os.remove(tmp_dest)
-        time.sleep(10)
+        # Only wait between attempts, not after the final one.
+        if attempt < max_attempts:
+            time.sleep(10)
 
     getLogger().warning(
         "Could not pre-provision the ML.NET SSWE model into the payload after retries "
@@ -1112,7 +1115,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
         if args.os_group == "windows":
             helix_pre_commands += [f"set \"MICROSOFTML_RESOURCE_PATH=%HELIX_CORRELATION_PAYLOAD%\\{MLNET_RESOURCES_PAYLOAD_SUBDIR}\""]
         else:
-            helix_pre_commands += [f"export MICROSOFTML_RESOURCE_PATH=$HELIX_CORRELATION_PAYLOAD/{MLNET_RESOURCES_PAYLOAD_SUBDIR}"]
+            helix_pre_commands += [f"export MICROSOFTML_RESOURCE_PATH=\"$HELIX_CORRELATION_PAYLOAD/{MLNET_RESOURCES_PAYLOAD_SUBDIR}\""]
 
     ci_setup_arguments.local_build = args.local_build
 

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -9,6 +9,7 @@ import shutil
 from subprocess import CalledProcessError
 import sys
 import tempfile
+import time
 from traceback import format_exc
 import urllib.request
 import xml.etree.ElementTree as ET
@@ -119,6 +120,64 @@ class RunPerformanceJobArgs:
     build_config: str = DEFAULT_BUILD_CONFIG
     live_libraries_build_config: Optional[str] = None
     cross_build: bool = False
+
+# Subdirectory (inside the Helix correlation payload) that holds the pre-downloaded ML.NET resources.
+# On the Helix machine this is referenced as <HELIX_CORRELATION_PAYLOAD>/mlnet-resources.
+MLNET_RESOURCES_PAYLOAD_SUBDIR = "mlnet-resources"
+
+def try_provision_mlnet_resources(payload_dir: str) -> bool:
+    """
+    Pre-download the ML.NET SSWE word-embedding model into the correlation payload.
+
+    The Microsoft.ML.Benchmarks (StochasticDualCoordinateAscentClassifierBench.TrainSentiment)
+    apply a pretrained word embedding (SSWE 'sentiment.emd', ~70 MB). ML.NET downloads this model
+    from https://aka.ms/mlnet-resources at benchmark runtime if it isn't already present on disk.
+    On the Helix machines that download regularly stalls, which hangs the entire mlnet work item
+    until it hits the work item timeout and is killed, discarding ALL mlnet results (so every mlnet
+    benchmark appears to fail).
+
+    To remove the runtime network dependency, we download the model here on the build agent (which
+    has reliable connectivity) into the correlation payload. The caller then points
+    MICROSOFTML_RESOURCE_PATH at it on the Helix machine so ML.NET loads the model from disk and
+    never makes the network call.
+
+    ML.NET resolves the model at <MICROSOFTML_RESOURCE_PATH>/Text/Sswe/sentiment.emd.
+
+    This is best-effort: if the download fails the function returns False and the caller skips
+    setting the env var, leaving the previous (runtime-download) behavior unchanged.
+    """
+    resource_root = os.path.join(payload_dir, MLNET_RESOURCES_PAYLOAD_SUBDIR)
+    dest = os.path.join(resource_root, "Text", "Sswe", "sentiment.emd")
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+    # The direct blob URL is the redirect target of the aka.ms link; prefer it to avoid the redirect,
+    # and fall back to the aka.ms link in case the blob path ever changes.
+    urls = [
+        "https://mlpublicassets.blob.core.windows.net/assets/Text/Sswe/sentiment.emd",
+        "https://aka.ms/mlnet-resources/Text/Sswe/sentiment.emd",
+    ]
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, 6):
+        for url in urls:
+            try:
+                getLogger().info(f"Downloading ML.NET SSWE model from {url} (attempt {attempt})")
+                with urllib.request.urlopen(url, timeout=300) as response, open(dest, "wb") as f:
+                    shutil.copyfileobj(response, f)
+                size = os.path.getsize(dest)
+                if size <= 0:
+                    raise Exception("downloaded file is empty")
+                getLogger().info(f"Downloaded ML.NET SSWE model ({size} bytes) to {dest}")
+                return True
+            except Exception as e:
+                last_error = e
+                getLogger().warning(f"Failed to download ML.NET SSWE model from {url}: {e}")
+        time.sleep(10)
+
+    getLogger().warning(
+        "Could not pre-provision the ML.NET SSWE model into the payload after retries "
+        f"(last error: {last_error}); ML.NET will attempt to download it at benchmark runtime.")
+    return False
 
 def get_pre_commands(
         os_group: str,
@@ -703,6 +762,14 @@ def run_performance_job(args: RunPerformanceJobArgs):
     getLogger().info("Copying performance repository to payload directory")
     shutil.copytree(args.performance_repo_dir, performance_payload_dir, ignore=shutil.ignore_patterns("CorrelationStaging", ".git", "artifacts", ".dotnet", ".venv", ".vs"))
 
+    # For ML.NET runs, pre-download the SSWE word-embedding model into the payload so the benchmarks
+    # don't have to fetch it from the network on the (flaky) Helix machines. See
+    # try_provision_mlnet_resources for details. The matching MICROSOFTML_RESOURCE_PATH env var is
+    # set in the Helix pre-commands below when this succeeds.
+    mlnet_resources_provisioned = False
+    if args.run_kind == "mlnet":
+        mlnet_resources_provisioned = try_provision_mlnet_resources(payload_dir)
+
     if args.internal:
         creator = ""
         scenario_arguments = ["--upload-to-perflab-container"]
@@ -1024,6 +1091,15 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     helix_pre_commands = get_pre_commands(args.os_group, args.os_distro, args.internal, args.runtime_type, args.codegen_type, args.build_config, v8_version)
     helix_post_commands = get_post_commands(args.os_group, args.internal, args.runtime_type)
+
+    # Point ML.NET at the SSWE model that was pre-downloaded into the correlation payload above, so it
+    # loads the word embedding from disk instead of downloading it at benchmark runtime (which hangs
+    # the work item on Helix). %HELIX_CORRELATION_PAYLOAD% is expanded by the shell at run time.
+    if mlnet_resources_provisioned:
+        if args.os_group == "windows":
+            helix_pre_commands += [f"set \"MICROSOFTML_RESOURCE_PATH=%HELIX_CORRELATION_PAYLOAD%\\{MLNET_RESOURCES_PAYLOAD_SUBDIR}\""]
+        else:
+            helix_pre_commands += [f"export MICROSOFTML_RESOURCE_PATH=$HELIX_CORRELATION_PAYLOAD/{MLNET_RESOURCES_PAYLOAD_SUBDIR}"]
 
     ci_setup_arguments.local_build = args.local_build
 


### PR DESCRIPTION
## Problem

Every ML.NET performance benchmark in the `performance-ci` pipeline (public definitionId=38) is timing out. The whole `mlnet` work item hangs and is eventually killed at the work item timeout, discarding **all** ML.NET results, so every mlnet test shows as failed.

Example failing run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1478345

## Root cause

The culprit is `StochasticDualCoordinateAscentClassifierBench.TrainSentiment`, which applies a pretrained SSWE word embedding. ML.NET downloads that model (`sentiment.emd`, ~70 MB) from `aka.ms/mlnet-resources` **at benchmark runtime** if it isn't already on disk. On the Helix machines that download now stalls (a hung connection, not a fast failure), so the benchmark hangs at `// BeforeActualRun` and the work item runs until it times out.

I reproduced this locally: with the model download blocked (stalling proxy) and the cache cleared, `TrainSentiment` hangs at `// BeforeActualRun` exactly like the Helix log; pre-provisioning the model + setting `MICROSOFTML_RESOURCE_PATH` runs it to completion with zero network. Updating `Microsoft.ML` (tested 5.0.0) does **not** help — the runtime download persists in all versions.

## Fix

In `scripts/run_performance_job.py`, for `run_kind == "mlnet"` only:

1. Download the SSWE model on the build agent (which has reliable connectivity) into the correlation payload at `mlnet-resources/Text/Sswe/sentiment.emd`, with retries and a blob→aka.ms fallback.
2. Set `MICROSOFTML_RESOURCE_PATH` to that payload dir via the Helix pre-commands, so ML.NET loads the embedding from disk and never makes the network call.

This is best-effort and strictly gated on `run_kind == "mlnet"`: non-mlnet runs are unaffected, and if the agent download fails it logs a warning and falls back to today's behavior.

## Why now?

The benchmark hasn't changed since 2019 and this isn't caused by any PR — the trigger is environmental on the download path (Helix egress/proxy/TLS tightening, blob throttling, and/or a .NET 9+ HttpClient behavior change against this endpoint — .NET 8 sometimes completed while 9.0/main/ubuntu hung). It manifests as a multi-hour timeout because it's a *stalled* read rather than a fast failure. Pre-staging the asset removes the dependency regardless of which is the actual culprit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>