### PR TITLE
Fail Linux Helix jobs after prerequisite errors

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -336,7 +336,7 @@ def get_pre_commands(
                 # machine_health takes the machine out of Helix rotation and notifies the perf team.
                 # Runs directly from the correlation payload since the venv/PYTHONPATH are not set up
                 # yet at this point. Never allowed to change the (already failing) exit code.
-                'if [ "x$PERF_PREREQS_INSTALL_FAILED" = "x1" ]; then python3 "$HELIX_CORRELATION_PAYLOAD/performance/scripts/machine_health.py" check || true; fi'
+                'if [ "x$PERF_PREREQS_INSTALL_FAILED" = "x1" ]; then python3 "$HELIX_CORRELATION_PAYLOAD/performance/scripts/machine_health.py" check || true; exit 1; fi'
             ]
 
     # Set MONO_ENV_OPTIONS with for Mono Interpreter runs


### PR DESCRIPTION
## Summary

- exit Linux Helix work items from the shared prerequisite pre-command when setup fails
- run `machine_health.py` before exiting and ignore only its status so it cannot mask the prerequisite failure
- make custom scenario projects fail consistently without project-specific guards

## Validation

- `python -m py_compile scripts/run_performance_job.py`
- generated Linux pre-command inspection
- shell execution with machine health succeeding, failing, and prerequisites succeeding