### PR TITLE
Measure only the app package in iOS SOD jobs

### DIFF
--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -76,12 +76,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- SizeOnDisk recursively measures pub, so stage only the IPA and versions.json (removed by test.py in the lab). -->
     <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) IPA Size')">
-      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub</PreCommands>
+      <PreCommands>mkdir -p "$HELIX_WORKITEM_ROOT/pub" &amp;&amp; cp "$HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/%(HelixWorkItem.IPAName).ipa" "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa" &amp;&amp; cp "$HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/versions.json" "$HELIX_WORKITEM_ROOT/pub/versions.json"</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
+    <!-- Extract only Payload so the app bundle is measured without the IPA's Symbols directory. -->
     <HelixWorkItem Include="@(MAUIiOSScenario -> 'SOD - %(Identity) Extracted Size')">
-      <PreCommands>cp -r $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName) $HELIX_WORKITEM_ROOT/pub; mv $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; unzip -d $HELIX_WORKITEM_ROOT/pub $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip; rm $HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip</PreCommands>
+      <PreCommands>mkdir -p "$HELIX_WORKITEM_ROOT/pub" &amp;&amp; cp "$HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/%(HelixWorkItem.IPAName).ipa" "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa" &amp;&amp; cp "$HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/%(HelixWorkItem.ScenarioDirectoryName)/versions.json" "$HELIX_WORKITEM_ROOT/pub/versions.json" &amp;&amp; mv "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).ipa" "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip" &amp;&amp; unzip -d "$HELIX_WORKITEM_ROOT/pub" "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip" 'Payload/*' &amp;&amp; rm "$HELIX_WORKITEM_ROOT/pub/%(HelixWorkItem.IPAName).zip"</PreCommands>
       <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot; $(ScenarioArgs)</Command>
     </HelixWorkItem>
     <HelixWorkItem Include="@(MAUIiOSScenario -> 'Build Time - %(Identity)')">


### PR DESCRIPTION
## Summary

- stage only the IPA and `versions.json` for the iOS SizeOnDisk work items
- extract only `Payload` so the extracted metric measures the installed app bundle

This is the iOS counterpart to #5265, which made the equivalent Android change and has already merged.

## Metric changes

`IPA Size` now reports exactly one file — the distributable package. Previously it also counted publish/restore binlogs and the dSYM bundles that sit beside the IPA in the publish directory, which inflated the metric by 2.5x–5.7x depending on configuration.

`Extracted Size` now reports only the app bundle. Previously it also counted Apple's top-level `Symbols` directory, which the .NET iOS SDK adds to the IPA via `_CreateIpaSymbols` for crash symbolication but which is not part of the installed app. That directory accounted for 40–72% of the previous totals, so expect a one-time step down in this series.

Both metrics keep their existing names, so the change appears as a level shift rather than a new series. Startup, memory, and build-time work items are untouched.

This also aligns the iOS scenarios with how app size is measured elsewhere: the package file for distribution size, and the `.app` bundle for installed size.