### PR TITLE
Update BenchmarkDotNet to 0.16.0-nightly.20260703.576

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26261.101</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>11.0.0-preview.5.26261.101</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.16.0-nightly.20260518.1249</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.16.0-nightly.20260703.576</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>11.0.0-preview.5.26261.101</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26330.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -69,7 +69,7 @@
     <When Condition="'$(TargetFramework)' == 'net10.0'">
         <PropertyGroup>
             <LangVersion>14</LangVersion>
-            <ExtensionsVersion>10.0.0</ExtensionsVersion>
+            <ExtensionsVersion>10.0.3</ExtensionsVersion>
             <SystemVersion>10.0.0</SystemVersion>
         </PropertyGroup>
     </When>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -56,6 +56,7 @@
         <PropertyGroup>
             <LangVersion>12.0</LangVersion>
             <ExtensionsVersion>8.0.0</ExtensionsVersion>
+            <PrimitivesVersion>10.0.3</PrimitivesVersion>
             <SystemVersion>8.0.0</SystemVersion>
         </PropertyGroup>
     </When>
@@ -63,6 +64,7 @@
         <PropertyGroup>
             <LangVersion>13</LangVersion>
             <ExtensionsVersion>9.0.0</ExtensionsVersion>
+            <PrimitivesVersion>10.0.3</PrimitivesVersion>
             <SystemVersion>9.0.0</SystemVersion>
         </PropertyGroup>
     </When>
@@ -88,6 +90,13 @@
         </PropertyGroup>
     </Otherwise>
   </Choose>
+  <!-- BenchmarkDotNet -> Microsoft.Diagnostics.Runtime -> Azure.Identity -> Azure.Core (1.53.0) requires
+       Microsoft.Extensions.Primitives >= 10.0.3. Because Primitives is a direct reference, NuGet flags the
+       net8.0/net9.0 pins (8.0.0/9.0.0) as a downgrade (NU1605). Float only Primitives to the transitive floor
+       on those TFMs (set above); the implementation packages stay on their native TFM versions. -->
+  <PropertyGroup>
+    <PrimitivesVersion Condition="'$(PrimitivesVersion)' == ''">$(ExtensionsVersion)</PrimitivesVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Jil" Version="3.0.0-alpha2" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
@@ -101,7 +110,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="$(ExtensionsVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(PrimitivesVersion)" />
     <PackageReference Include="protobuf-net" Version="3.0.73" />
     <PackageReference Include="System.Drawing.Common" Version="$(SystemVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Formats.Cbor" Version="$(SystemVersion)" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))" />


### PR DESCRIPTION
Updates BenchmarkDotNet from `0.16.0-nightly.20260518.1249` to `0.16.0-nightly.20260703.576` (BDN `main` HEAD, commit `40736e96f0c528a4f90423e925d63fd7dd3f1bad`).

## Changes

- **`eng/Versions.props`** — `BenchmarkDotNetVersion` → `0.16.0-nightly.20260703.576`.
- **`src/benchmarks/micro/MicroBenchmarks.csproj`** — bump the `net10.0` `ExtensionsVersion` `10.0.0` → `10.0.3`. BDN `.576` upgrades `Microsoft.Diagnostics.Runtime` to `4.0.726401`, which transitively requires `Microsoft.Extensions.* >= 10.0.3` via `Azure.Core 1.53.0`; the `10.0.0` pin caused an `NU1605` downgrade error during restore.

## Verification

Ran both perf pipelines (702 fast, 1012 slow) pinning the runtime to a fixed baseline commit so BDN is the only variable, then compared against baseline via Kusto. No systematic measurement regression on any configuration:

| Area | Result |
|---|---|
| coreclr x64 (Viper Ubuntu/Windows) | median ~0.00%, balanced ±3% |
| coreclr Arm64 (Cobalt) | median -0.07%, within hardware noise floor |
| mono JIT / Interpreter | median ~0.00-0.04%, balanced ±3% |
| wasm interpreter v8 | median -0.05% (n=5683), balanced |
| wasm coreclr v8 | median -0.01% (n=5644), balanced |
| wasm aot v8 | median -0.08% (n=5290), balanced |

WASM queues were validated separately against a runtime commit with a known-good WASM setup. All three WASM variants (interpreter/coreclr/AOT) are clean noise. Regression rates for the non-WASM configs sit at or below the main-to-main noise floor.

**Verdict: no measurement impact — safe to merge.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
