### PR TITLE
Add optional PerfLab counter regression thresholds

### DIFF
--- a/src/tools/Reporting/Directory.Packages.props
+++ b/src/tools/Reporting/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.11" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -4,14 +4,18 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 using Xunit;
 
 namespace Reporting.Tests;
 
 public class ReporterTests
 {
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     // this matches the output from the reporter made in GetReporterWithSpecifiedEnvironment
     private const string ExpectedTestTable =
 @"TestName
@@ -31,7 +35,6 @@ Metric         |Average                  |Min                      |Max
 ---------------|-------------------------|-------------------------|-------------------------
 CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |10000000000000000.000 ns 
 ";
-
     private const string NoResultsTable =
 @"TestName
 No results in file.
@@ -142,8 +145,9 @@ No results in file.
         var environment = new PerfLabEnvironmentProviderMock();
         var reporter = GetReporterWithSpecifiedEnvironment(environment);
         var jsonString = reporter.GetJson();
+        Assert.NotNull(jsonString);
 
-        var jsonObj = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        var jsonObj = DeserializeReporter(jsonString);
 
         Assert.Equal(environment.GetEnvironmentVariable("HELIX_CORRELATION_ID"), jsonObj.Run.CorrelationId);
         Assert.Equal(environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME"), jsonObj.Run.WorkItemName);
@@ -176,16 +180,17 @@ No results in file.
     {
         var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
         var jsonString = reporter.GetJson();
-        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][0];
+        Assert.NotNull(jsonString);
 
-        Assert.Equal(JTokenType.Boolean, jsonCounter["higherIsBetter"].Type);
-        Assert.False(jsonCounter["higherIsBetter"].Value<bool>());
-        Assert.Null(jsonCounter["regressionThreshold"]);
-        Assert.Null(jsonCounter["direction"]);
+        using var document = JsonDocument.Parse(jsonString);
+        var jsonCounter = document.RootElement.GetProperty("tests")[0].GetProperty("counters")[0];
 
-        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        Assert.Equal(JsonValueKind.False, jsonCounter.GetProperty("higherIsBetter").ValueKind);
+        Assert.False(jsonCounter.TryGetProperty("regressionThreshold", out _));
+        Assert.False(jsonCounter.TryGetProperty("direction", out _));
+
+        var deserialized = DeserializeReporter(jsonString);
         Assert.False(deserialized.Tests[0].Counters[0].HigherIsBetter);
-        Assert.Equal(CounterDirection.LowerIsBetter, deserialized.Tests[0].Counters[0].Direction);
         Assert.Null(deserialized.Tests[0].Counters[0].RegressionThreshold);
     }
 
@@ -196,281 +201,21 @@ No results in file.
         reporter.Tests[0].Counters[0].RegressionThreshold = 0.02;
 
         var jsonString = reporter.GetJson();
-        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][0];
-        Assert.Equal(0.02, jsonCounter["regressionThreshold"].Value<double>());
+        Assert.NotNull(jsonString);
 
-        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        using var document = JsonDocument.Parse(jsonString);
+        var jsonCounter = document.RootElement.GetProperty("tests")[0].GetProperty("counters")[0];
+        Assert.Equal(0.02, jsonCounter.GetProperty("regressionThreshold").GetDouble());
+
+        var deserialized = DeserializeReporter(jsonString);
         Assert.Equal(0.02, deserialized.Tests[0].Counters[0].RegressionThreshold);
