### PR TITLE
Update BenchmarkDotNet to 0.16.0-nightly.20260714.579

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26261.101</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>11.0.0-preview.5.26261.101</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.16.0-nightly.20260703.576</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.16.0-nightly.20260714.579</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>11.0.0-preview.5.26261.101</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26330.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>


### PR DESCRIPTION
Bumps `BenchmarkDotNetVersion` in `eng/Versions.props` from `0.16.0-nightly.20260703.576` to `0.16.0-nightly.20260714.579` (latest official BDN nightly).

## Verification

- **Pre-flight build:** MicroBenchmarks restores and builds cleanly for `net8.0`/`net9.0`/`net10.0` with the new package — zero NU1605, no `.csproj` changes required.
- **Perf pipelines:** dnceng/internal **702** (fast) and **1012** (slow, `runScheduledJobs=True`) run against an ADO test branch carrying only this version bump. Both completed; the only leg failures were transient "Send job to Helix" infra errors (1 leg each), not BDN failures.
- **Analysis:** Kusto comparison of the BDN579 test run vs the BDN576 baseline (main `c20a1f84`, #5258), holding the runtime product version constant, alongside a same-runtime BDN576 **noise floor** (main #5258 vs #5259).

## Verdict: SAFE

Median change is ≈ 0 across every configuration and regression rates sit within or below the noise floor.

```
Config                            Tests | BDN regr/impr | Noise regr/impr | Median%
--------------------------------- ----- | ------------- | --------------- | -------
Cobalt Arm64  micro (coreclr)      6586 | 22.0% / 18.2% | 17.1% / 21.4%   | +0.29
Cobalt Arm64  sve                   338 | 14.5% /  0.3% | 15.4% /  0.3%   | +0.01
Viper x64 lin micro coreclr        6588 |  5.3% /  5.9% |  7.3% /  7.8%   | -0.01
Viper x64 lin micro wasm           5685 |  6.5% /  3.6% |  4.7% /  3.6%   | -0.44
Viper x64 lin micro wasm-aot       5290 |  5.4% /  2.6% |  2.3% /  6.2%   | -0.28
Viper x64 lin mono JIT             6581 |  5.5% /  6.1% |  5.1% / 12.2%   |  0.00
Viper x64 lin mono AOT             5229 |  5.1% /  3.5% |  5.8% /  5.7%   |  0.00
Viper x64 lin mono Interpreter     6512 | 13.3% / 12.1% |  5.9% /  6.9%   | -0.10
Viper x64 win micro coreclr        6601 |  6.1% /  5.2% |  6.1% /  7.1%   | -0.02
```

Noise floor = two consecutive BDN576 main runs (#5258 vs #5259), runtime held constant. Regression = >5% worse on the default counter (direction-aware). The only elevated config, mono Interpreter, is symmetric (13.3% regr vs 12.1% impr, median −0.1) — added run-to-run variance, not a directional regression. Wasm coverage is included and the baseline's wasm jobs were healthy.
