### PR TITLE
Add Pixel 10a mobile performance coverage

### DIFF
--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -76,6 +76,13 @@ parameters:
     type: object
     default:
       enabled: true
+  - name: androidMachines
+    type: object
+    default:
+      - logicalMachine: perfpixel4a
+        machinePool: ''
+      - logicalMachine: perfpixel10a
+        machinePool: Pixel10a
 
 jobs:
   - template: /eng/pipelines/performance/templates/perf-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
@@ -92,65 +99,70 @@ jobs:
 
     # Android CoreCLR JIT (includes static linking variant) — controlled by androidCoreclrJit toggle
     - ${{ if eq(parameters.androidCoreclrJit.enabled, true) }}:
-      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-        parameters:
-          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-            - windows_x64
-          jobParameters:
-            runtimeType: AndroidCoreCLR
-            codeGenType: JIT
-            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-            runKind: android_scenarios
-            isScenario: true
-            logicalMachine: 'perfpixel4a'
-            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-            ${{ each parameter in parameters.jobParameters }}:
-              ${{ parameter.key }}: ${{ parameter.value }}
+      - ${{ each machine in parameters.androidMachines }}:
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+              - windows_x64
+            jobParameters:
+              runtimeType: AndroidCoreCLR
+              codeGenType: JIT
+              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+              runKind: android_scenarios
+              isScenario: true
+              logicalMachine: ${{ machine.logicalMachine }}
+              machinePool: ${{ machine.machinePool }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
-      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-        parameters:
-          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-            - windows_x64
-          jobParameters:
-            runtimeType: AndroidCoreCLR
-            codeGenType: JIT
-            linkingType: static
-            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-            runKind: android_scenarios
-            isScenario: true
-            logicalMachine: 'perfpixel4a'
-            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-            ${{ each parameter in parameters.jobParameters }}:
-              ${{ parameter.key }}: ${{ parameter.value }}
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+              - windows_x64
+            jobParameters:
+              runtimeType: AndroidCoreCLR
+              codeGenType: JIT
+              linkingType: static
+              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+              runKind: android_scenarios
+              isScenario: true
+              logicalMachine: ${{ machine.logicalMachine }}
+              machinePool: ${{ machine.machinePool }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
     # Android CoreCLR R2R — controlled by androidCoreclrR2r toggle
     - ${{ if eq(parameters.androidCoreclrR2r.enabled, true) }}:
-      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-        parameters:
-          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-            - windows_x64
-          jobParameters:
-            runtimeType: AndroidCoreCLR
-            codeGenType: R2R
-            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-            runKind: android_scenarios
-            isScenario: true
-            logicalMachine: 'perfpixel4a'
-            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-            ${{ each parameter in parameters.jobParameters }}:
-              ${{ parameter.key }}: ${{ parameter.value }}
+      - ${{ each machine in parameters.androidMachines }}:
+        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+          parameters:
+            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+            buildConfig: release
+            runtimeFlavor: coreclr
+            platforms:
+              - windows_x64
+            jobParameters:
+              runtimeType: AndroidCoreCLR
+              codeGenType: R2R
+              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+              runKind: android_scenarios
+              isScenario: true
+              logicalMachine: ${{ machine.logicalMachine }}
+              machinePool: ${{ machine.machinePool }}
+              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+              ${{ each parameter in parameters.jobParameters }}:
+                ${{ parameter.key }}: ${{ parameter.value }}
 
   # Mono microbenchmarks — controlled by monoMicro toggle
   - ${{ if eq(parameters.monoMicro.enabled, true) }}:

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -76,13 +76,6 @@ parameters:
     type: object
     default:
       enabled: true
-  - name: androidMachines
-    type: object
-    default:
-      - logicalMachine: perfpixel4a
-        machinePool: ''
-      - logicalMachine: perfpixel10a
-        machinePool: Pixel10a
 
 jobs:
   - template: /eng/pipelines/performance/templates/perf-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
@@ -99,70 +92,123 @@ jobs:
 
     # Android CoreCLR JIT (includes static linking variant) — controlled by androidCoreclrJit toggle
     - ${{ if eq(parameters.androidCoreclrJit.enabled, true) }}:
-      - ${{ each machine in parameters.androidMachines }}:
-        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-          parameters:
-            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-              - windows_x64
-            jobParameters:
-              runtimeType: AndroidCoreCLR
-              codeGenType: JIT
-              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-              runKind: android_scenarios
-              isScenario: true
-              logicalMachine: ${{ machine.logicalMachine }}
-              machinePool: ${{ machine.machinePool }}
-              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-              ${{ each parameter in parameters.jobParameters }}:
-                ${{ parameter.key }}: ${{ parameter.value }}
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: JIT
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel4a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
 
-        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-          parameters:
-            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-              - windows_x64
-            jobParameters:
-              runtimeType: AndroidCoreCLR
-              codeGenType: JIT
-              linkingType: static
-              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-              runKind: android_scenarios
-              isScenario: true
-              logicalMachine: ${{ machine.logicalMachine }}
-              machinePool: ${{ machine.machinePool }}
-              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-              ${{ each parameter in parameters.jobParameters }}:
-                ${{ parameter.key }}: ${{ parameter.value }}
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: JIT
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel10a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
+
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: JIT
+            linkingType: static
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel4a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
+
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: JIT
+            linkingType: static
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel10a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
 
     # Android CoreCLR R2R — controlled by androidCoreclrR2r toggle
     - ${{ if eq(parameters.androidCoreclrR2r.enabled, true) }}:
-      - ${{ each machine in parameters.androidMachines }}:
-        - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-          parameters:
-            jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-            buildConfig: release
-            runtimeFlavor: coreclr
-            platforms:
-              - windows_x64
-            jobParameters:
-              runtimeType: AndroidCoreCLR
-              codeGenType: R2R
-              projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-              runKind: android_scenarios
-              isScenario: true
-              logicalMachine: ${{ machine.logicalMachine }}
-              machinePool: ${{ machine.machinePool }}
-              runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-              performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-              ${{ each parameter in parameters.jobParameters }}:
-                ${{ parameter.key }}: ${{ parameter.value }}
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: R2R
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel4a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
+
+      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+        parameters:
+          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+          buildConfig: release
+          runtimeFlavor: coreclr
+          platforms:
+            - windows_x64
+          jobParameters:
+            runtimeType: AndroidCoreCLR
+            codeGenType: R2R
+            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+            runKind: android_scenarios
+            isScenario: true
+            logicalMachine: 'perfpixel10a'
+            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+            ${{ each parameter in parameters.jobParameters }}:
+              ${{ parameter.key }}: ${{ parameter.value }}
 
   # Mono microbenchmarks — controlled by monoMicro toggle
   - ${{ if eq(parameters.monoMicro.enabled, true) }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -413,6 +413,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -433,6 +434,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -455,6 +457,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -475,6 +478,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -496,6 +500,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -595,6 +600,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:
@@ -615,6 +621,7 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-pixel10a
         - win-x64-android-arm64-galaxy
       isPublic: false
       jobParameters:

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -134,6 +134,18 @@ jobs:
       machinePool: Pixel8
       ${{ insert }}: ${{ parameters.jobParameters }}
 
+- ${{ if and(containsValue(parameters.buildMachines, 'win-x64-android-arm64-pixel10a'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 Pixel 10a only used in private builds currently
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: windows
+      archType: x64
+      osVersion: 22H2
+      pool:
+        vmImage: 'windows-2022'
+      queue: Windows.11.Amd64.Pixel.10.Perf
+      machinePool: Pixel10a
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
 - ${{ if and(containsValue(parameters.buildMachines, 'win-x64-android-arm64-galaxy'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 Galaxy only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:

--- a/eng/pipelines/templates/run-performance-job.yml
+++ b/eng/pipelines/templates/run-performance-job.yml
@@ -55,7 +55,7 @@ parameters:
   javascriptEngine: ''              # optional -- JavaScript engine to use
   iOSLlvmBuild: false               # optional -- Whether to build iOS with LLVM
   iOSStripSymbols: true            # optional -- Whether to strip symbols from the iOS build
-  machinePool: ''                   # optional -- Machine pool name (e.g. Pixel8, Pixel10a, GalaxyA16, iPhone17)
+  machinePool: ''                   # optional -- Machine pool name (e.g. Pixel8, GalaxyA16, iPhone17)
   additionalSetupParameters: ''     # optional -- Additional arguments to pass to the script
   liveLibrariesBuildConfig: ''      # optional -- Build configuration when generating Core_Root for libraries
   crossBuild: false                 # optional -- Whether the Core_Root is being cross-compiled

--- a/eng/pipelines/templates/run-performance-job.yml
+++ b/eng/pipelines/templates/run-performance-job.yml
@@ -55,7 +55,7 @@ parameters:
   javascriptEngine: ''              # optional -- JavaScript engine to use
   iOSLlvmBuild: false               # optional -- Whether to build iOS with LLVM
   iOSStripSymbols: true            # optional -- Whether to strip symbols from the iOS build
-  machinePool: ''                   # optional -- Machine pool name (e.g. Pixel8, GalaxyA16, iPhone17)
+  machinePool: ''                   # optional -- Machine pool name (e.g. Pixel8, Pixel10a, GalaxyA16, iPhone17)
   additionalSetupParameters: ''     # optional -- Additional arguments to pass to the script
   liveLibrariesBuildConfig: ''      # optional -- Build configuration when generating Core_Root for libraries
   crossBuild: false                 # optional -- Whether the Core_Root is being cross-compiled

--- a/helix.yml
+++ b/helix.yml
@@ -6,6 +6,7 @@ jobs:
     variables:
       architecture: 'x64'
       queue: ''
+      machinePool: ''
       framework: 'net8.0'
       runCategories: ''
       kind: ''
@@ -31,7 +32,7 @@ jobs:
         localFolder: '{{ performanceRepoDir }}'
     dockerfile: performance/eng/performance/helix_sender.Dockerfile
     dockerImageName: helix_sender
-    dockerCommand: python ./performance/scripts/run_performance_job.py --queue {{ queue }} --framework {{ framework }} --run-kind {{ kind }} --core-root-dir /performance/coreRoot --performance-repo-dir /performance/performance --architecture {{ architecture }} --os-group {{ osGroup }} --os-sub-group {{ osSubGroup }} {% if internal %}--internal{% endif %} --run-categories "{{ runCategories }}" {% if bdnArgs != blank and bdnArgs != empty %} --extra-bdn-args "{{ bdnArgs }}" {% endif %} --partition-count {{ partitionCount }} --project-file {{ projectFile }} {% if isScenario %} --is-scenario {% endif %} {% if isLocalBuild %} --local-build {% endif %}
+    dockerCommand: python ./performance/scripts/run_performance_job.py --queue {{ queue }} --framework {{ framework }} --run-kind {{ kind }} --core-root-dir /performance/coreRoot --performance-repo-dir /performance/performance --architecture {{ architecture }} --os-group {{ osGroup }} --os-sub-group {{ osSubGroup }} {% if internal %}--internal{% endif %} --run-categories "{{ runCategories }}" {% if bdnArgs != blank and bdnArgs != empty %} --extra-bdn-args "{{ bdnArgs }}" {% endif %} --partition-count {{ partitionCount }} --project-file {{ projectFile }} {% if isScenario %} --is-scenario {% endif %} {% if isLocalBuild %} --local-build {% endif %} {% if machinePool != blank and machinePool != empty %} --machine-pool {{ machinePool }} {% endif %}
     dockerContextDirectory: .
     arguments: '--env HelixAccessToken --env SYSTEM_ACCESSTOKEN'
     environmentVariables:
@@ -98,6 +99,15 @@ profiles:
         variables:
           osGroup: windows
           queue: Windows.11.Amd64.Pixel.Perf
+          machinePool: Pixel8
+
+  win-x64-android-arm64-pixel10a:
+    jobs:
+      benchmark:
+        variables:
+          osGroup: windows
+          queue: Windows.11.Amd64.Pixel.10.Perf
+          machinePool: Pixel10a
     
   win-x64-android-arm64-galaxy:
     jobs:

--- a/helix.yml
+++ b/helix.yml
@@ -6,7 +6,6 @@ jobs:
     variables:
       architecture: 'x64'
       queue: ''
-      machinePool: ''
       framework: 'net8.0'
       runCategories: ''
       kind: ''
@@ -32,7 +31,7 @@ jobs:
         localFolder: '{{ performanceRepoDir }}'
     dockerfile: performance/eng/performance/helix_sender.Dockerfile
     dockerImageName: helix_sender
-    dockerCommand: python ./performance/scripts/run_performance_job.py --queue {{ queue }} --framework {{ framework }} --run-kind {{ kind }} --core-root-dir /performance/coreRoot --performance-repo-dir /performance/performance --architecture {{ architecture }} --os-group {{ osGroup }} --os-sub-group {{ osSubGroup }} {% if internal %}--internal{% endif %} --run-categories "{{ runCategories }}" {% if bdnArgs != blank and bdnArgs != empty %} --extra-bdn-args "{{ bdnArgs }}" {% endif %} --partition-count {{ partitionCount }} --project-file {{ projectFile }} {% if isScenario %} --is-scenario {% endif %} {% if isLocalBuild %} --local-build {% endif %} {% if machinePool != blank and machinePool != empty %} --machine-pool {{ machinePool }} {% endif %}
+    dockerCommand: python ./performance/scripts/run_performance_job.py --queue {{ queue }} --framework {{ framework }} --run-kind {{ kind }} --core-root-dir /performance/coreRoot --performance-repo-dir /performance/performance --architecture {{ architecture }} --os-group {{ osGroup }} --os-sub-group {{ osSubGroup }} {% if internal %}--internal{% endif %} --run-categories "{{ runCategories }}" {% if bdnArgs != blank and bdnArgs != empty %} --extra-bdn-args "{{ bdnArgs }}" {% endif %} --partition-count {{ partitionCount }} --project-file {{ projectFile }} {% if isScenario %} --is-scenario {% endif %} {% if isLocalBuild %} --local-build {% endif %}
     dockerContextDirectory: .
     arguments: '--env HelixAccessToken --env SYSTEM_ACCESSTOKEN'
     environmentVariables:
@@ -99,7 +98,6 @@ profiles:
         variables:
           osGroup: windows
           queue: Windows.11.Amd64.Pixel.Perf
-          machinePool: Pixel8
 
   win-x64-android-arm64-pixel10a:
     jobs:
@@ -107,7 +105,6 @@ profiles:
         variables:
           osGroup: windows
           queue: Windows.11.Amd64.Pixel.10.Perf
-          machinePool: Pixel10a
     
   win-x64-android-arm64-galaxy:
     jobs:

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -1144,8 +1144,10 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if wasm:
         args.run_env_vars["PERFLAB_EVALUATE_OVERHEAD"] = "1"
 
-    # Set device name from machine pool for mobile queues
-    if args.machine_pool and args.queue and args.queue in (
+    # Pixel 10a runtime jobs use a logical machine rather than a machine pool.
+    if args.logical_machine == "perfpixel10a" and args.queue == "Windows.11.Amd64.Pixel.10.Perf":
+        args.run_env_vars["DEVICE_NAME"] = "Pixel10a"
+    elif args.machine_pool and args.queue and args.queue in (
         "Windows.11.Amd64.Pixel.Perf",
         "Windows.11.Amd64.Pixel.10.Perf",
         "Windows.11.Amd64.Galaxy.Lowend.Perf",

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -1144,10 +1144,8 @@ def run_performance_job(args: RunPerformanceJobArgs):
     if wasm:
         args.run_env_vars["PERFLAB_EVALUATE_OVERHEAD"] = "1"
 
-    # Pixel 10a runtime jobs use a logical machine rather than a machine pool.
-    if args.logical_machine == "perfpixel10a" and args.queue == "Windows.11.Amd64.Pixel.10.Perf":
-        args.run_env_vars["DEVICE_NAME"] = "Pixel10a"
-    elif args.machine_pool and args.queue and args.queue in (
+    # Set device name from machine pool for mobile queues
+    if args.machine_pool and args.queue and args.queue in (
         "Windows.11.Amd64.Pixel.Perf",
         "Windows.11.Amd64.Pixel.10.Perf",
         "Windows.11.Amd64.Galaxy.Lowend.Perf",

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -438,6 +438,7 @@ def logical_machine_to_queue(logical_machine: str, internal: bool, os_group: str
                 "perftiger": "Windows.11.Amd64.Tiger.Perf",
                 "perftiger_crossgen": "Windows.11.Amd64.Tiger.Perf",
                 "perfpixel4a": "Windows.11.Amd64.Pixel.Perf",
+                "perfpixel10a": "Windows.11.Amd64.Pixel.10.Perf",
                 "perfampere": "Windows.Server.Arm64.Perf",
                 "perfviper": "Windows.11.Amd64.Viper.Perf",
                 "cloudvm": "Windows.10.Amd64"
@@ -1146,6 +1147,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     # Set device name from machine pool for mobile queues
     if args.machine_pool and args.queue and args.queue in (
         "Windows.11.Amd64.Pixel.Perf",
+        "Windows.11.Amd64.Pixel.10.Perf",
         "Windows.11.Amd64.Galaxy.Lowend.Perf",
         "Mac.iPhone.17.Perf",
     ):

--- a/src/scenarios/shared/androidhelper.py
+++ b/src/scenarios/shared/androidhelper.py
@@ -21,6 +21,39 @@ class AndroidHelper:
         # Original values for Android package verifier settings
         self.startverifierverifyadbinstalls = None
         self.startpackageverifierenable = None
+        self.startforceenablepssprofiling = None
+
+    def enable_pss_profiling(self):
+        getLogger().info("Capturing current force_enable_pss_profiling setting")
+        cmdline = xharness_adb() + [
+            'shell', 'settings', 'get', 'global', 'force_enable_pss_profiling'
+        ]
+        get_pss_profiling_cmd = RunCommand(cmdline, verbose=True)
+        get_pss_profiling_cmd.run()
+        self.startforceenablepssprofiling = get_pss_profiling_cmd.stdout.strip()
+
+        if self.startforceenablepssprofiling != '1':
+            getLogger().info("Enabling PSS profiling for Android memory consumption")
+            cmdline = xharness_adb() + [
+                'shell', 'settings', 'put', 'global', 'force_enable_pss_profiling', '1'
+            ]
+            RunCommand(cmdline, verbose=True).run()
+
+    def restore_pss_profiling(self):
+        if self.startforceenablepssprofiling is None:
+            return
+
+        getLogger().info("Restoring force_enable_pss_profiling to its pretest value")
+        if self.startforceenablepssprofiling == '' or self.startforceenablepssprofiling.lower() == 'null':
+            cmdline = xharness_adb() + [
+                'shell', 'settings', 'delete', 'global', 'force_enable_pss_profiling'
+            ]
+        else:
+            cmdline = xharness_adb() + [
+                'shell', 'settings', 'put', 'global', 'force_enable_pss_profiling', self.startforceenablepssprofiling
+            ]
+        RunCommand(cmdline, verbose=True).run()
+        self.startforceenablepssprofiling = None
 
     def setup_device(self, packagename: str, packagepath: str, animationsdisabled: bool, forcewaitstart: bool = True, skip_install: bool = False, skip_xharness_warmup: bool = False, skip_package_verifier: bool = False, skip_test_launch: bool = False, screen_timeout_ms: int = 2 * 60 * 1000):
         if not skip_install and packagepath is None:
@@ -375,7 +408,12 @@ class AndroidHelper:
             'input',
             'keyevent'
         ]
-                
+
+        try:
+            self.restore_pss_profiling()
+        except CalledProcessError:
+            getLogger().warning("Failed to restore force_enable_pss_profiling", exc_info=True)
+
         if not skip_uninstall:
             getLogger().info("Stopping App for uninstall")
             RunCommand(self.stopappcommand, verbose=True).run()

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -487,6 +487,13 @@ ex: C:\repos\performance;C:\repos\runtime
                     'proc'
                 ]
 
+                captureMemoryStatsCmd = xharness_adb() + [
+                    'shell',
+                    'dumpsys',
+                    'meminfo',
+                    self.packagename
+                ]
+
                 clearLogsCmd = xharness_adb() + [
                     'logcat',
                     '-c'
@@ -500,6 +507,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     startStats = RunCommand(androidHelper.startappcommand, verbose=True)
                     startStats.run()
                     time.sleep(self.runtimeseconds)
+                    RunCommand(captureMemoryStatsCmd, verbose=True).run()
                     captureProcStats = RunCommand(captureProcStatsCmd, verbose=True)
                     captureProcStats.run()
 

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -467,8 +467,8 @@ ex: C:\repos\performance;C:\repos\runtime
 
             androidHelper = AndroidHelper()
             try:
-                androidHelper.enable_pss_profiling()
                 androidHelper.setup_device(self.packagename, self.packagepath, self.animationsdisabled)
+                androidHelper.enable_pss_profiling()
 
                 # Create the fullydrawn command
                 clearProcStatsCmd = xharness_adb() + [

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -467,6 +467,7 @@ ex: C:\repos\performance;C:\repos\runtime
 
             androidHelper = AndroidHelper()
             try:
+                androidHelper.enable_pss_profiling()
                 androidHelper.setup_device(self.packagename, self.packagepath, self.animationsdisabled)
 
                 # Create the fullydrawn command
@@ -513,7 +514,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     regexSearchString = r"TOTAL: [0-9]{2,3}% \((\d+MB-\d+MB-\d+MB\/\d+MB-\d+MB-\d+MB\/\d+MB-\d+MB-\d+MB over \d+)\)"
                     dirtyCapture = re.search(regexSearchString, captureProcStats.stdout)
                     if not dirtyCapture:
-                        raise Exception("Failed to capture the reported start time!")
+                        raise Exception("Failed to capture Android memory statistics from procstats!")
                     splitNumber = dirtyCapture.group(1).replace("MB", "").strip().split(" over ")
                     splitMemory = splitNumber[0].split("/")
                     pss = splitMemory[0].split("-")


### PR DESCRIPTION
## Summary
- add Pixel 10a to all existing Pixel SDK/MAUI performance test matrices
- run the runtime Android JIT, static-linking, and R2R variants on Pixel 10a
- map the new queue to the `Pixel10a` device name while preserving Pixel 8 coverage

## Testing
- parsed the changed YAML files
- validated Python syntax and Pixel 8/Pixel 10a matrix parity

Internal Run: https://dev.azure.com/dnceng/internal/_build/results?buildId=3063540&view=results