-    }
-
-    [Fact]
-    public void UnknownDirectionIsSerializedForNonTopCounter()
-    {
-        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
-        reporter.Tests[0].AddCounter(new Counter
-        {
-            Name = "Storage only",
-            Direction = CounterDirection.Unknown,
-            MetricName = "value",
-            Results = [2.0]
-        });
-
-        var jsonString = reporter.GetJson();
-        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][1];
-        Assert.Equal(JTokenType.Null, jsonCounter["higherIsBetter"].Type);
-
-        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
-        var counter = deserialized.Tests[0].Counters[1];
-        Assert.Equal(CounterDirection.Unknown, counter.Direction);
-        Assert.Throws<InvalidOperationException>(() => counter.HigherIsBetter);
-    }
-
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-0.01)]
-    [InlineData(1.01)]
-    [InlineData(double.NaN)]
-    [InlineData(double.PositiveInfinity)]
-    [InlineData(double.NegativeInfinity)]
-    public void InvalidRegressionThresholdIsRejected(double threshold)
-    {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Counter { RegressionThreshold = threshold });
-    }
-
-    [Theory]
-    [InlineData(true, true)]
-    [InlineData(false, true)]
-    public void UnknownDirectionIsRejectedForDefaultOrTopCounter(bool defaultCounter, bool topCounter)
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        var test = new Test
-        {
-            Counters = [
-                new Counter
-                {
-                    DefaultCounter = defaultCounter,
-                    TopCounter = topCounter,
-                    Direction = CounterDirection.Unknown
-                }
-            ]
-        };
-
-        reporter.AddTest(test);
-        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
-    }
-
-    [Theory]
-    [InlineData(null, true)]
-    [InlineData("", true)]
-    [InlineData(" ", true)]
-    [InlineData(null, false)]
-    [InlineData("", false)]
-    [InlineData(" ", false)]
-    public void AddCounterRejectsBlankMetricNameForDefaultOrTopCounter(string metricName, bool defaultCounter)
-    {
-        var test = new Test();
-
-        Assert.Throws<InvalidOperationException>(() => test.AddCounter(new Counter
-        {
-            DefaultCounter = defaultCounter,
-            TopCounter = true,
-            MetricName = metricName
-        }));
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void SerializationRejectsDirectlyAssignedBlankMetricName(string metricName)
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        reporter.AddTest(new Test
-        {
-            Counters = [
-                new Counter
-                {
-                    DefaultCounter = true,
-                    TopCounter = true,
-                    MetricName = metricName
-                }
-            ]
-        });
-
-        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void DeserializationRejectsBlankMetricName(string metricName)
-    {
-        var json = new JObject
-        {
-            ["name"] = "Test",
-            ["counters"] = new JArray
-            {
-                new JObject
-                {
-                    ["name"] = "Default",
-                    ["topCounter"] = true,
-                    ["defaultCounter"] = true,
-                    ["higherIsBetter"] = false,
-                    ["metricName"] = metricName is null ? JValue.CreateNull() : new JValue(metricName)
-                }
-            }
-        }.ToString();
-
-        var exception = Assert.ThrowsAny<Exception>(() => JsonConvert.DeserializeObject<Test>(json));
-        Assert.IsType<InvalidOperationException>(exception.GetBaseException());
-    }
-
-    [Fact]
-    public void ValidMetricNameRoundTrips()
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        var test = new Test();
-        test.AddCounter(new Counter
-        {
-            Name = "Default",
-            DefaultCounter = true,
-            TopCounter = true,
-            MetricName = "ms"
-        });
-        reporter.AddTest(test);
-
-        var deserialized = JsonConvert.DeserializeObject<Reporter>(reporter.GetJson());
-        Assert.Equal("ms", deserialized.Tests[0].Counters[0].MetricName);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData(" ")]
-    public void NonTopCounterAllowsBlankMetricName(string metricName)
-    {
-        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
-        reporter.Tests[0].AddCounter(new Counter
-        {
-            Name = "Storage only",
-            MetricName = metricName,
-            Results = [2.0]
-        });
-
-        var json = reporter.GetJson();
-        var deserialized = JsonConvert.DeserializeObject<Reporter>(json);
-        Assert.Equal(metricName, deserialized.Tests[0].Counters[1].MetricName);
-        Assert.Contains("Storage only", reporter.WriteResultTable());
-    }
-
-    [Fact]
-    public void SerializationRejectsTestWithoutDefaultCounter()
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        reporter.AddTest(new Test
-        {
-            Counters = [
-                new Counter
-                {
-                    Name = "Not default"
-                }
-            ]
-        });
-
-        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
-    }
-
-    [Fact]
-    public void SerializationRejectsDirectlyAssignedMultipleDefaultCounters()
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        reporter.AddTest(new Test
-        {
-            Counters = [
-                new Counter
-                {
-                    Name = "First",
-                    DefaultCounter = true,
-                    TopCounter = true
-                },
-                new Counter
-                {
-                    Name = "Second",
-                    DefaultCounter = true,
-                    TopCounter = true
-                }
-            ]
-        });
-
-        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
-    }
-
-    [Fact]
-    public void DeserializationRejectsMultipleDefaultCounters()
-    {
-        const string json =
-@"{
-  ""name"": ""Test"",
-  ""counters"": [
-    {
-      ""name"": ""First"",
-      ""topCounter"": true,
-      ""defaultCounter"": true,
-      ""higherIsBetter"": false
-    },
-    {
-      ""name"": ""Second"",
-      ""topCounter"": true,
-      ""defaultCounter"": true,
-      ""higherIsBetter"": false
-    }
-  ]
-}";
-
-        var exception = Assert.ThrowsAny<Exception>(() => JsonConvert.DeserializeObject<Test>(json));
-        Assert.IsType<InvalidOperationException>(exception.GetBaseException());
-    }
-
-    [Fact]
-    public void AddCounterRejectsDefaultCounterThatIsNotTop()
-    {
-        var test = new Test();
-
-        Assert.Throws<InvalidOperationException>(() => test.AddCounter(new Counter
-        {
-            DefaultCounter = true
-        }));
-    }
-
-    [Fact]
-    public void SerializationRejectsDirectlyAssignedDuplicateCounterNames()
-    {
-        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
-        reporter.AddTest(new Test
-        {
-            Counters = [
-                new Counter
-                {
-                    Name = "Duplicate",
-                    DefaultCounter = true,
-                    TopCounter = true
-                },
-                new Counter
-                {
-                    Name = "Duplicate"
-                }
-            ]
-        });
-
-        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
     }
 
     [Fact]
     public void EnforceDefaultCounterConstraint()
     {
         var t = new Test();
-        var c = new Counter { DefaultCounter = true, TopCounter = true };
+        var c = new Counter { DefaultCounter = true };
         t.AddCounter(c);
         Assert.Throws<Exception>(() => t.AddCounter(c));
     }
