### PR TITLE
Fix MAUI Android inner loop MSBuild arg splitting on Helix

### DIFF
--- a/eng/performance/maui_scenarios_android_innerloop.proj
+++ b/eng/performance/maui_scenarios_android_innerloop.proj
@@ -16,8 +16,13 @@
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'mono'">/p:UseMonoRuntime=true</_MSBuildArgs>
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">/p:UseMonoRuntime=false</_MSBuildArgs>
 
-    <!-- CoreCLR: disable ReadyToRun so inner loop measures JIT behavior -->
-    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
+    <!-- CoreCLR: disable ReadyToRun so inner loop measures JIT behavior.
+         Use spaces (not ';') to separate args: _MSBuildArgs is passed as a
+         single quoted argument in the Helix PreCommands/Command, and Helix
+         treats ';' as a command separator when generating the run script
+         (that's why the env-var 'set ...;set ...' blocks work). A ';' here
+         would split the quoted argument across separate command lines. -->
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">$(_MSBuildArgs) /p:PublishReadyToRun=false /p:PublishReadyToRunComposite=false</_MSBuildArgs>
 
     <!-- AndroidRid: defaults based on target OS but can be overridden.
          Windows targets physical devices; Linux targets emulators. -->


### PR DESCRIPTION
## Problem

An inner loop MAUI Android device run showed MSBuild `/p:` arguments being executed as standalone shell commands:

```
(.venv) D:\...>/p:PublishReadyToRun=false
The filename, directory name, or volume label syntax is incorrect.

(.venv) D:\...>/p:PublishReadyToRunComposite=false /p:RuntimeIdentifier=android-arm64 /p:SupportedOSPlatformVersion=24 /p:TargetFrameworks=net11.0-android"
The filename, directory name, or volume label syntax is incorrect.
```

`setup_helix.py`'s restore also silently received only the first arg (`/p:UseMonoRuntime=false`), dropping the R2R args.

## Root cause

In `eng/performance/maui_scenarios_android_innerloop.proj`, the coreclr branch built `_MSBuildArgs` joining args with `;`:

```
$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false
```

`_MSBuildArgs` is passed to Helix as a single quoted argument (`--msbuild-args "$(_MSBuildArgs)"` and `setup_helix.py ... "$(_MSBuildArgs)"`). Helix treats `;` as a **command separator** when generating the run script — the same behavior the `set X=Y;set A=B` env-var blocks rely on. So the semicolons split the quoted argument across separate command lines: the first piece kept the opening quote, and the remaining `/p:` pieces ran as their own commands.

Mono builds were unaffected because that path never introduced a `;`.

## Fix

Use spaces instead of `;`, consistent with every other append in that PropertyGroup. The Python side (`re.split(r'[;\s]+', ...)` in both `runner.py` and `setup_helix.py`) already splits on whitespace, so args still parse correctly into the `subprocess.run` argument list — and now every arg actually reaches Python and MSBuild.