### PR TITLE
Report correct runtime commit for SDK measurements

### DIFF
--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -362,26 +362,6 @@ jobs:
 ###########################################
 
 - ${{ if parameters.runPrivateJobs }}:
-  # Temporary validation job: Android CoreCLR Release on one device.
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: Default
-        buildConfig: Release
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-- ${{ if false }}: # Existing private jobs disabled for targeted validation.
 
   # Scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -362,6 +362,26 @@ jobs:
 ###########################################
 
 - ${{ if parameters.runPrivateJobs }}:
+  # Temporary validation job: Android CoreCLR Release on one device.
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: Default
+        buildConfig: Release
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+- ${{ if false }}: # Existing private jobs disabled for targeted validation.
 
   # Scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -308,7 +308,8 @@ class CiSetupArgs:
             target_windows: bool = True,
             physical_promotion_status: Optional[str] = None,
             r2r_status: Optional[str] = None,
-            experiment_name: Optional[str] = None):
+            experiment_name: Optional[str] = None,
+            collect_sdk_repository_commits: bool = False):
         self.channel = channel
         self.quiet = quiet
         self.commit_sha = commit_sha
@@ -337,6 +338,7 @@ class CiSetupArgs:
         self.physical_promotion_status = physical_promotion_status
         self.r2r_status = r2r_status
         self.experiment_name = experiment_name
+        self.collect_sdk_repository_commits = collect_sdk_repository_commits
         self.perf_repo_branch = "main"
         self.only_sanity_check = False
 
@@ -459,6 +461,13 @@ def main(args: CiSetupArgs):
 
         assert commit_sha is not None # verified at start of main
 
+        runtime_commit_hash = None
+        if args.collect_sdk_repository_commits:
+            try:
+                runtime_commit_hash = dotnet.get_runtime_commit_hash(commit_sha)
+            except (OSError, ValueError) as error:
+                getLogger().warning(f"Unable to resolve runtime commit from dotnet/dotnet commit {commit_sha}: {error}")
+
         if args.local_build:
             source_timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         elif(args.commit_time is not None):
@@ -494,6 +503,10 @@ def main(args: CiSetupArgs):
             out_file.write(variable_format % ('PERFLAB_BRANCH', branch))
             out_file.write(variable_format % ('PERFLAB_PERFHASH', perfHash))
             out_file.write(variable_format % ('PERFLAB_HASH', commit_sha))
+            if args.collect_sdk_repository_commits:
+                out_file.write(variable_format % ('PERFLAB_DATA_dotnet_commit_hash', commit_sha))
+            if runtime_commit_hash:
+                out_file.write(variable_format % ('PERFLAB_DATA_runtime_commit_hash', runtime_commit_hash))
             out_file.write(variable_format % ('PERFLAB_QUEUE', args.queue))
             out_file.write(variable_format % ('PERFLAB_BUILDNUM', args.build_number))
             out_file.write(variable_format % ('PERFLAB_BUILDARCH', args.architecture))

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -35,6 +35,8 @@ from performance.tracer import setup_tracing, get_tracer
 setup_tracing()
 tracer = get_tracer()
 