@@ -497,10 +242,17 @@ No results in file.
     public void AddCountersEnumerable()
     {
         var t = new Test();
-        var c1 = new Counter { Name = "Counter1", DefaultCounter = true, TopCounter = true };
+        var c1 = new Counter { Name = "Counter1", DefaultCounter = true };
         var c2 = new Counter { Name = "Counter2" };
-        t.AddCounters([c2, c1]);
+        t.AddCounters([c1, c2]);
         Assert.Equal(2, t.Counters.Count);
+    }
+
+    private static Reporter DeserializeReporter(string json)
+    {
+        var reporter = JsonSerializer.Deserialize<Reporter>(json, s_jsonSerializerOptions);
+        Assert.NotNull(reporter);
+        return reporter;
     }
 
     private static Reporter GetReporterWithSpecifiedEnvironment(PerfLabEnvironmentProviderMock enviroment, string counterName = null, double result = 1.1)
@@ -514,7 +266,6 @@ No results in file.
                 new Counter
                 {
                     DefaultCounter = true,
-                    TopCounter = true,
                     HigherIsBetter = false,
                     MetricName = "ns",
                     Name = counterName ?? "CounterName",

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -57,6 +58,7 @@ No results in file.
                 new Counter
                 {
                     DefaultCounter = true,
+                    TopCounter = true,
                     MetricName = "ns",
                     Name = "CounterName",
                     Results = []
@@ -79,6 +81,7 @@ No results in file.
                 new Counter
                 {
                     DefaultCounter = true,
+                    TopCounter = true,
                     MetricName = "ns",
                     Name = "CounterName",
                     Results = null
@@ -169,10 +172,200 @@ No results in file.
     }
 
     [Fact]
+    public void LegacyCounterJsonRemainsCompatible()
+    {
+        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
+        var jsonString = reporter.GetJson();
+        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][0];
+
+        Assert.Equal(JTokenType.Boolean, jsonCounter["higherIsBetter"].Type);
+        Assert.False(jsonCounter["higherIsBetter"].Value<bool>());
+        Assert.Null(jsonCounter["regressionThreshold"]);
+        Assert.Null(jsonCounter["direction"]);
+
+        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        Assert.False(deserialized.Tests[0].Counters[0].HigherIsBetter);
+        Assert.Equal(CounterDirection.LowerIsBetter, deserialized.Tests[0].Counters[0].Direction);
+        Assert.Null(deserialized.Tests[0].Counters[0].RegressionThreshold);
+    }
+
+    [Fact]
+    public void RegressionThresholdIsSerialized()
+    {
+        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
+        reporter.Tests[0].Counters[0].RegressionThreshold = 0.02;
+
+        var jsonString = reporter.GetJson();
+        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][0];
+        Assert.Equal(0.02, jsonCounter["regressionThreshold"].Value<double>());
+
+        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        Assert.Equal(0.02, deserialized.Tests[0].Counters[0].RegressionThreshold);
+    }
+
+    [Fact]
+    public void UnknownDirectionIsSerializedForNonTopCounter()
+    {
+        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
+        reporter.Tests[0].AddCounter(new Counter
+        {
+            Name = "Storage only",
+            Direction = CounterDirection.Unknown,
+            MetricName = "value",
+            Results = [2.0]
+        });
+
+        var jsonString = reporter.GetJson();
+        var jsonCounter = JObject.Parse(jsonString)["tests"][0]["counters"][1];
+        Assert.Equal(JTokenType.Null, jsonCounter["higherIsBetter"].Type);
+
+        var deserialized = JsonConvert.DeserializeObject<Reporter>(jsonString);
+        var counter = deserialized.Tests[0].Counters[1];
+        Assert.Equal(CounterDirection.Unknown, counter.Direction);
+        Assert.Throws<InvalidOperationException>(() => counter.HigherIsBetter);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void InvalidRegressionThresholdIsRejected(double threshold)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Counter { RegressionThreshold = threshold });
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void UnknownDirectionIsRejectedForDefaultOrTopCounter(bool defaultCounter, bool topCounter)
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        var test = new Test
+        {
+            Counters = [
+                new Counter
+                {
+                    DefaultCounter = defaultCounter,
+                    TopCounter = topCounter,
+                    Direction = CounterDirection.Unknown
+                }
+            ]
+        };
+
+        reporter.AddTest(test);
+        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Fact]
+    public void SerializationRejectsTestWithoutDefaultCounter()
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        reporter.AddTest(new Test
+        {
+            Counters = [
+                new Counter
+                {
+                    Name = "Not default"
+                }
+            ]
+        });
+
+        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Fact]
+    public void SerializationRejectsDirectlyAssignedMultipleDefaultCounters()
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        reporter.AddTest(new Test
+        {
+            Counters = [
+                new Counter
+                {
+                    Name = "First",
+                    DefaultCounter = true,
+                    TopCounter = true
+                },
+                new Counter
+                {
+                    Name = "Second",
+                    DefaultCounter = true,
+                    TopCounter = true
+                }
+            ]
+        });
+
+        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Fact]
+    public void DeserializationRejectsMultipleDefaultCounters()
+    {
+        const string json =
+@"{
+  ""name"": ""Test"",
+  ""counters"": [
+    {
+      ""name"": ""First"",
+      ""topCounter"": true,
+      ""defaultCounter"": true,
+      ""higherIsBetter"": false
+    },
+    {
+      ""name"": ""Second"",
+      ""topCounter"": true,
+      ""defaultCounter"": true,
+      ""higherIsBetter"": false
+    }
+  ]
+}";
+
+        var exception = Assert.ThrowsAny<Exception>(() => JsonConvert.DeserializeObject<Test>(json));
+        Assert.IsType<InvalidOperationException>(exception.GetBaseException());
+    }
+
+    [Fact]
+    public void AddCounterRejectsDefaultCounterThatIsNotTop()
+    {
+        var test = new Test();
+
+        Assert.Throws<InvalidOperationException>(() => test.AddCounter(new Counter
+        {
+            DefaultCounter = true
+        }));
+    }
+
+    [Fact]
+    public void SerializationRejectsDirectlyAssignedDuplicateCounterNames()
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        reporter.AddTest(new Test
+        {
+            Counters = [
+                new Counter
+                {
+                    Name = "Duplicate",
+                    DefaultCounter = true,
+                    TopCounter = true
+                },
+                new Counter
+                {
+                    Name = "Duplicate"
+                }
+            ]
+        });
+
+        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Fact]
     public void EnforceDefaultCounterConstraint()
     {
         var t = new Test();
-        var c = new Counter { DefaultCounter = true };
+        var c = new Counter { DefaultCounter = true, TopCounter = true };
         t.AddCounter(c);
         Assert.Throws<Exception>(() => t.AddCounter(c));
     }
