### PR TITLE
Reenable Zstandard benchmarks

### DIFF
--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -276,8 +276,7 @@
     <Compile Remove="libraries\System.Reflection.Metadata\*.cs" />
   </ItemGroup>
 
-  <!-- Disabled: System.IO.Compression.Zstandard.dll is not yet included in the testhost payload. -->
-  <ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
     <Compile Remove="libraries\System.IO.Compression\Zstandard.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Reenable the Zstandard benchmarks.

Closes https://github.com/dotnet/runtime/issues/124952.