### PR TITLE
Add .NET 12 feeds and channel mapping

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,8 @@
     <!--  End: Package sources from dotnet-maui -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <add key="dotnet12" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12/nuget/v3/index.json" />
+    <add key="dotnet12-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet12-transport/nuget/v3/index.json" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
     <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -4,6 +4,16 @@ class ChannelMap():
     channel_map = {
         'main': {
             'tfm': 'net11.0',
+            'branch': '12.0',
+            'quality': 'daily'
+        },
+        '11.0': {
+            'tfm': 'net11.0',
+            'branch': '11.0',
+            'quality': 'daily'
+        },
+        'release/11.0': {
+            'tfm': 'net11.0',
             'branch': '11.0',
             'quality': 'daily'
         },


### PR DESCRIPTION
## Summary

- add the public `dotnet12` and `dotnet12-transport` NuGet feeds
- point the `main` channel at the `12.0` SDK branch while retaining the `net11.0` TFM
- add explicit `11.0` and `release/11.0` channel mappings

This follows the previous rollout pattern from #4969 (feeds), #5014 (next SDK channel with the existing TFM), #5064 (later TFM switch), and #4439 (explicit version channel mappings).

## Validation

- verified both .NET 12 feed endpoints are reachable
- validated the channel map resolves `main` to branch `12.0` with TFM `net11.0`, while the new .NET 11 channels continue to resolve branch `11.0`