@@ -199,9 +392,9 @@ No results in file.
     public void AddCountersEnumerable()
     {
         var t = new Test();
-        var c1 = new Counter { Name = "Counter1", DefaultCounter = true };
+        var c1 = new Counter { Name = "Counter1", DefaultCounter = true, TopCounter = true };
         var c2 = new Counter { Name = "Counter2" };
-        t.AddCounters([c1, c2]);
+        t.AddCounters([c2, c1]);
         Assert.Equal(2, t.Counters.Count);
     }
 
@@ -216,6 +409,7 @@ No results in file.
                 new Counter
                 {
                     DefaultCounter = true,
+                    TopCounter = true,
                     HigherIsBetter = false,
                     MetricName = "ns",
                     Name = counterName ?? "CounterName",

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Runtime.InteropServices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Reporting.Tests;
@@ -122,7 +122,7 @@ No results in file.
     public void WriteReportWithLongNameTableWithoutEnvironment()
     {
         PerfLabEnvironmentProviderMock environment = new NonPerfLabEnvironmentProviderMock();
-        var reporter = GetReporterWithSpecifiedEnvironment(environment, counterName:"ThisIsALongerCounterName");
+        var reporter = GetReporterWithSpecifiedEnvironment(environment, counterName: "ThisIsALongerCounterName");
         var table = reporter.WriteResultTable();
         Assert.Equal(LongCounterNameTable, table);
     }
@@ -257,6 +257,111 @@ No results in file.
 
         reporter.AddTest(test);
         Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData(" ", true)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    public void AddCounterRejectsBlankMetricNameForDefaultOrTopCounter(string metricName, bool defaultCounter)
+    {
+        var test = new Test();
+
+        Assert.Throws<InvalidOperationException>(() => test.AddCounter(new Counter
+        {
+            DefaultCounter = defaultCounter,
+            TopCounter = true,
+            MetricName = metricName
+        }));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void SerializationRejectsDirectlyAssignedBlankMetricName(string metricName)
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        reporter.AddTest(new Test
+        {
+            Counters = [
+                new Counter
+                {
+                    DefaultCounter = true,
+                    TopCounter = true,
+                    MetricName = metricName
+                }
+            ]
+        });
+
+        Assert.Throws<InvalidOperationException>(() => reporter.GetJson());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void DeserializationRejectsBlankMetricName(string metricName)
+    {
+        var json = new JObject
+        {
+            ["name"] = "Test",
+            ["counters"] = new JArray
+            {
+                new JObject
+                {
+                    ["name"] = "Default",
+                    ["topCounter"] = true,
+                    ["defaultCounter"] = true,
+                    ["higherIsBetter"] = false,
+                    ["metricName"] = metricName is null ? JValue.CreateNull() : new JValue(metricName)
+                }
+            }
+        }.ToString();
+
+        var exception = Assert.ThrowsAny<Exception>(() => JsonConvert.DeserializeObject<Test>(json));
+        Assert.IsType<InvalidOperationException>(exception.GetBaseException());
+    }
+
+    [Fact]
+    public void ValidMetricNameRoundTrips()
+    {
+        var reporter = new Reporter(new PerfLabEnvironmentProviderMock());
+        var test = new Test();
+        test.AddCounter(new Counter
+        {
+            Name = "Default",
+            DefaultCounter = true,
+            TopCounter = true,
+            MetricName = "ms"
+        });
+        reporter.AddTest(test);
+
+        var deserialized = JsonConvert.DeserializeObject<Reporter>(reporter.GetJson());
+        Assert.Equal("ms", deserialized.Tests[0].Counters[0].MetricName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void NonTopCounterAllowsBlankMetricName(string metricName)
+    {
+        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock());
+        reporter.Tests[0].AddCounter(new Counter
+        {
+            Name = "Storage only",
+            MetricName = metricName,
+            Results = [2.0]
+        });
+
+        var json = reporter.GetJson();
+        var deserialized = JsonConvert.DeserializeObject<Reporter>(json);
+        Assert.Equal(metricName, deserialized.Tests[0].Counters[1].MetricName);
+        Assert.Contains("Storage only", reporter.WriteResultTable());
     }
 
     [Fact]

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -11,11 +11,6 @@ namespace Reporting.Tests;
 
 public class ReporterTests
 {
-    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     // this matches the output from the reporter made in GetReporterWithSpecifiedEnvironment
     private const string ExpectedTestTable =
 @"TestName
@@ -212,6 +207,19 @@ No results in file.
     }
 
     [Fact]
+    public void NonFiniteResultsRoundTrip()
+    {
+        var reporter = GetReporterWithSpecifiedEnvironment(new PerfLabEnvironmentProviderMock(), result: double.NaN);
+
+        var jsonString = reporter.GetJson();
+        Assert.NotNull(jsonString);
+        Assert.Contains("\"NaN\"", jsonString);
+
+        var deserialized = DeserializeReporter(jsonString);
+        Assert.True(double.IsNaN(deserialized.Tests[0].Counters[0].Results[0]));
+    }
+
+    [Fact]
     public void EnforceDefaultCounterConstraint()
     {
         var t = new Test();
@@ -249,11 +257,7 @@ No results in file.
     }
 
     private static Reporter DeserializeReporter(string json)
-    {
-        var reporter = JsonSerializer.Deserialize<Reporter>(json, s_jsonSerializerOptions);
-        Assert.NotNull(reporter);
-        return reporter;
-    }
+        => Reporter.FromJson(json);
 
     private static Reporter GetReporterWithSpecifiedEnvironment(PerfLabEnvironmentProviderMock enviroment, string counterName = null, double result = 1.1)
     {

--- a/src/tools/Reporting/Reporting/Counter.cs
+++ b/src/tools/Reporting/Reporting/Counter.cs
@@ -2,23 +2,97 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Reporting;
 
+public enum CounterDirection
+{
+    Unknown,
+    LowerIsBetter,
+    HigherIsBetter
+}
+
 public class Counter
 {
+    private const double MaximumRegressionThreshold = 1.0;
+    private CounterDirection _direction = CounterDirection.LowerIsBetter;
+    private double? _regressionThreshold;
+
     public string Name { get; set; } = "Counter";
 
     public bool TopCounter { get; set; }
 
     public bool DefaultCounter { get; set; }
 
-    public bool HigherIsBetter { get; set; }
+    [JsonIgnore]
+    public bool HigherIsBetter
+    {
+        get => _direction switch
+        {
+            CounterDirection.HigherIsBetter => true,
+            CounterDirection.LowerIsBetter => false,
+            _ => throw new InvalidOperationException($"Counter '{Name}' has an unknown direction.")
+        };
+        set => _direction = value ? CounterDirection.HigherIsBetter : CounterDirection.LowerIsBetter;
+    }
+
+    [JsonIgnore]
+    public CounterDirection Direction
+    {
+        get => _direction;
+        set
+        {
+            if (value is not CounterDirection.Unknown and not CounterDirection.LowerIsBetter and not CounterDirection.HigherIsBetter)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown counter direction.");
+            }
+
+            _direction = value;
+        }
+    }
+
+    [JsonProperty("higherIsBetter", NullValueHandling = NullValueHandling.Include)]
+    private bool? SerializedHigherIsBetter
+    {
+        get => _direction == CounterDirection.Unknown ? null : _direction == CounterDirection.HigherIsBetter;
+        set => _direction = value switch
+        {
+            true => CounterDirection.HigherIsBetter,
+            false => CounterDirection.LowerIsBetter,
+            null => CounterDirection.Unknown
+        };
+    }
 
     public string MetricName { get; set; } = "Count";
 
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public double? RegressionThreshold
+    {
+        get => _regressionThreshold;
+        set
+        {
+            if (value is double threshold &&
+                (double.IsNaN(threshold) || double.IsInfinity(threshold) || threshold <= 0 || threshold > MaximumRegressionThreshold))
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"Regression threshold must be finite and in the range (0, {MaximumRegressionThreshold}].");
+            }
+
+            _regressionThreshold = value;
+        }
+    }
+
     public IList<double>? Results { get; set; }
+
+    internal void Validate()
+    {
+        if (_direction == CounterDirection.Unknown && (DefaultCounter || TopCounter))
+        {
+            throw new InvalidOperationException($"Counter '{Name}' must have a known direction when it is a default or top counter.");
+        }
+    }
 
     public override string ToString() => $"{nameof(Name)}: {Name}, {nameof(TopCounter)}: {TopCounter}, {nameof(DefaultCounter)}: {DefaultCounter}, {nameof(MetricName)}: {MetricName}";
 }

--- a/src/tools/Reporting/Reporting/Counter.cs
+++ b/src/tools/Reporting/Reporting/Counter.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Reporting;
 
@@ -91,6 +91,11 @@ public class Counter
         if (_direction == CounterDirection.Unknown && (DefaultCounter || TopCounter))
         {
             throw new InvalidOperationException($"Counter '{Name}' must have a known direction when it is a default or top counter.");
+        }
+
+        if ((DefaultCounter || TopCounter) && string.IsNullOrWhiteSpace(MetricName))
+        {
+            throw new InvalidOperationException($"Counter '{Name}' must have a nonblank metric name when it is a default or top counter.");
         }
     }
 

