### PR TITLE
Add CoreCLR WASM R2R performance lane

### DIFF
--- a/eng/pipelines/runtime-wasm-perf-jobs.yml
+++ b/eng/pipelines/runtime-wasm-perf-jobs.yml
@@ -154,3 +154,28 @@ jobs:
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
+
+  # Run CoreCLR WASM R2R microbenchmarks using the same runtime payload.
+  # Browser WASM supports per-assembly R2R rather than composite R2R.
+  - ${{ if not(startswith(variables['Build.SourceBranch'], 'refs/heads/release')) }}:
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+        - linux_x64
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runtimeType: wasm_coreclr
+          codeGenType: 'wasm'
+          r2rRunType: 'r2r'
+          runKind: micro
+          logicalMachine: 'perfviper'
+          javascriptEngine: 'v8'
+          additionalJobIdentifier: coreclr_r2r_v8
+          downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}

--- a/scripts/build_runtime_payload.py
+++ b/scripts/build_runtime_payload.py
@@ -403,6 +403,18 @@ def _get_wasm_local_package_version(built_nugets_dir: str) -> str:
             f"WebAssembly SDK and Crossgen2 package versions do not match: "
             f"{wasm_sdk_packages[0].name}, {crossgen2_packages[0].name}")
 
+    illink_packages = [
+        package for package in Path(built_nugets_dir).glob("Microsoft.NET.ILLink.Tasks.*.nupkg")
+        if not package.name.endswith(".symbols.nupkg")
+    ]
+    if len(illink_packages) != 1:
+        raise ValueError(
+            f"Expected one ILLink package in {built_nugets_dir}, found {len(illink_packages)}")
+    if illink_packages[0].name != f"Microsoft.NET.ILLink.Tasks.{package_version}.nupkg":
+        raise ValueError(
+            f"WebAssembly SDK and ILLink package versions do not match: "
+            f"{wasm_sdk_packages[0].name}, {illink_packages[0].name}")
+
     return package_version
 
 

--- a/scripts/build_runtime_payload.py
+++ b/scripts/build_runtime_payload.py
@@ -325,13 +325,16 @@ def build_wasm_payload(
 def build_wasm_coreclr_payload(
     browser_wasm_coreclr_archive_or_dir: str,
     payload_parent_dir: str,
-) -> None:
+) -> str:
     """Create a WASM CoreCLR-only payload (dotnet).
 
     This is a self-contained payload for running CoreCLR WASM benchmarks without
     requiring Mono artifacts. The archive/directory layout is expected to contain
     a `staging/` folder with `dotnet-none` (SDK) and
     `microsoft.netcore.app.runtime.browser-wasm` (CoreCLR runtime pack) subfolders.
+
+    Returns:
+        The shared version of the locally built WebAssembly SDK and Crossgen2 packages.
     """
 
     wasm_dotnet_dir = os.path.join(payload_parent_dir, "dotnet")
