### PR TITLE
Revert unnecessary --experimental-wasm-exnref flag for wasm perf (#5247)

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -443,12 +443,6 @@ def get_bdn_arguments(
             "--wasmProcessTimeout", "20",
         ]
 
-        # The runtime now uses the standardized exnref WASM exception-handling proposal,
-        # which V8 keeps behind --experimental-wasm-exnref. Pass it through to the engine
-        # via BDN's --wasmArgs (the escaped quotes keep it a single token on the Helix shell).
-        if javascript_engine == "v8":
-            bdn_arguments += ["\\\"--wasmArgs=--experimental-wasm-exnref\\\""]
-
         if is_aot:
             bdn_arguments += [
                 "--aotcompilermode", "wasm",
@@ -465,12 +459,6 @@ def get_bdn_arguments(
             "--buildTimeout", "1200",
             "--wasmProcessTimeout", "20"
         ]
-
-        # The runtime now uses the standardized exnref WASM exception-handling proposal,
-        # which V8 keeps behind --experimental-wasm-exnref. Pass it through to the engine
-        # via BDN's --wasmArgs (the escaped quotes keep it a single token on the Helix shell).
-        if javascript_engine == "v8":
-            bdn_arguments += ["\\\"--wasmArgs=--experimental-wasm-exnref\\\""]
 
     if runtime_type == "coreclr_r2r_interpreter":
         if os_group == "windows":


### PR DESCRIPTION
Reverts the `--experimental-wasm-exnref` flag added in #5247. That flag is unnecessary and has no effect.

**Why**
- Per dotnet/runtime#129849 (Failure 3, the wasm-perf leg), the perf leg's V8 engine is resolved solely from runtime's `eng/testing/BrowserVersions.props` (`linux_V8Version`) via jsvu. That issue explicitly states **no dotnet/performance change is required**; the fix is the `BrowserVersions.props` V8 bump (already landed).
- Verified directly against real `d8` 15.1.103 on **both win32 and linux64** (the platform jsvu installs on Helix): the runtime's own gate — the `wasm-feature-detect` 1.8.0 `exceptionsFinal()` probe used by `startup.ts` — returns **SUPPORTED**. V8 15.1.103 ships exnref by default.
- `--experimental-wasm-exnref` does not exist in V8 15.1 → reported as `unknown flag` (harmless, but noise).

No behavior change for passing runs; this just removes the dead flag.