--- a/src/tools/Reporting/Reporting/Counter.cs
+++ b/src/tools/Reporting/Reporting/Counter.cs
@@ -2,102 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Reporting;
 
-public enum CounterDirection
-{
-    Unknown,
-    LowerIsBetter,
-    HigherIsBetter
-}
-
 public class Counter
 {
-    private const double MaximumRegressionThreshold = 1.0;
-    private CounterDirection _direction = CounterDirection.LowerIsBetter;
-    private double? _regressionThreshold;
-
     public string Name { get; set; } = "Counter";
 
     public bool TopCounter { get; set; }
 
     public bool DefaultCounter { get; set; }
 
-    [JsonIgnore]
-    public bool HigherIsBetter
-    {
-        get => _direction switch
-        {
-            CounterDirection.HigherIsBetter => true,
-            CounterDirection.LowerIsBetter => false,
-            _ => throw new InvalidOperationException($"Counter '{Name}' has an unknown direction.")
-        };
-        set => _direction = value ? CounterDirection.HigherIsBetter : CounterDirection.LowerIsBetter;
-    }
-
-    [JsonIgnore]
-    public CounterDirection Direction
-    {
-        get => _direction;
-        set
-        {
-            if (value is not CounterDirection.Unknown and not CounterDirection.LowerIsBetter and not CounterDirection.HigherIsBetter)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown counter direction.");
-            }
-
-            _direction = value;
-        }
-    }
-
-    [JsonProperty("higherIsBetter", NullValueHandling = NullValueHandling.Include)]
-    private bool? SerializedHigherIsBetter
-    {
-        get => _direction == CounterDirection.Unknown ? null : _direction == CounterDirection.HigherIsBetter;
-        set => _direction = value switch
-        {
-            true => CounterDirection.HigherIsBetter,
-            false => CounterDirection.LowerIsBetter,
-            null => CounterDirection.Unknown
-        };
-    }
+    public bool HigherIsBetter { get; set; }
 
     public string MetricName { get; set; } = "Count";
 
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-    public double? RegressionThreshold
-    {
-        get => _regressionThreshold;
-        set
-        {
-            if (value is double threshold &&
-                (double.IsNaN(threshold) || double.IsInfinity(threshold) || threshold <= 0 || threshold > MaximumRegressionThreshold))
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), value, $"Regression threshold must be finite and in the range (0, {MaximumRegressionThreshold}].");
-            }
-
-            _regressionThreshold = value;
-        }
-    }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? RegressionThreshold { get; set; }
 
     public IList<double>? Results { get; set; }
