### PR TITLE
[Android] Add CoreCLR full R2R scenario run

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -17,12 +17,8 @@
 
     <!-- Mono AOT -->
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'mono' and '$(CodegenType)' == 'AOT'">$(_MSBuildArgs);/p:RunAOTCompilation=true;/p:AndroidEnableProfiledAot=false</_MSBuildArgs>
-    <!-- CoreCLR JIT -->
-    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'JIT'">$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
-    <!-- CoreCLR R2R -->
-    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'R2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
-    <!-- CoreCLR R2R composite -->
-    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'R2RComposite'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=true</_MSBuildArgs>
+    <!-- CoreCLR full R2R -->
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'FullR2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:_MauiPublishReadyToRunPartial=false</_MSBuildArgs>
     <!-- CoreCLR NativeAOT -->
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
     

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -427,6 +427,26 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+  # Maui Android scenario benchmarks (CoreCLR Full R2R) - Release
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: FullR2R
+        buildConfig: Release
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
   # Maui Android scenario benchmarks (CoreCLR NativeAOT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:


### PR DESCRIPTION
## Summary

- add Release CoreCLR FullR2R MAUI Android runs on Pixel 8 and Galaxy A16
- opt into full R2R with `PublishReadyToRun=true` and `_MauiPublishReadyToRunPartial=false`
- remove unused Android CoreCLR JIT, R2R, and R2RComposite argument mappings

Related to https://github.com/dotnet/maui/issues/36587

## Validation

All 13 Android jobs succeeded in [internal build 3038952](https://dev.azure.com/dnceng/internal/_build/results?buildId=3038952).

- [FullR2R Pixel 8](https://dev.azure.com/dnceng/internal/_build/results?buildId=3038952&view=logs&j=df76184e-52fe-5fd2-024d-983107e11e0a)
- [FullR2R Galaxy A16](https://dev.azure.com/dnceng/internal/_build/results?buildId=3038952&view=logs&j=4b87c75e-a3f9-572a-5d64-f9625accde07)
