### PR TITLE
Configure r2r to disable runtime code generation in the r2r_interpreter configuration

### DIFF
--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -553,6 +553,10 @@ def get_bdn_arguments(
             bdn_arguments += ["\\\"--wasmArgs=--experimental-wasm-exnref\\\""]
 
     if runtime_type == "coreclr_r2r_interpreter":
+        bdn_arguments += [
+            "--msbuild-arguments",
+            "/p:PublishReadyToRunCrossgen2ExtraArgs=--target-allows-runtime-code-generation:false",
+        ]
         if os_group == "windows":
             bdn_arguments += [
                 "--runtimes", "r2r11_0",

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -22,6 +22,7 @@ namespace MicroBenchmarks
             int? partitionIndex;
             List<string> exclusionFilterValue;
             List<string> categoryExclusionFilterValue;
+            List<string> msBuildArguments;
             bool getDiffableDisasm;
 
             // Parse and remove any additional parameters that we need that aren't part of BDN
@@ -31,6 +32,7 @@ namespace MicroBenchmarks
                 argsList = CommandLineOptions.ParseAndRemoveIntParameter(argsList, "--partition-index", out partitionIndex);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--exclusion-filter", out exclusionFilterValue);
                 argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--category-exclusion-filter", out categoryExclusionFilterValue);
+                argsList = CommandLineOptions.ParseAndRemoveStringsParameter(argsList, "--msbuild-arguments", out msBuildArguments);
                 CommandLineOptions.ParseAndRemoveBooleanParameter(argsList, "--disasm-diff", out getDiffableDisasm);
 
                 CommandLineOptions.ValidatePartitionParameters(partitionCount, partitionIndex);
@@ -56,7 +58,8 @@ namespace MicroBenchmarks
                         partitionIndex: partitionIndex,
                         exclusionFilterValue: exclusionFilterValue,
                         categoryExclusionFilterValue: categoryExclusionFilterValue,
-                        getDiffableDisasm: getDiffableDisasm)
+                        getDiffableDisasm: getDiffableDisasm,
+                        msBuildArguments: msBuildArguments)
                     .AddValidator(new NoWasmValidator(Categories.NoWASM)))
                 .ConfigureAwait(false);
 

--- a/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
+++ b/src/harness/BenchmarkDotNet.Extensions/RecommendedConfig.cs
@@ -28,7 +28,8 @@ namespace BenchmarkDotNet.Extensions
             List<string>? exclusionFilterValue = null,
             List<string>? categoryExclusionFilterValue = null,
             Job? job = null,
-            bool getDiffableDisasm = false)
+            bool getDiffableDisasm = false,
+            IReadOnlyList<string>? msBuildArguments = null)
         {
             if (job is null)
             {
@@ -41,6 +42,11 @@ namespace BenchmarkDotNet.Extensions
                     .WithEvaluateOverhead(Environment.GetEnvironmentVariable("PERFLAB_EVALUATE_OVERHEAD") == "1") // WASM has significant method-call overhead (1-10ns); subtract it when enabled
                     .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
                 #pragma warning restore CS0618
+            }
+
+            if (msBuildArguments is not null && msBuildArguments.Count > 0)
+            {
+                job = job.WithMsBuildArguments(msBuildArguments.ToArray());
             }
 
             var config = ManualConfig.CreateEmpty()


### PR DESCRIPTION
This configuration used to be hardcoded in crossgen2, but it workaround was recently reverted with proper support added in https://github.com/dotnet/runtime/commit/5b11923ecac20a8367b4ca60a9b9739479319e9a. This means r2r_interpreter configuration needs to pass `--target-allows-runtime-code-generation:false` to crossgen. This can be achieved by having the bdn autogenerated project receive the msbuild property `PublishReadyToRunCrossgen2ExtraArgs` initialized to this extra arg.

Given bdn doesn't support this configuration via its cli arguments (https://github.com/dotnet/BenchmarkDotNet/blob/master/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs), we add a new argument to the microbenchmark project `--msbuild-arguments`, which will be forwarded to bdn via the job arguments (job.WithMsBuildArguments).