-
-    internal void Validate()
-    {
-        if (_direction == CounterDirection.Unknown && (DefaultCounter || TopCounter))
-        {
-            throw new InvalidOperationException($"Counter '{Name}' must have a known direction when it is a default or top counter.");
-        }
-
-        if ((DefaultCounter || TopCounter) && string.IsNullOrWhiteSpace(MetricName))
-        {
-            throw new InvalidOperationException($"Counter '{Name}' must have a nonblank metric name when it is a default or top counter.");
-        }
-    }
 
     public override string ToString() => $"{nameof(Name)}: {Name}, {nameof(TopCounter)}: {TopCounter}, {nameof(DefaultCounter)}: {DefaultCounter}, {nameof(MetricName)}: {MetricName}";
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -10,8 +10,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Reporting;
@@ -19,13 +19,10 @@ namespace Reporting;
 public class Reporter
 {
     private readonly static CultureInfo _culture = CultureInfo.InvariantCulture;
-    private readonly static JsonSerializerSettings _jsonSerializerSettings = new()
+    private readonly static JsonSerializerOptions _jsonSerializerOptions = new()
     {
-        ContractResolver = new DefaultContractResolver
-        {
-            NamingStrategy = new CamelCaseNamingStrategy() { ProcessDictionaryKeys = false }
-        },
-        Culture = _culture
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
     };
 
     public List<Test> Tests { get; private set; } = [];
@@ -51,7 +48,6 @@ public class Reporter
         Os = os;
         Run = run;
         Tests = tests;
-        ValidateTests();
         InLab = new EnvironmentProvider().IsLabEnvironment();
     }
 