@@ -346,6 +349,7 @@ def build_wasm_coreclr_payload(
     extract_archive_or_copy(
         browser_wasm_coreclr_archive_or_dir, wasm_built_nugets_dir, prefix="staging/built-nugets/"
     )
+    local_package_version = _get_wasm_local_package_version(wasm_built_nugets_dir)
 
     # Determine version from the runtime pack directory structure
     runtime_pack_src = os.path.join(
@@ -373,6 +377,33 @@ def build_wasm_coreclr_payload(
             getLogger().warning("Microsoft.NETCore.App.Ref pack not found – cannot determine version")
 
     _set_permissions_recursive([wasm_dotnet_dir, wasm_built_nugets_dir], mode=0o664)
+    return local_package_version
+
+
+def _get_wasm_local_package_version(built_nugets_dir: str) -> str:
+    package_prefix = "Microsoft.NET.Sdk.WebAssembly.Pack."
+    wasm_sdk_packages = [
+        package for package in Path(built_nugets_dir).glob(f"{package_prefix}*.nupkg")
+        if not package.name.endswith(".symbols.nupkg")
+    ]
+    if len(wasm_sdk_packages) != 1:
+        raise ValueError(
+            f"Expected one WebAssembly SDK package in {built_nugets_dir}, found {len(wasm_sdk_packages)}")
+
+    package_version = wasm_sdk_packages[0].name[len(package_prefix):-len(".nupkg")]
+    crossgen2_packages = [
+        package for package in Path(built_nugets_dir).glob("Microsoft.NETCore.App.Crossgen2.*.nupkg")
+        if not package.name.endswith(".symbols.nupkg")
+    ]
+    if len(crossgen2_packages) != 1:
+        raise ValueError(
+            f"Expected one Crossgen2 package in {built_nugets_dir}, found {len(crossgen2_packages)}")
+    if not crossgen2_packages[0].name.endswith(f".{package_version}.nupkg"):
+        raise ValueError(
+            f"WebAssembly SDK and Crossgen2 package versions do not match: "
+            f"{wasm_sdk_packages[0].name}, {crossgen2_packages[0].name}")
+
+    return package_version
 
 
 def build_r2r_interpreter_payload(

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -9,7 +9,7 @@ from argparse import ArgumentTypeError
 from argparse import SUPPRESS
 from io import StringIO
 from logging import getLogger
-from os import path
+from os import environ, path
 from subprocess import CalledProcessError
 from traceback import format_exc
 from typing import Any
@@ -150,6 +150,15 @@ def add_arguments(parser: ArgumentParser) -> ArgumentParser:
     )
 
     parser.add_argument(
+        '--wasm-ready-to-run',
+        dest='wasm_ready_to_run',
+        required=False,
+        default=False,
+        action='store_true',
+        help='Publish CoreCLR WASM benchmarks as ReadyToRun'
+    )
+
+    parser.add_argument(
         '--bdn-arguments',
         dest='bdn_arguments',
         required=False,
@@ -233,7 +242,28 @@ def __process_arguments(args: list[str]):
     )
 
     parser = add_arguments(parser)
-    return parser.parse_args(args)
+    parsed_args = parser.parse_args(args)
+
+    try:
+        validate_wasm_ready_to_run(parsed_args)
+    except ArgumentTypeError as error:
+        parser.error(str(error))
+
+    return parsed_args
+
+
+def validate_wasm_ready_to_run(args: Any) -> None:
+    if args.wasm_ready_to_run and (not args.wasm or args.wasm_runtime_flavor != 'CoreCLR'):
+        raise ArgumentTypeError('--wasm-ready-to-run requires --wasm --wasm-runtime-flavor CoreCLR')
+
+
+def configure_wasm_ready_to_run(args: Any) -> None:
+    validate_wasm_ready_to_run(args)
+
+    # BenchmarkDotNet builds generated projects in child processes. MSBuild
+    # imports environment variables as properties, which lets the generated
+    # WASM project opt into R2R without requiring a new BDN command-line option.
+    environ['PERFLAB_WASM_READY_TO_RUN'] = str(args.wasm_ready_to_run).lower()
 
 
 def __get_benchmarkdotnet_arguments(framework: str, args: Any) -> list[str]:
@@ -362,6 +392,8 @@ def run(
     __log_script_header("Running .NET micro benchmarks for '{}'".format(
         framework
     ))
+
+    configure_wasm_ready_to_run(args)
 
     # dotnet exec
     run_args = __get_benchmarkdotnet_arguments(framework, args)

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -644,6 +644,8 @@ def get_run_configurations(
 
     if r2r_run_type == "nor2r":
         configurations["R2RType"] = "nor2r"
+    elif r2r_run_type == "r2r":
+        configurations["R2RType"] = "r2r"
 
     if runtime_type == "coreclr_r2r_interpreter":
         configurations["R2RType"] = "r2r_interpreter"
@@ -690,7 +692,17 @@ def get_run_configurations(
 
     return configurations
 
-def get_work_item_command(os_group: str, target_csproj: str, architecture: str, perf_lab_framework: str, internal: bool, wasm: bool, bdn_artifacts_dir: str, wasm_coreclr: bool = False, only_sanity_check: bool = False):
+def get_work_item_command(
+        os_group: str,
+        target_csproj: str,
+        architecture: str,
+        perf_lab_framework: str,
+        internal: bool,
+        wasm: bool,
+        bdn_artifacts_dir: str,
+        wasm_coreclr: bool = False,
+        wasm_ready_to_run: bool = False,
+        only_sanity_check: bool = False):
     if os_group == "windows":
         work_item_command = [
             "python",
@@ -720,6 +732,8 @@ def get_work_item_command(os_group: str, target_csproj: str, architecture: str, 
         work_item_command += ["--run-isolated", "--wasm", "--dotnet-path", "$HELIX_CORRELATION_PAYLOAD/dotnet/"]
         if wasm_coreclr:
             work_item_command += ["--wasm-runtime-flavor", "CoreCLR"]
+            if wasm_ready_to_run:
+                work_item_command += ["--wasm-ready-to-run"]
 
     work_item_command += ["--bdn-artifacts", bdn_artifacts_dir]
 
@@ -1372,7 +1386,17 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
     def get_work_item_command_for_artifact_dir(artifact_dir: str):
         assert args.target_csproj is not None
-        return get_work_item_command(args.os_group, args.target_csproj, args.architecture, perf_lab_framework, args.internal, wasm, artifact_dir, wasm_coreclr, args.only_sanity_check)
+        return get_work_item_command(
+            args.os_group,
+            args.target_csproj,
+            args.architecture,
+            perf_lab_framework,
+            args.internal,
+            wasm,
+            artifact_dir,
+            wasm_coreclr,
+            wasm_coreclr and args.r2r_run_type == "r2r",
+            args.only_sanity_check)
     
     work_item_command = get_work_item_command_for_artifact_dir(bdn_artifacts_directory)
     baseline_work_item_command = get_work_item_command_for_artifact_dir(bdn_baseline_artifacts_dir)

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -208,7 +208,8 @@ def get_pre_commands(
         runtime_type: str,
         codegen_type: str,
         build_config: str,
-        v8_version: str):
+        v8_version: str,
+        wasm_local_package_version: Optional[str] = None):
     helix_pre_commands: list[str] = []
 
     # Remember the previous PYTHONPATH that was set so it can be restored in the post commands
@@ -284,7 +285,14 @@ def get_pre_commands(
                 ]
 
     # Set up everything needed for WASM runs (both Mono and CoreCLR)
-    if runtime_type in ("wasm", "wasm_coreclr"):  
+    if runtime_type in ("wasm", "wasm_coreclr"):
+        if runtime_type == "wasm_coreclr":
+            if not wasm_local_package_version:
+                raise ValueError("CoreCLR WASM requires a local WebAssembly toolchain package version")
+            install_prerequisites += [
+                f"export PERFLAB_WASM_PACKAGE_VERSION={wasm_local_package_version}"
+            ]
+
         if os_distro == "azurelinux":
             # Azure Linux uses tdnf package manager
             install_prerequisites += [
@@ -954,13 +962,14 @@ def run_performance_job(args: RunPerformanceJobArgs):
             shutil.copytree(args.mono_dotnet_dir, mono_dotnet_path, dirs_exist_ok=True)
 
     v8_version = ""
+    wasm_local_package_version = None
     if wasm_coreclr:
         if args.libraries_download_dir is None:
             raise Exception("Libraries not downloaded for wasm_coreclr runs")
         
         getLogger().info("Building wasm_coreclr payload directory")
         browser_wasm_coreclr_dir = os.path.join(args.libraries_download_dir, "BrowserWasmCoreCLR")
-        build_wasm_coreclr_payload(
+        wasm_local_package_version = build_wasm_coreclr_payload(
             browser_wasm_coreclr_dir,
             payload_dir,
         )
@@ -1147,7 +1156,15 @@ def run_performance_job(args: RunPerformanceJobArgs):
     else:
         agent_python = "python3"
 
-    helix_pre_commands = get_pre_commands(args.os_group, args.os_distro, args.internal, args.runtime_type, args.codegen_type, args.build_config, v8_version)
+    helix_pre_commands = get_pre_commands(
+        args.os_group,
+        args.os_distro,
+        args.internal,
+        args.runtime_type,
+        args.codegen_type,
+        args.build_config,
+        v8_version,
+        wasm_local_package_version)
     helix_post_commands = get_post_commands(args.os_group, args.internal, args.runtime_type)
 
     # Point ML.NET at the SSWE model that was pre-downloaded into the correlation payload above, so it

--- a/scripts/tests/test_run_performance_job.py
+++ b/scripts/tests/test_run_performance_job.py
@@ -12,6 +12,7 @@ def get_generated_apt_commands(*, internal: bool, runtime_type: str) -> list[str
         codegen_type="jit",
         build_config="Release",
         v8_version="12.0.0",
+        wasm_local_package_version="11.0.0-ci" if runtime_type == "wasm_coreclr" else None,
     )
 
     return [

--- a/scripts/tests/test_wasm_coreclr_r2r.py
+++ b/scripts/tests/test_wasm_coreclr_r2r.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import xml.etree.ElementTree as ET
 from argparse import Namespace
 from pathlib import Path
 
@@ -64,6 +65,25 @@ def test_ready_to_run_has_distinct_result_configuration():
     assert configurations["CompilationMode"] == "wasm"
     assert configurations["RuntimeType"] == "coreclr"
     assert configurations["R2RType"] == "r2r"
+
+
+def test_ready_to_run_validates_resolved_runtime_pack_items():
+    targets_path = scripts_dir.parent / "src" / "benchmarks" / "micro" / "MicroBenchmarks.Wasm.targets"
+    target = ET.parse(targets_path).find("./Target[@Name='ValidateWasmReadyToRunConfiguration']")
+
+    assert target is not None
+    assert target.attrib["DependsOnTargets"] == "UpdateTargetingAndRuntimePack"
+
+    conditions = [error.attrib["Condition"] for error in target.findall("Error")]
+    assert any(
+        "_PerformanceWasmResolvedRuntimePack->'%(NuGetPackageId)'" in condition
+        for condition in conditions
+    )
+    assert any(
+        "_PerformanceWasmResolvedFrameworkReference->'%(RuntimePackName)'" in condition
+        for condition in conditions
+    )
+    assert all("_PerformanceWasmRuntimePackName" not in condition for condition in conditions)
 
 
 def test_coreclr_payload_detects_local_toolchain_package_version(tmp_path):

--- a/scripts/tests/test_wasm_coreclr_r2r.py
+++ b/scripts/tests/test_wasm_coreclr_r2r.py
@@ -9,7 +9,8 @@ scripts_dir = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(scripts_dir))
 
 import micro_benchmarks
-from run_performance_job import get_run_configurations, get_work_item_command
+from build_runtime_payload import build_wasm_coreclr_payload
+from run_performance_job import get_pre_commands, get_run_configurations, get_work_item_command
 
 
 def test_ready_to_run_requires_coreclr_wasm():
@@ -63,3 +64,46 @@ def test_ready_to_run_has_distinct_result_configuration():
     assert configurations["CompilationMode"] == "wasm"
     assert configurations["RuntimeType"] == "coreclr"
     assert configurations["R2RType"] == "r2r"
+
+
+def test_coreclr_payload_detects_local_toolchain_package_version(tmp_path):
+    artifact = tmp_path / "artifact" / "staging"
+    ref_pack = artifact / "dotnet-none" / "packs" / "Microsoft.NETCore.App.Ref" / "11.0.0-rc.1.26431.109"
+    runtime_pack = artifact / "microsoft.netcore.app.runtime.browser-wasm" / "Release"
+    built_nugets = artifact / "built-nugets"
+    ref_pack.mkdir(parents=True)
+    runtime_pack.mkdir(parents=True)
+    built_nugets.mkdir(parents=True)
+    (built_nugets / "Microsoft.NET.Sdk.WebAssembly.Pack.11.0.0-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NETCore.App.Crossgen2.linux-x64.11.0.0-ci.nupkg").touch()
+
+    version = build_wasm_coreclr_payload(str(artifact.parent), str(tmp_path / "payload"))
+
+    assert version == "11.0.0-ci"
+
+
+def test_coreclr_payload_rejects_mismatched_toolchain_package_versions(tmp_path):
+    artifact = tmp_path / "artifact" / "staging"
+    (artifact / "dotnet-none").mkdir(parents=True)
+    built_nugets = artifact / "built-nugets"
+    built_nugets.mkdir(parents=True)
+    (built_nugets / "Microsoft.NET.Sdk.WebAssembly.Pack.11.0.0-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NETCore.App.Crossgen2.linux-x64.11.0.1-ci.nupkg").touch()
+
+    with pytest.raises(ValueError, match="versions do not match"):
+        build_wasm_coreclr_payload(str(artifact.parent), str(tmp_path / "payload"))
+
+
+def test_coreclr_pre_commands_export_local_toolchain_package_version():
+    commands = get_pre_commands(
+        os_group="linux",
+        os_distro="ubuntu",
+        internal=False,
+        runtime_type="wasm_coreclr",
+        codegen_type="wasm",
+        build_config="Release",
+        v8_version="15.1.206",
+        wasm_local_package_version="11.0.0-ci",
+    )
+
+    assert any("PERFLAB_WASM_PACKAGE_VERSION=11.0.0-ci" in command for command in commands)

--- a/scripts/tests/test_wasm_coreclr_r2r.py
+++ b/scripts/tests/test_wasm_coreclr_r2r.py
@@ -1,0 +1,65 @@
+import os
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+scripts_dir = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(scripts_dir))
+
+import micro_benchmarks
+from run_performance_job import get_run_configurations, get_work_item_command
+
+
+def test_ready_to_run_requires_coreclr_wasm():
+    with pytest.raises(SystemExit):
+        micro_benchmarks.__process_arguments([
+            "--frameworks", "net11.0",
+            "--wasm-ready-to-run",
+        ])
+
+
+def test_ready_to_run_configures_msbuild_environment(monkeypatch):
+    monkeypatch.delenv("PERFLAB_WASM_READY_TO_RUN", raising=False)
+    args = Namespace(
+        wasm=True,
+        wasm_runtime_flavor="CoreCLR",
+        wasm_ready_to_run=True,
+    )
+
+    micro_benchmarks.configure_wasm_ready_to_run(args)
+
+    assert os.environ["PERFLAB_WASM_READY_TO_RUN"] == "true"
+
+
+def test_ready_to_run_argument_is_forwarded_to_helix_work_item():
+    command = get_work_item_command(
+        os_group="linux",
+        target_csproj="src/benchmarks/micro/MicroBenchmarks.csproj",
+        architecture="x64",
+        perf_lab_framework="net11.0",
+        internal=True,
+        wasm=True,
+        bdn_artifacts_dir="/tmp/artifacts",
+        wasm_coreclr=True,
+        wasm_ready_to_run=True,
+    )
+
+    assert "--wasm-runtime-flavor" in command
+    assert "--wasm-ready-to-run" in command
+
+
+def test_ready_to_run_has_distinct_result_configuration():
+    configurations = get_run_configurations(
+        run_kind="micro",
+        runtime_type="wasm_coreclr",
+        codegen_type="wasm",
+        r2r_run_type="r2r",
+        runtime_flavor="coreclr",
+        javascript_engine="v8",
+    )
+
+    assert configurations["CompilationMode"] == "wasm"
+    assert configurations["RuntimeType"] == "coreclr"
+    assert configurations["R2RType"] == "r2r"

--- a/scripts/tests/test_wasm_coreclr_r2r.py
+++ b/scripts/tests/test_wasm_coreclr_r2r.py
@@ -76,6 +76,7 @@ def test_coreclr_payload_detects_local_toolchain_package_version(tmp_path):
     built_nugets.mkdir(parents=True)
     (built_nugets / "Microsoft.NET.Sdk.WebAssembly.Pack.11.0.0-ci.nupkg").touch()
     (built_nugets / "Microsoft.NETCore.App.Crossgen2.linux-x64.11.0.0-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NET.ILLink.Tasks.11.0.0-ci.nupkg").touch()
 
     version = build_wasm_coreclr_payload(str(artifact.parent), str(tmp_path / "payload"))
 
@@ -89,8 +90,22 @@ def test_coreclr_payload_rejects_mismatched_toolchain_package_versions(tmp_path)
     built_nugets.mkdir(parents=True)
     (built_nugets / "Microsoft.NET.Sdk.WebAssembly.Pack.11.0.0-ci.nupkg").touch()
     (built_nugets / "Microsoft.NETCore.App.Crossgen2.linux-x64.11.0.1-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NET.ILLink.Tasks.11.0.0-ci.nupkg").touch()
 
     with pytest.raises(ValueError, match="versions do not match"):
+        build_wasm_coreclr_payload(str(artifact.parent), str(tmp_path / "payload"))
+
+
+def test_coreclr_payload_requires_matching_illink_package(tmp_path):
+    artifact = tmp_path / "artifact" / "staging"
+    (artifact / "dotnet-none").mkdir(parents=True)
+    built_nugets = artifact / "built-nugets"
+    built_nugets.mkdir(parents=True)
+    (built_nugets / "Microsoft.NET.Sdk.WebAssembly.Pack.11.0.0-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NETCore.App.Crossgen2.linux-x64.11.0.0-ci.nupkg").touch()
+    (built_nugets / "Microsoft.NET.ILLink.Tasks.11.0.1-ci.nupkg").touch()
+
+    with pytest.raises(ValueError, match="ILLink package versions do not match"):
         build_wasm_coreclr_payload(str(artifact.parent), str(tmp_path / "payload"))
 
 

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -10,6 +10,24 @@
     <_WasmStrictVersionMatch>false</_WasmStrictVersionMatch>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true' and '$(UseMonoRuntime)' == 'false'">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunComposite>false</PublishReadyToRunComposite>
+    <PublishReadyToRunContainerFormat>wasm</PublishReadyToRunContainerFormat>
+    <WasmEnableWebcil>true</WasmEnableWebcil>
+  </PropertyGroup>
+
+  <Target Name="ValidateWasmReadyToRunConfiguration"
+          BeforeTargets="PrepareForWasmBuild"
+          Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true'">
+    <Error Condition="'$(UseMonoRuntime)' != 'false'"
+           Text="CoreCLR WASM R2R requires UseMonoRuntime=false." />
+    <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(WasmEnableWebcil)' != 'true'"
+           Text="CoreCLR WASM R2R project properties were not applied." />
+    <Error Condition="'$(_PerformanceWasmRuntimePackName)' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
+           Text="CoreCLR WASM R2R resolved an unexpected runtime pack '$(_PerformanceWasmRuntimePackName)'." />
+  </Target>
+
   <ItemGroup>
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.Serialization.xml" />
 

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -14,6 +14,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunComposite>false</PublishReadyToRunComposite>
     <PublishReadyToRunContainerFormat>wasm</PublishReadyToRunContainerFormat>
+    <PublishTrimmed>true</PublishTrimmed>
     <WasmEnableWebcil>true</WasmEnableWebcil>
   </PropertyGroup>
 
@@ -22,7 +23,7 @@
           Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true'">
     <Error Condition="'$(UseMonoRuntime)' != 'false'"
            Text="CoreCLR WASM R2R requires UseMonoRuntime=false." />
-    <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(WasmEnableWebcil)' != 'true'"
+    <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(PublishTrimmed)' != 'true' or '$(WasmEnableWebcil)' != 'true'"
            Text="CoreCLR WASM R2R project properties were not applied." />
     <Error Condition="'$(PERFLAB_WASM_PACKAGE_VERSION)' == ''"
            Text="CoreCLR WASM R2R requires a local WebAssembly toolchain package version." />

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -19,14 +19,23 @@
   </PropertyGroup>
 
   <Target Name="ValidateWasmReadyToRunConfiguration"
+          DependsOnTargets="UpdateTargetingAndRuntimePack"
           BeforeTargets="PrepareForWasmBuild"
           Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true'">
+    <ItemGroup>
+      <_PerformanceWasmResolvedRuntimePack Include="@(ResolvedRuntimePack)"
+                                           Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
+      <_PerformanceWasmResolvedFrameworkReference Include="@(ResolvedFrameworkReference)"
+                                                  Condition="'%(ResolvedFrameworkReference.Identity)' == 'Microsoft.NETCore.App'" />
+    </ItemGroup>
     <Error Condition="'$(UseMonoRuntime)' != 'false'"
            Text="CoreCLR WASM R2R requires UseMonoRuntime=false." />
     <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(PublishTrimmed)' != 'true' or '$(WasmEnableWebcil)' != 'true'"
            Text="CoreCLR WASM R2R project properties were not applied." />
-    <Error Condition="'$(_PerformanceWasmRuntimePackName)' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
-           Text="CoreCLR WASM R2R resolved an unexpected runtime pack '$(_PerformanceWasmRuntimePackName)'." />
+    <Error Condition="'@(_PerformanceWasmResolvedRuntimePack->Count())' != '1' or '@(_PerformanceWasmResolvedRuntimePack->'%(NuGetPackageId)')' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
+           Text="CoreCLR WASM R2R resolved an unexpected runtime pack '@(_PerformanceWasmResolvedRuntimePack->'%(NuGetPackageId)')'." />
+    <Error Condition="'@(_PerformanceWasmResolvedFrameworkReference->Count())' != '1' or '@(_PerformanceWasmResolvedFrameworkReference->'%(RuntimePackName)')' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
+           Text="CoreCLR WASM R2R resolved an unexpected framework runtime pack '@(_PerformanceWasmResolvedFrameworkReference->'%(RuntimePackName)')'." />
   </Target>
 
   <Target Name="ValidateWasmReadyToRunOutputs"

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -25,8 +25,6 @@
            Text="CoreCLR WASM R2R requires UseMonoRuntime=false." />
     <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(PublishTrimmed)' != 'true' or '$(WasmEnableWebcil)' != 'true'"
            Text="CoreCLR WASM R2R project properties were not applied." />
-    <Error Condition="'$(PERFLAB_WASM_PACKAGE_VERSION)' == ''"
-           Text="CoreCLR WASM R2R requires a local WebAssembly toolchain package version." />
     <Error Condition="'$(_PerformanceWasmRuntimePackName)' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
            Text="CoreCLR WASM R2R resolved an unexpected runtime pack '$(_PerformanceWasmRuntimePackName)'." />
   </Target>

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -24,6 +24,8 @@
            Text="CoreCLR WASM R2R requires UseMonoRuntime=false." />
     <Error Condition="'$(PublishReadyToRun)' != 'true' or '$(PublishReadyToRunComposite)' != 'false' or '$(PublishReadyToRunContainerFormat)' != 'wasm' or '$(WasmEnableWebcil)' != 'true'"
            Text="CoreCLR WASM R2R project properties were not applied." />
+    <Error Condition="'$(PERFLAB_WASM_PACKAGE_VERSION)' == ''"
+           Text="CoreCLR WASM R2R requires a local WebAssembly toolchain package version." />
     <Error Condition="'$(_PerformanceWasmRuntimePackName)' != 'Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)'"
            Text="CoreCLR WASM R2R resolved an unexpected runtime pack '$(_PerformanceWasmRuntimePackName)'." />
   </Target>

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -30,6 +30,13 @@
            Text="CoreCLR WASM R2R resolved an unexpected runtime pack '$(_PerformanceWasmRuntimePackName)'." />
   </Target>
 
+  <Target Name="ValidateWasmReadyToRunOutputs"
+          AfterTargets="_CreateR2RImages"
+          Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true'">
+    <Error Condition="'@(_ReadyToRunFilesToPublish)' == ''"
+           Text="CoreCLR WASM R2R did not produce any ReadyToRun images." />
+  </Target>
+
   <ItemGroup>
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.Serialization.xml" />
 

--- a/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
+++ b/src/benchmarks/micro/MicroBenchmarks.Wasm.targets
@@ -39,6 +39,10 @@
   <ItemGroup>
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.Serialization.xml" />
 
+    <!-- Crossgen currently emits invalid WASM for Jil's ISO8601 TimeSpan deserializer. -->
+    <PublishReadyToRunExclude Include="Jil.dll"
+                              Condition="'$(PERFLAB_WASM_READY_TO_RUN)' == 'true'" />
+
     <_AOT_InternalForceInterpretAssemblies Include="Microsoft.CodeAnalysis.CSharp.dll" />
     <_AOT_InternalForceInterpretAssemblies Include="Microsoft.CodeAnalysis.dll" />
   </ItemGroup>

--- a/src/scenarios/build-common/WasmOverridePacks.targets
+++ b/src/scenarios/build-common/WasmOverridePacks.targets
@@ -79,6 +79,10 @@
                           Condition="'$(UseMonoRuntime)' == 'false'">
         <Crossgen2PackVersion Condition="'%(KnownCrossgen2Pack.TargetFramework)' == '$(TargetFramework)'">$(_PerformanceWasmToolchainPackVersion)</Crossgen2PackVersion>
       </KnownCrossgen2Pack>
+      <KnownILLinkPack Update="@(KnownILLinkPack)"
+                       Condition="'$(UseMonoRuntime)' == 'false'">
+        <ILLinkPackVersion Condition="'%(KnownILLinkPack.TargetFramework)' == '$(TargetFramework)'">$(_PerformanceWasmToolchainPackVersion)</ILLinkPackVersion>
+      </KnownILLinkPack>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/scenarios/build-common/WasmOverridePacks.targets
+++ b/src/scenarios/build-common/WasmOverridePacks.targets
@@ -1,4 +1,9 @@
 <Project>
+  <PropertyGroup>
+    <_PerformanceWasmRuntimePackName Condition="'$(UseMonoRuntime)' == 'false'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
+    <_PerformanceWasmRuntimePackName Condition="'$(_PerformanceWasmRuntimePackName)' == ''">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
+  </PropertyGroup>
+
   <!-- SDK tries to download runtime packs when RuntimeIdentifier is set, remove them from PackageDownload item. -->
   <Target Name="RemoveRuntimePackFromDownloadItem"
           AfterTargets="ProcessFrameworkReferences">
@@ -16,16 +21,16 @@
     <ItemGroup>
       <ResolvedRuntimePack
           FrameworkName="Microsoft.NETCore.App"
-          NuGetPackageId="Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)"
+          NuGetPackageId="$(_PerformanceWasmRuntimePackName)"
           NuGetPackageVersion="$(_RuntimePackInWorkloadVersionCurrent)"
           PackageDirectory="$(NetCoreTargetingPackRoot)\%(Identity)\$(_RuntimePackInWorkloadVersionCurrent)"
           RuntimeIdentifier="$(RuntimeIdentifier)" />
 
       <ResolvedFrameworkReference
           Condition="'%(Identity)' == 'Microsoft.NETCore.App'"
-          RuntimePackName="Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)"
+          RuntimePackName="$(_PerformanceWasmRuntimePackName)"
           RuntimePackVersion="$(_RuntimePackInWorkloadVersionCurrent)"
-          RuntimePackPath="$(NetCoreTargetingPackRoot)\Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)\$(_RuntimePackInWorkloadVersionCurrent)"
+          RuntimePackPath="$(NetCoreTargetingPackRoot)\$(_PerformanceWasmRuntimePackName)\$(_RuntimePackInWorkloadVersionCurrent)"
           RuntimeIdentifier="$(RuntimeIdentifier)" />
     </ItemGroup>
   </Target>

--- a/src/scenarios/build-common/WasmOverridePacks.targets
+++ b/src/scenarios/build-common/WasmOverridePacks.targets
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <_PerformanceWasmRuntimePackName Condition="'$(UseMonoRuntime)' == 'false'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
     <_PerformanceWasmRuntimePackName Condition="'$(_PerformanceWasmRuntimePackName)' == ''">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
+    <_PerformanceWasmToolchainPackVersion Condition="'$(PERFLAB_WASM_PACKAGE_VERSION)' != ''">$(PERFLAB_WASM_PACKAGE_VERSION)</_PerformanceWasmToolchainPackVersion>
+    <_PerformanceWasmToolchainPackVersion Condition="'$(_PerformanceWasmToolchainPackVersion)' == ''">$(_RuntimePackInWorkloadVersionCurrent)</_PerformanceWasmToolchainPackVersion>
   </PropertyGroup>
 
   <!-- SDK tries to download runtime packs when RuntimeIdentifier is set, remove them from PackageDownload item. -->
@@ -65,6 +67,9 @@
 
   <ItemGroup>
     <KnownWebAssemblySdkPack Update="Microsoft.NET.Sdk.WebAssembly.Pack"
-      WebAssemblySdkPackVersion="$(_RuntimePackInWorkloadVersionCurrent)" />
+      WebAssemblySdkPackVersion="$(_PerformanceWasmToolchainPackVersion)" />
+    <KnownCrossgen2Pack Update="Microsoft.NETCore.App.Crossgen2"
+      Condition="'$(UseMonoRuntime)' == 'false'"
+      Crossgen2PackVersion="$(_PerformanceWasmToolchainPackVersion)" />
   </ItemGroup>
 </Project>

--- a/src/scenarios/build-common/WasmOverridePacks.targets
+++ b/src/scenarios/build-common/WasmOverridePacks.targets
@@ -3,7 +3,6 @@
     <_PerformanceWasmRuntimePackName Condition="'$(UseMonoRuntime)' == 'false'">Microsoft.NETCore.App.Runtime.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
     <_PerformanceWasmRuntimePackName Condition="'$(_PerformanceWasmRuntimePackName)' == ''">Microsoft.NETCore.App.Runtime.Mono.$(RuntimeIdentifier)</_PerformanceWasmRuntimePackName>
     <_PerformanceWasmToolchainPackVersion Condition="'$(PERFLAB_WASM_PACKAGE_VERSION)' != ''">$(PERFLAB_WASM_PACKAGE_VERSION)</_PerformanceWasmToolchainPackVersion>
-    <_PerformanceWasmToolchainPackVersion Condition="'$(_PerformanceWasmToolchainPackVersion)' == ''">$(_RuntimePackInWorkloadVersionCurrent)</_PerformanceWasmToolchainPackVersion>
   </PropertyGroup>
 
   <!-- SDK tries to download runtime packs when RuntimeIdentifier is set, remove them from PackageDownload item. -->
@@ -65,11 +64,21 @@
     </ItemGroup>
   </Target>
 
-  <ItemGroup>
-    <KnownWebAssemblySdkPack Update="Microsoft.NET.Sdk.WebAssembly.Pack"
-      WebAssemblySdkPackVersion="$(_PerformanceWasmToolchainPackVersion)" />
-    <KnownCrossgen2Pack Update="Microsoft.NETCore.App.Crossgen2"
-      Condition="'$(UseMonoRuntime)' == 'false'"
-      Crossgen2PackVersion="$(_PerformanceWasmToolchainPackVersion)" />
-  </ItemGroup>
+  <!-- Workload manifests can update these items after project evaluation. Apply
+       the local cohort immediately before the SDK consumes them. -->
+  <Target Name="_UpdatePerformanceWasmToolchainPacks"
+          BeforeTargets="ProcessFrameworkReferences">
+    <PropertyGroup>
+      <_PerformanceWasmToolchainPackVersion Condition="'$(_PerformanceWasmToolchainPackVersion)' == ''">$(_RuntimePackInWorkloadVersionCurrent)</_PerformanceWasmToolchainPackVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <KnownWebAssemblySdkPack Update="@(KnownWebAssemblySdkPack)">
+        <WebAssemblySdkPackVersion Condition="'%(KnownWebAssemblySdkPack.TargetFramework)' == '$(TargetFramework)'">$(_PerformanceWasmToolchainPackVersion)</WebAssemblySdkPackVersion>
+      </KnownWebAssemblySdkPack>
+      <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack)"
+                          Condition="'$(UseMonoRuntime)' == 'false'">
+        <Crossgen2PackVersion Condition="'%(KnownCrossgen2Pack.TargetFramework)' == '$(TargetFramework)'">$(_PerformanceWasmToolchainPackVersion)</Crossgen2PackVersion>
+      </KnownCrossgen2Pack>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary

- add a dedicated CoreCLR browser-WASM R2R microbenchmark lane on V8
- propagate the R2R selection through Helix and the microbenchmark harness
- publish per-assembly WASM R2R with a distinct `R2RType=r2r` result dimension
- resolve the CoreCLR browser runtime pack in shared WASM pack overrides
- fail fast if CoreCLR/R2R/webcil/runtime-pack settings are not applied

## Dependency

Depends on dotnet/runtime#133040 and finally dotnet/runtime#133203, which stages the matching host Crossgen2 pack in `BrowserWasmCoreCLR`.

## Validation

- focused Python tests for argument validation, environment propagation, Helix forwarding, and result dimensions
- direct MSBuild evaluation of R2R and runtime-pack properties
- fail-fast MSBuild validation for invalid Mono/R2R configuration
- XML and YAML parsing

## Remaining validation

Run `runtime-wasm-perf` with this branch and the runtime artifact together, confirm `CreateReadyToRunImages` executes, and verify uploaded results are labeled `R2RType=r2r`.