### PR TITLE
[Android] Update full R2R property

### DIFF
--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -18,7 +18,7 @@
     <!-- Mono AOT -->
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'mono' and '$(CodegenType)' == 'AOT'">$(_MSBuildArgs);/p:RunAOTCompilation=true;/p:AndroidEnableProfiledAot=false</_MSBuildArgs>
     <!-- CoreCLR full R2R -->
-    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'FullR2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:_MauiPublishReadyToRunPartial=false</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'FullR2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:MauiEnableFullReadyToRun=true</_MSBuildArgs>
     <!-- CoreCLR NativeAOT -->
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
     


### PR DESCRIPTION
## Summary

Use MAUI's public `MauiEnableFullReadyToRun` property for the Android SDK FullR2R measurements instead of the removed private `_MauiPublishReadyToRunPartial` switch.

This follows dotnet/maui#37094 and dotnet/android#12299.