### PR TITLE
[MAUI] Measure only APK in Android SOD jobs

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -82,12 +82,13 @@
 
 <!-- We only run the android tests from Windows machines (at least for now) -->
   <ItemGroup>
+    <!-- SizeOnDisk recursively measures pub, so stage only the APK and versions.json (removed by test.py in the lab). -->
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'SOD - %(Identity) APK Size')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('pixel'))">
-      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y</PreCommands>
+      <PreCommands>echo on; if not exist "%HELIX_WORKITEM_ROOT%\pub" mkdir "%HELIX_WORKITEM_ROOT%\pub"; copy /Y "%HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\%(HelixWorkItem.ApkName).apk" "%HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).apk"; copy /Y "%HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\versions.json" "%HELIX_WORKITEM_ROOT%\pub\versions.json"</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'SOD - %(Identity) Extracted Size')" Condition="!$(HelixTargetQueue.ToLowerInvariant().Contains('pixel'))">
-      <PreCommands>echo on; xcopy %HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName) %HELIX_WORKITEM_ROOT%\pub\ /E /I /Y; ren %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).apk %(HelixWorkItem.ApkName).zip; powershell.exe -nologo -noprofile -command "&amp; {Expand-Archive %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip -DestinationPath %HELIX_WORKITEM_ROOT%\pub\}"; del %HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip</PreCommands>
+      <PreCommands>echo on; if not exist "%HELIX_WORKITEM_ROOT%\pub" mkdir "%HELIX_WORKITEM_ROOT%\pub"; copy /Y "%HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\%(HelixWorkItem.ApkName).apk" "%HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).apk"; copy /Y "%HELIX_CORRELATION_PAYLOAD%\$(PreparePayloadOutDirectoryName)\%(HelixWorkItem.ScenarioDirectoryName)\versions.json" "%HELIX_WORKITEM_ROOT%\pub\versions.json"; ren "%HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).apk" "%(HelixWorkItem.ApkName).zip"; powershell.exe -nologo -noprofile -command "&amp; {Expand-Archive '%HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip' -DestinationPath '%HELIX_WORKITEM_ROOT%\pub'}"; del "%HELIX_WORKITEM_ROOT%\pub\%(HelixWorkItem.ApkName).zip"</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIAndroidScenario -> 'Device Startup - %(Identity)')">


### PR DESCRIPTION
## Summary

- stage only the signed APK and `versions.json` for MAUI Android SizeOnDisk work items
- prevent R8 mapping files, binlogs, and resource-designer assemblies from being reported as APK size
- preserve the existing extracted-APK measurement and leave startup/build-time payloads unchanged

## Background

Related: https://github.com/dotnet/android/issues/12184

@matouskozak The NativeAOT MAUI sample-content chart jumped from roughly 27 MB to 53 MB after dotnet/android enabled the trimmable typemap by default. The trimmable path also enables R8, which publishes a large `mapping.txt` beside the APK.

The SOD work item recursively copied the complete correlation output into `pub`, and `SizeOnDisk` recursively measured that directory. Running the unmodified scenario against a reproduced payload reported **52,797,806 bytes**, comprising:

- APK: 21,561,293 bytes
- `mapping.txt`: 28,318,349 bytes
- publish and restore binlogs: 2,056,465 bytes
- resource designer: 861,696 bytes
- `versions.json`: 3 bytes

The actual trimmable APK is smaller than the previous managed-typemap APK; the regression is in measurement composition.

This change stages only the APK and `versions.json` for the two SOD work items. `test.py` consumes and removes `versions.json` in lab runs before invoking SizeOnDisk.

## Validation

- APK Size: **21,561,293 bytes**, one counted APK
- Extracted Size: **53,077,875 bytes**, 1,435 APK member files
- no mapping files, binlogs, or loose build outputs are included in either result