+DOTNET_SOURCE_MANIFEST_URL = "https://raw.githubusercontent.com/dotnet/dotnet/{commit}/src/source-manifest.json"
+
 @tracer.start_as_current_span(name="info")
 def info(verbose: bool) -> None:
     """
@@ -617,6 +619,26 @@ def get_dotnet_sdk(
 
     with open(path.join(sdk_path, sdk, '.version')) as sdk_version_file:
         return sdk_version_file.readline().strip()
+
+def get_runtime_commit_hash(dotnet_commit_hash: str) -> str:
+    source_manifest_url = DOTNET_SOURCE_MANIFEST_URL.format(commit=dotnet_commit_hash)
+    with urlopen(source_manifest_url, timeout=60) as response:
+        source_manifest = json.load(response)
+
+    if not isinstance(source_manifest, dict):
+        raise ValueError(f"Invalid source manifest in {source_manifest_url}")
+
+    repositories = source_manifest.get("repositories")
+    if not isinstance(repositories, list):
+        raise ValueError(f"Repository list not found in {source_manifest_url}")
+
+    for repository in repositories:
+        if isinstance(repository, dict) and repository.get("path") == "runtime":
+            runtime_commit_hash = repository.get("commitSha")
+            if isinstance(runtime_commit_hash, str) and runtime_commit_hash:
+                return runtime_commit_hash
+
+    raise ValueError(f"Runtime commit hash not found in {source_manifest_url}")
 
 @tracer.start_as_current_span("dotnet_get_repository")
 def get_repository(repository: str) -> tuple[str, str]:

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -864,7 +864,12 @@ def run_performance_job(args: RunPerformanceJobArgs):
         queue=args.queue,
         build_configs=[f"{k}={v}" for k, v in configurations.items()],
         architecture=args.architecture,
-        get_perf_hash=True)
+        get_perf_hash=True,
+        collect_sdk_repository_commits=args.run_kind in [
+            "maui_scenarios_android",
+            "maui_scenarios_android_innerloop",
+            "maui_scenarios_ios"
+        ])
 
     ci_setup_arguments.build_number = args.build_number
     ci_setup_arguments.only_sanity_check = args.only_sanity_check

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -83,8 +83,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
     mobile_sdks = {
         "net_android": "Mono.Android.dll",
         "net_ios": "Microsoft.iOS.dll",
-        "net_maui": "Microsoft.Maui.dll",
-        "runtime": "System.Runtime.dll"
+        "net_maui": "Microsoft.Maui.dll"
     }
     results = dict[str, str]()
 
@@ -99,8 +98,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
 
         version, commit = parse_version_output(result)
         results[f"{sdk}_version"] = version
-        if sdk != "runtime":
-            results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
+        results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
 
     # Add datetime of the SDK installation to the results
     now = datetime.utcnow()

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -7,6 +7,9 @@ import platform
 import subprocess
 from performance.logger import getLogger
 from datetime import datetime
+from urllib.request import urlopen
+
+DOTNET_SOURCE_MANIFEST_URL = "https://raw.githubusercontent.com/dotnet/dotnet/{commit}/src/source-manifest.json"
 
 def versions_write_json(versiondict: dict[str, str], outputfile: str = 'versions.json'):
     with open(outputfile, 'w', encoding='utf-8') as file:
@@ -43,6 +46,19 @@ def get_version_from_dll(dll_path: str):
         return get_version_from_dll_powershell(dll_path)
     else:
         return get_version_from_dll_powershell_ios(dll_path)
+
+def get_runtime_commit_hash(dotnet_commit_hash: str) -> str:
+    source_manifest_url = DOTNET_SOURCE_MANIFEST_URL.format(commit=dotnet_commit_hash)
+    with urlopen(source_manifest_url, timeout=60) as response:
+        source_manifest = json.load(response)
+
+    for repository in source_manifest.get("repositories", []):
+        if repository.get("path") == "runtime":
+            runtime_commit_hash = repository.get("commitSha")
+            if runtime_commit_hash:
+                return runtime_commit_hash
+
+    raise ValueError(f"Runtime commit hash not found in {source_manifest_url}")
 
 def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> dict[str, str]:
     '''
@@ -99,7 +115,11 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
 
         version, commit = parse_version_output(result)
         results[f"{sdk}_version"] = version
-        results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
+        if sdk == "runtime":
+            results["PERFLAB_DATA_dotnet_commit_hash"] = commit
+            results["PERFLAB_DATA_runtime_commit_hash"] = get_runtime_commit_hash(commit)
+        else:
+            results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
 
     # Add datetime of the SDK installation to the results
     now = datetime.utcnow()

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -7,6 +7,7 @@ import platform
 import subprocess
 from performance.logger import getLogger
 from datetime import datetime
+from urllib.error import URLError
 from urllib.request import urlopen
 
 DOTNET_SOURCE_MANIFEST_URL = "https://raw.githubusercontent.com/dotnet/dotnet/{commit}/src/source-manifest.json"
@@ -117,7 +118,10 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
         results[f"{sdk}_version"] = version
         if sdk == "runtime":
             results["PERFLAB_DATA_dotnet_commit_hash"] = commit
-            results["PERFLAB_DATA_runtime_commit_hash"] = get_runtime_commit_hash(commit)
+            try:
+                results["PERFLAB_DATA_runtime_commit_hash"] = get_runtime_commit_hash(commit)
+            except (URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as error:
+                getLogger().warning(f"Unable to resolve runtime commit from dotnet/dotnet commit {commit}: {error}")
         else:
             results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
 

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -120,7 +120,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
             results["PERFLAB_DATA_dotnet_commit_hash"] = commit
             try:
                 results["PERFLAB_DATA_runtime_commit_hash"] = get_runtime_commit_hash(commit)
-            except (URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as error:
+            except Exception as error:
                 getLogger().warning(f"Unable to resolve runtime commit from dotnet/dotnet commit {commit}: {error}")
         else:
             results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -7,10 +7,6 @@ import platform
 import subprocess
 from performance.logger import getLogger
 from datetime import datetime
-from urllib.error import URLError
-from urllib.request import urlopen
-
-DOTNET_SOURCE_MANIFEST_URL = "https://raw.githubusercontent.com/dotnet/dotnet/{commit}/src/source-manifest.json"
 
 def versions_write_json(versiondict: dict[str, str], outputfile: str = 'versions.json'):
     with open(outputfile, 'w', encoding='utf-8') as file:
@@ -47,19 +43,6 @@ def get_version_from_dll(dll_path: str):
         return get_version_from_dll_powershell(dll_path)
     else:
         return get_version_from_dll_powershell_ios(dll_path)
-
-def get_runtime_commit_hash(dotnet_commit_hash: str) -> str:
-    source_manifest_url = DOTNET_SOURCE_MANIFEST_URL.format(commit=dotnet_commit_hash)
-    with urlopen(source_manifest_url, timeout=60) as response:
-        source_manifest = json.load(response)
-
-    for repository in source_manifest.get("repositories", []):
-        if repository.get("path") == "runtime":
-            runtime_commit_hash = repository.get("commitSha")
-            if runtime_commit_hash:
-                return runtime_commit_hash
-
-    raise ValueError(f"Runtime commit hash not found in {source_manifest_url}")
 
 def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> dict[str, str]:
     '''
@@ -116,13 +99,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
 
         version, commit = parse_version_output(result)
         results[f"{sdk}_version"] = version
-        if sdk == "runtime":
-            results["PERFLAB_DATA_dotnet_commit_hash"] = commit
-            try:
-                results["PERFLAB_DATA_runtime_commit_hash"] = get_runtime_commit_hash(commit)
-            except Exception as error:
-                getLogger().warning(f"Unable to resolve runtime commit from dotnet/dotnet commit {commit}: {error}")
-        else:
+        if sdk != "runtime":
             results[f"PERFLAB_DATA_{sdk}_commit_hash"] = commit
 
     # Add datetime of the SDK installation to the results


### PR DESCRIPTION
## Summary

- preserve the extracted dotnet/dotnet VMR commit as `PERFLAB_DATA_dotnet_commit_hash`
- resolve the corresponding dotnet/runtime commit from the VMR `src/source-manifest.json`
- report that value as `PERFLAB_DATA_runtime_commit_hash`

## Validation

Private Android CoreCLR Release sanity build succeeded: [build 3055756](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=3055756).