### PR TITLE
Keep the main performance channel on the .NET 11 SDK

### DIFF
--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -4,7 +4,7 @@ class ChannelMap():
     channel_map = {
         'main': {
             'tfm': 'net11.0',
-            'branch': '12.0',
+            'branch': '11.0',
             'quality': 'daily'
         },
         '11.0': {


### PR DESCRIPTION
Avoid generating net12.0 benchmark projects with an SDK that still supports only net11.0 targeting.
This was tested in https://dev.azure.com/dnceng/internal/_build/results?buildId=3072516&view=results and seems to have fixed most of the issues.
This should be reverted once net12 is fully working, likely once https://redirect.github.com/dotnet/sdk/pull/56086 is merged.