@@ -72,8 +68,7 @@ public class Reporter
             return null;
         }
 
-        ValidateTests();
-        return JsonConvert.SerializeObject(this, Formatting.Indented, _jsonSerializerSettings);
+        return JsonSerializer.Serialize(this, _jsonSerializerOptions);
     }
 
     public string WriteResultTable()
@@ -268,11 +263,4 @@ public class Reporter
         return $"{LeftJustify(counter.Name, counterWidth)}|{LeftJustify(average, resultWidth)}|{LeftJustify(min, resultWidth)}|{LeftJustify(max, resultWidth)}";
     }
 
-    private void ValidateTests()
-    {
-        foreach (var test in Tests)
-        {
-            test.Validate();
-        }
-    }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -51,6 +51,7 @@ public class Reporter
         Os = os;
         Run = run;
         Tests = tests;
+        ValidateTests();
         InLab = new EnvironmentProvider().IsLabEnvironment();
     }
 
@@ -65,7 +66,15 @@ public class Reporter
     }
 
     public string? GetJson()
-        => InLab ? JsonConvert.SerializeObject(this, Formatting.Indented, _jsonSerializerSettings) : null;
+    {
+        if (!InLab)
+        {
+            return null;
+        }
+
+        ValidateTests();
+        return JsonConvert.SerializeObject(this, Formatting.Indented, _jsonSerializerSettings);
+    }
 
     public string WriteResultTable()
     {
@@ -257,5 +266,13 @@ public class Reporter
         var max = ((FormattableString)$"{counter.Results.Max():F3} {counter.MetricName}").ToString(_culture);
         var min = ((FormattableString)$"{counter.Results.Min():F3} {counter.MetricName}").ToString(_culture);
         return $"{LeftJustify(counter.Name, counterWidth)}|{LeftJustify(average, resultWidth)}|{LeftJustify(min, resultWidth)}|{LeftJustify(max, resultWidth)}";
+    }
+
+    private void ValidateTests()
+    {
+        foreach (var test in Tests)
+        {
+            test.Validate();
+        }
     }
 }

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -12,6 +10,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Reporting;
@@ -90,7 +90,7 @@ public class Reporter
 
             var countersWithResults = test.Counters.Where(c => c.Results != null && c.Results.Count > 0);
             var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
-            var resultWidth = Math.Max(countersWithResults.Max(c => c.Results.Max().ToString("F3", _culture).Length + c.MetricName.Length) + 2, 15);
+            var resultWidth = Math.Max(countersWithResults.Max(c => c.Results.Max().ToString("F3", _culture).Length + (c.MetricName?.Length ?? 0)) + 2, 15);
             ret.AppendLine(test.Name);
             ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
             ret.AppendLine($"{new string('-', counterWidth)}|{new string('-', resultWidth)}|{new string('-', resultWidth)}|{new string('-', resultWidth)}");

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -21,6 +21,7 @@ public class Reporter
     private readonly static CultureInfo _culture = CultureInfo.InvariantCulture;
     private readonly static JsonSerializerOptions _jsonSerializerOptions = new()
     {
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true
     };
@@ -70,6 +71,10 @@ public class Reporter
 
         return JsonSerializer.Serialize(this, _jsonSerializerOptions);
     }
