### PR TITLE
Update BenchmarkDotNet to 0.16.0-nightly.20260801.595

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26261.101</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>11.0.0-preview.5.26261.101</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>11.0.0-preview.5.26261.101</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.16.0-nightly.20260703.576</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.16.0-nightly.20260801.595</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>11.0.0-preview.5.26261.101</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26330.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>


### PR DESCRIPTION
Bumps `BenchmarkDotNet` from `0.16.0-nightly.20260703.576` to `0.16.0-nightly.20260801.595` (`eng/Versions.props`).

## Verification

Built BDN `595` from `dotnet/BenchmarkDotNet` master HEAD (commit `80844f2e`), verified the self-built package is byte-identical to the official MyGet nightly, pushed to the `benchmark-dotnet-prerelease` feed, and ran both perf pipelines (702 fast + 1012 slow with `runScheduledJobs=True`) on an ADO test branch with the runtime commit pinned identically to the baseline (`0eb548`, `rc.1.26381`) so **BDN is the only variable**.

### Verdict: SAFE — no BDN-attributable regressions

Every run configuration shows **symmetric** run-to-run variance (regressions ≈ improvements) with **median ≈ 0%**, matching the same-machine noise floor. All counts are at a 5% threshold.

```
Config                              Queue                 Tests   Regr         Impr         Median%
----------------------------------  --------------------  ------  -----------  -----------  -------
CoreCLR                             Cobalt Arm64           6,586  668 (10.1%)  502 ( 7.6%)   -0.03
CoreCLR                             Viper x64 (Ubuntu)     6,588  660 (10.0%)  688 (10.4%)   -0.17
CoreCLR                             Viper x64 (Windows)    6,601  545 ( 8.3%)  552 ( 8.4%)   +0.01
Mono - JIT                          Viper x64              6,581  386 ( 5.9%)  369 ( 5.6%)   -0.01
Mono - Interpreter                  Viper x64              6,512  348 ( 5.3%)  388 ( 6.0%)   -0.02
Mono - AOT + LLVM                   Viper x64              5,199  233 ( 4.5%)  272 ( 5.2%)    0.00
WASM - aot v8                       Viper x64              5,290  415 ( 7.8%)  326 ( 6.2%)   +0.03
WASM - coreclr v8                   Viper x64              5,644  653 (11.6%)  712 (12.6%)   -0.28
WASM - interp v8                    Viper x64              5,683  548 ( 9.6%)  444 ( 7.8%)   +0.05
SVE                                 Cobalt Arm64             338   11 ( 3.3%)    4 ( 1.2%)    0.00
Android scenarios                   Pixel                      4    0            1            0.00
iOS scenarios                       iPhone 17                  4    0            0            0.00

Noise floor (same-runtime main N-1 vs N, micro, 5% threshold):
Cobalt Arm64        6,586  589 ( 8.9%)  576 ( 8.7%)   0.00
Viper x64 (Ubuntu)  6,588  612 ( 9.3%)  597 ( 9.1%)  -0.06
Viper x64 (Windows) 6,601  327 ( 5.0%)  326 ( 4.9%)  -0.01
```

The BDN-update regression/improvement counts sit at or near the pure-noise floor and are balanced in both directions, confirming the deltas are measurement noise rather than a systematic BDN effect.

### Notes
- Only `eng/Versions.props` changed; the new BDN's transitive dependency delta (Perfolizer, Pragmastat, System.Memory) is already mirrored on `dotnet-public`, so **no `MicroBenchmarks.csproj` restore fix was required** (no `Microsoft.Extensions.Primitives` NU1605 floor change).
- Two 702 legs (R2RInterpreter arm64, mono-AOT x64) failed at *Send job to Helix* (transient infra, not a build/BDN break); those configs simply have no data this run.
- The 1012 arm64 `micro_mono` slot ran Mono JIT+Interpreter in scheduled mode vs the baseline's AOT+LLVM, so that specific cross-build comparison is config-mismatched and excluded — Mono is instead fully covered (all 3 configs, config-matched) on Viper x64 above.