### PR TITLE
Migrate perf artifact download steps to DownloadPipelineArtifact@2

### DIFF
--- a/eng/pipelines/templates/download-artifact-step.yml
+++ b/eng/pipelines/templates/download-artifact-step.yml
@@ -7,14 +7,12 @@ parameters:
 
 steps:
   # Download artifact
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     displayName: 'Download ${{ parameters.displayName }}'
     inputs:
       buildType: current
-      downloadType: single
-      downloadPath: '$(Build.SourcesDirectory)/__download__'
       artifactName: '${{ parameters.artifactName }}'
-      checkDownloadedFiles: true
+      targetPath: '$(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}'
 
   # Unzip artifact
   - task: ExtractFiles@1

--- a/eng/pipelines/templates/download-specific-artifact-step.yml
+++ b/eng/pipelines/templates/download-specific-artifact-step.yml
@@ -11,18 +11,17 @@ parameters:
 
 steps:
   # Download artifact
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     displayName: 'Download specific ${{ parameters.displayName }}'
     inputs:
       buildType: specific
       project: ${{ parameters.project }}
-      pipeline: ${{ parameters.pipeline }}
+      definition: ${{ parameters.pipeline }}
       buildVersionToDownload: specific
       branchName: ${{ parameters.branchName }}
-      buildId: ${{ parameters.buildId }}
-      downloadType: single
-      downloadPath: '$(Build.SourcesDirectory)/__download__'
+      pipelineId: ${{ parameters.buildId }}
       artifactName: '${{ parameters.artifactName }}'
+      targetPath: '$(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}'
 
   # Unzip artifact
   - task: ExtractFiles@1


### PR DESCRIPTION
## Summary

Migrates the shared artifact download templates from `DownloadBuildArtifacts@0` to `DownloadPipelineArtifact@2`:

- `eng/pipelines/templates/download-artifact-step.yml`
- `eng/pipelines/templates/download-specific-artifact-step.yml`

## Why

`DownloadBuildArtifacts@0` can only read legacy **Build Artifacts**. When a producer publishes a **Pipeline Artifact**, this task fails with `Unsupported artifact type: PipelineArtifact` and downloads nothing, causing the downstream `ExtractFiles@1` (Unzip) step to fail with `ENOENT`.

`DownloadPipelineArtifact@2` downloads **both** Build and Pipeline Artifacts (see the [task reference](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/download-pipeline-artifact-v2) — "Download build and pipeline artifacts"). Migrating the download side first is therefore backward compatible: it keeps working with today's Build Artifact producers and unblocks producers moving to Pipeline Artifacts.

## Context

dotnet/runtime is migrating `eng/pipelines` from `PublishBuildArtifacts@1` to `PublishPipelineArtifact@1` in dotnet/runtime#128498. That change makes the `BrowserWasm` / `BrowserWasmCoreCLR` artifacts (consumed here via `runtime-perf-job.yml` → `download-artifact-step.yml`) Pipeline Artifacts, which the current `DownloadBuildArtifacts@0` cannot read.

**Merge order:** this PR should merge **before** dotnet/runtime#128498 so the `runtime-wasm-perf` pipeline keeps working across the transition.

## Migration details

- Removed `downloadType` / `downloadPath` / `checkDownloadedFiles` (not applicable to `DownloadPipelineArtifact@2`).
- Added `targetPath: '$(Build.SourcesDirectory)/__download__/${{ parameters.artifactName }}'` so the existing `ExtractFiles@1` glob patterns (`__download__/<artifactName>/...`) continue to match.
- For the specific-build variant, mapped `pipeline` → `definition` and `buildId` → `pipelineId` (the `DownloadPipelineArtifact@2` input names).

> [!NOTE]
> This PR description and changes were generated with the assistance of GitHub Copilot.