+
+    public static Reporter FromJson(string json)
+        => JsonSerializer.Deserialize<Reporter>(json, _jsonSerializerOptions)
+            ?? throw new JsonException("The JSON payload did not contain a reporter.");
 
     public string WriteResultTable()
     {
@@ -262,5 +267,4 @@ public class Reporter
         var min = ((FormattableString)$"{counter.Results.Min():F3} {counter.MetricName}").ToString(_culture);
         return $"{LeftJustify(counter.Name, counterWidth)}|{LeftJustify(average, resultWidth)}|{LeftJustify(min, resultWidth)}|{LeftJustify(max, resultWidth)}";
     }
-
 }

--- a/src/tools/Reporting/Reporting/Reporting.csproj
+++ b/src/tools/Reporting/Reporting/Reporting.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
 

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Reporting;
 
@@ -20,6 +21,13 @@ public class Test
 
     public void AddCounter(Counter counter)
     {
+        counter.Validate();
+
+        if (counter.DefaultCounter && !counter.TopCounter)
+        {
+            throw new InvalidOperationException($"Default counter '{counter.Name}' must also be a top counter.");
+        }
+
         if (counter.DefaultCounter && Counters.Any(c => c.DefaultCounter))
         {
             throw new Exception($"Duplicate default counter, name: ${counter.Name}");
@@ -40,4 +48,35 @@ public class Test
             AddCounter(counter);
         }
     }
+
+    internal void Validate()
+    {
+        var defaultCounters = Counters.Where(c => c.DefaultCounter).ToList();
+        if (defaultCounters.Count != 1)
+        {
+            throw new InvalidOperationException($"Test '{Name}' must have exactly one default counter, but found {defaultCounters.Count}.");
+        }
+
+        if (!defaultCounters[0].TopCounter)
+        {
+            throw new InvalidOperationException($"Default counter '{defaultCounters[0].Name}' must also be a top counter.");
+        }
+
+        var duplicateCounter = Counters.GroupBy(c => c.Name).FirstOrDefault(group => group.Count() > 1);
+        if (duplicateCounter is not null)
+        {
+            throw new InvalidOperationException($"Duplicate counter name, name: ${duplicateCounter.Key}");
+        }
+
+        foreach (var counter in Counters)
+        {
+            counter.Validate();
+        }
+    }
+
+    [OnSerializing]
+    private void OnSerializing(StreamingContext _) => Validate();
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext _) => Validate();
 }

--- a/src/tools/Reporting/Reporting/Test.cs
+++ b/src/tools/Reporting/Reporting/Test.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 
 namespace Reporting;
 
@@ -21,13 +20,6 @@ public class Test
 
     public void AddCounter(Counter counter)
     {
-        counter.Validate();
-
-        if (counter.DefaultCounter && !counter.TopCounter)
-        {
-            throw new InvalidOperationException($"Default counter '{counter.Name}' must also be a top counter.");
-        }
-
         if (counter.DefaultCounter && Counters.Any(c => c.DefaultCounter))
         {
             throw new Exception($"Duplicate default counter, name: ${counter.Name}");
@@ -48,35 +40,4 @@ public class Test
             AddCounter(counter);
         }
     }
-
-    internal void Validate()
-    {
-        var defaultCounters = Counters.Where(c => c.DefaultCounter).ToList();
-        if (defaultCounters.Count != 1)
-        {
-            throw new InvalidOperationException($"Test '{Name}' must have exactly one default counter, but found {defaultCounters.Count}.");
-        }
-
-        if (!defaultCounters[0].TopCounter)
-        {
-            throw new InvalidOperationException($"Default counter '{defaultCounters[0].Name}' must also be a top counter.");
-        }
-
-        var duplicateCounter = Counters.GroupBy(c => c.Name).FirstOrDefault(group => group.Count() > 1);
-        if (duplicateCounter is not null)
-        {
-            throw new InvalidOperationException($"Duplicate counter name, name: ${duplicateCounter.Key}");
-        }
-
-        foreach (var counter in Counters)
-        {
-            counter.Validate();
-        }
-    }
-
-    [OnSerializing]
-    private void OnSerializing(StreamingContext _) => Validate();
-
-    [OnDeserialized]
-    private void OnDeserialized(StreamingContext _) => Validate();
 }


### PR DESCRIPTION
## Summary

- add an optional per-counter `regressionThreshold` to the PerfLab Reporting contract
- keep `HigherIsBetter` as the existing boolean direction field, with no additional direction enum or validation layer
- migrate the Reporting project and tests from Newtonsoft.Json to System.Text.Json
- provide `Reporter.FromJson` for contract round-tripping and preserve named floating-point literal handling
- keep result-table output usable when counters or counter results are empty

## Validation

- 16 Reporting tests
- Reporting package build